### PR TITLE
fix: lowercase repository URL for npm provenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "githits",
   "description": "CLI companion for GitHits - code examples from global open source for developers and AI assistants",
-  "version": "0.1.3",
+  "version": "0.1.5",
   "type": "module",
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -48,10 +48,10 @@
   "homepage": "https://githits.com",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/GitHits-com/githits-cli.git"
+    "url": "git+https://github.com/githits-com/githits-cli.git"
   },
   "bugs": {
-    "url": "https://github.com/GitHits-com/githits-cli/issues"
+    "url": "https://github.com/githits-com/githits-cli/issues"
   },
   "engines": {
     "node": ">=20"


### PR DESCRIPTION
## Summary

`npm publish` fails with a 422 because npm's sigstore provenance verification compares `package.json`'s `repository.url` against the actual GitHub org name. The URL had `GitHits-com` (mixed case) while GitHub expects `githits-com` (lowercase), causing the mismatch.

This PR:
- Lowercases `repository.url` and `bugs.url` to match GitHub's org casing
- Bumps version to 0.1.5 (skipping 0.1.4 which failed to publish)

## Test plan

- [ ] CI passes
- [ ] After merge, `npm publish --access public` succeeds from GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)