### PR TITLE
feat(pkg-intel): add package_summary (pkg info + MCP)

### DIFF
--- a/docs/implementation/cli-commands.md
+++ b/docs/implementation/cli-commands.md
@@ -13,6 +13,7 @@ The CLI exposes three primary commands (`search`, `languages`, `feedback`) that 
 | `languages [query]` | — | `--json` | List or filter supported languages |
 | `feedback <solution_id>` | `--accept` or `--reject` | `-m, --message <text>`, `--json` | Submit feedback on a search result |
 | `code search <package> [query]` | package spec | `--keywords`, `--keyword`, `--match-mode`, `--category`, `--kind`, `--file`, `--intent`, `--limit`, `--wait`, `--json` | Search indexed dependency source code |
+| `pkg info <spec>` | package spec | `--verbose`, `--json` | Show a package overview (latest version, downloads, license, vulnerabilities) |
 
 ### `githits init`
 
@@ -85,6 +86,29 @@ Finds functions, classes, modules, and doc sections inside an indexed dependency
 **Capability gate.** The `code` group is registered only when the startup token advertises `code_navigation`, when `GITHITS_CODE_NAVIGATION=1` is set for local override, when `GITHITS_API_TOKEN` is present (opaque env token), or when stored auth is expired.
 
 **Troubleshooting.** Set `GITHITS_DEBUG=code-nav` to emit single-line JSON diagnostics to stderr on error paths. Include the output when filing an issue. Debug payloads never contain query text, tokens, or response bodies.
+
+### `githits pkg info`
+
+```
+githits pkg info npm:express
+githits pkg info pypi:requests --verbose
+githits pkg info crates:serde --json
+githits pkg info npm:@types/node
+```
+
+Shows a concise overview for a single package: latest version, license, description, repository + homepage, publication date, download count, GitHub metadata, install command, and known vulnerabilities. Default output is a compact terminal block. `--verbose` adds usage snippet, recent advisories, topics, and a recent-changes list. `--json` emits the lean hand-crafted envelope — every null field is omitted, every block that carries no actionable data is omitted entirely.
+
+**Package spec.** `<registry>:<name>`. Registries: `npm`, `pypi`, `hex`, `crates`, `nuget`, `maven`, `zig`, `vcpkg`, `packagist`. Scoped npm names (`npm:@types/node`) are supported.
+
+**Always latest.** `pkg info` returns the latest published version regardless of input. Passing `<spec>@<version>` is rejected with `INVALID_ARGUMENT` and a clear message — the tool never silently swaps to latest. Use `pkg vulns` (future) or `pkg deps` (future) for version-pinned queries.
+
+**`--verbose` + `--json`.** `--verbose` has no effect under `--json` — the JSON envelope always carries every field the verbose terminal view exposes (and more). The flag only affects human-readable output.
+
+**Output envelope.** Success payload is hand-crafted for agent token efficiency: `{registry, name, version, description?, license?, homepage?, repository?, publishedAt?, downloads?, github?, install?, usage?, vulnerabilities?, recentChanges?}`. Omitted fields reflect backend nulls, not dropped data. Error envelope: `{error, code, retryable, details?}` — same shape as `search_symbols`, same classifier family. Under `--json` the error envelope is written to **stderr** so stdout stays clean for `jq`.
+
+**Capability gate.** Same as `code`: `code_navigation` capability on the token, `GITHITS_CODE_NAVIGATION=1` override, `GITHITS_API_TOKEN` env token, or expired stored auth.
+
+**Troubleshooting.** `GITHITS_DEBUG=pkg-intel` emits PII-safe classified-error diagnostics (area, event, code, error class, detail keys). `GITHITS_DEBUG=pkg-graphql` emits transport-failure diagnostics from inside the POST helper. Use `GITHITS_DEBUG=*` to enable both.
 
 ## Architecture
 

--- a/docs/implementation/mcp-cli-parity.md
+++ b/docs/implementation/mcp-cli-parity.md
@@ -142,8 +142,38 @@ When a new tool lands with both MCP and CLI surfaces:
 |---|---|
 | `src/shared/code-navigation-defaults.ts` | Canonical defaults and sentinels. |
 | `src/shared/code-navigation-error-map.ts` | `mapCodeNavigationError` classifier and `MappedError` union. |
+| `src/shared/pkgseer-graphql.ts` | Low-level authenticated POST helper shared by every service that talks to the upstream endpoint. |
+| `src/shared/pkgseer-registry.ts` | Registry taxonomy (`PkgseerRegistry` union + lowercase↔uppercase converters). |
 | `src/shared/search-symbols-request.ts` | Shared request builder for `search_symbols`. |
 | `src/shared/search-symbols-response.ts` | Shared JSON envelope builders for `search_symbols`. |
-| `src/tools/search-symbols.ts` | MCP tool definition. |
+| `src/shared/package-summary-request.ts` | Shared request builder for `package_summary`. |
+| `src/shared/package-summary-response.ts` | Lean JSON envelope builder and terminal formatter for `package_summary`. |
+| `src/shared/package-intelligence-error-map.ts` | `mapPackageIntelligenceError` classifier (reuses `MappedError` from the code-nav map). |
+| `src/tools/search-symbols.ts` | MCP tool definition for `search_symbols`. |
+| `src/tools/package-summary.ts` | MCP tool definition for `package_summary`. |
 | `src/commands/code/search-symbols.ts` | CLI command. |
+| `src/commands/pkg/info.ts` | CLI command for `pkg info`. |
 | `src/tools/search-symbols-parity.test.ts` | Parity tests (cite rule IDs). |
+| `src/tools/package-summary-parity.test.ts` | Parity tests for `package_summary` (cite rule IDs). |
+
+## Per-tool notes
+
+### `package_summary`
+
+- **Permissive MCP schema + in-handler validation.** Matches the
+  `search_symbols` precedent. `buildPackageSummaryParams` is the
+  single validator used by both surfaces; raw Zod errors never
+  surface in the envelope.
+- **Parity assertion policy** (coded in
+  `src/tools/package-summary-parity.test.ts`):
+  - `toEqual` for service-sourced fixtures (happy, minimal-fields,
+    `NOT_FOUND`, `BACKEND_ERROR`) — envelopes are byte-identical
+    because both surfaces route through the same classifier and
+    response builder.
+  - `toMatchObject` for the `INVALID_ARGUMENT` fixture. CLI's
+    `parsePackageSpec` and MCP's in-handler
+    `buildPackageSummaryParams` produce surface-specific error text;
+    same envelope shape, different message.
+- **`@version` rejection.** CLI-only. The MCP tool has no `version`
+  input. The CLI's `pkg info` throws `InvalidPackageSpecError` on
+  any non-null parsed version — never silently swaps to latest.

--- a/docs/implementation/tools.md
+++ b/docs/implementation/tools.md
@@ -23,14 +23,25 @@ Both expose the same tools with identical names, parameters, and descriptions. T
 | `search_language` | `query` | Find supported programming language names before searching. |
 | `feedback` | `solution_id`, `accepted`, `feedback_text?` | Submit feedback on a search result to improve quality. |
 | `search_symbols` | `target`, `query?`, `keywords?`, `match_mode?`, `category?`, `kind?`, `file_path?`, `limit?`, `file_intent?`, `wait_timeout_ms?` | Capability-gated code navigation search over indexed dependency source. |
+| `package_summary` | `registry`, `package_name` | Package overview: latest version, license, description, repository, downloads, GitHub metadata, install command, and known vulnerabilities. Always returns the latest published version. |
 
-`search_symbols` is only registered when the startup token advertises `code_navigation` capability. The code-navigation endpoint can be overridden via `GITHITS_CODE_NAV_URL` for local development. Capability gating keeps the tool hidden from public/default flows while the feature is still rolling out.
+`search_symbols` and `package_summary` are only registered when the startup token advertises `code_navigation` capability. The backend endpoint can be overridden via `GITHITS_CODE_NAV_URL` for local development. Capability gating keeps the tools hidden from public/default flows while the feature is still rolling out.
 
 `search_symbols` shares request-construction, error classification, and JSON-payload shape with the CLI `githits code search` command via shared helpers under `src/shared/`. The parity rules are codified in [`mcp-cli-parity.md`](./mcp-cli-parity.md); the parity test (`src/tools/search-symbols-parity.test.ts`) asserts that both surfaces emit identical JSON for equivalent inputs.
 
 **Response shape.** `search_symbols` always requests `mode: DETAILED` and always selects the `code`, `resolution`, `kind`, and `category` fields. Responses include each match's full source code, precise symbol kind (from the unified symbol taxonomy), broad symbol category, and line range. The tool does not expose `mode` or `verbose` inputs — the service layer makes the choice once so both surfaces get the richest response without callers juggling the knobs. The legacy `chunkType` field is no longer selected or surfaced client-side; `kind` is the single source of truth for taxonomy. The text payload is always valid JSON (whether the result is success or error), so MCP clients can parse `content[0].text` without branching on `isError`.
 
 **Filter parameters.** `category` is the preferred surface for filtering (`callable`, `type`, `module`, `data`, `documentation`); `kind` is for the "I want this specific construct" case (27-value taxonomy). Both filters may be combined; both route through the shared `buildSearchSymbolsParams` helper.
+
+### `package_summary` response shape
+
+**Hand-crafted JSON envelope.** `package_summary` returns a lean JSON payload designed for agent token efficiency. Every GraphQL field dropped is deliberate — backend metadata (`schemaVersion`, `downloadsRefreshedAt`, `versionCount`, duplicate GitHub identifiers) does not reach the envelope. Null scalars are omitted; blocks (`github`, `vulnerabilities`, `downloads`, `recentChanges`) are omitted entirely when they carry no actionable data. `vulnerabilities` is omitted when `total === 0` or missing; when present, severity values include a CVSS-banded `severityLabel` (`critical` ≥9, `high` ≥7, `medium` ≥4, else `low`) for agent convenience.
+
+**Validation.** The MCP schema is permissive (`registry: z.string()`, `package_name: z.string()`) — validation happens in-handler via `buildPackageSummaryParams`, producing the same structured `{error, code, retryable}` envelope as CLI. Matches the `search_symbols` pattern of never surfacing raw Zod errors to agents.
+
+**Always latest.** The query exposes no `version` input because the upstream `packageSummary` resolver always returns the latest published version. The CLI `githits pkg info` rejects `<spec>@<version>` with `INVALID_ARGUMENT` rather than silently swapping — a silent-swap would break security-testing workflows that pin to an older vulnerable release.
+
+`package_summary` shares its envelope builder, terminal formatter, and error classifier with the CLI `githits pkg info` command via `src/shared/package-summary-request.ts`, `src/shared/package-summary-response.ts`, and `src/shared/package-intelligence-error-map.ts`. The parity test (`src/tools/package-summary-parity.test.ts`) asserts `toEqual` between CLI `--json` and MCP `content[0].text` for service-sourced fixtures, and `toMatchObject` for the `INVALID_ARGUMENT` fixture where surface-specific error text is acceptable.
 
 ## Entry Points
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,6 +10,7 @@ import {
   registerLoginCommand,
   registerLogoutCommand,
   registerMcpCommand,
+  registerPkgCommandGroup,
   registerSearchCommand,
 } from "./commands/index.js";
 
@@ -53,8 +54,12 @@ registerMcpCommand(program);
 registerSearchCommand(program);
 registerLanguagesCommand(program);
 registerFeedbackCommand(program);
-if (shouldRegisterCodeCommands(process.argv.slice(2))) {
+const argv = process.argv.slice(2);
+if (shouldEagerLoadGatedCommandGroup(argv, "code")) {
   await registerCodeCommandGroup(program);
+}
+if (shouldEagerLoadGatedCommandGroup(argv, "pkg")) {
+  await registerPkgCommandGroup(program);
 }
 
 // Auth status as subcommand of `auth`
@@ -66,10 +71,21 @@ registerAuthStatusCommand(authCommand);
 
 await program.parseAsync();
 
-function shouldRegisterCodeCommands(args: string[]): boolean {
+/**
+ * Argv-sniff optimisation for gated command groups. Returns `true`
+ * when the user's invocation might need the group registered — i.e.
+ * they typed the group name or asked for help. This is NOT a
+ * capability gate; the actual gate lives inside
+ * `registerXxxCommandGroup`. Here we only decide whether to build
+ * the container eagerly so registration can run.
+ */
+function shouldEagerLoadGatedCommandGroup(
+  args: string[],
+  groupName: string,
+): boolean {
   const [firstArg] = args;
   return (
-    firstArg === "code" ||
+    firstArg === groupName ||
     firstArg === "help" ||
     firstArg === "--help" ||
     firstArg === "-h"

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -36,6 +36,8 @@ export {
 
 export { createMcpServer, registerMcpCommand } from "./mcp.js";
 
+export { registerPkgCommandGroup } from "./pkg/index.js";
+
 export {
   registerSearchCommand,
   type SearchDependencies,

--- a/src/commands/mcp.test.ts
+++ b/src/commands/mcp.test.ts
@@ -7,6 +7,7 @@ import {
   createMockCodeNavigationService,
   createMockFileSystemService,
   createMockGitHitsService,
+  createMockPackageIntelligenceService,
 } from "../services/test-helpers.js";
 import {
   createMcpServer,
@@ -29,6 +30,7 @@ function createTestDeps(overrides: Partial<Dependencies> = {}): Dependencies {
     codeNavigationCliOverrideEnabled: false,
     codeNavigationUrl: undefined,
     codeNavigationService: undefined,
+    packageIntelligenceService: undefined,
     githitsService: createMockGitHitsService(),
     ...overrides,
   };
@@ -69,6 +71,66 @@ describe("createMcpServer", () => {
 
     const tools = getMcpToolDefinitions(deps);
     expect(tools.some((tool) => tool.name === "search_symbols")).toBe(true);
+  });
+
+  it("adds package_summary when capability is enabled and service wired", () => {
+    const deps = createTestDeps({
+      codeNavigationCapability: "enabled",
+      codeNavigationUrl: "https://pkgseer.dev",
+      codeNavigationService: createMockCodeNavigationService(),
+      packageIntelligenceService: createMockPackageIntelligenceService(),
+    });
+
+    const tools = getMcpToolDefinitions(deps);
+    expect(tools.map((tool) => tool.name)).toContain("package_summary");
+  });
+
+  it("omits package_summary when capability is disabled", () => {
+    const deps = createTestDeps({
+      codeNavigationCapability: "disabled",
+      codeNavigationUrl: "https://pkgseer.dev",
+      packageIntelligenceService: createMockPackageIntelligenceService(),
+    });
+
+    const tools = getMcpToolDefinitions(deps);
+    expect(tools.map((tool) => tool.name)).not.toContain("package_summary");
+  });
+
+  it("omits package_summary when service is missing even if capability enabled", () => {
+    const deps = createTestDeps({
+      codeNavigationCapability: "enabled",
+      codeNavigationUrl: "https://pkgseer.dev",
+      packageIntelligenceService: undefined,
+    });
+
+    const tools = getMcpToolDefinitions(deps);
+    expect(tools.map((tool) => tool.name)).not.toContain("package_summary");
+  });
+
+  it("adds package_summary for opaque env tokens (capability unknown + env token)", () => {
+    const deps = createTestDeps({
+      envApiToken: "ghi-opaque-token",
+      codeNavigationCapability: "unknown",
+      codeNavigationUrl: "https://pkgseer.dev",
+      packageIntelligenceService: createMockPackageIntelligenceService(),
+    });
+
+    const tools = getMcpToolDefinitions(deps);
+    expect(tools.some((tool) => tool.name === "package_summary")).toBe(true);
+  });
+
+  it("preserves half-open invariant: whenever package_summary is advertised, search_symbols is too (enabled path)", () => {
+    const deps = createTestDeps({
+      codeNavigationCapability: "enabled",
+      codeNavigationUrl: "https://pkgseer.dev",
+      codeNavigationService: createMockCodeNavigationService(),
+      packageIntelligenceService: createMockPackageIntelligenceService(),
+    });
+
+    const names = getMcpToolDefinitions(deps).map((t) => t.name);
+    if (names.includes("package_summary")) {
+      expect(names).toContain("search_symbols");
+    }
   });
 });
 

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -6,6 +6,7 @@ import { createContainer, type Dependencies } from "../container.js";
 import { dim, highlight, shouldUseColors } from "../shared/colors.js";
 import {
   createFeedbackTool,
+  createPackageSummaryTool,
   createSearchLanguageTool,
   createSearchSymbolsTool,
   createSearchTool,
@@ -24,13 +25,20 @@ export function getMcpToolDefinitions(
     createFeedbackTool(deps.githitsService),
   ];
 
-  if (
-    (deps.codeNavigationCapability === "enabled" ||
-      (deps.codeNavigationCapability === "unknown" &&
-        deps.envApiToken !== undefined)) &&
-    deps.codeNavigationService
-  ) {
+  // MCP capability predicate for pkgseer-backed tools. Narrower than
+  // the CLI gate by design — agents must not see tools that would
+  // silently fail. Shared with `search_symbols` below.
+  const pkgseerCapabilityOpen =
+    deps.codeNavigationCapability === "enabled" ||
+    (deps.codeNavigationCapability === "unknown" &&
+      deps.envApiToken !== undefined);
+
+  if (pkgseerCapabilityOpen && deps.codeNavigationService) {
     tools.push(createSearchSymbolsTool(deps.codeNavigationService));
+  }
+
+  if (pkgseerCapabilityOpen && deps.packageIntelligenceService) {
+    tools.push(createPackageSummaryTool(deps.packageIntelligenceService));
   }
 
   return tools;

--- a/src/commands/pkg/index.test.ts
+++ b/src/commands/pkg/index.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "bun:test";
+import { Command } from "commander";
+import { registerPkgCommandGroup } from "./index.js";
+
+describe("registerPkgCommandGroup", () => {
+  it("does not register the pkg group without override or capability", async () => {
+    const program = new Command();
+    await registerPkgCommandGroup(program, {
+      codeNavigationUrl: "https://pkgseer.dev",
+      overrideEnabled: false,
+      capability: "disabled",
+    });
+
+    expect(program.commands.some((command) => command.name() === "pkg")).toBe(
+      false,
+    );
+  });
+
+  it("registers the pkg command group when capability is enabled", async () => {
+    const program = new Command();
+    await registerPkgCommandGroup(program, {
+      codeNavigationUrl: "https://pkgseer.dev",
+      overrideEnabled: false,
+      capability: "enabled",
+    });
+
+    const pkgCommand = program.commands.find(
+      (command) => command.name() === "pkg",
+    );
+    expect(pkgCommand).toBeDefined();
+    expect(
+      pkgCommand?.commands.some((command) => command.name() === "info"),
+    ).toBe(true);
+  });
+
+  it("registers the pkg command group when override and URL are set", async () => {
+    const program = new Command();
+    await registerPkgCommandGroup(program, {
+      codeNavigationUrl: "https://pkgseer.dev",
+      overrideEnabled: true,
+      capability: "disabled",
+    });
+
+    const pkgCommand = program.commands.find(
+      (command) => command.name() === "pkg",
+    );
+    expect(pkgCommand).toBeDefined();
+    expect(
+      pkgCommand?.commands.some((command) => command.name() === "info"),
+    ).toBe(true);
+  });
+
+  it("registers the pkg command group for opaque env tokens", async () => {
+    const program = new Command();
+    await registerPkgCommandGroup(program, {
+      codeNavigationUrl: "https://pkgseer.dev",
+      overrideEnabled: false,
+      capability: "unknown",
+      envTokenPresent: true,
+    });
+
+    expect(program.commands.some((command) => command.name() === "pkg")).toBe(
+      true,
+    );
+  });
+
+  it("registers the pkg command group for expired stored auth", async () => {
+    const program = new Command();
+    await registerPkgCommandGroup(program, {
+      codeNavigationUrl: "https://pkgseer.dev",
+      overrideEnabled: false,
+      capability: "unknown",
+      expiredStoredAuth: true,
+    });
+
+    expect(program.commands.some((command) => command.name() === "pkg")).toBe(
+      true,
+    );
+  });
+});

--- a/src/commands/pkg/index.ts
+++ b/src/commands/pkg/index.ts
@@ -1,0 +1,74 @@
+import type { Command } from "commander";
+import { resolveStartupCodeNavigationRegistrationState } from "../../container.js";
+import {
+  type CodeNavigationCapability,
+  getCodeNavigationUrl,
+  getEnvApiToken,
+  isCodeNavigationCliOverrideEnabled,
+} from "../../services/index.js";
+import { registerPkgInfoCommand } from "./info.js";
+
+export interface PkgCommandGroupOptions {
+  codeNavigationUrl?: string;
+  overrideEnabled?: boolean;
+  capability?: CodeNavigationCapability;
+  envTokenPresent?: boolean;
+  expiredStoredAuth?: boolean;
+}
+
+/**
+ * Registers the capability-gated `pkg` command group. Structurally
+ * mirrors `registerCodeCommandGroup`:
+ *
+ * 1. URL early-exit — if the pkgseer endpoint isn't configured (no
+ *    `GITHITS_CODE_NAV_URL`, no sensible default), skip registration
+ *    entirely.
+ * 2. Capability gate — register only when the token advertises
+ *    `code_navigation`, `GITHITS_CODE_NAVIGATION=1` is set, an env
+ *    API token is present, or the stored auth has expired (we can't
+ *    inspect the caps inside an expired JWT, so show the command and
+ *    let the caller refresh).
+ *
+ * The capability check is intentionally duplicated with
+ * `registerCodeCommandGroup` rather than factored out — two tiny
+ * sites today, extract only once a third group arrives.
+ */
+export async function registerPkgCommandGroup(
+  program: Command,
+  options: PkgCommandGroupOptions = {},
+): Promise<void> {
+  const codeNavigationUrl = options.codeNavigationUrl ?? getCodeNavigationUrl();
+  if (!codeNavigationUrl) {
+    return;
+  }
+
+  const overrideEnabled =
+    options.overrideEnabled ?? isCodeNavigationCliOverrideEnabled();
+  const registrationState =
+    options.capability !== undefined || options.expiredStoredAuth !== undefined
+      ? {
+          capability: options.capability ?? "unknown",
+          expiredStoredAuth: options.expiredStoredAuth ?? false,
+        }
+      : await resolveStartupCodeNavigationRegistrationState();
+  const capability = registrationState.capability;
+  const envTokenPresent = options.envTokenPresent ?? Boolean(getEnvApiToken());
+
+  if (
+    !overrideEnabled &&
+    capability !== "enabled" &&
+    !envTokenPresent &&
+    !registrationState.expiredStoredAuth
+  ) {
+    return;
+  }
+
+  const pkgCommand = program
+    .command("pkg")
+    .summary("Package metadata, security, and docs")
+    .description(
+      "Inspect registry metadata, known vulnerabilities, and documentation for packages from npm, PyPI, Hex, Crates, NuGet, Maven, Packagist, vcpkg, and Zig.",
+    );
+
+  registerPkgInfoCommand(pkgCommand);
+}

--- a/src/commands/pkg/info.test.ts
+++ b/src/commands/pkg/info.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it, mock, spyOn } from "bun:test";
+import { PackageIntelligenceTargetNotFoundError } from "../../services/index.js";
+import {
+  createMockPackageIntelligenceService,
+  defaultPackageSummary,
+} from "../../services/test-helpers.js";
+import { AuthRequiredError } from "../../shared/require-auth.js";
+import { type PkgInfoCommandDependencies, pkgInfoAction } from "./info.js";
+
+describe("pkgInfoAction", () => {
+  const mcpUrl = "https://mcp.githits.com";
+
+  function createDeps(
+    overrides: Partial<PkgInfoCommandDependencies> = {},
+  ): PkgInfoCommandDependencies {
+    return {
+      packageIntelligenceService: createMockPackageIntelligenceService(),
+      codeNavigationUrl: "https://pkgseer.dev",
+      hasValidToken: true,
+      mcpUrl,
+      ...overrides,
+    };
+  }
+
+  it("renders the default terminal block via stdout.write", async () => {
+    const writes: string[] = [];
+    const writeSpy = spyOn(process.stdout, "write").mockImplementation(((
+      chunk: string | Uint8Array,
+    ) => {
+      writes.push(
+        typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk),
+      );
+      return true;
+    }) as typeof process.stdout.write);
+
+    await pkgInfoAction("npm:express", {}, createDeps());
+
+    const combined = writes.join("");
+    expect(combined).toContain("express @ 4.18.2 · MIT");
+    expect(combined).toContain("Repository");
+    expect(combined).toContain("Install");
+    writeSpy.mockRestore();
+  });
+
+  it("prints the lean JSON envelope when --json is provided", async () => {
+    const logSpy = spyOn(console, "log").mockImplementation(() => {});
+
+    await pkgInfoAction("npm:express", { json: true }, createDeps());
+
+    const output = logSpy.mock.calls[0]?.[0] as string;
+    const payload = JSON.parse(output);
+    expect(payload.name).toBe("express");
+    expect(payload.registry).toBe("npm");
+    expect(payload.version).toBe("4.18.2");
+    logSpy.mockRestore();
+  });
+
+  it("rejects @version with INVALID_ARGUMENT — non-JSON path writes stderr and exits 1", async () => {
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+
+    try {
+      await pkgInfoAction("npm:express@4.18.0", {}, createDeps());
+    } catch {
+      // expected process.exit throw
+    }
+
+    const combined = errorSpy.mock.calls.map((c) => c[0]).join("\n");
+    expect(combined).toContain(
+      "pkg info always returns the latest version; omit @4.18.0.",
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it("rejects @version with INVALID_ARGUMENT — --json path emits the envelope to stderr", async () => {
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+
+    try {
+      await pkgInfoAction("npm:express@4.18.0", { json: true }, createDeps());
+    } catch {
+      // expected process.exit throw
+    }
+
+    const output = errorSpy.mock.calls[0]?.[0] as string;
+    const payload = JSON.parse(output);
+    expect(payload.code).toBe("INVALID_ARGUMENT");
+    expect(payload.retryable).toBe(false);
+    expect(payload.error).toBe(
+      "pkg info always returns the latest version; omit @4.18.0.",
+    );
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it("classifies backend errors via mapPackageIntelligenceError", async () => {
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+
+    const service = createMockPackageIntelligenceService({
+      packageSummary: mock(() =>
+        Promise.reject(
+          new PackageIntelligenceTargetNotFoundError(
+            "Package 'npm:ghost' not found.",
+          ),
+        ),
+      ),
+    });
+
+    try {
+      await pkgInfoAction(
+        "npm:ghost",
+        {},
+        createDeps({ packageIntelligenceService: service }),
+      );
+    } catch {
+      // expected
+    }
+
+    expect(errorSpy.mock.calls[0]?.[0]).toBe("Package 'npm:ghost' not found.");
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it("routes service classification through --json error envelope", async () => {
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+
+    const service = createMockPackageIntelligenceService({
+      packageSummary: mock(() =>
+        Promise.reject(
+          new PackageIntelligenceTargetNotFoundError("Package not found"),
+        ),
+      ),
+    });
+
+    try {
+      await pkgInfoAction(
+        "npm:ghost",
+        { json: true },
+        createDeps({ packageIntelligenceService: service }),
+      );
+    } catch {
+      // expected
+    }
+
+    const output = errorSpy.mock.calls[0]?.[0] as string;
+    const payload = JSON.parse(output);
+    expect(payload.code).toBe("NOT_FOUND");
+    expect(payload.error).toBe("Package not found");
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it("throws AuthRequiredError before calling the service when unauthenticated", async () => {
+    const logSpy = spyOn(console, "log").mockImplementation(() => {});
+    const packageSummary = mock(() => Promise.resolve(defaultPackageSummary));
+    const service = createMockPackageIntelligenceService({ packageSummary });
+
+    await expect(
+      pkgInfoAction(
+        "npm:express",
+        {},
+        createDeps({
+          packageIntelligenceService: service,
+          hasValidToken: false,
+        }),
+      ),
+    ).rejects.toThrow(AuthRequiredError);
+
+    expect(packageSummary).not.toHaveBeenCalled();
+    logSpy.mockRestore();
+  });
+
+  it("errors when pkgseer URL / service are missing", async () => {
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+
+    try {
+      await pkgInfoAction(
+        "npm:express",
+        {},
+        createDeps({
+          packageIntelligenceService: undefined,
+          codeNavigationUrl: undefined,
+        }),
+      );
+    } catch {
+      // expected
+    }
+
+    const combined = errorSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(combined).toContain("Package intelligence is not configured");
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+});

--- a/src/commands/pkg/info.ts
+++ b/src/commands/pkg/info.ts
@@ -1,0 +1,131 @@
+import type { Command } from "commander";
+import { createContainer } from "../../container.js";
+import type { PackageIntelligenceService } from "../../services/index.js";
+import { shouldUseColors } from "../../shared/colors.js";
+import {
+  InvalidPackageSpecError,
+  mapPackageIntelligenceError,
+  parsePackageSpec,
+  requireAuth,
+} from "../../shared/index.js";
+import { buildPackageSummaryParams } from "../../shared/package-summary-request.js";
+import {
+  buildPackageSummarySuccessPayload,
+  formatPackageSummaryTerminal,
+} from "../../shared/package-summary-response.js";
+
+export interface PkgInfoCommandOptions {
+  verbose?: boolean;
+  json?: boolean;
+}
+
+export interface PkgInfoCommandDependencies {
+  packageIntelligenceService: PackageIntelligenceService | undefined;
+  codeNavigationUrl: string | undefined;
+  hasValidToken: boolean;
+  mcpUrl: string;
+}
+
+/**
+ * Core `pkg info` action. Rejects `@<version>` with a clear
+ * INVALID_ARGUMENT (never silently swaps to latest), then delegates
+ * to the shared request builder and response formatter.
+ */
+export async function pkgInfoAction(
+  spec: string,
+  options: PkgInfoCommandOptions,
+  deps: PkgInfoCommandDependencies,
+): Promise<void> {
+  requireAuth(deps);
+
+  try {
+    if (!deps.codeNavigationUrl || !deps.packageIntelligenceService) {
+      throw new InvalidPackageSpecError(
+        "Package intelligence is not configured for this environment.",
+      );
+    }
+
+    const parsed = parsePackageSpec(spec);
+    if (parsed.version !== undefined) {
+      throw new InvalidPackageSpecError(
+        `pkg info always returns the latest version; omit @${parsed.version}.`,
+      );
+    }
+
+    const { params } = buildPackageSummaryParams({
+      registry: parsed.registry,
+      packageName: parsed.name,
+    });
+    const summary =
+      await deps.packageIntelligenceService.packageSummary(params);
+
+    if (options.json) {
+      const payload = buildPackageSummarySuccessPayload(summary);
+      console.log(JSON.stringify(payload));
+      return;
+    }
+
+    const output = formatPackageSummaryTerminal(summary, {
+      verbose: options.verbose,
+      useColors: shouldUseColors(),
+    });
+    process.stdout.write(output);
+  } catch (error) {
+    handlePkgInfoCommandError(error, options.json ?? false);
+  }
+}
+
+function handlePkgInfoCommandError(error: unknown, json: boolean): never {
+  const mapped = mapPackageIntelligenceError(error);
+
+  if (json) {
+    console.error(
+      JSON.stringify({
+        error: mapped.message,
+        code: mapped.code,
+        retryable: mapped.retryable ?? false,
+        ...(mapped.details ? { details: mapped.details } : {}),
+      }),
+    );
+    process.exit(1);
+  }
+
+  // Bare mapped message — matches `search_symbols` structure, not its
+  // wording. Domain messages (`Package 'npm:foo' not found.`,
+  // `pkg info always returns the latest version; omit @4.18.0.`) are
+  // already caller-readable.
+  console.error(mapped.message);
+  process.exit(1);
+}
+
+const PKG_INFO_DESCRIPTION = `Get a package overview — latest version, license, description,
+repository, downloads, GitHub stars, install command, and known
+vulnerabilities. Use before picking a dependency or to orient on what
+a package is.
+
+Package spec: <registry>:<name>. Supported registries: npm, pypi, hex,
+crates, nuget, maven, zig, vcpkg, packagist.
+
+Always returns data for the latest published version.`;
+
+export function registerPkgInfoCommand(pkgCommand: Command): Command {
+  return pkgCommand
+    .command("info")
+    .summary("Show a package overview")
+    .description(PKG_INFO_DESCRIPTION)
+    .argument("<spec>", "Package spec, e.g. npm:express or pypi:requests")
+    .option(
+      "-v, --verbose",
+      "Show advisories, install usage, topics, and recent changes",
+    )
+    .option("--json", "Emit the lean JSON envelope")
+    .action(async (spec: string, options: PkgInfoCommandOptions) => {
+      const deps = await createContainer();
+      await pkgInfoAction(spec, options, {
+        packageIntelligenceService: deps.packageIntelligenceService,
+        codeNavigationUrl: deps.codeNavigationUrl,
+        hasValidToken: deps.hasValidToken,
+        mcpUrl: deps.mcpUrl,
+      });
+    });
+}

--- a/src/container.ts
+++ b/src/container.ts
@@ -23,6 +23,8 @@ import {
   KeychainUnavailableError,
   KeyringServiceImpl,
   MigratingAuthStorage,
+  type PackageIntelligenceService,
+  PackageIntelligenceServiceImpl,
   RefreshingGitHitsService,
   type TokenData,
   TokenManager,
@@ -93,6 +95,13 @@ export interface Dependencies {
   codeNavigationUrl: string | undefined;
   /** Optional code navigation service used by gated CLI/MCP paths */
   codeNavigationService: CodeNavigationService | undefined;
+  /**
+   * Optional package intelligence service — reads registry metadata,
+   * vulnerabilities, dependencies, and changelogs from the pkgseer
+   * endpoint. Shares the `code_navigation` capability gate and the
+   * same endpoint URL as the code-navigation service.
+   */
+  packageIntelligenceService: PackageIntelligenceService | undefined;
   /** GitHits REST API service */
   githitsService: GitHitsService;
 }
@@ -121,11 +130,12 @@ export async function createContainer(): Promise<Dependencies> {
   // Check for env API token first
   const envToken = getEnvApiToken();
   if (envToken) {
+    const tokenProvider = createStaticTokenProvider(envToken);
     const codeNavigationService = codeNavigationUrl
-      ? new CodeNavigationServiceImpl(
-          codeNavigationUrl,
-          createStaticTokenProvider(envToken),
-        )
+      ? new CodeNavigationServiceImpl(codeNavigationUrl, tokenProvider)
+      : undefined;
+    const packageIntelligenceService = codeNavigationUrl
+      ? new PackageIntelligenceServiceImpl(codeNavigationUrl, tokenProvider)
       : undefined;
 
     return {
@@ -142,6 +152,7 @@ export async function createContainer(): Promise<Dependencies> {
       codeNavigationCliOverrideEnabled,
       codeNavigationUrl,
       codeNavigationService,
+      packageIntelligenceService,
       githitsService: new GitHitsServiceImpl(apiUrl, envToken),
     };
   }
@@ -151,6 +162,9 @@ export async function createContainer(): Promise<Dependencies> {
   const apiToken = await tokenManager.getToken();
   const codeNavigationService = codeNavigationUrl
     ? new CodeNavigationServiceImpl(codeNavigationUrl, tokenManager)
+    : undefined;
+  const packageIntelligenceService = codeNavigationUrl
+    ? new PackageIntelligenceServiceImpl(codeNavigationUrl, tokenManager)
     : undefined;
 
   return {
@@ -167,6 +181,7 @@ export async function createContainer(): Promise<Dependencies> {
     codeNavigationCliOverrideEnabled,
     codeNavigationUrl,
     codeNavigationService,
+    packageIntelligenceService,
     githitsService: new RefreshingGitHitsService(apiUrl, tokenManager),
   };
 }

--- a/src/services/code-navigation-service.ts
+++ b/src/services/code-navigation-service.ts
@@ -1,19 +1,20 @@
 import { z } from "zod";
-import { version } from "../../package.json";
+import {
+  type PkgseerGraphqlResponse,
+  PkgseerTransportError,
+  postPkgseerGraphql,
+} from "../shared/pkgseer-graphql.js";
+import type { PkgseerRegistry } from "../shared/pkgseer-registry.js";
 import { executeWithTokenRefresh } from "./execute-with-token-refresh.js";
 import { AuthenticationError } from "./githits-service.js";
 import type { TokenProvider } from "./token-manager.js";
 
-export type CodeNavigationRegistry =
-  | "NPM"
-  | "PYPI"
-  | "HEX"
-  | "CRATES"
-  | "NUGET"
-  | "MAVEN"
-  | "ZIG"
-  | "VCPKG"
-  | "PACKAGIST";
+/**
+ * Back-compat alias — the canonical registry union now lives in
+ * `src/shared/pkgseer-registry.ts`. Re-exported here so existing
+ * consumers of `CodeNavigationRegistry` compile unchanged.
+ */
+export type CodeNavigationRegistry = PkgseerRegistry;
 
 export type SearchSymbolsMatchMode = "OR" | "AND";
 
@@ -476,49 +477,48 @@ export class CodeNavigationServiceImpl implements CodeNavigationService {
       );
     }
 
-    let response: Response;
+    let response: PkgseerGraphqlResponse;
     try {
-      response = await this.fetchFn(`${this.baseUrl()}/api/graphql`, {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${token}`,
-          "Content-Type": "application/json",
-          "User-Agent": `githits-cli/${version}`,
+      response = await postPkgseerGraphql({
+        endpointUrl: this.codeNavigationUrl,
+        token,
+        query: SEARCH_SYMBOLS_QUERY,
+        variables: {
+          registry: params.target.registry,
+          packageName: params.target.packageName,
+          repoUrl: params.target.repoUrl,
+          gitRef: params.target.gitRef,
+          query: params.query,
+          keywords: params.keywords,
+          matchMode: params.matchMode,
+          kind: params.kind,
+          category: params.category,
+          filePath: params.filePath,
+          version: params.target.version,
+          limit: params.limit,
+          fileIntent: params.fileIntent,
+          waitTimeoutMs: params.waitTimeoutMs,
         },
-        body: JSON.stringify({
-          query: SEARCH_SYMBOLS_QUERY,
-          variables: {
-            registry: params.target.registry,
-            packageName: params.target.packageName,
-            repoUrl: params.target.repoUrl,
-            gitRef: params.target.gitRef,
-            query: params.query,
-            keywords: params.keywords,
-            matchMode: params.matchMode,
-            kind: params.kind,
-            category: params.category,
-            filePath: params.filePath,
-            version: params.target.version,
-            limit: params.limit,
-            fileIntent: params.fileIntent,
-            waitTimeoutMs: params.waitTimeoutMs,
-          },
-        }),
+        fetchFn: this.fetchFn,
       });
     } catch (cause) {
-      throw new CodeNavigationNetworkError(
-        "Could not reach the code navigation service. Check your connection or set GITHITS_CODE_NAV_URL.",
-        { cause },
-      );
+      // Helper owns transport-level error wrapping; re-map to the
+      // domain error class so `mapCodeNavigationError` still routes
+      // to `NETWORK`. Other error classes bubble unchanged.
+      if (cause instanceof PkgseerTransportError) {
+        throw new CodeNavigationNetworkError(
+          "Could not reach the code navigation service. Check your connection or set GITHITS_CODE_NAV_URL.",
+          { cause },
+        );
+      }
+      throw cause;
     }
 
-    if (!response.ok) {
-      throw await this.createHttpError(response);
+    if (response.status < 200 || response.status >= 300) {
+      throw this.createHttpError(response);
     }
 
-    const parsed = graphQLResponseSchema.safeParse(
-      await response.json().catch(() => null),
-    );
+    const parsed = graphQLResponseSchema.safeParse(response.parsedBody);
     if (!parsed.success) {
       throw new MalformedCodeNavigationResponseError(
         "Malformed response from code navigation service.",
@@ -588,14 +588,9 @@ export class CodeNavigationServiceImpl implements CodeNavigationService {
     };
   }
 
-  private baseUrl(): string {
-    return this.codeNavigationUrl.replace(/\/+$/, "");
-  }
-
-  private async createHttpError(response: Response): Promise<Error> {
+  private createHttpError(response: PkgseerGraphqlResponse): Error {
     const status = response.status;
-    const body = await response.text().catch(() => "");
-    const detail = parseDetail(body);
+    const detail = parseDetail(response.responseBody);
 
     if (status === 401) {
       return new AuthenticationError(

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -81,6 +81,28 @@ export {
 } from "./keyring-service.js";
 export { MigratingAuthStorage } from "./migrating-auth-storage.js";
 export type {
+  ChangelogEntry,
+  GithubRepository,
+  PackageIdentity,
+  PackageIntelligenceService,
+  PackageSecurityOverview,
+  PackageSummary,
+  PackageSummaryParams,
+  QuickstartInfo,
+  VulnerabilityOverview,
+} from "./package-intelligence-service.js";
+export {
+  MalformedPackageIntelligenceResponseError,
+  PackageIntelligenceAccessError,
+  PackageIntelligenceBackendError,
+  PackageIntelligenceFeatureFlagRequiredError,
+  PackageIntelligenceGraphQLError,
+  PackageIntelligenceNetworkError,
+  PackageIntelligenceServiceImpl,
+  PackageIntelligenceTargetNotFoundError,
+  PackageIntelligenceValidationError,
+} from "./package-intelligence-service.js";
+export type {
   CheckboxChoice,
   ConfirmChoice,
   PromptService,

--- a/src/services/package-intelligence-service.test.ts
+++ b/src/services/package-intelligence-service.test.ts
@@ -1,0 +1,503 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { AuthenticationError } from "./githits-service.js";
+import {
+  MalformedPackageIntelligenceResponseError,
+  PackageIntelligenceAccessError,
+  PackageIntelligenceBackendError,
+  PackageIntelligenceFeatureFlagRequiredError,
+  PackageIntelligenceNetworkError,
+  PackageIntelligenceServiceImpl,
+  PackageIntelligenceTargetNotFoundError,
+  PackageIntelligenceValidationError,
+} from "./package-intelligence-service.js";
+import { createMockTokenProvider } from "./test-helpers.js";
+
+function asFetchFn<T extends (...args: never[]) => unknown>(
+  fn: T,
+): typeof fetch {
+  return fn as unknown as typeof fetch;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const HAPPY_BODY = {
+  data: {
+    packageSummary: {
+      package: {
+        name: "express",
+        registry: "NPM",
+        description: "Fast web framework",
+        latestVersion: "4.18.2",
+        latestVersionPublishedAt: "2023-05-28T00:00:00Z",
+        homepage: "https://expressjs.com",
+        repositoryUrl: "https://github.com/expressjs/express",
+        license: "MIT",
+        downloadsLastMonth: 86_000_000,
+        downloadsTotal: null,
+        githubRepository: {
+          stargazersCount: 63_400,
+          forksCount: 14_300,
+          openIssuesCount: 123,
+          archived: false,
+          language: "JavaScript",
+          topics: ["framework", "http", "middleware"],
+          pushedAt: "2024-05-10T00:00:00Z",
+        },
+      },
+      security: {
+        vulnerabilityCount: 5,
+        hasCurrentVulnerabilities: true,
+        recentVulnerabilities: [
+          {
+            osvId: "GHSA-xxxx-xxxx-xxxx",
+            summary: "Open redirect",
+            severityScore: 7.5,
+            publishedAt: "2024-06-01T00:00:00Z",
+          },
+        ],
+      },
+      quickstart: {
+        installCommand: "npm install express",
+        usageExample: "const express = require('express')",
+      },
+      latestChangelogs: [
+        {
+          version: "4.18.2",
+          publishedAt: "2023-05-28T00:00:00Z",
+          body: "Bug fixes",
+        },
+      ],
+    },
+  },
+};
+
+describe("PackageIntelligenceServiceImpl", () => {
+  const ENDPOINT = "https://pkgseer.dev";
+
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("maps a happy-path response to PackageSummary", async () => {
+    const fetchFn = mock(() => Promise.resolve(jsonResponse(HAPPY_BODY)));
+    const service = new PackageIntelligenceServiceImpl(
+      ENDPOINT,
+      createMockTokenProvider(),
+      asFetchFn(fetchFn),
+    );
+
+    const result = await service.packageSummary({
+      registry: "NPM",
+      packageName: "express",
+    });
+
+    expect(result.package.name).toBe("express");
+    expect(result.package.latestVersion).toBe("4.18.2");
+    expect(result.package.downloadsLastMonth).toBe(86_000_000);
+    expect(result.package.githubRepository?.stargazersCount).toBe(63_400);
+    expect(result.security?.vulnerabilityCount).toBe(5);
+    expect(result.quickstart?.installCommand).toBe("npm install express");
+    expect(result.latestChangelogs?.[0]?.version).toBe("4.18.2");
+  });
+
+  it("preserves null blocks (security / quickstart / github absent)", async () => {
+    const body = {
+      data: {
+        packageSummary: {
+          package: {
+            name: "obscure",
+            latestVersion: "0.0.1",
+            description: null,
+            registry: "PYPI",
+            latestVersionPublishedAt: null,
+            homepage: null,
+            repositoryUrl: null,
+            license: null,
+            downloadsLastMonth: null,
+            downloadsTotal: null,
+            githubRepository: null,
+          },
+          security: null,
+          quickstart: null,
+          latestChangelogs: null,
+        },
+      },
+    };
+
+    const fetchFn = mock(() => Promise.resolve(jsonResponse(body)));
+    const service = new PackageIntelligenceServiceImpl(
+      ENDPOINT,
+      createMockTokenProvider(),
+      asFetchFn(fetchFn),
+    );
+
+    const result = await service.packageSummary({
+      registry: "PYPI",
+      packageName: "obscure",
+    });
+
+    expect(result.package.name).toBe("obscure");
+    expect(result.package.githubRepository).toBeUndefined();
+    expect(result.security).toBeUndefined();
+    expect(result.quickstart).toBeUndefined();
+    expect(result.latestChangelogs).toBeUndefined();
+  });
+
+  it("throws MalformedPackageIntelligenceResponseError when name is null", async () => {
+    const body = {
+      data: {
+        packageSummary: {
+          package: { name: null, latestVersion: "1.0.0" },
+          security: null,
+          quickstart: null,
+          latestChangelogs: null,
+        },
+      },
+    };
+    const fetchFn = mock(() => Promise.resolve(jsonResponse(body)));
+    const service = new PackageIntelligenceServiceImpl(
+      ENDPOINT,
+      createMockTokenProvider(),
+      asFetchFn(fetchFn),
+    );
+
+    await expect(
+      service.packageSummary({ registry: "NPM", packageName: "x" }),
+    ).rejects.toBeInstanceOf(MalformedPackageIntelligenceResponseError);
+  });
+
+  it("throws MalformedPackageIntelligenceResponseError when latestVersion is null", async () => {
+    const body = {
+      data: {
+        packageSummary: {
+          package: { name: "x", latestVersion: null },
+          security: null,
+          quickstart: null,
+          latestChangelogs: null,
+        },
+      },
+    };
+    const fetchFn = mock(() => Promise.resolve(jsonResponse(body)));
+    const service = new PackageIntelligenceServiceImpl(
+      ENDPOINT,
+      createMockTokenProvider(),
+      asFetchFn(fetchFn),
+    );
+
+    await expect(
+      service.packageSummary({ registry: "NPM", packageName: "x" }),
+    ).rejects.toBeInstanceOf(MalformedPackageIntelligenceResponseError);
+  });
+
+  it("sends packageSummary query with registry + name vars and latestChangelogs(limit: 3)", async () => {
+    let capturedBody: string | undefined;
+    const fetchFn = mock((_url: string, init?: RequestInit) => {
+      capturedBody = init?.body as string;
+      return Promise.resolve(jsonResponse(HAPPY_BODY));
+    });
+    const service = new PackageIntelligenceServiceImpl(
+      ENDPOINT,
+      createMockTokenProvider(),
+      asFetchFn(fetchFn),
+    );
+
+    await service.packageSummary({ registry: "NPM", packageName: "express" });
+
+    expect(capturedBody).toBeDefined();
+    const parsed = JSON.parse(capturedBody ?? "{}");
+    expect(parsed.query).toContain("packageSummary(registry: $registry");
+    expect(parsed.query).toContain("latestChangelogs(limit: 3)");
+    expect(parsed.variables).toEqual({ registry: "NPM", name: "express" });
+  });
+
+  it("sends Bearer token and hits the correct URL", async () => {
+    let capturedUrl: string | undefined;
+    let capturedAuth: string | undefined;
+    const fetchFn = mock((url: string, init?: RequestInit) => {
+      capturedUrl = url;
+      capturedAuth = (init?.headers as Record<string, string>)?.Authorization;
+      return Promise.resolve(jsonResponse(HAPPY_BODY));
+    });
+    const service = new PackageIntelligenceServiceImpl(
+      "https://pkgseer.dev/",
+      createMockTokenProvider({
+        getToken: mock(() => Promise.resolve("tok-123")),
+      }),
+      asFetchFn(fetchFn),
+    );
+
+    await service.packageSummary({ registry: "NPM", packageName: "express" });
+
+    expect(capturedUrl).toBe("https://pkgseer.dev/api/graphql");
+    expect(capturedAuth).toBe("Bearer tok-123");
+  });
+
+  it("classifies HTTP 401 as AuthenticationError and triggers token refresh", async () => {
+    let callCount = 0;
+    const fetchFn = mock(() => {
+      callCount++;
+      if (callCount === 1) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ detail: "unauthorized" }), {
+            status: 401,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      }
+      return Promise.resolve(jsonResponse(HAPPY_BODY));
+    });
+    const refreshed = mock(() => Promise.resolve("new-token"));
+    const tokenProvider = createMockTokenProvider({
+      getToken: mock(() => Promise.resolve("old-token")),
+      forceRefresh: refreshed,
+    });
+
+    const service = new PackageIntelligenceServiceImpl(
+      ENDPOINT,
+      tokenProvider,
+      asFetchFn(fetchFn),
+    );
+
+    const result = await service.packageSummary({
+      registry: "NPM",
+      packageName: "express",
+    });
+
+    expect(refreshed).toHaveBeenCalledTimes(1);
+    expect(result.package.name).toBe("express");
+  });
+
+  it("propagates AuthenticationError when no refreshed token is available", async () => {
+    const fetchFn = mock(() =>
+      Promise.resolve(
+        new Response("{}", {
+          status: 401,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    );
+    const tokenProvider = createMockTokenProvider({
+      getToken: mock(() => Promise.resolve("token")),
+      forceRefresh: mock(() => Promise.resolve(undefined)),
+    });
+
+    const service = new PackageIntelligenceServiceImpl(
+      ENDPOINT,
+      tokenProvider,
+      asFetchFn(fetchFn),
+    );
+
+    await expect(
+      service.packageSummary({ registry: "NPM", packageName: "express" }),
+    ).rejects.toBeInstanceOf(AuthenticationError);
+  });
+
+  it("GraphQL-level UNAUTHORIZED (on 2xx response) still triggers token refresh", async () => {
+    let callCount = 0;
+    const fetchFn = mock(() => {
+      callCount++;
+      if (callCount === 1) {
+        return Promise.resolve(
+          jsonResponse({
+            errors: [
+              { message: "unauthorized", extensions: { code: "UNAUTHORIZED" } },
+            ],
+          }),
+        );
+      }
+      return Promise.resolve(jsonResponse(HAPPY_BODY));
+    });
+    const refreshed = mock(() => Promise.resolve("new-token"));
+    const tokenProvider = createMockTokenProvider({
+      getToken: mock(() => Promise.resolve("old-token")),
+      forceRefresh: refreshed,
+    });
+
+    const service = new PackageIntelligenceServiceImpl(
+      ENDPOINT,
+      tokenProvider,
+      asFetchFn(fetchFn),
+    );
+
+    const result = await service.packageSummary({
+      registry: "NPM",
+      packageName: "express",
+    });
+
+    expect(refreshed).toHaveBeenCalledTimes(1);
+    expect(result.package.name).toBe("express");
+  });
+
+  it("classifies 403 as PackageIntelligenceAccessError", async () => {
+    const fetchFn = mock(() =>
+      Promise.resolve(jsonResponse({ detail: "no access" }, 403)),
+    );
+    const service = new PackageIntelligenceServiceImpl(
+      ENDPOINT,
+      createMockTokenProvider(),
+      asFetchFn(fetchFn),
+    );
+
+    await expect(
+      service.packageSummary({ registry: "NPM", packageName: "x" }),
+    ).rejects.toBeInstanceOf(PackageIntelligenceAccessError);
+  });
+
+  it("classifies GraphQL FEATURE_FLAG_REQUIRED as PackageIntelligenceFeatureFlagRequiredError", async () => {
+    const fetchFn = mock(() =>
+      Promise.resolve(
+        jsonResponse({
+          errors: [
+            {
+              message: "flag missing",
+              extensions: { code: "FEATURE_FLAG_REQUIRED" },
+            },
+          ],
+        }),
+      ),
+    );
+    const service = new PackageIntelligenceServiceImpl(
+      ENDPOINT,
+      createMockTokenProvider(),
+      asFetchFn(fetchFn),
+    );
+
+    await expect(
+      service.packageSummary({ registry: "NPM", packageName: "x" }),
+    ).rejects.toBeInstanceOf(PackageIntelligenceFeatureFlagRequiredError);
+  });
+
+  it("classifies GraphQL NOT_FOUND as PackageIntelligenceTargetNotFoundError", async () => {
+    const fetchFn = mock(() =>
+      Promise.resolve(
+        jsonResponse({
+          errors: [
+            { message: "no such package", extensions: { code: "NOT_FOUND" } },
+          ],
+        }),
+      ),
+    );
+    const service = new PackageIntelligenceServiceImpl(
+      ENDPOINT,
+      createMockTokenProvider(),
+      asFetchFn(fetchFn),
+    );
+
+    await expect(
+      service.packageSummary({ registry: "NPM", packageName: "ghost" }),
+    ).rejects.toBeInstanceOf(PackageIntelligenceTargetNotFoundError);
+  });
+
+  it("classifies GraphQL VALIDATION_ERROR as PackageIntelligenceValidationError", async () => {
+    const fetchFn = mock(() =>
+      Promise.resolve(
+        jsonResponse({
+          errors: [
+            {
+              message: "bad input",
+              extensions: { code: "VALIDATION_ERROR" },
+            },
+          ],
+        }),
+      ),
+    );
+    const service = new PackageIntelligenceServiceImpl(
+      ENDPOINT,
+      createMockTokenProvider(),
+      asFetchFn(fetchFn),
+    );
+
+    await expect(
+      service.packageSummary({ registry: "NPM", packageName: "x" }),
+    ).rejects.toBeInstanceOf(PackageIntelligenceValidationError);
+  });
+
+  it("classifies 5xx plain-text body via parseDetail as PackageIntelligenceBackendError", async () => {
+    const fetchFn = mock(() =>
+      Promise.resolve(
+        new Response("Gateway Timeout", {
+          status: 504,
+          headers: { "Content-Type": "text/plain" },
+        }),
+      ),
+    );
+    const service = new PackageIntelligenceServiceImpl(
+      ENDPOINT,
+      createMockTokenProvider(),
+      asFetchFn(fetchFn),
+    );
+
+    try {
+      await service.packageSummary({ registry: "NPM", packageName: "x" });
+      throw new Error("expected backend error");
+    } catch (error) {
+      expect(error).toBeInstanceOf(PackageIntelligenceBackendError);
+      expect((error as PackageIntelligenceBackendError).status).toBe(504);
+      expect((error as PackageIntelligenceBackendError).message).toContain(
+        "Gateway Timeout",
+      );
+    }
+  });
+
+  it("classifies malformed JSON body (non-GraphQL shape) as MalformedPackageIntelligenceResponseError", async () => {
+    const fetchFn = mock(() =>
+      Promise.resolve(
+        new Response("not-json", {
+          status: 200,
+          headers: { "Content-Type": "text/plain" },
+        }),
+      ),
+    );
+    const service = new PackageIntelligenceServiceImpl(
+      ENDPOINT,
+      createMockTokenProvider(),
+      asFetchFn(fetchFn),
+    );
+
+    await expect(
+      service.packageSummary({ registry: "NPM", packageName: "x" }),
+    ).rejects.toBeInstanceOf(MalformedPackageIntelligenceResponseError);
+  });
+
+  it("classifies `data: null` without errors as MalformedPackageIntelligenceResponseError", async () => {
+    const fetchFn = mock(() => Promise.resolve(jsonResponse({ data: null })));
+    const service = new PackageIntelligenceServiceImpl(
+      ENDPOINT,
+      createMockTokenProvider(),
+      asFetchFn(fetchFn),
+    );
+
+    await expect(
+      service.packageSummary({ registry: "NPM", packageName: "x" }),
+    ).rejects.toBeInstanceOf(MalformedPackageIntelligenceResponseError);
+  });
+
+  it("wraps fetch rejections as PackageIntelligenceNetworkError preserving cause", async () => {
+    const cause = new Error("ENOTFOUND");
+    const fetchFn = mock(() => Promise.reject(cause));
+    const service = new PackageIntelligenceServiceImpl(
+      ENDPOINT,
+      createMockTokenProvider(),
+      asFetchFn(fetchFn),
+    );
+
+    try {
+      await service.packageSummary({ registry: "NPM", packageName: "x" });
+      throw new Error("expected network error");
+    } catch (error) {
+      expect(error).toBeInstanceOf(PackageIntelligenceNetworkError);
+      expect((error as PackageIntelligenceNetworkError).cause).toBeDefined();
+    }
+  });
+});

--- a/src/services/package-intelligence-service.ts
+++ b/src/services/package-intelligence-service.ts
@@ -1,0 +1,554 @@
+/**
+ * Package intelligence service — reads registry metadata, dependency
+ * reports, vulnerability overviews, and changelogs from the pkgseer
+ * GraphQL endpoint.
+ *
+ * Wire-level plumbing (URL, headers, POST, transport-error wrapping)
+ * lives in `src/shared/pkgseer-graphql.ts`. This service owns:
+ * - Domain error classes (`PackageIntelligence*Error`).
+ * - GraphQL-error classification on structured responses.
+ * - Zod schema validation for the `PackageSummary` response shape.
+ * - Outer `executeWithTokenRefresh` wrapper so GraphQL-level
+ *   `UNAUTHORIZED` errors — classified after the POST — continue to
+ *   trigger token refresh.
+ */
+
+import { z } from "zod";
+import {
+  type PkgseerGraphqlResponse,
+  PkgseerTransportError,
+  postPkgseerGraphql,
+} from "../shared/pkgseer-graphql.js";
+import type { PkgseerRegistry } from "../shared/pkgseer-registry.js";
+import { executeWithTokenRefresh } from "./execute-with-token-refresh.js";
+import { AuthenticationError } from "./githits-service.js";
+import type { TokenProvider } from "./token-manager.js";
+
+export interface PackageSummaryParams {
+  registry: PkgseerRegistry;
+  packageName: string;
+}
+
+export interface PackageIdentity {
+  name: string;
+  registry?: string;
+  description?: string;
+  latestVersion: string;
+  latestVersionPublishedAt?: string;
+  homepage?: string;
+  repositoryUrl?: string;
+  license?: string;
+  downloadsLastMonth?: number;
+  downloadsTotal?: number;
+  githubRepository?: GithubRepository;
+}
+
+export interface GithubRepository {
+  stargazersCount?: number;
+  forksCount?: number;
+  openIssuesCount?: number;
+  archived?: boolean;
+  language?: string;
+  topics?: string[];
+  pushedAt?: string;
+}
+
+export interface VulnerabilityOverview {
+  osvId?: string;
+  summary?: string;
+  severityScore?: number;
+  publishedAt?: string;
+}
+
+export interface PackageSecurityOverview {
+  vulnerabilityCount?: number;
+  hasCurrentVulnerabilities?: boolean;
+  recentVulnerabilities?: VulnerabilityOverview[];
+}
+
+export interface QuickstartInfo {
+  installCommand?: string;
+  usageExample?: string;
+}
+
+export interface ChangelogEntry {
+  version?: string;
+  publishedAt?: string;
+  body?: string;
+}
+
+export interface PackageSummary {
+  package: PackageIdentity;
+  security?: PackageSecurityOverview;
+  quickstart?: QuickstartInfo;
+  latestChangelogs?: ChangelogEntry[];
+}
+
+export interface PackageIntelligenceService {
+  packageSummary(params: PackageSummaryParams): Promise<PackageSummary>;
+}
+
+// --------------------------------------------------------------------
+// Error classes
+// --------------------------------------------------------------------
+
+export class PackageIntelligenceAccessError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PackageIntelligenceAccessError";
+  }
+}
+
+export class PackageIntelligenceFeatureFlagRequiredError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PackageIntelligenceFeatureFlagRequiredError";
+  }
+}
+
+export class PackageIntelligenceNetworkError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = "PackageIntelligenceNetworkError";
+  }
+}
+
+export class PackageIntelligenceBackendError extends Error {
+  constructor(
+    message: string,
+    public readonly status?: number,
+    public readonly graphqlCode?: string,
+    public readonly retryable?: boolean,
+  ) {
+    super(message);
+    this.name = "PackageIntelligenceBackendError";
+  }
+}
+
+/**
+ * Legacy fallback for GraphQL errors without a recognised
+ * `extensions.code`. New backend builds should hit
+ * `PackageIntelligenceBackendError` via `createGraphQLError`; this
+ * exists for rollover-window compatibility.
+ */
+export class PackageIntelligenceGraphQLError extends Error {
+  constructor(
+    message: string,
+    public readonly code?: string,
+  ) {
+    super(message);
+    this.name = "PackageIntelligenceGraphQLError";
+  }
+}
+
+export class PackageIntelligenceTargetNotFoundError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PackageIntelligenceTargetNotFoundError";
+  }
+}
+
+export class PackageIntelligenceValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PackageIntelligenceValidationError";
+  }
+}
+
+export class MalformedPackageIntelligenceResponseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "MalformedPackageIntelligenceResponseError";
+  }
+}
+
+// --------------------------------------------------------------------
+// Zod schema for the packageSummary response shape
+// --------------------------------------------------------------------
+
+const githubRepositorySchema = z
+  .object({
+    stargazersCount: z.number().int().nullable().optional(),
+    forksCount: z.number().int().nullable().optional(),
+    openIssuesCount: z.number().int().nullable().optional(),
+    archived: z.boolean().nullable().optional(),
+    language: z.string().nullable().optional(),
+    topics: z.array(z.string()).nullable().optional(),
+    pushedAt: z.string().nullable().optional(),
+  })
+  .nullable()
+  .optional();
+
+const packageIdentitySchema = z.object({
+  name: z.string().nullable().optional(),
+  registry: z.string().nullable().optional(),
+  description: z.string().nullable().optional(),
+  latestVersion: z.string().nullable().optional(),
+  latestVersionPublishedAt: z.string().nullable().optional(),
+  homepage: z.string().nullable().optional(),
+  repositoryUrl: z.string().nullable().optional(),
+  license: z.string().nullable().optional(),
+  downloadsLastMonth: z.number().int().nullable().optional(),
+  downloadsTotal: z.number().int().nullable().optional(),
+  githubRepository: githubRepositorySchema,
+});
+
+const vulnerabilityOverviewSchema = z.object({
+  osvId: z.string().nullable().optional(),
+  summary: z.string().nullable().optional(),
+  severityScore: z.number().nullable().optional(),
+  publishedAt: z.string().nullable().optional(),
+});
+
+const packageSecurityOverviewSchema = z
+  .object({
+    vulnerabilityCount: z.number().int().nullable().optional(),
+    hasCurrentVulnerabilities: z.boolean().nullable().optional(),
+    recentVulnerabilities: z
+      .array(vulnerabilityOverviewSchema)
+      .nullable()
+      .optional(),
+  })
+  .nullable()
+  .optional();
+
+const quickstartInfoSchema = z
+  .object({
+    installCommand: z.string().nullable().optional(),
+    usageExample: z.string().nullable().optional(),
+  })
+  .nullable()
+  .optional();
+
+const changelogEntrySchema = z.object({
+  version: z.string().nullable().optional(),
+  publishedAt: z.string().nullable().optional(),
+  body: z.string().nullable().optional(),
+});
+
+const packageSummaryResponseSchema = z.object({
+  package: packageIdentitySchema.nullable().optional(),
+  security: packageSecurityOverviewSchema,
+  quickstart: quickstartInfoSchema,
+  latestChangelogs: z.array(changelogEntrySchema).nullable().optional(),
+});
+
+const graphQLErrorSchema = z.object({
+  message: z.string(),
+  extensions: z.record(z.string(), z.unknown()).optional(),
+});
+
+const graphQLResponseSchema = z.object({
+  data: z
+    .object({
+      packageSummary: packageSummaryResponseSchema.nullable().optional(),
+    })
+    .nullable()
+    .optional(),
+  errors: z.array(graphQLErrorSchema).optional(),
+});
+
+const PACKAGE_SUMMARY_QUERY = `
+query PackageSummary($registry: Registry!, $name: String!) {
+  packageSummary(registry: $registry, name: $name) {
+    package {
+      name
+      registry
+      description
+      latestVersion
+      latestVersionPublishedAt
+      homepage
+      repositoryUrl
+      license
+      downloadsLastMonth
+      downloadsTotal
+      githubRepository {
+        stargazersCount
+        forksCount
+        openIssuesCount
+        archived
+        language
+        topics
+        pushedAt
+      }
+    }
+    security {
+      vulnerabilityCount
+      hasCurrentVulnerabilities
+      recentVulnerabilities {
+        osvId
+        summary
+        severityScore
+        publishedAt
+      }
+    }
+    quickstart {
+      installCommand
+      usageExample
+    }
+    latestChangelogs(limit: 3) {
+      version
+      publishedAt
+      body
+    }
+  }
+}`;
+
+// --------------------------------------------------------------------
+// Service implementation
+// --------------------------------------------------------------------
+
+export class PackageIntelligenceServiceImpl
+  implements PackageIntelligenceService
+{
+  constructor(
+    private readonly endpointUrl: string,
+    private readonly tokenProvider: TokenProvider,
+    private readonly fetchFn: typeof fetch = globalThis.fetch,
+  ) {}
+
+  async packageSummary(params: PackageSummaryParams): Promise<PackageSummary> {
+    return executeWithTokenRefresh({
+      getToken: () => this.tokenProvider.getToken(),
+      forceRefresh: () => this.tokenProvider.forceRefresh(),
+      shouldRefresh: (error) => error instanceof AuthenticationError,
+      executeWithToken: (token) => this.executePackageSummary(token, params),
+    });
+  }
+
+  private async executePackageSummary(
+    token: string,
+    params: PackageSummaryParams,
+  ): Promise<PackageSummary> {
+    let response: PkgseerGraphqlResponse;
+    try {
+      response = await postPkgseerGraphql({
+        endpointUrl: this.endpointUrl,
+        token,
+        query: PACKAGE_SUMMARY_QUERY,
+        variables: {
+          registry: params.registry,
+          name: params.packageName,
+        },
+        fetchFn: this.fetchFn,
+      });
+    } catch (cause) {
+      if (cause instanceof PkgseerTransportError) {
+        throw new PackageIntelligenceNetworkError(
+          "Could not reach the package intelligence service. Check your connection or set GITHITS_CODE_NAV_URL.",
+          { cause },
+        );
+      }
+      throw cause;
+    }
+
+    if (response.status < 200 || response.status >= 300) {
+      throw this.createHttpError(response);
+    }
+
+    const parsed = graphQLResponseSchema.safeParse(response.parsedBody);
+    if (!parsed.success) {
+      throw new MalformedPackageIntelligenceResponseError(
+        "Malformed response from the package-intelligence service.",
+      );
+    }
+
+    if (parsed.data.errors && parsed.data.errors.length > 0) {
+      throw this.createGraphQLError(parsed.data.errors);
+    }
+
+    const data = parsed.data.data?.packageSummary;
+    if (!data) {
+      throw new MalformedPackageIntelligenceResponseError(
+        "Empty response from the package-intelligence service.",
+      );
+    }
+
+    return this.normalise(data);
+  }
+
+  private createHttpError(response: PkgseerGraphqlResponse): Error {
+    const status = response.status;
+    const detail = parseDetail(response.responseBody);
+
+    if (status === 401) {
+      return new AuthenticationError(
+        "Authentication required. Run `githits login` to authenticate.",
+      );
+    }
+
+    if (status === 403) {
+      return new PackageIntelligenceAccessError(detail ?? "Access denied.");
+    }
+
+    if (status >= 500) {
+      return new PackageIntelligenceBackendError(
+        detail
+          ? `Server error (${status}): ${detail}`
+          : `Server error (${status})`,
+        status,
+      );
+    }
+
+    return new PackageIntelligenceBackendError(
+      detail ?? `Request failed with status ${status}`,
+      status,
+    );
+  }
+
+  private createGraphQLError(
+    errors: Array<z.infer<typeof graphQLErrorSchema>>,
+  ): Error {
+    const message = errors.map((error) => error.message).join(", ");
+    const extensions = getPrimaryExtensions(errors);
+    const code =
+      typeof extensions?.code === "string" ? extensions.code : undefined;
+    const retryable =
+      typeof extensions?.retryable === "boolean"
+        ? extensions.retryable
+        : undefined;
+
+    switch (code) {
+      case "NOT_FOUND":
+      case "PACKAGE_NOT_FOUND":
+        return new PackageIntelligenceTargetNotFoundError(message);
+
+      case "UNSUPPORTED_REGISTRY":
+      case "VALIDATION_ERROR":
+        return new PackageIntelligenceValidationError(message);
+
+      case "FEATURE_FLAG_REQUIRED":
+        return new PackageIntelligenceFeatureFlagRequiredError(message);
+
+      case "UNAUTHORIZED":
+        return new AuthenticationError(
+          "Authentication required. Run `githits login` to authenticate.",
+        );
+
+      case "FORBIDDEN":
+        return new PackageIntelligenceAccessError(
+          "Access denied. This feature may not be enabled for your account.",
+        );
+
+      case "UPSTREAM_ERROR":
+      case "TIMEOUT":
+      case "RATE_LIMITED":
+      case "INTERNAL_ERROR":
+      case "UNKNOWN_ERROR":
+        return new PackageIntelligenceBackendError(
+          message,
+          undefined,
+          code,
+          retryable,
+        );
+
+      default:
+        break;
+    }
+
+    return new PackageIntelligenceBackendError(
+      message,
+      undefined,
+      code,
+      retryable,
+    );
+  }
+
+  private normalise(
+    data: z.infer<typeof packageSummaryResponseSchema>,
+  ): PackageSummary {
+    const name = data.package?.name ?? undefined;
+    const latestVersion = data.package?.latestVersion ?? undefined;
+    if (!name || !latestVersion) {
+      throw new MalformedPackageIntelligenceResponseError(
+        "Package summary response missing required name/latestVersion.",
+      );
+    }
+
+    const pkg = data.package;
+    const github = pkg?.githubRepository;
+
+    const identity: PackageIdentity = {
+      name,
+      latestVersion,
+      registry: pkg?.registry ?? undefined,
+      description: pkg?.description ?? undefined,
+      latestVersionPublishedAt: pkg?.latestVersionPublishedAt ?? undefined,
+      homepage: pkg?.homepage ?? undefined,
+      repositoryUrl: pkg?.repositoryUrl ?? undefined,
+      license: pkg?.license ?? undefined,
+      downloadsLastMonth: pkg?.downloadsLastMonth ?? undefined,
+      downloadsTotal: pkg?.downloadsTotal ?? undefined,
+      githubRepository: github
+        ? {
+            stargazersCount: github.stargazersCount ?? undefined,
+            forksCount: github.forksCount ?? undefined,
+            openIssuesCount: github.openIssuesCount ?? undefined,
+            archived: github.archived ?? undefined,
+            language: github.language ?? undefined,
+            topics: github.topics ?? undefined,
+            pushedAt: github.pushedAt ?? undefined,
+          }
+        : undefined,
+    };
+
+    const security: PackageSecurityOverview | undefined = data.security
+      ? {
+          vulnerabilityCount: data.security.vulnerabilityCount ?? undefined,
+          hasCurrentVulnerabilities:
+            data.security.hasCurrentVulnerabilities ?? undefined,
+          recentVulnerabilities:
+            data.security.recentVulnerabilities?.map((vuln) => ({
+              osvId: vuln.osvId ?? undefined,
+              summary: vuln.summary ?? undefined,
+              severityScore: vuln.severityScore ?? undefined,
+              publishedAt: vuln.publishedAt ?? undefined,
+            })) ?? undefined,
+        }
+      : undefined;
+
+    const quickstart: QuickstartInfo | undefined = data.quickstart
+      ? {
+          installCommand: data.quickstart.installCommand ?? undefined,
+          usageExample: data.quickstart.usageExample ?? undefined,
+        }
+      : undefined;
+
+    const latestChangelogs: ChangelogEntry[] | undefined =
+      data.latestChangelogs?.map((entry) => ({
+        version: entry.version ?? undefined,
+        publishedAt: entry.publishedAt ?? undefined,
+        body: entry.body ?? undefined,
+      })) ?? undefined;
+
+    return {
+      package: identity,
+      security,
+      quickstart,
+      latestChangelogs,
+    };
+  }
+}
+
+function parseDetail(body: string): string | undefined {
+  if (!body) return undefined;
+  try {
+    const parsed = JSON.parse(body) as Record<string, unknown>;
+    if (typeof parsed.detail === "string") return parsed.detail;
+    if (typeof parsed.error === "string") return parsed.error;
+  } catch {
+    return body;
+  }
+  return undefined;
+}
+
+function getPrimaryExtensions(
+  errors: Array<z.infer<typeof graphQLErrorSchema>>,
+): Record<string, unknown> | undefined {
+  for (const error of errors) {
+    if (error.extensions && Object.keys(error.extensions).length > 0) {
+      return error.extensions;
+    }
+  }
+  return undefined;
+}

--- a/src/services/test-helpers.ts
+++ b/src/services/test-helpers.ts
@@ -20,6 +20,10 @@ import type { ExecResult, ExecService } from "./exec-service.js";
 import type { FileSystemService } from "./filesystem-service.js";
 import type { GitHitsService } from "./githits-service.js";
 import type { KeyringService } from "./keyring-service.js";
+import type {
+  PackageIntelligenceService,
+  PackageSummary,
+} from "./package-intelligence-service.js";
 import type { ConfirmChoice, PromptService } from "./prompt-service.js";
 import type { TokenProvider } from "./token-manager.js";
 
@@ -221,6 +225,87 @@ export function createMockCodeNavigationService(
 ): CodeNavigationService {
   return {
     searchSymbols: mock(() => Promise.resolve(defaultSearchSymbolsResult)),
+    ...impl,
+  };
+}
+
+/**
+ * Fully-populated `PackageSummary` fixture. Every optional field is
+ * present so omission-rule tests can subtract from a realistic shape.
+ */
+export const defaultPackageSummary: PackageSummary = {
+  package: {
+    name: "express",
+    registry: "NPM",
+    description: "Fast, unopinionated, minimalist web framework for Node.js",
+    latestVersion: "4.18.2",
+    latestVersionPublishedAt: "2023-05-28T00:00:00Z",
+    homepage: "https://expressjs.com",
+    repositoryUrl: "https://github.com/expressjs/express",
+    license: "MIT",
+    downloadsLastMonth: 86_000_000,
+    downloadsTotal: 1_200_000_000,
+    githubRepository: {
+      stargazersCount: 63_400,
+      forksCount: 14_300,
+      openIssuesCount: 123,
+      archived: false,
+      language: "JavaScript",
+      topics: ["framework", "http", "middleware", "nodejs", "web"],
+      pushedAt: "2024-05-10T00:00:00Z",
+    },
+  },
+  security: {
+    vulnerabilityCount: 5,
+    hasCurrentVulnerabilities: true,
+    recentVulnerabilities: [
+      {
+        osvId: "GHSA-xxxx-xxxx-xxxx",
+        summary: "Open redirect vulnerability in default error handler",
+        severityScore: 7.5,
+        publishedAt: "2024-06-01T00:00:00Z",
+      },
+      {
+        osvId: "GHSA-yyyy-yyyy-yyyy",
+        summary: "Prototype pollution via query parser",
+        severityScore: 5.3,
+        publishedAt: "2024-03-12T00:00:00Z",
+      },
+    ],
+  },
+  quickstart: {
+    installCommand: "npm install express",
+    usageExample: "const express = require('express')\nconst app = express()",
+  },
+  latestChangelogs: [
+    {
+      version: "4.18.2",
+      publishedAt: "2023-05-28T00:00:00Z",
+      body: "Security fix for CVE-xxxx\n\nFull changelog body...",
+    },
+    {
+      version: "4.18.1",
+      publishedAt: "2023-05-10T00:00:00Z",
+      body: "Bug fixes\n\nAnother body...",
+    },
+    {
+      version: "4.18.0",
+      publishedAt: "2023-04-01T00:00:00Z",
+      body: "New router API\n\nYet another body...",
+    },
+  ],
+};
+
+/**
+ * Creates a mock PackageIntelligenceService. Default `packageSummary`
+ * resolves to {@link defaultPackageSummary} — override per-test as
+ * needed.
+ */
+export function createMockPackageIntelligenceService(
+  impl: Partial<PackageIntelligenceService> = {},
+): PackageIntelligenceService {
+  return {
+    packageSummary: mock(() => Promise.resolve(defaultPackageSummary)),
     ...impl,
   };
 }

--- a/src/shared/code-navigation.ts
+++ b/src/shared/code-navigation.ts
@@ -1,22 +1,13 @@
 import type {
-  CodeNavigationRegistry,
   SearchSymbolsFileIntent,
   SearchSymbolsKind,
   SearchSymbolsMatchMode,
   SymbolCategory,
 } from "../services/index.js";
-
-const registryMap = {
-  npm: "NPM",
-  pypi: "PYPI",
-  hex: "HEX",
-  crates: "CRATES",
-  nuget: "NUGET",
-  maven: "MAVEN",
-  zig: "ZIG",
-  vcpkg: "VCPKG",
-  packagist: "PACKAGIST",
-} as const satisfies Record<string, CodeNavigationRegistry>;
+import {
+  type PkgseerRegistryArg,
+  toPkgseerRegistry,
+} from "./pkgseer-registry.js";
 
 /**
  * Lowercase user-facing kind values → the backend's uppercase
@@ -83,12 +74,18 @@ const matchModeMap = {
   and: "AND",
 } as const satisfies Record<string, SearchSymbolsMatchMode>;
 
-export type CodeNavigationRegistryArg = keyof typeof registryMap;
+/**
+ * Back-compat alias for {@link PkgseerRegistryArg}. The registry map
+ * now lives in `pkgseer-registry.ts` as single source of truth; this
+ * re-export keeps existing call-sites working without churn.
+ */
+export type CodeNavigationRegistryArg = PkgseerRegistryArg;
 
-export function toCodeNavigationRegistry(
-  registry: CodeNavigationRegistryArg,
-): CodeNavigationRegistry {
-  return registryMap[registry];
+/**
+ * Back-compat alias for {@link toPkgseerRegistry}.
+ */
+export function toCodeNavigationRegistry(registry: CodeNavigationRegistryArg) {
+  return toPkgseerRegistry(registry);
 }
 
 export function toSearchSymbolsMatchMode(

--- a/src/shared/format-date.test.ts
+++ b/src/shared/format-date.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "bun:test";
+import { toIsoDate, toRelativeDate } from "./format-date.js";
+
+describe("toIsoDate", () => {
+  it("returns YYYY-MM-DD in UTC regardless of local timezone", () => {
+    // This ISO is 2023-05-28T00:00:00Z. Even if local time is
+    // 2023-05-27 late evening, the UTC slice must read 2023-05-28.
+    expect(toIsoDate("2023-05-28T00:00:00Z")).toBe("2023-05-28");
+  });
+
+  it("slices off time component", () => {
+    expect(toIsoDate("2024-03-12T14:30:45.123Z")).toBe("2024-03-12");
+  });
+
+  it("returns null for null / undefined / empty string", () => {
+    expect(toIsoDate(null)).toBe(null);
+    expect(toIsoDate(undefined)).toBe(null);
+    expect(toIsoDate("")).toBe(null);
+  });
+
+  it("returns null for unparseable input", () => {
+    expect(toIsoDate("not-a-date")).toBe(null);
+  });
+
+  it("is UTC-stable across a mid-day-UTC boundary (locale-safety)", () => {
+    // An ISO at 23:30 UTC falls on "today" in UTC. A local-time
+    // implementation would render the next day in some timezones.
+    expect(toIsoDate("2024-05-10T23:30:00Z")).toBe("2024-05-10");
+    // And the inverse: a 00:30 UTC falls on the stated day.
+    expect(toIsoDate("2024-05-11T00:30:00Z")).toBe("2024-05-11");
+  });
+});
+
+describe("toRelativeDate", () => {
+  const NOW = new Date("2024-06-01T12:00:00Z");
+
+  it("returns 'just now' within a minute", () => {
+    expect(toRelativeDate("2024-06-01T11:59:30Z", NOW)).toBe("just now");
+  });
+
+  it("returns minutes / hours / days / months / years with correct pluralisation", () => {
+    expect(toRelativeDate("2024-06-01T11:59:00Z", NOW)).toBe("1 minute ago");
+    expect(toRelativeDate("2024-06-01T11:30:00Z", NOW)).toBe("30 minutes ago");
+    expect(toRelativeDate("2024-06-01T11:00:00Z", NOW)).toBe("1 hour ago");
+    expect(toRelativeDate("2024-05-31T12:00:00Z", NOW)).toBe("1 day ago");
+    expect(toRelativeDate("2024-05-20T12:00:00Z", NOW)).toBe("12 days ago");
+    expect(toRelativeDate("2024-04-01T12:00:00Z", NOW)).toBe("2 months ago");
+    expect(toRelativeDate("2023-06-01T12:00:00Z", NOW)).toBe("1 year ago");
+    expect(toRelativeDate("2020-06-01T12:00:00Z", NOW)).toBe("4 years ago");
+  });
+
+  it("returns null for null / undefined / empty / unparseable", () => {
+    expect(toRelativeDate(null, NOW)).toBe(null);
+    expect(toRelativeDate(undefined, NOW)).toBe(null);
+    expect(toRelativeDate("", NOW)).toBe(null);
+    expect(toRelativeDate("not-a-date", NOW)).toBe(null);
+  });
+
+  it("degrades to absolute ISO date for future timestamps", () => {
+    expect(toRelativeDate("2025-06-01T12:00:00Z", NOW)).toBe("2025-06-01");
+  });
+
+  it("works with default clock when no `now` is passed", () => {
+    // Can't pin exact output, but should produce a string or null
+    // that doesn't throw.
+    const result = toRelativeDate(new Date().toISOString());
+    expect(typeof result === "string" || result === null).toBe(true);
+  });
+});

--- a/src/shared/format-date.ts
+++ b/src/shared/format-date.ts
@@ -1,0 +1,57 @@
+/**
+ * Date utilities for user-facing surfaces.
+ *
+ * - `toIsoDate` emits a `YYYY-MM-DD` slice of the UTC ISO. We commit
+ *   to UTC rather than local time so the same backend timestamp
+ *   renders identically across machines, CI, and test runs; it also
+ *   protects against locale-dependent test flakes.
+ * - `toRelativeDate` emits a coarse human-readable distance (`2 days
+ *   ago`, `3 months ago`). Takes an optional `now` so tests can pin
+ *   the clock.
+ *
+ * Both functions accept nullable input and return `null` on
+ * missing/invalid dates rather than throwing — the response builder
+ * treats them as omission sources, not exceptions.
+ */
+
+export function toIsoDate(iso?: string | null): string | null {
+  if (!iso) return null;
+  const parsed = new Date(iso);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return parsed.toISOString().slice(0, 10);
+}
+
+const MINUTE = 60;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+const MONTH = 30 * DAY;
+const YEAR = 365 * DAY;
+
+export function toRelativeDate(
+  iso?: string | null,
+  now: Date = new Date(),
+): string | null {
+  if (!iso) return null;
+  const parsed = new Date(iso);
+  if (Number.isNaN(parsed.getTime())) return null;
+
+  const deltaSeconds = Math.floor((now.getTime() - parsed.getTime()) / 1000);
+  if (deltaSeconds < 0) {
+    // Future date — degrade to absolute form rather than emit
+    // nonsense like "in the future". Matches how agents render
+    // malformed data.
+    return toIsoDate(iso);
+  }
+
+  if (deltaSeconds < MINUTE) return "just now";
+  if (deltaSeconds < HOUR) return formatUnit(deltaSeconds, MINUTE, "minute");
+  if (deltaSeconds < DAY) return formatUnit(deltaSeconds, HOUR, "hour");
+  if (deltaSeconds < MONTH) return formatUnit(deltaSeconds, DAY, "day");
+  if (deltaSeconds < YEAR) return formatUnit(deltaSeconds, MONTH, "month");
+  return formatUnit(deltaSeconds, YEAR, "year");
+}
+
+function formatUnit(deltaSeconds: number, unit: number, label: string): string {
+  const n = Math.floor(deltaSeconds / unit);
+  return `${n} ${label}${n === 1 ? "" : "s"} ago`;
+}

--- a/src/shared/format-number.test.ts
+++ b/src/shared/format-number.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "bun:test";
+import { formatCompactNumber } from "./format-number.js";
+
+describe("formatCompactNumber", () => {
+  it("handles the locked boundary table from the plan", () => {
+    const cases: Array<[number, string]> = [
+      [0, "0"],
+      [1, "1"],
+      [999, "999"],
+      [1_000, "1.0k"],
+      [1_499, "1.4k"],
+      [1_500, "1.5k"],
+      [1_599, "1.5k"], // floor, not round
+      [9_949, "9.9k"],
+      [9_950, "9.9k"], // floor, not round
+      [9_999, "9.9k"], // never rounds *up* across boundary
+      [10_000, "10k"], // no decimal above 10
+      [10_999, "10k"],
+      [99_999, "99k"],
+      [100_000, "100k"],
+      [999_999, "999k"],
+      [1_000_000, "1.0M"],
+      [1_500_000, "1.5M"],
+      [9_999_999, "9.9M"],
+      [10_000_000, "10M"],
+      [1_000_000_000, "1.0B"],
+      [1_500_000_000, "1.5B"],
+    ];
+
+    for (const [input, expected] of cases) {
+      expect(formatCompactNumber(input)).toBe(expected);
+    }
+  });
+
+  it("emits `-` prefix for negatives with magnitude-floor semantics", () => {
+    expect(formatCompactNumber(-1)).toBe("-1");
+    expect(formatCompactNumber(-999)).toBe("-999");
+    expect(formatCompactNumber(-1_500)).toBe("-1.5k");
+    expect(formatCompactNumber(-1_599)).toBe("-1.5k");
+    expect(formatCompactNumber(-10_000)).toBe("-10k");
+    expect(formatCompactNumber(-1_000_000)).toBe("-1.0M");
+  });
+
+  it("throws RangeError for NaN and ±Infinity", () => {
+    expect(() => formatCompactNumber(Number.NaN)).toThrow(RangeError);
+    expect(() => formatCompactNumber(Number.POSITIVE_INFINITY)).toThrow(
+      RangeError,
+    );
+    expect(() => formatCompactNumber(Number.NEGATIVE_INFINITY)).toThrow(
+      RangeError,
+    );
+  });
+});

--- a/src/shared/format-number.ts
+++ b/src/shared/format-number.ts
@@ -1,0 +1,60 @@
+/**
+ * Compact human-readable formatting for counts (stars, forks,
+ * downloads). Uses K / M / B suffixes with floor semantics — we never
+ * round past a magnitude boundary, so `10000` renders as `"10k"`, not
+ * `"10.0k"` or `"10.1k"`.
+ *
+ * Rule set:
+ * - `|n| < 1000` → the integer itself, no suffix.
+ * - `1000 ≤ |n| < 1_000_000` → `"X.Yk"` for single-digit mantissas
+ *   (under 10), otherwise `"Xk"` / `"XYk"` / `"XYZk"` for ≥10.
+ * - `1_000_000 ≤ |n| < 1_000_000_000` → `M` suffix, same shape.
+ * - `|n| ≥ 1_000_000_000` → `B` suffix, same shape.
+ * - Negatives: `-` prefix with absolute-value formatting (magnitude-
+ *   floor, i.e. `-1599` → `"-1.5k"`, `-1600` → `"-1.6k"`).
+ * - Non-finite (`NaN`, `±Infinity`) throws `RangeError` — backend
+ *   fields are `Int` so this is defence in depth against schema drift.
+ */
+
+export function formatCompactNumber(n: number): string {
+  if (!Number.isFinite(n)) {
+    throw new RangeError(
+      `formatCompactNumber: non-finite input (${String(n)})`,
+    );
+  }
+
+  if (n === 0) return "0";
+
+  const negative = n < 0;
+  const abs = Math.abs(n);
+  const formatted = formatAbs(abs);
+  return negative ? `-${formatted}` : formatted;
+}
+
+function formatAbs(abs: number): string {
+  if (abs < 1_000) {
+    // Floor to integer — guards against the vanishingly rare
+    // non-integer input (schema says Int, but be defensive).
+    return String(Math.trunc(abs));
+  }
+  if (abs < 1_000_000) {
+    return withSuffix(abs, 1_000, "k");
+  }
+  if (abs < 1_000_000_000) {
+    return withSuffix(abs, 1_000_000, "M");
+  }
+  return withSuffix(abs, 1_000_000_000, "B");
+}
+
+function withSuffix(abs: number, divisor: number, suffix: string): string {
+  const scaled = abs / divisor;
+  // Floor at one decimal to avoid rounding *up* across magnitude
+  // boundaries (e.g. `9999` scaled is 9.999 → floor-1dp → 9.9, not
+  // 10.0 — which would be wrong twice, both the decimal and the
+  // suffix).
+  if (scaled < 10) {
+    const oneDp = Math.floor(scaled * 10) / 10;
+    return `${oneDp.toFixed(1)}${suffix}`;
+  }
+  return `${Math.floor(scaled)}${suffix}`;
+}

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -41,6 +41,7 @@ export {
   InvalidKeywordsError,
   normaliseKeywords,
 } from "./normalise-keywords.js";
+export { mapPackageIntelligenceError } from "./package-intelligence-error-map.js";
 export {
   InvalidArgumentError,
   InvalidPackageSpecError,
@@ -51,6 +52,26 @@ export {
   parsePackageSpec,
   UnsupportedRegistryError,
 } from "./package-spec.js";
+export {
+  buildPackageSummaryParams,
+  type PackageSummaryRequestBuildResult,
+  type PackageSummaryRequestInput,
+} from "./package-summary-request.js";
+export {
+  buildPackageSummarySuccessPayload,
+  formatPackageSummaryTerminal,
+  type LeanPackageSummary,
+  type SeverityLabel,
+  severityLabel,
+} from "./package-summary-response.js";
+export {
+  isKnownPkgseerRegistryArg,
+  knownPkgseerRegistryArgs,
+  type PkgseerRegistry,
+  type PkgseerRegistryArg,
+  toPkgseerRegistry,
+  toPkgseerRegistryLowercase,
+} from "./pkgseer-registry.js";
 export { AuthRequiredError, requireAuth } from "./require-auth.js";
 export {
   buildSearchSymbolsParams,

--- a/src/shared/package-intelligence-error-map.test.ts
+++ b/src/shared/package-intelligence-error-map.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { AuthenticationError } from "../services/githits-service.js";
+import {
+  MalformedPackageIntelligenceResponseError,
+  PackageIntelligenceAccessError,
+  PackageIntelligenceBackendError,
+  PackageIntelligenceFeatureFlagRequiredError,
+  PackageIntelligenceGraphQLError,
+  PackageIntelligenceNetworkError,
+  PackageIntelligenceTargetNotFoundError,
+  PackageIntelligenceValidationError,
+} from "../services/package-intelligence-service.js";
+import { mapPackageIntelligenceError } from "./package-intelligence-error-map.js";
+
+describe("mapPackageIntelligenceError", () => {
+  it("maps PackageIntelligenceTargetNotFoundError to NOT_FOUND", () => {
+    const mapped = mapPackageIntelligenceError(
+      new PackageIntelligenceTargetNotFoundError("Package not found"),
+    );
+    expect(mapped.code).toBe("NOT_FOUND");
+    expect(mapped.retryable).toBe(false);
+    expect(mapped.message).toBe("Package not found");
+  });
+
+  it("maps PackageIntelligenceValidationError to INVALID_ARGUMENT", () => {
+    const mapped = mapPackageIntelligenceError(
+      new PackageIntelligenceValidationError("Bad input"),
+    );
+    expect(mapped.code).toBe("INVALID_ARGUMENT");
+    expect(mapped.retryable).toBe(false);
+  });
+
+  it("maps PackageIntelligenceAccessError and FeatureFlagRequiredError to ACCESS_DENIED", () => {
+    expect(
+      mapPackageIntelligenceError(new PackageIntelligenceAccessError("denied"))
+        .code,
+    ).toBe("ACCESS_DENIED");
+    expect(
+      mapPackageIntelligenceError(
+        new PackageIntelligenceFeatureFlagRequiredError("flag missing"),
+      ).code,
+    ).toBe("ACCESS_DENIED");
+  });
+
+  it("maps AuthenticationError to AUTH_REQUIRED", () => {
+    expect(
+      mapPackageIntelligenceError(new AuthenticationError("login required"))
+        .code,
+    ).toBe("AUTH_REQUIRED");
+  });
+
+  it("maps PackageIntelligenceNetworkError to NETWORK (retryable)", () => {
+    const mapped = mapPackageIntelligenceError(
+      new PackageIntelligenceNetworkError("offline"),
+    );
+    expect(mapped.code).toBe("NETWORK");
+    expect(mapped.retryable).toBe(true);
+  });
+
+  it("maps MalformedPackageIntelligenceResponseError to PROTOCOL_ERROR", () => {
+    const mapped = mapPackageIntelligenceError(
+      new MalformedPackageIntelligenceResponseError("bad shape"),
+    );
+    expect(mapped.code).toBe("PROTOCOL_ERROR");
+    expect(mapped.retryable).toBe(false);
+  });
+
+  it("dispatches PackageIntelligenceBackendError by graphqlCode", () => {
+    const timeout = mapPackageIntelligenceError(
+      new PackageIntelligenceBackendError("timed out", 504, "TIMEOUT"),
+    );
+    expect(timeout.code).toBe("TIMEOUT");
+    expect(timeout.retryable).toBe(true);
+
+    const rateLimited = mapPackageIntelligenceError(
+      new PackageIntelligenceBackendError("too many", 429, "RATE_LIMITED"),
+    );
+    expect(rateLimited.code).toBe("RATE_LIMITED");
+    expect(rateLimited.retryable).toBe(true);
+
+    const upstream = mapPackageIntelligenceError(
+      new PackageIntelligenceBackendError("bad gateway", 502, "UPSTREAM_ERROR"),
+    );
+    expect(upstream.code).toBe("BACKEND_ERROR");
+    expect(upstream.retryable).toBe(true);
+
+    const internal = mapPackageIntelligenceError(
+      new PackageIntelligenceBackendError("oops", 500, "INTERNAL_ERROR"),
+    );
+    expect(internal.code).toBe("BACKEND_ERROR");
+    expect(internal.retryable).toBe(false);
+  });
+
+  it("respects backend-provided retryable override on PackageIntelligenceBackendError", () => {
+    const mapped = mapPackageIntelligenceError(
+      new PackageIntelligenceBackendError(
+        "custom",
+        500,
+        "INTERNAL_ERROR",
+        true,
+      ),
+    );
+    expect(mapped.retryable).toBe(true);
+  });
+
+  it("maps legacy PackageIntelligenceGraphQLError to BACKEND_ERROR", () => {
+    const mapped = mapPackageIntelligenceError(
+      new PackageIntelligenceGraphQLError("legacy", "SOME_CODE"),
+    );
+    expect(mapped.code).toBe("BACKEND_ERROR");
+    expect(mapped.details?.graphqlCode).toBe("SOME_CODE");
+  });
+
+  it("maps name-prefixed Invalid*/Unsupported* errors to INVALID_ARGUMENT", () => {
+    class InvalidPackageSpecError extends Error {
+      constructor() {
+        super("bad spec");
+        this.name = "InvalidPackageSpecError";
+      }
+    }
+    class UnsupportedRegistryError extends Error {
+      constructor() {
+        super("bad registry");
+        this.name = "UnsupportedRegistryError";
+      }
+    }
+    expect(
+      mapPackageIntelligenceError(new InvalidPackageSpecError()).code,
+    ).toBe("INVALID_ARGUMENT");
+    expect(
+      mapPackageIntelligenceError(new UnsupportedRegistryError()).code,
+    ).toBe("INVALID_ARGUMENT");
+  });
+
+  it("falls through to UNKNOWN only for truly unrecognised errors", () => {
+    const mapped = mapPackageIntelligenceError(new Error("mystery"));
+    expect(mapped.code).toBe("UNKNOWN");
+  });
+
+  it("handles non-Error thrown values", () => {
+    const mapped = mapPackageIntelligenceError("raw string");
+    expect(mapped.code).toBe("UNKNOWN");
+    expect(mapped.message).toBe("Unknown error");
+  });
+});
+
+describe("mapPackageIntelligenceError — debug emissions", () => {
+  let originalDebug: string | undefined;
+  let stderrLines: string[];
+  let originalWrite: typeof process.stderr.write;
+
+  beforeEach(() => {
+    originalDebug = process.env.GITHITS_DEBUG;
+    process.env.GITHITS_DEBUG = "pkg-intel";
+    stderrLines = [];
+    originalWrite = process.stderr.write.bind(process.stderr);
+    // biome-ignore lint/suspicious/noExplicitAny: test-only monkeypatch
+    process.stderr.write = ((chunk: string | Uint8Array) => {
+      stderrLines.push(
+        typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk),
+      );
+      return true;
+    }) as any;
+  });
+
+  afterEach(() => {
+    process.stderr.write = originalWrite;
+    if (originalDebug === undefined) {
+      delete process.env.GITHITS_DEBUG;
+    } else {
+      process.env.GITHITS_DEBUG = originalDebug;
+    }
+  });
+
+  it("emits a single pkg-intel line with only PII-safe keys", () => {
+    mapPackageIntelligenceError(
+      new PackageIntelligenceTargetNotFoundError("Package not found"),
+    );
+
+    const combined = stderrLines.join("");
+    expect(combined).toContain('"area":"pkg-intel"');
+    expect(combined).toContain('"event":"error-classified"');
+    expect(combined).toContain('"code":"NOT_FOUND"');
+    expect(combined).toContain(
+      '"errorName":"PackageIntelligenceTargetNotFoundError"',
+    );
+    // Must not carry message text
+    expect(combined).not.toContain("Package not found");
+  });
+});

--- a/src/shared/package-intelligence-error-map.ts
+++ b/src/shared/package-intelligence-error-map.ts
@@ -1,0 +1,155 @@
+/**
+ * Classify errors raised from {@link PackageIntelligenceService} into
+ * the shared `MappedError` envelope. Every `PackageIntelligence*Error`
+ * subclass maps to a specific `MappedErrorCode`; shared cases
+ * (`AuthenticationError`, name-prefixed `Invalid*` / `Unsupported*`)
+ * reuse the same mapping rules as
+ * {@link mapCodeNavigationError}. Every classified error emits a
+ * single debug line under the `pkg-intel` area.
+ */
+
+import { AuthenticationError } from "../services/githits-service.js";
+import {
+  MalformedPackageIntelligenceResponseError,
+  PackageIntelligenceAccessError,
+  PackageIntelligenceBackendError,
+  PackageIntelligenceFeatureFlagRequiredError,
+  PackageIntelligenceGraphQLError,
+  PackageIntelligenceNetworkError,
+  PackageIntelligenceTargetNotFoundError,
+  PackageIntelligenceValidationError,
+} from "../services/package-intelligence-service.js";
+import type {
+  MappedError,
+  MappedErrorCode,
+  MappedErrorDetails,
+} from "./code-navigation-error-map.js";
+import { debugLog } from "./debug-log.js";
+
+// Re-export for caller convenience — callers of
+// `mapPackageIntelligenceError` use the same envelope type as code-nav
+// callers, so they import it alongside the classifier.
+export type { MappedError, MappedErrorCode, MappedErrorDetails };
+
+/**
+ * Map a thrown error from `PackageIntelligenceServiceImpl` into the
+ * shared `MappedError` envelope. Unrecognised errors fall to
+ * `UNKNOWN`; a table test guards that no named class ever falls
+ * through.
+ */
+export function mapPackageIntelligenceError(error: unknown): MappedError {
+  const mapped = classify(error);
+  debugLog("pkg-intel", {
+    event: "error-classified",
+    code: mapped.code,
+    errorName: error instanceof Error ? error.name : typeof error,
+    detailKeys: mapped.details ? Object.keys(mapped.details) : [],
+  });
+  return mapped;
+}
+
+function classify(error: unknown): MappedError {
+  if (error instanceof PackageIntelligenceTargetNotFoundError) {
+    return {
+      code: "NOT_FOUND",
+      message: error.message,
+      retryable: false,
+    };
+  }
+  if (error instanceof PackageIntelligenceValidationError) {
+    return {
+      code: "INVALID_ARGUMENT",
+      message: error.message,
+      retryable: false,
+    };
+  }
+  if (
+    error instanceof PackageIntelligenceAccessError ||
+    error instanceof PackageIntelligenceFeatureFlagRequiredError
+  ) {
+    return {
+      code: "ACCESS_DENIED",
+      message: error.message,
+      retryable: false,
+    };
+  }
+  if (error instanceof AuthenticationError) {
+    return {
+      code: "AUTH_REQUIRED",
+      message: error.message,
+      retryable: false,
+    };
+  }
+  if (error instanceof PackageIntelligenceNetworkError) {
+    return { code: "NETWORK", message: error.message, retryable: true };
+  }
+  if (error instanceof PackageIntelligenceBackendError) {
+    return classifyBackendError(error);
+  }
+  if (error instanceof PackageIntelligenceGraphQLError) {
+    return {
+      code: "BACKEND_ERROR",
+      message: error.message,
+      retryable: false,
+      details: error.code ? { graphqlCode: error.code } : undefined,
+    };
+  }
+  if (error instanceof MalformedPackageIntelligenceResponseError) {
+    return {
+      code: "PROTOCOL_ERROR",
+      message: error.message,
+      retryable: false,
+    };
+  }
+  if (isInvalidArgumentError(error)) {
+    return {
+      code: "INVALID_ARGUMENT",
+      message: error.message,
+      retryable: false,
+    };
+  }
+  if (error instanceof Error) {
+    return { code: "UNKNOWN", message: error.message, retryable: false };
+  }
+  return { code: "UNKNOWN", message: "Unknown error", retryable: false };
+}
+
+function classifyBackendError(
+  error: PackageIntelligenceBackendError,
+): MappedError {
+  const details: MappedErrorDetails = {};
+  if (typeof error.status === "number") details.status = error.status;
+  if (error.graphqlCode) details.graphqlCode = error.graphqlCode;
+
+  const build = (code: MappedErrorCode, defaultRetryable: boolean) => ({
+    code,
+    message: error.message,
+    retryable: error.retryable ?? defaultRetryable,
+    details: Object.keys(details).length > 0 ? details : undefined,
+  });
+
+  switch (error.graphqlCode) {
+    case "TIMEOUT":
+      return build("TIMEOUT", true);
+    case "RATE_LIMITED":
+      return build("RATE_LIMITED", true);
+    case "UPSTREAM_ERROR":
+      return build("BACKEND_ERROR", true);
+    case "INTERNAL_ERROR":
+    case "UNKNOWN_ERROR":
+    default:
+      return build("BACKEND_ERROR", false);
+  }
+}
+
+/**
+ * Name-prefix rule shared with `mapCodeNavigationError` — callers that
+ * raise `InvalidPackageSpecError` / `UnsupportedRegistryError` land on
+ * `INVALID_ARGUMENT` without this module importing them directly.
+ */
+function isInvalidArgumentError(error: unknown): error is Error {
+  if (!(error instanceof Error)) return false;
+  return (
+    error.name.startsWith("Invalid") || error.name.startsWith("Unsupported")
+  );
+}

--- a/src/shared/package-summary-request.test.ts
+++ b/src/shared/package-summary-request.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "bun:test";
+import {
+  InvalidPackageSpecError,
+  UnsupportedRegistryError,
+} from "./package-spec.js";
+import { buildPackageSummaryParams } from "./package-summary-request.js";
+
+describe("buildPackageSummaryParams", () => {
+  it("maps lowercase registry to uppercase backend enum", () => {
+    const { params } = buildPackageSummaryParams({
+      registry: "npm",
+      packageName: "express",
+    });
+    expect(params.registry).toBe("NPM");
+    expect(params.packageName).toBe("express");
+  });
+
+  it("normalises whitespace on package name", () => {
+    const { params } = buildPackageSummaryParams({
+      registry: "npm",
+      packageName: "  express  ",
+    });
+    expect(params.packageName).toBe("express");
+  });
+
+  it("normalises registry case and whitespace", () => {
+    const { params } = buildPackageSummaryParams({
+      registry: "  NPM  ",
+      packageName: "express",
+    });
+    expect(params.registry).toBe("NPM");
+  });
+
+  it("rejects empty packageName with InvalidPackageSpecError", () => {
+    expect(() =>
+      buildPackageSummaryParams({ registry: "npm", packageName: "" }),
+    ).toThrow(InvalidPackageSpecError);
+    expect(() =>
+      buildPackageSummaryParams({ registry: "npm", packageName: "   " }),
+    ).toThrow(InvalidPackageSpecError);
+  });
+
+  it("rejects unknown registry with UnsupportedRegistryError", () => {
+    expect(() =>
+      buildPackageSummaryParams({ registry: "cargo", packageName: "serde" }),
+    ).toThrow(UnsupportedRegistryError);
+  });
+
+  it("rejects empty registry", () => {
+    expect(() =>
+      buildPackageSummaryParams({ registry: "", packageName: "express" }),
+    ).toThrow(UnsupportedRegistryError);
+  });
+
+  it("accepts every supported registry", () => {
+    const registries = [
+      "npm",
+      "pypi",
+      "hex",
+      "crates",
+      "nuget",
+      "maven",
+      "zig",
+      "vcpkg",
+      "packagist",
+    ];
+    for (const registry of registries) {
+      expect(() =>
+        buildPackageSummaryParams({ registry, packageName: "x" }),
+      ).not.toThrow();
+    }
+  });
+});

--- a/src/shared/package-summary-request.ts
+++ b/src/shared/package-summary-request.ts
@@ -1,0 +1,61 @@
+/**
+ * Shared request builder for the `package_summary` tool. Both the CLI
+ * command and the MCP tool normalise their inputs here, so the two
+ * surfaces cannot diverge on validation rules or registry coercion.
+ *
+ * Responsibilities:
+ * - Trim whitespace on `packageName` and reject empty strings with
+ *   an `InvalidPackageSpecError` (name-prefixed so the shared
+ *   classifier routes it to `INVALID_ARGUMENT`).
+ * - Map lowercase registry surface values to the uppercase backend
+ *   enum via `toPkgseerRegistry`, rejecting unknown registries with
+ *   `UnsupportedRegistryError`.
+ *
+ * Unlike `buildSearchSymbolsParams` this builder has no defaults to
+ * apply, so it returns only `{ params }` — no `defaulted` array.
+ */
+
+import type { PackageSummaryParams } from "../services/index.js";
+import {
+  InvalidPackageSpecError,
+  UnsupportedRegistryError,
+} from "./package-spec.js";
+import {
+  isKnownPkgseerRegistryArg,
+  type PkgseerRegistryArg,
+  toPkgseerRegistry,
+} from "./pkgseer-registry.js";
+
+export interface PackageSummaryRequestInput {
+  /** Lowercase registry surface value (`npm`, `pypi`, …). */
+  registry: string;
+  /** Raw package name — may carry surrounding whitespace. */
+  packageName: string;
+}
+
+export interface PackageSummaryRequestBuildResult {
+  params: PackageSummaryParams;
+}
+
+export function buildPackageSummaryParams(
+  input: PackageSummaryRequestInput,
+): PackageSummaryRequestBuildResult {
+  const trimmedName = input.packageName?.trim() ?? "";
+  if (!trimmedName) {
+    throw new InvalidPackageSpecError("Package name is required.");
+  }
+
+  const normalisedRegistry = input.registry?.trim().toLowerCase() ?? "";
+  if (!isKnownPkgseerRegistryArg(normalisedRegistry)) {
+    throw new UnsupportedRegistryError(
+      `Unsupported registry '${input.registry}'. Supported: npm, pypi, hex, crates, nuget, maven, zig, vcpkg, packagist.`,
+    );
+  }
+
+  return {
+    params: {
+      registry: toPkgseerRegistry(normalisedRegistry as PkgseerRegistryArg),
+      packageName: trimmedName,
+    },
+  };
+}

--- a/src/shared/package-summary-response.test.ts
+++ b/src/shared/package-summary-response.test.ts
@@ -1,0 +1,350 @@
+import { describe, expect, it } from "bun:test";
+import type { PackageSummary } from "../services/index.js";
+import { defaultPackageSummary } from "../services/test-helpers.js";
+import {
+  buildPackageSummarySuccessPayload,
+  formatPackageSummaryTerminal,
+  severityLabel,
+} from "./package-summary-response.js";
+
+const FIXED_NOW = new Date("2024-06-01T12:00:00Z");
+
+function happyFixture(): PackageSummary {
+  return structuredClone(defaultPackageSummary);
+}
+
+describe("buildPackageSummarySuccessPayload — happy path", () => {
+  it("includes every top-level section when the fixture is fully populated", () => {
+    const payload = buildPackageSummarySuccessPayload(defaultPackageSummary);
+    expect(payload.registry).toBe("npm");
+    expect(payload.name).toBe("express");
+    expect(payload.version).toBe("4.18.2");
+    expect(payload.description).toContain("Fast");
+    expect(payload.license).toBe("MIT");
+    expect(payload.homepage).toBe("https://expressjs.com");
+    expect(payload.repository).toBe("https://github.com/expressjs/express");
+    expect(payload.publishedAt).toBe("2023-05-28");
+    expect(payload.downloads?.lastMonth).toBe(86_000_000);
+    expect(payload.github?.stars).toBe(63_400);
+    expect(payload.install).toBe("npm install express");
+    expect(payload.vulnerabilities?.total).toBe(5);
+    expect(payload.vulnerabilities?.affectsLatest).toBe(true);
+    expect(payload.vulnerabilities?.recent?.[0]?.severityLabel).toBe("high");
+    expect(payload.recentChanges?.length).toBe(3);
+  });
+
+  it("lowercases the registry value", () => {
+    const fixture = happyFixture();
+    fixture.package.registry = "NPM";
+    expect(buildPackageSummarySuccessPayload(fixture).registry).toBe("npm");
+  });
+});
+
+describe("buildPackageSummarySuccessPayload — omission rules", () => {
+  it("omits description/license/homepage/repository/publishedAt when null", () => {
+    const fixture = happyFixture();
+    fixture.package.description = undefined;
+    fixture.package.license = undefined;
+    fixture.package.homepage = undefined;
+    fixture.package.repositoryUrl = undefined;
+    fixture.package.latestVersionPublishedAt = undefined;
+    const payload = buildPackageSummarySuccessPayload(fixture);
+    expect(payload.description).toBeUndefined();
+    expect(payload.license).toBeUndefined();
+    expect(payload.homepage).toBeUndefined();
+    expect(payload.repository).toBeUndefined();
+    expect(payload.publishedAt).toBeUndefined();
+  });
+
+  it("omits downloads block when both lastMonth and total are undefined", () => {
+    const fixture = happyFixture();
+    fixture.package.downloadsLastMonth = undefined;
+    fixture.package.downloadsTotal = undefined;
+    const payload = buildPackageSummarySuccessPayload(fixture);
+    expect(payload.downloads).toBeUndefined();
+  });
+
+  it("keeps downloads partial-object when only one leaf is populated", () => {
+    const fixture = happyFixture();
+    fixture.package.downloadsTotal = undefined;
+    const payload = buildPackageSummarySuccessPayload(fixture);
+    expect(payload.downloads).toEqual({ lastMonth: 86_000_000 });
+  });
+
+  it("omits github block entirely when the fixture has no github data", () => {
+    const fixture = happyFixture();
+    fixture.package.githubRepository = undefined;
+    const payload = buildPackageSummarySuccessPayload(fixture);
+    expect(payload.github).toBeUndefined();
+  });
+
+  it("omits github.topics when empty array", () => {
+    const fixture = happyFixture();
+    if (fixture.package.githubRepository) {
+      fixture.package.githubRepository.topics = [];
+    }
+    const payload = buildPackageSummarySuccessPayload(fixture);
+    expect(payload.github?.topics).toBeUndefined();
+  });
+
+  it("omits vulnerabilities block when total is 0", () => {
+    const fixture = happyFixture();
+    fixture.security = {
+      vulnerabilityCount: 0,
+      hasCurrentVulnerabilities: false,
+      recentVulnerabilities: [],
+    };
+    const payload = buildPackageSummarySuccessPayload(fixture);
+    expect(payload.vulnerabilities).toBeUndefined();
+  });
+
+  it("omits vulnerabilities block when vulnerabilityCount is null/missing", () => {
+    const fixture = happyFixture();
+    fixture.security = {
+      vulnerabilityCount: undefined,
+      hasCurrentVulnerabilities: false,
+      recentVulnerabilities: [],
+    };
+    expect(
+      buildPackageSummarySuccessPayload(fixture).vulnerabilities,
+    ).toBeUndefined();
+
+    fixture.security = undefined;
+    expect(
+      buildPackageSummarySuccessPayload(fixture).vulnerabilities,
+    ).toBeUndefined();
+  });
+
+  it("keeps total+affectsLatest when total > 0 but recent list is empty", () => {
+    const fixture = happyFixture();
+    fixture.security = {
+      vulnerabilityCount: 3,
+      hasCurrentVulnerabilities: true,
+      recentVulnerabilities: [],
+    };
+    const payload = buildPackageSummarySuccessPayload(fixture);
+    expect(payload.vulnerabilities?.total).toBe(3);
+    expect(payload.vulnerabilities?.affectsLatest).toBe(true);
+    expect(payload.vulnerabilities?.recent).toBeUndefined();
+  });
+
+  it("omits install/usage individually when null, and drops quickstart block when empty", () => {
+    const fixture = happyFixture();
+    fixture.quickstart = { installCommand: undefined, usageExample: undefined };
+    const payload = buildPackageSummarySuccessPayload(fixture);
+    expect(payload.install).toBeUndefined();
+    expect(payload.usage).toBeUndefined();
+  });
+
+  it("drops recentChanges entries with null version but preserves backend order", () => {
+    const fixture = happyFixture();
+    fixture.latestChangelogs = [
+      { version: undefined, body: "mystery" },
+      { version: "2.0.0", body: "second" },
+      { version: "1.0.0", body: "first" },
+    ];
+    const payload = buildPackageSummarySuccessPayload(fixture);
+    expect(payload.recentChanges?.map((e) => e.version)).toEqual([
+      "2.0.0",
+      "1.0.0",
+    ]);
+  });
+
+  it("omits recentChanges entirely when all entries have null version", () => {
+    const fixture = happyFixture();
+    fixture.latestChangelogs = [
+      { version: undefined },
+      { version: undefined },
+      { version: undefined },
+    ];
+    const payload = buildPackageSummarySuccessPayload(fixture);
+    expect(payload.recentChanges).toBeUndefined();
+  });
+
+  it("derives summary from body's first non-empty line (120-char trim)", () => {
+    const fixture = happyFixture();
+    const longBody = "A".repeat(200);
+    fixture.latestChangelogs = [
+      {
+        version: "1.0.0",
+        body: longBody,
+      },
+    ];
+    const summary =
+      buildPackageSummarySuccessPayload(fixture).recentChanges?.[0]?.summary;
+    expect(summary).toBeDefined();
+    expect(summary?.length).toBeLessThanOrEqual(121); // 120 + trailing ellipsis
+    expect(summary?.endsWith("…")).toBe(true);
+  });
+});
+
+describe("buildPackageSummarySuccessPayload — data transformations", () => {
+  it("converts publishedAt to UTC YYYY-MM-DD", () => {
+    const fixture = happyFixture();
+    // 23:59 UTC still falls on the stated date.
+    fixture.package.latestVersionPublishedAt = "2024-05-10T23:59:00Z";
+    const payload = buildPackageSummarySuccessPayload(fixture);
+    expect(payload.publishedAt).toBe("2024-05-10");
+  });
+
+  it("normalises \\r\\n in usage to \\n", () => {
+    const fixture = happyFixture();
+    if (fixture.quickstart) {
+      fixture.quickstart.usageExample = "line 1\r\nline 2\r\nline 3";
+    }
+    const payload = buildPackageSummarySuccessPayload(fixture);
+    expect(payload.usage).toBe("line 1\nline 2\nline 3");
+  });
+
+  it("omits severity/severityLabel when the score is null or non-positive", () => {
+    const fixture = happyFixture();
+    fixture.security = {
+      vulnerabilityCount: 1,
+      hasCurrentVulnerabilities: true,
+      recentVulnerabilities: [
+        {
+          osvId: "GHSA-a",
+          summary: "no score",
+          severityScore: undefined,
+          publishedAt: "2024-01-01T00:00:00Z",
+        },
+        {
+          osvId: "GHSA-b",
+          summary: "zero score",
+          severityScore: 0,
+          publishedAt: "2024-01-01T00:00:00Z",
+        },
+      ],
+    };
+    const payload = buildPackageSummarySuccessPayload(fixture);
+    const recent = payload.vulnerabilities?.recent ?? [];
+    expect(recent[0]?.severity).toBeUndefined();
+    expect(recent[0]?.severityLabel).toBeUndefined();
+    expect(recent[1]?.severity).toBeUndefined();
+  });
+});
+
+describe("severityLabel — CVSS banding boundaries", () => {
+  it("bands at the locked thresholds (<4 low, <7 medium, <9 high, ≥9 critical)", () => {
+    expect(severityLabel(0.1)).toBe("low");
+    expect(severityLabel(3.9)).toBe("low");
+    expect(severityLabel(4.0)).toBe("medium");
+    expect(severityLabel(6.9)).toBe("medium");
+    expect(severityLabel(7.0)).toBe("high");
+    expect(severityLabel(8.9)).toBe("high");
+    expect(severityLabel(9.0)).toBe("critical");
+    expect(severityLabel(10.0)).toBe("critical");
+  });
+});
+
+describe("formatPackageSummaryTerminal", () => {
+  it("renders the default block with header, description, fields, and vuln footer", () => {
+    const output = formatPackageSummaryTerminal(defaultPackageSummary, {
+      useColors: false,
+      now: FIXED_NOW,
+    });
+    expect(output).toContain("express @ 4.18.2 · MIT");
+    expect(output).toContain("Fast, unopinionated");
+    expect(output).toContain("Repository");
+    expect(output).toContain("5 known vulnerabilities · latest affected");
+  });
+
+  it("verbose mode adds Usage, Recent advisories, Topics, and Recent changes", () => {
+    const output = formatPackageSummaryTerminal(defaultPackageSummary, {
+      verbose: true,
+      useColors: false,
+      now: FIXED_NOW,
+    });
+    expect(output).toContain("Usage");
+    expect(output).toContain("const express");
+    expect(output).toContain("Recent advisories");
+    expect(output).toContain("GHSA-xxxx-xxxx-xxxx");
+    expect(output).toContain("Topics");
+    expect(output).toContain("Recent changes");
+  });
+
+  it("no-color output contains no ANSI escape sequences", () => {
+    const output = formatPackageSummaryTerminal(defaultPackageSummary, {
+      useColors: false,
+      now: FIXED_NOW,
+      verbose: true,
+    });
+    expect(output).not.toContain("\x1b[");
+  });
+
+  it("vuln footer uses singular form for total = 1", () => {
+    const fixture = happyFixture();
+    fixture.security = {
+      vulnerabilityCount: 1,
+      hasCurrentVulnerabilities: true,
+      recentVulnerabilities: [],
+    };
+    const output = formatPackageSummaryTerminal(fixture, {
+      useColors: false,
+      now: FIXED_NOW,
+    });
+    expect(output).toContain("1 known vulnerability");
+  });
+
+  it("omits the vuln footer when there are zero vulnerabilities", () => {
+    const fixture = happyFixture();
+    fixture.security = {
+      vulnerabilityCount: 0,
+      hasCurrentVulnerabilities: false,
+      recentVulnerabilities: [],
+    };
+    const output = formatPackageSummaryTerminal(fixture, {
+      useColors: false,
+      now: FIXED_NOW,
+    });
+    expect(output).not.toContain("known vulnerabilities");
+    expect(output).not.toContain("known vulnerability");
+  });
+
+  it("omits license separator when license is null", () => {
+    const fixture = happyFixture();
+    fixture.package.license = undefined;
+    const output = formatPackageSummaryTerminal(fixture, {
+      useColors: false,
+      now: FIXED_NOW,
+    });
+    expect(output.startsWith("express @ 4.18.2\n")).toBe(true);
+  });
+
+  it("renders without github block when fixture has no github repo", () => {
+    const fixture = happyFixture();
+    fixture.package.githubRepository = undefined;
+    const output = formatPackageSummaryTerminal(fixture, {
+      useColors: false,
+      now: FIXED_NOW,
+    });
+    expect(output).not.toContain("GitHub");
+    expect(output).not.toContain("★");
+  });
+
+  it("wraps description at 80 cols and uses 80-col fallback when stdout.columns is undefined", () => {
+    const fixture = happyFixture();
+    fixture.package.description = "lorem ipsum ".repeat(20).trim();
+    const output = formatPackageSummaryTerminal(fixture, {
+      useColors: false,
+      now: FIXED_NOW,
+      terminalWidth: undefined,
+    });
+    const descriptionLines = output
+      .split("\n")
+      .filter((line) => line.startsWith("lorem"));
+    for (const line of descriptionLines) {
+      expect(line.length).toBeLessThanOrEqual(80);
+    }
+  });
+
+  it("renders topics in verbose mode without colorizing the label gutter", () => {
+    const output = formatPackageSummaryTerminal(defaultPackageSummary, {
+      verbose: true,
+      useColors: false,
+      now: FIXED_NOW,
+    });
+    // The label "Topics" starts at column 0 with a fixed-width gutter
+    expect(output).toMatch(/\nTopics\s{4}\s{2}framework/);
+  });
+});

--- a/src/shared/package-summary-response.ts
+++ b/src/shared/package-summary-response.ts
@@ -1,0 +1,529 @@
+/**
+ * Hand-crafted response envelope for the `package_summary` tool,
+ * shared by CLI `--json` output and MCP `content[0].text`.
+ *
+ * Principles:
+ * - **Token-efficient.** Every field dropped from the GraphQL payload
+ *   is a deliberate decision. Metadata (`schemaVersion`, refresh
+ *   timestamps, `versionCount`, duplicate GitHub identifiers) is
+ *   omitted; only fields that inform an agent decision survive.
+ * - **Null-omitted.** Scalars go missing when null; blocks go missing
+ *   when every leaf is null; arrays go missing when empty. Agent
+ *   callers receive present data only, not a skeleton.
+ * - **Stable.** Two identical queries produce byte-identical output
+ *   (no clock-dependent fields, no iteration-order tricks), so the
+ *   parity test can deep-equal across surfaces.
+ */
+
+import type {
+  ChangelogEntry,
+  PackageSecurityOverview,
+  PackageSummary,
+  VulnerabilityOverview,
+} from "../services/index.js";
+import { colorize, dim, highlight } from "./colors.js";
+import { toIsoDate, toRelativeDate } from "./format-date.js";
+import { formatCompactNumber } from "./format-number.js";
+import { toPkgseerRegistryLowercase } from "./pkgseer-registry.js";
+
+// --------------------------------------------------------------------
+// Lean JSON envelope
+// --------------------------------------------------------------------
+
+export type SeverityLabel = "critical" | "high" | "medium" | "low";
+
+export interface LeanDownloads {
+  lastMonth?: number;
+  total?: number;
+}
+
+export interface LeanGithub {
+  stars?: number;
+  forks?: number;
+  openIssues?: number;
+  archived?: boolean;
+  language?: string;
+  topics?: string[];
+  lastPushedAt?: string;
+}
+
+export interface LeanVulnerability {
+  id?: string;
+  summary?: string;
+  severity?: number;
+  severityLabel?: SeverityLabel;
+  publishedAt?: string;
+}
+
+export interface LeanVulnerabilities {
+  total: number;
+  affectsLatest: boolean;
+  recent?: LeanVulnerability[];
+}
+
+export interface LeanRecentChange {
+  version: string;
+  date?: string;
+  summary?: string;
+}
+
+export interface LeanPackageSummary {
+  registry: string;
+  name: string;
+  version: string;
+  description?: string;
+  license?: string;
+  homepage?: string;
+  repository?: string;
+  publishedAt?: string;
+  downloads?: LeanDownloads;
+  github?: LeanGithub;
+  install?: string;
+  usage?: string;
+  vulnerabilities?: LeanVulnerabilities;
+  recentChanges?: LeanRecentChange[];
+}
+
+/**
+ * Build the lean envelope from a validated {@link PackageSummary}.
+ * Pure, deterministic — no I/O, no clock, no env reads.
+ */
+export function buildPackageSummarySuccessPayload(
+  summary: PackageSummary,
+): LeanPackageSummary {
+  const pkg = summary.package;
+
+  const payload: LeanPackageSummary = {
+    registry: lowerRegistry(pkg.registry),
+    name: pkg.name,
+    version: pkg.latestVersion,
+  };
+
+  assignIfDefined(payload, "description", pkg.description);
+  assignIfDefined(payload, "license", pkg.license);
+  assignIfDefined(payload, "homepage", pkg.homepage);
+  assignIfDefined(payload, "repository", pkg.repositoryUrl);
+  assignIfDefined(
+    payload,
+    "publishedAt",
+    toIsoDate(pkg.latestVersionPublishedAt),
+  );
+
+  const downloads = buildDownloads(pkg.downloadsLastMonth, pkg.downloadsTotal);
+  if (downloads) payload.downloads = downloads;
+
+  const github = buildGithub(pkg.githubRepository);
+  if (github) payload.github = github;
+
+  if (summary.quickstart?.installCommand) {
+    payload.install = summary.quickstart.installCommand;
+  }
+  const usage = normaliseUsage(summary.quickstart?.usageExample);
+  if (usage) payload.usage = usage;
+
+  const vulns = buildVulnerabilities(summary.security);
+  if (vulns) payload.vulnerabilities = vulns;
+
+  const recent = buildRecentChanges(summary.latestChangelogs);
+  if (recent) payload.recentChanges = recent;
+
+  return payload;
+}
+
+function lowerRegistry(value: string | undefined): string {
+  if (!value) return "";
+  const upper = value.toUpperCase();
+  try {
+    // Type assertion is safe when the backend echoes a known enum
+    // value; fall through for unexpected strings (schema drift).
+    // biome-ignore lint/suspicious/noExplicitAny: boundary guard
+    return toPkgseerRegistryLowercase(upper as any);
+  } catch {
+    return value.toLowerCase();
+  }
+}
+
+function assignIfDefined<T, K extends keyof T>(
+  target: T,
+  key: K,
+  value: T[K] | null | undefined,
+): void {
+  if (value !== undefined && value !== null) {
+    target[key] = value;
+  }
+}
+
+function buildDownloads(
+  lastMonth: number | undefined,
+  total: number | undefined,
+): LeanDownloads | undefined {
+  const result: LeanDownloads = {};
+  if (typeof lastMonth === "number") result.lastMonth = lastMonth;
+  if (typeof total === "number") result.total = total;
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+function buildGithub(
+  github: PackageSummary["package"]["githubRepository"],
+): LeanGithub | undefined {
+  if (!github) return undefined;
+  const result: LeanGithub = {};
+  if (typeof github.stargazersCount === "number") {
+    result.stars = github.stargazersCount;
+  }
+  if (typeof github.forksCount === "number") {
+    result.forks = github.forksCount;
+  }
+  if (typeof github.openIssuesCount === "number") {
+    result.openIssues = github.openIssuesCount;
+  }
+  if (typeof github.archived === "boolean") {
+    result.archived = github.archived;
+  }
+  if (github.language) {
+    result.language = github.language;
+  }
+  if (github.topics && github.topics.length > 0) {
+    result.topics = github.topics;
+  }
+  const lastPushedAt = toIsoDate(github.pushedAt);
+  if (lastPushedAt) result.lastPushedAt = lastPushedAt;
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+function normaliseUsage(usage: string | undefined): string | undefined {
+  if (!usage) return undefined;
+  // Guard against \r\n artefacts on Windows-authored backends so the
+  // output renders consistently and the MCP JSON stays clean.
+  const cleaned = usage.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  return cleaned.length > 0 ? cleaned : undefined;
+}
+
+function buildVulnerabilities(
+  security: PackageSecurityOverview | undefined,
+): LeanVulnerabilities | undefined {
+  if (!security) return undefined;
+  const total = security.vulnerabilityCount ?? 0;
+  if (total === 0) return undefined;
+
+  const result: LeanVulnerabilities = {
+    total,
+    affectsLatest: security.hasCurrentVulnerabilities ?? false,
+  };
+
+  const recent = security.recentVulnerabilities
+    ?.map(buildVulnerability)
+    .filter((entry): entry is LeanVulnerability => entry !== undefined);
+  if (recent && recent.length > 0) {
+    result.recent = recent;
+  }
+  return result;
+}
+
+function buildVulnerability(
+  entry: VulnerabilityOverview,
+): LeanVulnerability | undefined {
+  const lean: LeanVulnerability = {};
+  if (entry.osvId) lean.id = entry.osvId;
+  if (entry.summary) lean.summary = entry.summary;
+  if (typeof entry.severityScore === "number" && entry.severityScore > 0) {
+    lean.severity = entry.severityScore;
+    lean.severityLabel = severityLabel(entry.severityScore);
+  }
+  const publishedAt = toIsoDate(entry.publishedAt);
+  if (publishedAt) lean.publishedAt = publishedAt;
+  return Object.keys(lean).length > 0 ? lean : undefined;
+}
+
+export function severityLabel(score: number): SeverityLabel {
+  if (score >= 9) return "critical";
+  if (score >= 7) return "high";
+  if (score >= 4) return "medium";
+  return "low";
+}
+
+function buildRecentChanges(
+  entries: ChangelogEntry[] | undefined,
+): LeanRecentChange[] | undefined {
+  if (!entries || entries.length === 0) return undefined;
+  const filtered = entries
+    .filter((entry): entry is ChangelogEntry => !!entry.version)
+    .map((entry) => {
+      const lean: LeanRecentChange = { version: entry.version as string };
+      const date = toIsoDate(entry.publishedAt);
+      if (date) lean.date = date;
+      const summary = pickChangelogSummary(entry);
+      if (summary) lean.summary = summary;
+      return lean;
+    });
+  return filtered.length > 0 ? filtered : undefined;
+}
+
+function pickChangelogSummary(entry: ChangelogEntry): string | undefined {
+  // ChangelogEntry has no dedicated summary field on the schema, so
+  // we derive one from the first non-empty line of the body. Many
+  // changelogs lead with markdown headers (`## What's Changed`,
+  // `### Bug fixes`) — strip the `#` markers so the summary reads as
+  // prose. Trimmed to 120 chars with trailing ellipsis.
+  if (!entry.body) return undefined;
+  const firstLine = entry.body
+    .split(/\r?\n/)
+    .map((line) => stripMarkdownHeading(line.trim()))
+    .find((line) => line.length > 0);
+  if (!firstLine) return undefined;
+  return firstLine.length > 120
+    ? `${firstLine.slice(0, 120).trimEnd()}…`
+    : firstLine;
+}
+
+function stripMarkdownHeading(line: string): string {
+  // Remove leading `#` markers (1-6) followed by whitespace.
+  return line.replace(/^#{1,6}\s+/, "").trim();
+}
+
+// --------------------------------------------------------------------
+// Terminal formatter
+// --------------------------------------------------------------------
+
+export interface FormatTerminalOptions {
+  verbose?: boolean;
+  useColors?: boolean;
+  /** Column width for wrapping the description line. Defaults to 80. */
+  terminalWidth?: number;
+  /**
+   * Clock injection for relative-date rendering. Tests pin this; in
+   * production `new Date()` is used.
+   */
+  now?: Date;
+}
+
+/**
+ * Render a {@link PackageSummary} for terminal display. Pure.
+ */
+export function formatPackageSummaryTerminal(
+  summary: PackageSummary,
+  options: FormatTerminalOptions = {},
+): string {
+  const lean = buildPackageSummarySuccessPayload(summary);
+  const useColors = options.useColors ?? false;
+  const width = resolveWidth(options.terminalWidth);
+  const now = options.now ?? new Date();
+
+  const sections: string[] = [];
+
+  // Header — `name @ version · license`
+  const header = lean.license
+    ? `${colorize(lean.name, "bold", useColors)} @ ${lean.version} · ${lean.license}`
+    : `${colorize(lean.name, "bold", useColors)} @ ${lean.version}`;
+  sections.push(header);
+
+  // Description, wrapped.
+  if (lean.description) {
+    sections.push(wrapText(lean.description, width));
+  }
+
+  // Field list.
+  const fields = buildFieldList(lean, summary, useColors, now);
+  if (fields.length > 0) {
+    sections.push(fields.join("\n"));
+  }
+
+  // Vulnerabilities footer.
+  if (lean.vulnerabilities) {
+    sections.push(formatVulnFooter(lean.vulnerabilities, useColors));
+  }
+
+  if (options.verbose) {
+    const verbose = buildVerboseSections(lean, useColors);
+    if (verbose.length > 0) sections.push(verbose);
+  }
+
+  return `${sections.join("\n\n")}\n`;
+}
+
+function resolveWidth(explicit: number | undefined): number {
+  if (typeof explicit === "number" && explicit > 0) {
+    return Math.min(explicit, 80);
+  }
+  const columns = process.stdout?.columns;
+  if (typeof columns === "number" && columns > 0) {
+    return Math.min(columns, 80);
+  }
+  return 80;
+}
+
+function wrapText(text: string, width: number): string {
+  const words = text.split(/\s+/);
+  const lines: string[] = [];
+  let current = "";
+  for (const word of words) {
+    if (current.length === 0) {
+      current = word;
+      continue;
+    }
+    if (current.length + 1 + word.length > width) {
+      lines.push(current);
+      current = word;
+    } else {
+      current += ` ${word}`;
+    }
+  }
+  if (current.length > 0) lines.push(current);
+  return lines.join("\n");
+}
+
+interface LabelledField {
+  label: string;
+  value: string;
+}
+
+function buildFieldList(
+  lean: LeanPackageSummary,
+  summary: PackageSummary,
+  useColors: boolean,
+  now: Date,
+): string[] {
+  const fields: LabelledField[] = [];
+
+  if (lean.repository) {
+    fields.push({
+      label: "Repository",
+      value: dim(lean.repository, useColors),
+    });
+  }
+  if (lean.homepage) {
+    fields.push({ label: "Homepage", value: dim(lean.homepage, useColors) });
+  }
+
+  const publishedRelative = toRelativeDate(
+    summary.package.latestVersionPublishedAt,
+    now,
+  );
+  if (publishedRelative) {
+    fields.push({ label: "Published", value: publishedRelative });
+  }
+
+  if (lean.downloads?.lastMonth !== undefined) {
+    fields.push({
+      label: "Downloads",
+      value: `${formatCompactNumber(lean.downloads.lastMonth)} / month`,
+    });
+  } else if (lean.downloads?.total !== undefined) {
+    fields.push({
+      label: "Downloads",
+      value: `${formatCompactNumber(lean.downloads.total)} total`,
+    });
+  }
+
+  if (lean.github) {
+    fields.push({ label: "GitHub", value: formatGithubLine(lean.github) });
+  }
+
+  if (lean.install) {
+    fields.push({ label: "Install", value: lean.install });
+  }
+
+  // Label column sized to the widest *raw* label (no ANSI, matching
+  // the locked padding rule). Minimum 10 cols for a readable gutter.
+  const labelWidth = Math.max(10, ...fields.map((field) => field.label.length));
+
+  return fields.map(
+    (field) => `${field.label.padEnd(labelWidth)}  ${field.value}`,
+  );
+}
+
+function formatGithubLine(github: LeanGithub): string {
+  const parts: string[] = [];
+  if (github.stars !== undefined) {
+    parts.push(`★ ${formatCompactNumber(github.stars)}`);
+  }
+  if (github.forks !== undefined) {
+    parts.push(`${formatCompactNumber(github.forks)} forks`);
+  }
+  if (github.openIssues !== undefined) {
+    parts.push(`${formatCompactNumber(github.openIssues)} open issues`);
+  }
+  if (github.archived) {
+    parts.push("archived");
+  }
+  return parts.join(" · ");
+}
+
+function formatVulnFooter(
+  vulns: LeanVulnerabilities,
+  useColors: boolean,
+): string {
+  const noun = vulns.total === 1 ? "vulnerability" : "vulnerabilities";
+  const base = `${vulns.total} known ${noun}`;
+  const full = vulns.affectsLatest ? `${base} · latest affected` : base;
+  return colorize(full, "yellow", useColors);
+}
+
+function buildVerboseSections(
+  lean: LeanPackageSummary,
+  useColors: boolean,
+): string {
+  const blocks: string[] = [];
+
+  if (lean.usage) {
+    blocks.push(
+      [
+        highlight("Usage", useColors),
+        lean.usage
+          .split("\n")
+          .map((line) => `  ${line}`)
+          .join("\n"),
+      ].join("\n"),
+    );
+  }
+
+  if (lean.vulnerabilities?.recent && lean.vulnerabilities.recent.length > 0) {
+    blocks.push(
+      formatVerboseAdvisories(lean.vulnerabilities.recent, useColors),
+    );
+  }
+
+  if (lean.github?.topics && lean.github.topics.length > 0) {
+    blocks.push(`${"Topics".padEnd(10)}  ${lean.github.topics.join(", ")}`);
+  }
+
+  if (lean.recentChanges && lean.recentChanges.length > 0) {
+    blocks.push(formatVerboseChanges(lean.recentChanges, useColors));
+  }
+
+  return blocks.join("\n\n");
+}
+
+function formatVerboseAdvisories(
+  advisories: LeanVulnerability[],
+  useColors: boolean,
+): string {
+  const labelWidth = Math.max(
+    ...advisories.map((a) => (a.severityLabel ?? "").length),
+  );
+  const lines = [highlight("Recent advisories", useColors)];
+  for (const advisory of advisories) {
+    const parts: string[] = [];
+    const label = (advisory.severityLabel ?? "").padEnd(labelWidth);
+    if (label.trim().length > 0) parts.push(label);
+    if (advisory.id) parts.push(advisory.id);
+    if (advisory.publishedAt) parts.push(advisory.publishedAt);
+    if (advisory.summary) parts.push(advisory.summary);
+    lines.push(`  ${parts.join("  ")}`);
+  }
+  return lines.join("\n");
+}
+
+function formatVerboseChanges(
+  entries: LeanRecentChange[],
+  useColors: boolean,
+): string {
+  const lines = [highlight("Recent changes", useColors)];
+  for (const entry of entries) {
+    const parts: string[] = [entry.version];
+    if (entry.date) parts.push(entry.date);
+    if (entry.summary) parts.push(entry.summary);
+    lines.push(`  ${parts.join("  ")}`);
+  }
+  return lines.join("\n");
+}

--- a/src/shared/pkgseer-graphql.test.ts
+++ b/src/shared/pkgseer-graphql.test.ts
@@ -1,0 +1,260 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import {
+  PkgseerTransportError,
+  postPkgseerGraphql,
+} from "./pkgseer-graphql.js";
+
+function makeResponse(
+  body: string,
+  init?: { status?: number; headers?: Record<string, string> },
+): Response {
+  return new Response(body, {
+    status: init?.status ?? 200,
+    headers: init?.headers ?? { "Content-Type": "application/json" },
+  });
+}
+
+/**
+ * Cast helper — Bun's `mock()` return type is missing `preconnect`,
+ * which `typeof fetch` requires. Tests only exercise the call-path,
+ * so the cast is safe.
+ */
+function asFetchFn<T extends (...args: never[]) => unknown>(
+  fn: T,
+): typeof fetch {
+  return fn as unknown as typeof fetch;
+}
+
+const VALID_JSON = JSON.stringify({
+  data: { packageSummary: { package: { name: "express" } } },
+});
+
+describe("postPkgseerGraphql", () => {
+  const ENDPOINT = "https://pkgseer.dev";
+  const TOKEN = "test-token";
+
+  let originalDebug: string | undefined;
+
+  beforeEach(() => {
+    originalDebug = process.env.GITHITS_DEBUG;
+    delete process.env.GITHITS_DEBUG;
+  });
+
+  afterEach(() => {
+    if (originalDebug === undefined) {
+      delete process.env.GITHITS_DEBUG;
+    } else {
+      process.env.GITHITS_DEBUG = originalDebug;
+    }
+  });
+
+  it("returns structured response for 200 + valid JSON", async () => {
+    const fetchFn = mock(() => Promise.resolve(makeResponse(VALID_JSON)));
+
+    const result = await postPkgseerGraphql({
+      endpointUrl: ENDPOINT,
+      token: TOKEN,
+      query: "query { x }",
+      variables: { registry: "NPM" },
+      fetchFn: asFetchFn(fetchFn),
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.responseBody).toBe(VALID_JSON);
+    expect(result.parsedBody).toEqual(JSON.parse(VALID_JSON));
+  });
+
+  it("returns parsedBody: null for 200 + invalid JSON", async () => {
+    const fetchFn = mock(() =>
+      Promise.resolve(
+        makeResponse("not-json", {
+          headers: { "Content-Type": "text/plain" },
+        }),
+      ),
+    );
+
+    const result = await postPkgseerGraphql({
+      endpointUrl: ENDPOINT,
+      token: TOKEN,
+      query: "query { x }",
+      variables: {},
+      fetchFn: asFetchFn(fetchFn),
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.responseBody).toBe("not-json");
+    expect(result.parsedBody).toBe(null);
+  });
+
+  it("returns structured response for 5xx + JSON body (does not throw)", async () => {
+    const body = JSON.stringify({ detail: "upstream exploded" });
+    const fetchFn = mock(() =>
+      Promise.resolve(makeResponse(body, { status: 502 })),
+    );
+
+    const result = await postPkgseerGraphql({
+      endpointUrl: ENDPOINT,
+      token: TOKEN,
+      query: "query { x }",
+      variables: {},
+      fetchFn: asFetchFn(fetchFn),
+    });
+
+    expect(result.status).toBe(502);
+    expect(result.responseBody).toBe(body);
+    expect(result.parsedBody).toEqual({ detail: "upstream exploded" });
+  });
+
+  it("returns parsedBody: null for 5xx + plain-text body", async () => {
+    const fetchFn = mock(() =>
+      Promise.resolve(
+        makeResponse("Server Error", {
+          status: 500,
+          headers: { "Content-Type": "text/plain" },
+        }),
+      ),
+    );
+
+    const result = await postPkgseerGraphql({
+      endpointUrl: ENDPOINT,
+      token: TOKEN,
+      query: "query { x }",
+      variables: {},
+      fetchFn: asFetchFn(fetchFn),
+    });
+
+    expect(result.status).toBe(500);
+    expect(result.responseBody).toBe("Server Error");
+    expect(result.parsedBody).toBe(null);
+  });
+
+  it("sends Authorization, Content-Type, and User-Agent headers", async () => {
+    let capturedHeaders: Record<string, string> | undefined;
+    const fetchFn = mock((_url: string, init?: RequestInit) => {
+      capturedHeaders = init?.headers as Record<string, string>;
+      return Promise.resolve(makeResponse(VALID_JSON));
+    });
+
+    await postPkgseerGraphql({
+      endpointUrl: ENDPOINT,
+      token: TOKEN,
+      query: "query { x }",
+      variables: {},
+      fetchFn: asFetchFn(fetchFn),
+    });
+
+    expect(capturedHeaders?.Authorization).toBe(`Bearer ${TOKEN}`);
+    expect(capturedHeaders?.["Content-Type"]).toBe("application/json");
+    expect(capturedHeaders?.["User-Agent"]).toMatch(/^githits-cli\/\S+$/);
+  });
+
+  it("normalises trailing slashes on endpointUrl", async () => {
+    let capturedUrl: string | undefined;
+    const fetchFn = mock((url: string) => {
+      capturedUrl = url;
+      return Promise.resolve(makeResponse(VALID_JSON));
+    });
+
+    await postPkgseerGraphql({
+      endpointUrl: "https://pkgseer.dev///",
+      token: TOKEN,
+      query: "query { x }",
+      variables: {},
+      fetchFn: asFetchFn(fetchFn),
+    });
+
+    expect(capturedUrl).toBe("https://pkgseer.dev/api/graphql");
+  });
+
+  it("calls fetchFn exactly once per request", async () => {
+    const fetchFn = mock(() => Promise.resolve(makeResponse(VALID_JSON)));
+
+    await postPkgseerGraphql({
+      endpointUrl: ENDPOINT,
+      token: TOKEN,
+      query: "query { x }",
+      variables: {},
+      fetchFn: asFetchFn(fetchFn),
+    });
+
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws PkgseerTransportError when fetch rejects (DNS/socket/abort)", async () => {
+    const cause = new Error("ENOTFOUND");
+    cause.name = "TypeError";
+    const fetchFn = mock(() => Promise.reject(cause));
+
+    try {
+      await postPkgseerGraphql({
+        endpointUrl: ENDPOINT,
+        token: TOKEN,
+        query: "query { x }",
+        variables: {},
+        fetchFn: asFetchFn(fetchFn),
+      });
+      throw new Error("expected PkgseerTransportError");
+    } catch (error) {
+      expect(error).toBeInstanceOf(PkgseerTransportError);
+      expect((error as PkgseerTransportError).cause).toBe(cause);
+    }
+  });
+
+  it("does not retry on 401 — caller owns refresh (negative scope assertion)", async () => {
+    const fetchFn = mock(() =>
+      Promise.resolve(makeResponse("{}", { status: 401 })),
+    );
+
+    const result = await postPkgseerGraphql({
+      endpointUrl: ENDPOINT,
+      token: TOKEN,
+      query: "query { x }",
+      variables: {},
+      fetchFn: asFetchFn(fetchFn),
+    });
+
+    expect(result.status).toBe(401);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("emits one pkg-graphql debug line on transport failure (payload PII-safe)", async () => {
+    process.env.GITHITS_DEBUG = "pkg-graphql";
+
+    const stderrLines: string[] = [];
+    const originalWrite = process.stderr.write.bind(process.stderr);
+    // Capture stderr for the duration of the call.
+    // biome-ignore lint/suspicious/noExplicitAny: test-only monkeypatch
+    process.stderr.write = ((chunk: string | Uint8Array) => {
+      stderrLines.push(
+        typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk),
+      );
+      return true;
+    }) as any;
+
+    try {
+      const fetchFn = mock(() => Promise.reject(new Error("ENOTFOUND")));
+      try {
+        await postPkgseerGraphql({
+          endpointUrl: ENDPOINT,
+          token: TOKEN,
+          query: "query { x }",
+          variables: {},
+          fetchFn: asFetchFn(fetchFn),
+        });
+      } catch {
+        // expected
+      }
+    } finally {
+      process.stderr.write = originalWrite;
+    }
+
+    const combined = stderrLines.join("");
+    expect(combined).toContain('"area":"pkg-graphql"');
+    expect(combined).toContain('"event":"transport-error"');
+    expect(combined).toContain('"hasCause":true');
+    // PII guards: no URL, no token, no query text.
+    expect(combined).not.toContain("pkgseer.dev");
+    expect(combined).not.toContain(TOKEN);
+    expect(combined).not.toContain("query { x }");
+  });
+});

--- a/src/shared/pkgseer-graphql.ts
+++ b/src/shared/pkgseer-graphql.ts
@@ -1,0 +1,131 @@
+/**
+ * Low-level authenticated POST helper for the pkgseer GraphQL
+ * endpoint. Shared by every service that talks to the endpoint.
+ *
+ * Scope boundary — deliberately narrow:
+ * - Owns: URL trailing-slash normalisation, required headers
+ *   (`Authorization`, `Content-Type`, `User-Agent`), one POST attempt,
+ *   optional `fetchFn` injection, structured response shape, transport
+ *   wrapping via {@link PkgseerTransportError}.
+ * - Does NOT own: token refresh, GraphQL-error classification, Zod
+ *   schema validation, HTTP status dispatch. Those live per-service
+ *   so that GraphQL-level `UNAUTHORIZED` (which we only learn *after*
+ *   the POST completes) can still trigger the service's
+ *   `executeWithTokenRefresh` wrapper.
+ *
+ * Return contract:
+ * - On any HTTP response (2xx, 4xx, 5xx): returns
+ *   `{ status, responseBody, parsedBody }`. `parsedBody` is the
+ *   JSON-parsed body when valid JSON, otherwise `null`. **Never
+ *   throws for a completed response**, regardless of status.
+ * - On fetch rejection (DNS, socket, abort): emits one
+ *   `pkg-graphql` debug line, then throws
+ *   {@link PkgseerTransportError} preserving the rejection `cause`.
+ */
+
+import { version } from "../../package.json";
+import { debugLog } from "./debug-log.js";
+
+export interface PkgseerGraphqlRequest {
+  /** Full endpoint URL, e.g. `https://pkgseer.dev`. Trailing slashes tolerated. */
+  endpointUrl: string;
+  /** Resolved bearer token. Caller is responsible for obtaining + refreshing. */
+  token: string;
+  /** GraphQL query string. */
+  query: string;
+  /** GraphQL variables object. */
+  variables: Record<string, unknown>;
+  /** Fetch implementation — defaults to `globalThis.fetch`. Injected for tests. */
+  fetchFn?: typeof fetch;
+  /** Override `User-Agent`. Defaults to `githits-cli/<version>`. */
+  userAgent?: string;
+}
+
+export interface PkgseerGraphqlResponse {
+  status: number;
+  responseBody: string;
+  /**
+   * `responseBody` parsed as JSON when valid; `null` when the body is
+   * empty, malformed, or not a JSON object. Callers decide whether
+   * `null` is an error (e.g. 200 + null → malformed-response) or
+   * expected (e.g. 5xx + plain-text body → fall through to raw text).
+   */
+  parsedBody: unknown;
+}
+
+/**
+ * Thrown when `fetch` itself rejects — no HTTP response reached the
+ * caller. Distinct from HTTP-level errors (which surface as a normal
+ * response with non-2xx `status`). Callers catch and re-wrap into
+ * their domain `NetworkError` class.
+ */
+export class PkgseerTransportError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = "PkgseerTransportError";
+  }
+}
+
+/**
+ * Normalise the endpoint base URL by stripping trailing slashes. The
+ * helper appends `/api/graphql` itself so callers don't repeat the
+ * path fragment.
+ */
+function baseUrl(endpointUrl: string): string {
+  return endpointUrl.replace(/\/+$/, "");
+}
+
+/**
+ * One authenticated POST to the pkgseer GraphQL endpoint. See module
+ * comment for the scope boundary.
+ */
+export async function postPkgseerGraphql(
+  request: PkgseerGraphqlRequest,
+): Promise<PkgseerGraphqlResponse> {
+  const fetchFn = request.fetchFn ?? globalThis.fetch;
+  const userAgent = request.userAgent ?? `githits-cli/${version}`;
+
+  let response: Response;
+  try {
+    response = await fetchFn(`${baseUrl(request.endpointUrl)}/api/graphql`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${request.token}`,
+        "Content-Type": "application/json",
+        "User-Agent": userAgent,
+      },
+      body: JSON.stringify({
+        query: request.query,
+        variables: request.variables,
+      }),
+    });
+  } catch (cause) {
+    debugLog("pkg-graphql", {
+      event: "transport-error",
+      errorName: cause instanceof Error ? cause.name : typeof cause,
+      hasCause: true,
+    });
+    throw new PkgseerTransportError(
+      "Network request failed before a response was received. Caller should re-wrap with a domain-specific message.",
+      { cause },
+    );
+  }
+
+  const responseBody = await response.text().catch(() => "");
+  const parsedBody = parseJsonOrNull(responseBody);
+
+  return {
+    status: response.status,
+    responseBody,
+    parsedBody,
+  };
+}
+
+function parseJsonOrNull(body: string): unknown {
+  if (!body) return null;
+  try {
+    return JSON.parse(body);
+  } catch {
+    return null;
+  }
+}

--- a/src/shared/pkgseer-registry.test.ts
+++ b/src/shared/pkgseer-registry.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "bun:test";
+import {
+  isKnownPkgseerRegistryArg,
+  knownPkgseerRegistryArgs,
+  type PkgseerRegistry,
+  type PkgseerRegistryArg,
+  toPkgseerRegistry,
+  toPkgseerRegistryLowercase,
+} from "./pkgseer-registry.js";
+
+describe("toPkgseerRegistry", () => {
+  it("maps every lowercase surface value to its uppercase backend enum", () => {
+    const cases: Array<[PkgseerRegistryArg, PkgseerRegistry]> = [
+      ["npm", "NPM"],
+      ["pypi", "PYPI"],
+      ["hex", "HEX"],
+      ["crates", "CRATES"],
+      ["nuget", "NUGET"],
+      ["maven", "MAVEN"],
+      ["zig", "ZIG"],
+      ["vcpkg", "VCPKG"],
+      ["packagist", "PACKAGIST"],
+    ];
+
+    for (const [arg, expected] of cases) {
+      expect(toPkgseerRegistry(arg)).toBe(expected);
+    }
+  });
+});
+
+describe("toPkgseerRegistryLowercase", () => {
+  it("round-trips every uppercase enum back to its lowercase arg", () => {
+    for (const arg of knownPkgseerRegistryArgs()) {
+      expect(toPkgseerRegistryLowercase(toPkgseerRegistry(arg))).toBe(arg);
+    }
+  });
+});
+
+describe("isKnownPkgseerRegistryArg", () => {
+  it("accepts every registered lowercase surface value", () => {
+    for (const arg of knownPkgseerRegistryArgs()) {
+      expect(isKnownPkgseerRegistryArg(arg)).toBe(true);
+    }
+  });
+
+  it("rejects unknown strings", () => {
+    expect(isKnownPkgseerRegistryArg("NPM")).toBe(false);
+    expect(isKnownPkgseerRegistryArg("foobar")).toBe(false);
+    expect(isKnownPkgseerRegistryArg("")).toBe(false);
+  });
+});

--- a/src/shared/pkgseer-registry.ts
+++ b/src/shared/pkgseer-registry.ts
@@ -1,0 +1,73 @@
+/**
+ * Registry taxonomy shared by code-navigation and package-intelligence
+ * services. Single source of truth for:
+ *
+ * - `PkgseerRegistry` — the uppercase backend enum (what GraphQL expects).
+ * - `PkgseerRegistryArg` — the lowercase surface value (CLI + MCP input).
+ * - Lowercase ↔ uppercase conversion.
+ *
+ * Back-compat: `src/shared/code-navigation.ts` re-exports these under
+ * the existing `CodeNavigationRegistry*` names.
+ */
+
+export type PkgseerRegistry =
+  | "NPM"
+  | "PYPI"
+  | "HEX"
+  | "CRATES"
+  | "NUGET"
+  | "MAVEN"
+  | "ZIG"
+  | "VCPKG"
+  | "PACKAGIST";
+
+const registryMap = {
+  npm: "NPM",
+  pypi: "PYPI",
+  hex: "HEX",
+  crates: "CRATES",
+  nuget: "NUGET",
+  maven: "MAVEN",
+  zig: "ZIG",
+  vcpkg: "VCPKG",
+  packagist: "PACKAGIST",
+} as const satisfies Record<string, PkgseerRegistry>;
+
+export type PkgseerRegistryArg = keyof typeof registryMap;
+
+/**
+ * Lowercase surface value → uppercase backend enum. Exhaustive over
+ * the surface union; callers that pass arbitrary strings should
+ * validate via {@link isKnownPkgseerRegistryArg} first.
+ */
+export function toPkgseerRegistry(
+  registry: PkgseerRegistryArg,
+): PkgseerRegistry {
+  return registryMap[registry];
+}
+
+/**
+ * Uppercase backend enum → lowercase surface value. Used when
+ * lowering a response field for user display.
+ */
+export function toPkgseerRegistryLowercase(
+  registry: PkgseerRegistry,
+): PkgseerRegistryArg {
+  for (const [lower, upper] of Object.entries(registryMap)) {
+    if (upper === registry) return lower as PkgseerRegistryArg;
+  }
+  // Exhaustive over `PkgseerRegistry`; only reachable on schema drift.
+  throw new Error(
+    `Unknown registry value: ${String(registry)} (schema drift?)`,
+  );
+}
+
+export function isKnownPkgseerRegistryArg(
+  value: string,
+): value is PkgseerRegistryArg {
+  return value in registryMap;
+}
+
+export function knownPkgseerRegistryArgs(): ReadonlyArray<PkgseerRegistryArg> {
+  return Object.keys(registryMap) as PkgseerRegistryArg[];
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,4 +1,5 @@
 export { createFeedbackTool } from "./feedback.js";
+export { createPackageSummaryTool } from "./package-summary.js";
 export { createSearchTool } from "./search.js";
 export { createSearchLanguageTool } from "./search-language.js";
 export { createSearchSymbolsTool } from "./search-symbols.js";

--- a/src/tools/package-summary-parity.test.ts
+++ b/src/tools/package-summary-parity.test.ts
@@ -1,0 +1,211 @@
+// PARITY TEST — enforces rule IDs from docs/implementation/mcp-cli-parity.md:
+//   PARITY-JSON-KEYS       CLI --json output and MCP text payload parse to
+//                          deepEqual JSON objects for equivalent inputs.
+//   PARITY-ERROR-ENVELOPE  Both surfaces emit { error, code, retryable, details? }
+//                          on every error path; MCP error text is always valid
+//                          JSON.
+//
+// Assertion policy (locked to match shipped `search_symbols` precedent):
+//   - Success fixtures + service-sourced error fixtures → `toEqual`.
+//     Both surfaces route through the same classifier / envelope builder,
+//     so envelopes are byte-identical.
+//   - INVALID_ARGUMENT fixture (empty `packageName`) → `toMatchObject`.
+//     CLI rejects in `parsePackageSpec` / `buildPackageSummaryParams`;
+//     MCP rejects in `buildPackageSummaryParams` inside the handler
+//     (schema is permissive). Both land on INVALID_ARGUMENT with
+//     `retryable: false`, but the surface-specific validator produces
+//     different `error` text — that divergence is intentional.
+//
+// Rule IDs are stable; changes to either this test or the parity doc
+// are coordinated.
+
+import { describe, expect, it, mock, spyOn } from "bun:test";
+import {
+  type PkgInfoCommandDependencies,
+  pkgInfoAction,
+} from "../commands/pkg/info.js";
+import {
+  PackageIntelligenceBackendError,
+  PackageIntelligenceTargetNotFoundError,
+} from "../services/index.js";
+import {
+  createMockPackageIntelligenceService,
+  defaultPackageSummary,
+} from "../services/test-helpers.js";
+import { createPackageSummaryTool } from "./package-summary.js";
+
+function cliDeps(
+  overrides: Partial<PkgInfoCommandDependencies> = {},
+): PkgInfoCommandDependencies {
+  return {
+    packageIntelligenceService: createMockPackageIntelligenceService(),
+    codeNavigationUrl: "https://pkgseer.dev",
+    hasValidToken: true,
+    mcpUrl: "https://mcp.example.com",
+    ...overrides,
+  };
+}
+
+async function cliJson(
+  spec: string,
+  deps: PkgInfoCommandDependencies = cliDeps(),
+): Promise<unknown> {
+  const logSpy = spyOn(console, "log").mockImplementation(() => {});
+  const errSpy = spyOn(console, "error").mockImplementation(() => {});
+  const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+    throw new Error("process.exit");
+  });
+  try {
+    try {
+      await pkgInfoAction(spec, { json: true }, deps);
+    } catch {
+      // CLI error paths call process.exit — caught.
+    }
+    const fromLog = logSpy.mock.calls[0]?.[0] as string | undefined;
+    const fromErr = errSpy.mock.calls[0]?.[0] as string | undefined;
+    const raw = fromLog ?? fromErr;
+    return raw ? JSON.parse(raw) : undefined;
+  } finally {
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+    exitSpy.mockRestore();
+  }
+}
+
+async function mcpJson(
+  args: { registry: string; package_name: string },
+  packageSummaryMock?: () => Promise<unknown>,
+): Promise<{ json: unknown; isError: boolean | undefined }> {
+  const service = createMockPackageIntelligenceService(
+    packageSummaryMock ? { packageSummary: packageSummaryMock as never } : {},
+  );
+  const tool = createPackageSummaryTool(service);
+  const result = await tool.handler(args, {});
+  const text = result.content[0]?.text ?? "";
+  return {
+    json: JSON.parse(text),
+    isError: result.isError,
+  };
+}
+
+describe("package_summary parity", () => {
+  it("PARITY-JSON-KEYS: happy path CLI === MCP", async () => {
+    const cli = await cliJson("npm:express");
+    const { json, isError } = await mcpJson({
+      registry: "npm",
+      package_name: "express",
+    });
+    expect(isError).toBeUndefined();
+    expect(cli).toEqual(json);
+  });
+
+  it("PARITY-JSON-KEYS: minimal-fields success CLI === MCP", async () => {
+    const minimal = {
+      package: {
+        name: "obscure",
+        latestVersion: "0.0.1",
+      },
+    };
+    const packageSummary = mock(() => Promise.resolve(minimal));
+    const service = createMockPackageIntelligenceService({
+      packageSummary: packageSummary as never,
+    });
+
+    const cli = await cliJson(
+      "npm:obscure",
+      cliDeps({ packageIntelligenceService: service }),
+    );
+    const { json } = await mcpJson(
+      { registry: "npm", package_name: "obscure" },
+      packageSummary as never,
+    );
+
+    expect(cli).toEqual(json);
+  });
+
+  it("PARITY-ERROR-ENVELOPE: NOT_FOUND CLI === MCP", async () => {
+    const error = new PackageIntelligenceTargetNotFoundError(
+      "Package 'npm:ghost' not found.",
+    );
+    const packageSummary = mock(() => Promise.reject(error));
+    const service = createMockPackageIntelligenceService({
+      packageSummary: packageSummary as never,
+    });
+
+    const cli = await cliJson(
+      "npm:ghost",
+      cliDeps({ packageIntelligenceService: service }),
+    );
+    const { json, isError } = await mcpJson(
+      { registry: "npm", package_name: "ghost" },
+      packageSummary as never,
+    );
+
+    expect(isError).toBe(true);
+    expect(cli).toEqual(json);
+    expect(cli).toEqual({
+      error: "Package 'npm:ghost' not found.",
+      code: "NOT_FOUND",
+      retryable: false,
+    });
+  });
+
+  it("PARITY-ERROR-ENVELOPE: BACKEND_ERROR CLI === MCP", async () => {
+    const error = new PackageIntelligenceBackendError(
+      "upstream timed out",
+      504,
+      "TIMEOUT",
+    );
+    const packageSummary = mock(() => Promise.reject(error));
+    const service = createMockPackageIntelligenceService({
+      packageSummary: packageSummary as never,
+    });
+
+    const cli = await cliJson(
+      "npm:express",
+      cliDeps({ packageIntelligenceService: service }),
+    );
+    const { json, isError } = await mcpJson(
+      { registry: "npm", package_name: "express" },
+      packageSummary as never,
+    );
+
+    expect(isError).toBe(true);
+    expect(cli).toEqual(json);
+    expect(cli).toMatchObject({
+      code: "TIMEOUT",
+      retryable: true,
+      error: "upstream timed out",
+    });
+  });
+
+  it("PARITY-ERROR-ENVELOPE: INVALID_ARGUMENT (empty packageName) — shape match via toMatchObject", async () => {
+    // CLI: parsePackageSpec rejects the bare "npm:" (no name) via
+    // InvalidPackageSpecError. MCP: buildPackageSummaryParams rejects
+    // the empty package_name with InvalidPackageSpecError too. The
+    // two surfaces share the classifier but produce different error
+    // text — same shape, different message.
+    const cli = await cliJson("npm:");
+    const { json, isError } = await mcpJson({
+      registry: "npm",
+      package_name: "",
+    });
+
+    expect(isError).toBe(true);
+    expect(cli).toMatchObject({
+      code: "INVALID_ARGUMENT",
+      retryable: false,
+      error: expect.any(String),
+    });
+    expect(json).toMatchObject({
+      code: "INVALID_ARGUMENT",
+      retryable: false,
+      error: expect.any(String),
+    });
+    // Both envelopes must contain the same recognisable shape even
+    // when the wording differs.
+    expect(Object.keys(cli as object).sort()).toEqual(
+      Object.keys(json as object).sort(),
+    );
+  });
+});

--- a/src/tools/package-summary.test.ts
+++ b/src/tools/package-summary.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, mock } from "bun:test";
+import { PackageIntelligenceTargetNotFoundError } from "../services/index.js";
+import {
+  createMockPackageIntelligenceService,
+  defaultPackageSummary,
+} from "../services/test-helpers.js";
+import { createPackageSummaryTool } from "./package-summary.js";
+
+function parseText(result: { content: Array<{ text: string }> }): unknown {
+  return JSON.parse(result.content[0]?.text ?? "");
+}
+
+describe("createPackageSummaryTool — metadata", () => {
+  it("registers the correct tool name, description, and schema keys", () => {
+    const tool = createPackageSummaryTool(
+      createMockPackageIntelligenceService(),
+    );
+    expect(tool.name).toBe("package_summary");
+    expect(tool.description).toContain("package overview");
+    expect(Object.keys(tool.schema)).toEqual(["registry", "package_name"]);
+    expect(tool.annotations?.readOnlyHint).toBe(true);
+  });
+});
+
+describe("createPackageSummaryTool — happy path", () => {
+  it("calls service.packageSummary with normalised params (uppercase registry)", async () => {
+    const packageSummary = mock(() => Promise.resolve(defaultPackageSummary));
+    const service = createMockPackageIntelligenceService({ packageSummary });
+    const tool = createPackageSummaryTool(service);
+
+    await tool.handler({ registry: "npm", package_name: "express" }, {});
+
+    expect(packageSummary).toHaveBeenCalledTimes(1);
+    const calls = packageSummary.mock.calls as unknown as Array<
+      [{ registry: string; packageName: string }]
+    >;
+    expect(calls[0]?.[0]?.registry).toBe("NPM");
+    expect(calls[0]?.[0]?.packageName).toBe("express");
+  });
+
+  it("returns JSON-stringified lean envelope in content[0].text on success", async () => {
+    const tool = createPackageSummaryTool(
+      createMockPackageIntelligenceService(),
+    );
+    const result = await tool.handler(
+      { registry: "npm", package_name: "express" },
+      {},
+    );
+    expect(result.isError).toBeUndefined();
+    const payload = parseText(result) as Record<string, unknown>;
+    expect(payload.registry).toBe("npm");
+    expect(payload.name).toBe("express");
+    expect(payload.version).toBe("4.18.2");
+  });
+});
+
+describe("createPackageSummaryTool — validation errors via in-handler builder", () => {
+  it("returns INVALID_ARGUMENT envelope for unknown registry", async () => {
+    const tool = createPackageSummaryTool(
+      createMockPackageIntelligenceService(),
+    );
+    const result = await tool.handler(
+      { registry: "cargo", package_name: "serde" },
+      {},
+    );
+    expect(result.isError).toBe(true);
+    const payload = parseText(result) as {
+      code: string;
+      retryable: boolean;
+      error: string;
+    };
+    expect(payload.code).toBe("INVALID_ARGUMENT");
+    expect(payload.retryable).toBe(false);
+    expect(payload.error.toLowerCase()).toContain("registry");
+  });
+
+  it("returns INVALID_ARGUMENT envelope for empty package_name", async () => {
+    const tool = createPackageSummaryTool(
+      createMockPackageIntelligenceService(),
+    );
+    const result = await tool.handler(
+      { registry: "npm", package_name: "" },
+      {},
+    );
+    expect(result.isError).toBe(true);
+    const payload = parseText(result) as { code: string };
+    expect(payload.code).toBe("INVALID_ARGUMENT");
+  });
+
+  it("returns INVALID_ARGUMENT envelope for whitespace-only package_name", async () => {
+    const tool = createPackageSummaryTool(
+      createMockPackageIntelligenceService(),
+    );
+    const result = await tool.handler(
+      { registry: "npm", package_name: "   " },
+      {},
+    );
+    expect(result.isError).toBe(true);
+    const payload = parseText(result) as { code: string };
+    expect(payload.code).toBe("INVALID_ARGUMENT");
+  });
+});
+
+describe("createPackageSummaryTool — service errors", () => {
+  it("classifies PackageIntelligenceTargetNotFoundError as NOT_FOUND envelope", async () => {
+    const service = createMockPackageIntelligenceService({
+      packageSummary: mock(() =>
+        Promise.reject(
+          new PackageIntelligenceTargetNotFoundError("Package not found"),
+        ),
+      ),
+    });
+    const tool = createPackageSummaryTool(service);
+    const result = await tool.handler(
+      { registry: "npm", package_name: "ghost" },
+      {},
+    );
+    expect(result.isError).toBe(true);
+    const payload = parseText(result) as {
+      code: string;
+      error: string;
+      retryable: boolean;
+    };
+    expect(payload.code).toBe("NOT_FOUND");
+    expect(payload.retryable).toBe(false);
+    expect(payload.error).toBe("Package not found");
+  });
+
+  it("classifies unexpected Error as UNKNOWN envelope", async () => {
+    const service = createMockPackageIntelligenceService({
+      packageSummary: mock(() => Promise.reject(new Error("boom"))),
+    });
+    const tool = createPackageSummaryTool(service);
+    const result = await tool.handler(
+      { registry: "npm", package_name: "express" },
+      {},
+    );
+    expect(result.isError).toBe(true);
+    const payload = parseText(result) as { code: string };
+    expect(payload.code).toBe("UNKNOWN");
+  });
+});

--- a/src/tools/package-summary.ts
+++ b/src/tools/package-summary.ts
@@ -1,0 +1,75 @@
+import { z } from "zod";
+import type { PackageIntelligenceService } from "../services/index.js";
+import { mapPackageIntelligenceError } from "../shared/package-intelligence-error-map.js";
+import { buildPackageSummaryParams } from "../shared/package-summary-request.js";
+import { buildPackageSummarySuccessPayload } from "../shared/package-summary-response.js";
+import { type ToolDefinition, textResult } from "./types.js";
+
+export interface PackageSummaryArgs {
+  registry: string;
+  package_name: string;
+}
+
+/**
+ * Permissive schema by design — validation happens inside the handler
+ * via `buildPackageSummaryParams`. That way, malformed input produces
+ * the structured `{error, code, retryable}` envelope (same as CLI),
+ * rather than a raw Zod error that agents would have to parse
+ * separately. See `search_symbols` precedent.
+ */
+const schema = {
+  registry: z
+    .string()
+    .describe(
+      "Package registry. One of: npm, pypi, hex, crates, nuget, maven, zig, vcpkg, packagist.",
+    ),
+  package_name: z
+    .string()
+    .describe("Package name (scoped names ok: @types/node)."),
+};
+
+const DESCRIPTION =
+  "Get a package overview — latest version, license, description, " +
+  "repository, downloads, GitHub stars, install command, and a count " +
+  "of known vulnerabilities. Use before recommending a package or to " +
+  "orient on what a dependency is. Works across npm, PyPI, Hex, " +
+  "Crates, NuGet, Maven, Packagist, vcpkg, Zig. Always returns data " +
+  "for the latest published version.";
+
+export function createPackageSummaryTool(
+  service: PackageIntelligenceService,
+): ToolDefinition<PackageSummaryArgs, typeof schema> {
+  return {
+    name: "package_summary",
+    description: DESCRIPTION,
+    schema,
+    annotations: { readOnlyHint: true },
+    handler: async (args) => {
+      try {
+        const { params } = buildPackageSummaryParams({
+          registry: args.registry,
+          packageName: args.package_name,
+        });
+        const summary = await service.packageSummary(params);
+        const payload = buildPackageSummarySuccessPayload(summary);
+        return textResult(JSON.stringify(payload));
+      } catch (error) {
+        const mapped = mapPackageIntelligenceError(error);
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({
+                error: mapped.message,
+                code: mapped.code,
+                retryable: mapped.retryable ?? false,
+                ...(mapped.details ? { details: mapped.details } : {}),
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+    },
+  };
+}


### PR DESCRIPTION
## Summary

First user-visible tool in the package-intelligence wave, landing behind the existing `code_navigation` capability gate.

- **`githits pkg info <spec>`** — CLI command rendering a concise terminal block with latest version, license, description, repository, downloads, GitHub metadata, install command, and known vulnerabilities. `--verbose` adds advisories, usage snippet, topics, and recent changes. `--json` emits a lean hand-crafted envelope where every null block is omitted whole.
- **`package_summary`** — MCP tool with the same envelope. Permissive Zod schema + in-handler validation via `buildPackageSummaryParams` produces the structured `{error, code, retryable, details?}` envelope (same shape as `search_symbols`) instead of surfacing raw Zod errors to agents.

`@version` in the spec is rejected with `INVALID_ARGUMENT` rather than silently swapping to latest — silent swap would break security-testing workflows on pinned older vulnerable releases.

## Commits (kept separate on purpose)

1. **`refactor: extract pkgseer-graphql and pkgseer-registry shared helpers`** — touches shipped code. Mechanical POST helper moves to `src/shared/pkgseer-graphql.ts`; registry map to `src/shared/pkgseer-registry.ts` (re-exported under old names for back-compat). `CodeNavigationServiceImpl` refactored to use the helper with a `PkgseerTransportError` catch. Shipped `code-navigation-service.test.ts` passes unchanged.
2. **`feat(pkg-intel): add package_summary tool and pkg info CLI command`** — service, error map, envelope builder, terminal formatter, MCP tool, CLI command + gate, parity test (5 fixtures), docs. Not yet registered.
3. **`feat(pkg-intel): register pkg group and package_summary MCP tool`** — the smallest commit that flips the feature from invisible to visible. Bisection anchor.

Kept separate so `git bisect` can pivot cleanly between "refactor only", "feature built but hidden", and "feature visible" if a `search_symbols` regression ever appears.

## Notable decisions

- **Token-efficient JSON.** The lean envelope drops backend metadata (`schemaVersion`, `downloadsRefreshedAt`, `versionCount`, duplicate GitHub identifiers) and omits null/zero-total blocks whole. Severity labels follow CVSS banding (≥9 critical, ≥7 high, ≥4 medium, else low). UTC date trim keeps output byte-stable across machines.
- **Permissive MCP schema.** Matches the `search_symbols` pattern. `buildPackageSummaryParams` is the single validator used by both surfaces, so envelope parity holds across CLI and MCP for invalid input.
- **`@version` rejection.** Bare domain message to stderr (`pkg info always returns the latest version; omit @4.18.0.`); structured envelope to stderr under `--json`. No silent swap.
- **Transport scope.** `postPkgseerGraphql` never throws for a completed HTTP response. Services keep `executeWithTokenRefresh`, GraphQL classification, `parseDetail`, and Zod validation so GraphQL-level `UNAUTHORIZED` (classified after a 2xx POST) still triggers refresh.
- **Gate layers.** Argv eager-load in `src/cli.ts`, capability gate inside each `registerXxxCommandGroup`, narrower MCP predicate in `getMcpToolDefinitions`. Half-open invariant tested: `package_summary` advertised ⇒ `search_symbols` advertised.
- **Parity assertion policy.** `toEqual` for service-sourced fixtures (happy, minimal-fields, `NOT_FOUND`, `BACKEND_ERROR`); `toMatchObject` for `INVALID_ARGUMENT` where CLI and MCP produce the same envelope shape but surface-specific error text.

## Tests

- `bun test` — 673 pass, 0 fail, 1445 `expect()` calls. ~100 new cases.
- `bun run typecheck` / `bun run build` / `bun run lint` — clean.
- Existing `code-navigation-service.test.ts` (20 tests) passes unchanged after the refactor.

## Live-backend smoke

Verified against the real pkgseer endpoint:

- [x] `pkg info npm:express` — default terminal block renders
- [x] `pkg info pypi:requests` / `crates:serde` / `hex:phoenix` — registries covered
- [x] `pkg info npm:@types/node` — scoped npm names
- [x] `pkg info npm:express@4.18.0` — exits 1 with `INVALID_ARGUMENT`, no silent swap
- [x] `pkg info npm:__nonexistent__` — exits 1 with `Package not found` (stderr)
- [x] `pkg info npm:express --verbose` — advisories, usage, topics, recent changes
- [x] `pkg info npm:express --json | jq .` — parses cleanly; no `undefined` values
- [x] `GITHITS_CODE_NAV_URL=<bad-host>` — renders neutral `Could not reach the package intelligence service.` (no backend name leak)
- [x] `GITHITS_DEBUG=pkg-intel` — single-line PII-safe JSON on error paths
- [x] MCP `tools/list` + `tools/call` — end-to-end over stdio

## Test plan

- [ ] `bun test` passes
- [ ] `bun run typecheck` clean
- [ ] `bun run build` clean
- [ ] `bun run lint` clean
- [ ] Manual smoke of the 9 scenarios above against a token that has `code_navigation` capability
- [ ] MCP stdio: `tools/list` shows `package_summary` under a gate-open token, absent under a gate-closed token
- [ ] `pkg info --help` renders under an open-gate token; absent under closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)