### PR TITLE
chore: bump version to 0.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "githits",
   "description": "CLI companion for GitHits - code examples from global open source for developers and AI assistants",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "type": "module",
   "files": [
     "dist",


### PR DESCRIPTION
## Summary

- Bumps version to 0.1.4 to publish the expired-login fix (PR #4) to npm
- No code changes, version bump only

## Test plan

- [x] `bun run build` succeeds
- [ ] After merge, publish to npm with `npm publish`

🤖 Generated with [Claude Code](https://claude.com/claude-code)