### PR TITLE
remove auth gate for start

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "githits",
   "description": "CLI companion for GitHits - code examples from global open source for developers and AI assistants",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "files": [
     "dist",

--- a/src/commands/mcp.test.ts
+++ b/src/commands/mcp.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, spyOn } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import type { Dependencies } from "../container.js";
 import {
   createMockAuthService,
@@ -7,7 +7,6 @@ import {
   createMockFileSystemService,
   createMockGitHitsService,
 } from "../services/test-helpers.js";
-import { AuthRequiredError } from "../shared/require-auth.js";
 import { createMcpServer, startMcpServer } from "./mcp.js";
 
 function createTestDeps(overrides: Partial<Dependencies> = {}): Dependencies {
@@ -45,12 +44,11 @@ describe("createMcpServer", () => {
 });
 
 describe("startMcpServer", () => {
-  it("throws AuthRequiredError on auth failure", async () => {
-    const consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+  it("starts successfully without a valid token", async () => {
     const deps = createTestDeps({ hasValidToken: false });
 
-    await expect(startMcpServer(deps)).rejects.toThrow(AuthRequiredError);
-
-    consoleSpy.mockRestore();
+    // Server should start and connect transport without throwing.
+    // Auth errors are deferred to individual tool calls.
+    await expect(startMcpServer(deps)).resolves.toBeUndefined();
   });
 });

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -4,7 +4,6 @@ import type { Command } from "commander";
 import { version } from "../../package.json";
 import { createContainer, type Dependencies } from "../container.js";
 import { dim, highlight, shouldUseColors } from "../shared/colors.js";
-import { AuthRequiredError, requireAuth } from "../shared/require-auth.js";
 import {
   createFeedbackTool,
   createSearchLanguageTool,
@@ -44,8 +43,6 @@ export function createMcpServer(deps: Dependencies): McpServer {
  * Start the MCP server. Exported for testability.
  */
 export async function startMcpServer(deps: Dependencies): Promise<void> {
-  requireAuth(deps, "to start MCP server");
-
   const server = createMcpServer(deps);
   const transport = new StdioServerTransport();
   await server.connect(transport);
@@ -101,13 +98,8 @@ Available tools: search, search_language, feedback`,
         showMcpSetupInstructions();
         return;
       }
-      try {
-        const deps = await createContainer();
-        await startMcpServer(deps);
-      } catch (error) {
-        if (error instanceof AuthRequiredError) process.exit(1);
-        throw error;
-      }
+      const deps = await createContainer();
+      await startMcpServer(deps);
     });
 
   mcpCommand
@@ -120,12 +112,7 @@ This command explicitly starts the server and is intended for use
 in MCP configuration files. Use 'githits mcp' for interactive setup.`,
     )
     .action(async () => {
-      try {
-        const deps = await createContainer();
-        await startMcpServer(deps);
-      } catch (error) {
-        if (error instanceof AuthRequiredError) process.exit(1);
-        throw error;
-      }
+      const deps = await createContainer();
+      await startMcpServer(deps);
     });
 }


### PR DESCRIPTION
## Problem
When the MCP server is launched by an AI client (e.g. Claude Code via plugin), requireAuth() in startMcpServer throws AuthRequiredError and triggers process.exit(1) before the MCP handshake completes. The client sees a silent Connection closed error and never discovers any tools:

`MCP server "plugin:githits:githits": Connection failed after 1467ms: MCP error -32000: Connection closed`

This makes the Claude Code plugin completely non-functional for any user who hasn't already run githits login out-of-band.


## Root Cause
requireAuth() was designed for interactive CLI commands where exiting with an auth message makes sense. For the MCP server, it kills the long-running process before the client can communicate with it — there's no opportunity to report the auth error back through the protocol.


## Fix
Remove requireAuth() from startMcpServer and the corresponding AuthRequiredError catch blocks from both action handlers. Auth enforcement is not removed — it is already handled per-request by RefreshingGitHitsService.withTokenRefresh(), which throws AuthenticationError when no token is available. withErrorHandling() catches this and returns a structured isError tool result that the AI client can act on (e.g. running githits login automatically).


## Changes
- src/commands/mcp.ts — Remove requireAuth call from startMcpServer, remove try/catch (AuthRequiredError) from both .action() handlers, remove unused imports
- src/commands/mcp.test.ts — Replace "throws AuthRequiredError on auth failure" test with "starts successfully without a valid token" test
- package.json — Bump version to 0.1.2

## Related
See companion [PR](https://github.com/githits-com/githits-claude-code-plugin/pull/1) in githits-claude-code-plugin which updates SKILL.md to instruct Claude to auto-run githits login when it receives an auth error from a tool call.