### PR TITLE
Surface support info via help text and error messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "githits",
   "description": "CLI companion for GitHits - code examples from global open source for developers and AI assistants",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "type": "module",
   "files": [
     "dist",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -31,7 +31,9 @@ Getting started:
   githits mcp                            Start MCP server for your AI assistant
   githits search "query" --lang python   Search for code examples
 
-Learn more at https://githits.com`,
+Learn more at https://githits.com
+Docs: https://app.githits.com/docs/
+Support: support@githits.com`,
   );
 
 // Auth commands

--- a/src/shared/require-auth.test.ts
+++ b/src/shared/require-auth.test.ts
@@ -19,6 +19,7 @@ describe("requireAuth", () => {
     const output = consoleSpy.mock.calls.map((c) => c[0]).join("\n");
     expect(output).toContain("Authentication required");
     expect(output).toContain("githits login");
+    expect(output).toContain("support@githits.com");
     consoleSpy.mockRestore();
   });
 

--- a/src/shared/require-auth.ts
+++ b/src/shared/require-auth.ts
@@ -36,6 +36,7 @@ export function requireAuth(
   console.log("To authenticate:");
   console.log("  githits login\n");
   console.log("Or set GITHITS_API_TOKEN environment variable.");
+  console.log("\nNeed help? support@githits.com");
 
   throw new AuthRequiredError(`Authentication required${suffix}`);
 }


### PR DESCRIPTION
## Summary

Surfaces support information where users naturally look: the CLI help footer and authentication error messages. 

## Changes

- Added docs URL (https://app.githits.com/docs/) and support email to CLI help footer
- Added support email to authentication error output
- Updated tests to verify support email appears in error messages
- Bumped version to 0.1.3

## Test Coverage

All 244 tests pass. Support email is verified in auth error test assertions.