### PR TITLE
chore(ci): migrate workflows and package metadata to Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -50,10 +50,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runtime: Node 20.x
-            node-version: "20.x"
-          - runtime: Node 22.x
-            node-version: "22.x"
           - runtime: Node 24.x
             node-version: "24.x"
           - runtime: Bun
@@ -61,7 +57,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -70,7 +66,7 @@ jobs:
 
       - name: Setup Node.js ${{ matrix.node-version }}
         if: matrix.node-version != ''
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
             id-token: write # Required for OIDC trusted publishing
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
               with:
                   fetch-depth: 0
 
@@ -42,9 +42,9 @@ jobs:
 
             - name: Setup Node.js
               if: steps.version.outputs.should_release == 'true'
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
-                  node-version: "22"
+                  node-version-file: ".node-version"
                   registry-url: "https://registry.npmjs.org"
 
             # Trusted publishing requires npm 11.5.1+

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ After the initial `npm link`, only `bun run build` is needed for subsequent chan
 
 ## Requirements
 
-- Node.js 20 or later
+- Node.js 24 or later
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "githits",
   "description": "CLI companion for GitHits - code examples from global open source for developers and AI assistants",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "type": "module",
   "files": [
     "dist",
@@ -54,7 +54,7 @@
     "url": "https://github.com/githits-com/githits-cli/issues"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=24"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary

Updates the GitHub Actions workflows and package metadata for the Node 24 migration. This removes deprecated Node 20-based action usage, aligns the package's supported runtime with Node 24, and bumps the package version to 0.1.7 for the next release.

## Changes

### Files Changed
- `.github/workflows/ci.yml` - upgrades `actions/checkout` and `actions/setup-node` to Node 24-compatible majors and removes Node 20/22 from the compat matrix
- `.github/workflows/release.yml` - upgrades workflow action versions and aligns release Node with `.node-version`
- `package.json` - bumps version to `0.1.7` and raises `engines.node` to `>=24`
- `README.md` - updates the documented Node requirement to 24+

## Verification

### Automated Checks
- [x] `bun install --frozen-lockfile`
- [x] `bun run typecheck`
- [x] `bun run format:check`
- [x] `bun run lint`
- [x] `bun run build`
- [x] `bun test`
- [x] `npm pack --dry-run`

### Manual Verification
- [x] `node dist/cli.js --version`
- [x] `node dist/cli.js --help`
- [x] Interactive CLI smoke test for `login`, `auth status`, `languages`, `search`, `feedback`, `mcp`, and `logout`

### Related Issues
- None linked
