### PR TITLE
feat(pkg-intel): add package_vulnerabilities (pkg vulns + MCP)

### DIFF
--- a/docs/implementation/cli-commands.md
+++ b/docs/implementation/cli-commands.md
@@ -14,6 +14,7 @@ The CLI exposes three primary commands (`search`, `languages`, `feedback`) that 
 | `feedback <solution_id>` | `--accept` or `--reject` | `-m, --message <text>`, `--json` | Submit feedback on a search result |
 | `code search <package> [query]` | package spec | `--keywords`, `--keyword`, `--match-mode`, `--category`, `--kind`, `--file`, `--intent`, `--limit`, `--wait`, `--json` | Search indexed dependency source code |
 | `pkg info <spec>` | package spec | `--verbose`, `--json` | Show a package overview (latest version, downloads, license, vulnerabilities) |
+| `pkg vulns <spec>` | package spec (optional `@version`) | `--severity`, `--include-withdrawn`, `--verbose`, `--json` | List known vulnerabilities for a package (npm/pypi/hex/crates) |
 
 ### `githits init`
 
@@ -100,7 +101,7 @@ Shows a concise overview for a single package: latest version, license, descript
 
 **Package spec.** `<registry>:<name>`. Registries: `npm`, `pypi`, `hex`, `crates`, `nuget`, `maven`, `zig`, `vcpkg`, `packagist`. Scoped npm names (`npm:@types/node`) are supported.
 
-**Always latest.** `pkg info` returns the latest published version regardless of input. Passing `<spec>@<version>` is rejected with `INVALID_ARGUMENT` and a clear message — the tool never silently swaps to latest. Use `pkg vulns` (future) or `pkg deps` (future) for version-pinned queries.
+**Always latest.** `pkg info` returns the latest published version regardless of input. Passing `<spec>@<version>` is rejected with `INVALID_ARGUMENT` and a clear message — the tool never silently swaps to latest. Use `pkg vulns` (supports `@version`) or `pkg deps` (future) for version-pinned queries.
 
 **`--verbose` + `--json`.** `--verbose` has no effect under `--json` — the JSON envelope always carries every field the verbose terminal view exposes (and more). The flag only affects human-readable output.
 
@@ -109,6 +110,44 @@ Shows a concise overview for a single package: latest version, license, descript
 **Capability gate.** Same as `code`: `code_navigation` capability on the token, `GITHITS_CODE_NAVIGATION=1` override, `GITHITS_API_TOKEN` env token, or expired stored auth.
 
 **Troubleshooting.** `GITHITS_DEBUG=pkg-intel` emits PII-safe classified-error diagnostics (area, event, code, error class, detail keys). `GITHITS_DEBUG=pkg-graphql` emits transport-failure diagnostics from inside the POST helper. Use `GITHITS_DEBUG=*` to enable both.
+
+### `githits pkg vulns`
+
+```
+githits pkg vulns npm:express
+githits pkg vulns npm:express@4.17.0
+githits pkg vulns pypi:requests --severity high
+githits pkg vulns crates:serde --json
+githits pkg vulns npm:minimatch --include-withdrawn --verbose
+```
+
+Lists known CVE / OSV advisories for a package: severity, affected version ranges, fix versions, and upgrade targets. Malicious-package advisories (supply-chain attacks flagged by OSV) surface in a separate `MALWARE` bucket that sorts above all CVE advisories.
+
+**Package spec.** `<registry>:<name>[@<version>]`. Unlike `pkg info`, `pkg vulns` supports `@<version>` because the backend query accepts a concrete version (useful for checking an older pinned release). Only `npm`, `pypi`, `hex`, and `crates` support vulnerability data; other registries are rejected client-side with `pkg vulns only supports npm, pypi, hex, and crates. Got: ${registry}.`
+
+**Filtering.** `--severity low|medium|high|critical` maps to a CVSS float threshold (`low=0.1, medium=4, high=7, critical=9`) and goes server-side. The backend's returned `vulnerabilityCount` reflects the filtered set — no client-side filtering, no dual-summary block. Callers wanting the full picture omit the flag. `--include-withdrawn` sends `includeWithdrawn: true` to the backend; withdrawn advisories bucket below active ones in the terminal list.
+
+**Zero-vulns hot path.** The common case (clean package) renders as header + one-line summary body (`No known vulnerabilities.`) — no breakdown, no advisory list, no footer. Agents checking "am I safe?" pay minimal token cost on the happy path.
+
+**Version validation.** `pkg vulns` expects canonical package versions. Tag-style inputs such as `@v4.18.0` are rejected client-side with `INVALID_ARGUMENT` and an actionable message telling the caller to drop the leading `v`, instead of forwarding the request to the backend and surfacing its current generic failure.
+
+**Malware marker.** Advisories with `isMalicious: true` render with a red/bold `MALWARE` column (optionally combined as `MALWARE · crit` when both flags exist). Count surfaces in the summary breakdown line as `N MALWARE · N crit · …`. Buckets partition every returned advisory: `MALWARE + crit + high + medium + low + unrated = advisories.length`, which equals `summary.total` when the backend keeps its count and list consistent. Non-malicious advisories without a CVSS score bucket under `unrated` so the breakdown reconciles with the header total (common for PyPI / Rust advisories where CVSS may be absent).
+
+**Affected-range truncation (terminal-width aware).** The `affected` detail row under each advisory caps at 4 ranges on narrow terminals (≤119 cols), 6 on standard-wide (120–159 cols), and 8 on ultrawide (≥160 cols). The remainder collapses into a dim `… (+N more; use -v)` hint. Verbose mode (`-v`) shows every range. JSON output is never truncated — machine consumers get the full list.
+
+**Unrated severity column.** Advisories with no CVSS score (common on RUSTSEC / PYSEC upstreams) render with a dim `unrated` label in the severity column rather than an empty gutter, matching the header-breakdown vocabulary. They sort below banded advisories within the active bucket.
+
+**Placeholder summary stripping.** When the upstream advisory feed returns the literal string `No summary available` (an OSV convention), both the JSON envelope and the terminal row drop the field entirely — absence of `summary` is the signal, and the advisory row is shorter as a result.
+
+**Upgrade-path ordering.** `upgradePaths` are de-duplicated and sorted ascending by semver-ish comparison (pre-release suffixes rank below the matching base release), so the footer presents the minimum-churn upgrade first: `Upgrade options: 3.11.0, 4.0.0-rc1, 4.5.0, 4.19.2, …` rather than the backend's advisory-iteration order.
+
+**Output envelope.** `{registry, name, version, requestedVersion?, summary: {total, affected?, bySeverity?}, advisories?, upgradePaths?}`. Each advisory: `{id?, aliases?, summary?, severity?, severityLabel?, affectedRanges?, fixedIn?, publishedAt?, modifiedAt?, withdrawnAt?, isMalicious?}`. `modifiedAt` included only when it differs from `publishedAt`. `isMalicious` included only when `true`.
+
+**Exit codes.** 0 on success including zero-vulns; 1 on any error. Under `--json`, the error envelope is written to **stderr**.
+
+**Capability gate.** Same as `pkg info` (inherits from the `code_navigation` token capability).
+
+**Troubleshooting.** Same debug areas as `pkg info` (`GITHITS_DEBUG=pkg-intel` for classified errors; `GITHITS_DEBUG=pkg-graphql` for transport failures).
 
 ## Architecture
 

--- a/docs/implementation/mcp-cli-parity.md
+++ b/docs/implementation/mcp-cli-parity.md
@@ -148,13 +148,18 @@ When a new tool lands with both MCP and CLI surfaces:
 | `src/shared/search-symbols-response.ts` | Shared JSON envelope builders for `search_symbols`. |
 | `src/shared/package-summary-request.ts` | Shared request builder for `package_summary`. |
 | `src/shared/package-summary-response.ts` | Lean JSON envelope builder and terminal formatter for `package_summary`. |
+| `src/shared/package-vulnerabilities-request.ts` | Shared request builder for `package_vulnerabilities`; owns the tool-local `supportsVulnerabilitiesRegistry` predicate and the severity-label → CVSS float map. |
+| `src/shared/package-vulnerabilities-response.ts` | Lean JSON envelope builder for `package_vulnerabilities` (shared); terminal formatter (CLI-only). |
 | `src/shared/package-intelligence-error-map.ts` | `mapPackageIntelligenceError` classifier (reuses `MappedError` from the code-nav map). |
 | `src/tools/search-symbols.ts` | MCP tool definition for `search_symbols`. |
 | `src/tools/package-summary.ts` | MCP tool definition for `package_summary`. |
+| `src/tools/package-vulnerabilities.ts` | MCP tool definition for `package_vulnerabilities`. |
 | `src/commands/code/search-symbols.ts` | CLI command. |
 | `src/commands/pkg/info.ts` | CLI command for `pkg info`. |
+| `src/commands/pkg/vulns.ts` | CLI command for `pkg vulns`. |
 | `src/tools/search-symbols-parity.test.ts` | Parity tests (cite rule IDs). |
 | `src/tools/package-summary-parity.test.ts` | Parity tests for `package_summary` (cite rule IDs). |
+| `src/tools/package-vulnerabilities-parity.test.ts` | Parity tests for `package_vulnerabilities` (cite rule IDs). |
 
 ## Per-tool notes
 
@@ -177,3 +182,51 @@ When a new tool lands with both MCP and CLI surfaces:
 - **`@version` rejection.** CLI-only. The MCP tool has no `version`
   input. The CLI's `pkg info` throws `InvalidPackageSpecError` on
   any non-null parsed version — never silently swaps to latest.
+
+### `package_vulnerabilities`
+
+- **Permissive MCP schema + in-handler validation.** Same pattern as
+  `package_summary`. `buildPackageVulnerabilitiesParams` is the
+  single validator used by both surfaces; raw Zod errors never
+  surface in the envelope.
+- **Filter-aware summary.** `minSeverity` + `includeWithdrawn` go
+  straight to the GraphQL query; the backend's `vulnerabilityCount`
+  reflects the filtered set. No client-side filtering, no
+  `summary.filtered` dual-block.
+- **Partitioning bySeverity buckets.** `summary.bySeverity` carries
+  a `malware` key for `isMalicious === true` advisories; severity
+  bands for non-malicious advisories with a positive CVSS score;
+  and `unrated` for non-malicious advisories with no score. Every
+  returned advisory lands in exactly one bucket — client-side
+  guarantee `MALWARE + crit + high + medium + low + unrated =
+  advisories.length`. The sum also equals `summary.total` whenever
+  the backend keeps `vulnerabilityCount` and `vulnerabilities[]`
+  consistent. Malware advisories sort first in the advisory list
+  regardless of severity score; `unrated` advisories sort last
+  within the active bucket.
+- **Scope of the shared helper.** `buildPackageVulnerabilitiesSuccessPayload`
+  is shared between CLI `--json` and MCP `content[0].text` — that's
+  what enforces envelope parity. The terminal formatter
+  `formatPackageVulnerabilitiesTerminal` is CLI-only (MCP always
+  emits JSON). The parity doc's default rule (CLI-local rendering)
+  still applies to the formatter; the envelope builder is the
+  explicit shared-helper exception.
+- **Parity assertion policy** (coded in
+  `src/tools/package-vulnerabilities-parity.test.ts`):
+  - `toEqual` for the service-sourced fixtures: happy, zero-vulns,
+    filtered-success, versioned-match (no `requestedVersion`),
+    versioned-real-diff (`requestedVersion` present), `NOT_FOUND`,
+    `VERSION_NOT_FOUND` (with structured details), `BACKEND_ERROR`.
+  - `toMatchObject` for builder-sourced `INVALID_ARGUMENT` cases
+    such as unsupported registry (`vcpkg`) and tag-style version
+    input (`v4.18.0`).
+- **Typed `VERSION_NOT_FOUND`.** Mirrors the code-nav precedent:
+  `PackageIntelligenceVersionNotFoundError` carries structured
+  fields sourced from GraphQL `extensions` (`packageName`,
+  `requestedVersion`, `availableVersions`). The classifier emits
+  structured `details` in the error envelope.
+- **Client-side `v`-prefix rejection.** `package_vulnerabilities`
+  validates version strings before the service call. Tag-style
+  inputs like `v4.18.0` are rejected as `INVALID_ARGUMENT` with an
+  actionable message instead of relying on the current production
+  backend, which returns a generic error for that input.

--- a/docs/implementation/tools.md
+++ b/docs/implementation/tools.md
@@ -24,8 +24,9 @@ Both expose the same tools with identical names, parameters, and descriptions. T
 | `feedback` | `solution_id`, `accepted`, `feedback_text?` | Submit feedback on a search result to improve quality. |
 | `search_symbols` | `target`, `query?`, `keywords?`, `match_mode?`, `category?`, `kind?`, `file_path?`, `limit?`, `file_intent?`, `wait_timeout_ms?` | Capability-gated code navigation search over indexed dependency source. |
 | `package_summary` | `registry`, `package_name` | Package overview: latest version, license, description, repository, downloads, GitHub metadata, install command, and known vulnerabilities. Always returns the latest published version. |
+| `package_vulnerabilities` | `registry`, `package_name`, `version?`, `min_severity?`, `include_withdrawn?` | Known vulnerabilities for a package on npm, PyPI, Hex, or Crates. Count summary, per-advisory OSV ID + severity + affected/fix ranges, and upgrade paths. Malware is surfaced in a disjoint bucket. |
 
-`search_symbols` and `package_summary` are only registered when the startup token advertises `code_navigation` capability. The backend endpoint can be overridden via `GITHITS_CODE_NAV_URL` for local development. Capability gating keeps the tools hidden from public/default flows while the feature is still rolling out.
+`search_symbols`, `package_summary`, and `package_vulnerabilities` are only registered when the startup token advertises `code_navigation` capability. The backend endpoint can be overridden via `GITHITS_CODE_NAV_URL` for local development. Capability gating keeps the tools hidden from public/default flows while the feature is still rolling out.
 
 `search_symbols` shares request-construction, error classification, and JSON-payload shape with the CLI `githits code search` command via shared helpers under `src/shared/`. The parity rules are codified in [`mcp-cli-parity.md`](./mcp-cli-parity.md); the parity test (`src/tools/search-symbols-parity.test.ts`) asserts that both surfaces emit identical JSON for equivalent inputs.
 
@@ -42,6 +43,22 @@ Both expose the same tools with identical names, parameters, and descriptions. T
 **Always latest.** The query exposes no `version` input because the upstream `packageSummary` resolver always returns the latest published version. The CLI `githits pkg info` rejects `<spec>@<version>` with `INVALID_ARGUMENT` rather than silently swapping — a silent-swap would break security-testing workflows that pin to an older vulnerable release.
 
 `package_summary` shares its envelope builder, terminal formatter, and error classifier with the CLI `githits pkg info` command via `src/shared/package-summary-request.ts`, `src/shared/package-summary-response.ts`, and `src/shared/package-intelligence-error-map.ts`. The parity test (`src/tools/package-summary-parity.test.ts`) asserts `toEqual` between CLI `--json` and MCP `content[0].text` for service-sourced fixtures, and `toMatchObject` for the `INVALID_ARGUMENT` fixture where surface-specific error text is acceptable.
+
+### `package_vulnerabilities` response shape
+
+**Filter-aware summary.** `min_severity` and `include_withdrawn` are passed straight to the GraphQL query. The backend's `vulnerabilityCount` reflects the filtered set — there is no client-side filtering and no `summary.filtered` dual-block. Callers wanting the unfiltered view omit the flag.
+
+**Partitioning buckets.** Advisories with `isMalicious: true` count **only** under `summary.bySeverity.malware`; severity bands (`critical`/`high`/`medium`/`low`) count non-malicious advisories with a positive CVSS score; non-malicious advisories with no score count under `summary.bySeverity.unrated`. Every returned advisory lands in exactly one bucket — the client-side guarantee is `MALWARE + crit + high + medium + low + unrated = advisories.length`. The sum also equals `summary.total` whenever the backend keeps `vulnerabilityCount` and `vulnerabilities[]` consistent (the expected case on all shipped registries). The malware bucket sorts to the top of the advisory list regardless of score. The `unrated` bucket ensures the terminal breakdown line reconciles with the header total on Rust / PyPI packages where a non-trivial fraction of advisories ship without a CVSS score.
+
+**Version validation.** `package_vulnerabilities` accepts canonical package versions only. Tag-style refs with a leading `v` (for example `v4.18.0`) are rejected client-side with `INVALID_ARGUMENT` before the backend call. This avoids the current production backend's unhelpful generic error for that input shape. This is intentionally narrow: proper ecosystem-aware version parsing and typed invalid-version errors belong in the backend, not in ad hoc CLI normalization rules.
+
+**Typed `VERSION_NOT_FOUND`.** Mirrors the code-nav precedent: a dedicated `PackageIntelligenceVersionNotFoundError` carries structured `{ packageName, requestedVersion, availableVersions? }` fields sourced from GraphQL `extensions`. Classifier routes it to `VERSION_NOT_FOUND` with a structured `details` block. When the backend returns a generic backend error whose message matches `/no matching version/i` (current production behaviour — the typed `extensions.code` is not yet emitted on `packageVulnerabilities`), the service promotes the error to `VersionNotFoundError` using the caller's `packageName` + `version` so CLI / MCP surfaces still render an actionable envelope. `availableVersions` remains undefined in the fallback path until the backend ships them.
+
+**Omission rules.** Null scalars omitted; empty arrays dropped; zero-count `bySeverity` keys dropped; the `bySeverity` block itself dropped when `total === 0`. `modifiedAt` included only when it differs from `publishedAt`. `isMalicious` included only when `true`.
+
+**Registry coverage.** Only npm, PyPI, Hex, and Crates have vulnerability data. The CLI + MCP reject the other five registries client-side with a tool-specific message (`pkg vulns only supports npm, pypi, hex, and crates. Got: ${registry}.`) — rejection predicate lives in `src/shared/package-vulnerabilities-request.ts` rather than the shared registry module, since it is a tool-specific capability matrix.
+
+`package_vulnerabilities` shares its envelope builder with the CLI `githits pkg vulns` command via `src/shared/package-vulnerabilities-request.ts` and `src/shared/package-vulnerabilities-response.ts`. The terminal formatter is CLI-only (MCP always emits JSON). The parity test (`src/tools/package-vulnerabilities-parity.test.ts`) asserts `toEqual` across the service-sourced success and typed-error fixtures, and `toMatchObject` for builder-sourced `INVALID_ARGUMENT` fixtures such as unsupported registries and tag-style `v`-prefixed versions.
 
 ## Server instructions
 

--- a/src/commands/mcp-instructions.test.ts
+++ b/src/commands/mcp-instructions.test.ts
@@ -48,6 +48,7 @@ const KNOWN_TOOLS = [
   "feedback",
   "search_symbols",
   "package_summary",
+  "package_vulnerabilities",
 ] as const;
 
 function mentionedTools(instructions: string): Set<string> {
@@ -102,6 +103,7 @@ describe("buildMcpInstructions", () => {
     expect(instructions).toContain("feedback");
     expect(instructions).not.toContain("Package tools");
     expect(instructions).not.toContain("package_summary");
+    expect(instructions).not.toContain("package_vulnerabilities");
     expect(instructions).not.toContain("search_symbols");
   });
 
@@ -117,6 +119,7 @@ describe("buildMcpInstructions", () => {
     expect(instructions).toContain("GitHits surfaces verified");
     expect(instructions).toContain("Package tools");
     expect(instructions).toContain("`package_summary`");
+    expect(instructions).toContain("`package_vulnerabilities`");
     expect(instructions).toContain("`search_symbols`");
   });
 
@@ -161,7 +164,7 @@ describe("buildMcpInstructions", () => {
     expect(instructions).toContain("natural-language example questions");
   });
 
-  it("half-open: only package intelligence service wired → mentions package_summary but not search_symbols", () => {
+  it("half-open: only package intelligence service wired → mentions package_summary + package_vulnerabilities but not search_symbols", () => {
     const deps = createTestDeps({
       codeNavigationCapability: "enabled",
       codeNavigationService: undefined,
@@ -171,6 +174,7 @@ describe("buildMcpInstructions", () => {
 
     expect(instructions).toContain("Package tools");
     expect(instructions).toContain("`package_summary`");
+    expect(instructions).toContain("`package_vulnerabilities`");
     expect(instructions).not.toContain("`search_symbols`");
     // The decision tip references search_symbols, so it must not
     // appear when search_symbols isn't registered.
@@ -233,7 +237,11 @@ describe("buildMcpInstructions", () => {
         // block narrates the workflow rather than bulleting them
         // individually, so `search_language` and `feedback` won't
         // appear in backtick form.
-        const packageTools = ["search_symbols", "package_summary"];
+        const packageTools = [
+          "search_symbols",
+          "package_summary",
+          "package_vulnerabilities",
+        ];
         for (const name of packageTools) {
           if (registered.has(name)) {
             expect(mentioned.has(name)).toBe(true);

--- a/src/commands/mcp-instructions.ts
+++ b/src/commands/mcp-instructions.ts
@@ -26,6 +26,9 @@ Package spec: \`registry:name[@version]\`.`;
 const PACKAGE_SUMMARY_BULLET =
   "- `package_summary` — instant package overview.";
 
+const PACKAGE_VULNERABILITIES_BULLET =
+  "- `package_vulnerabilities` — known CVE / OSV advisories for npm, PyPI, Hex, or Crates packages (optionally pinned to `@version`). Malicious-package advisories surface in a disjoint `malware` bucket; filter with `min_severity` or include retracted advisories with `include_withdrawn`.";
+
 const SEARCH_SYMBOLS_BULLET =
   "- `search_symbols` — text search across a dependency's source. On an INDEXING response, retry with a larger `wait_timeout_ms` (up to 60000).";
 
@@ -71,6 +74,7 @@ export function buildMcpInstructions(deps: Dependencies): string {
   const bullets: string[] = [];
   if (deps.packageIntelligenceService) {
     bullets.push(PACKAGE_SUMMARY_BULLET);
+    bullets.push(PACKAGE_VULNERABILITIES_BULLET);
   }
   if (deps.codeNavigationService) {
     bullets.push(SEARCH_SYMBOLS_BULLET);

--- a/src/commands/mcp.test.ts
+++ b/src/commands/mcp.test.ts
@@ -148,6 +148,45 @@ describe("createMcpServer", () => {
       expect(names).toContain("search_symbols");
     }
   });
+
+  it("adds package_vulnerabilities when capability is enabled and service wired", () => {
+    const deps = createTestDeps({
+      codeNavigationCapability: "enabled",
+      codeNavigationUrl: "https://pkgseer.dev",
+      codeNavigationService: createMockCodeNavigationService(),
+      packageIntelligenceService: createMockPackageIntelligenceService(),
+    });
+
+    const tools = getMcpToolDefinitions(deps);
+    expect(tools.map((tool) => tool.name)).toContain("package_vulnerabilities");
+  });
+
+  it("omits package_vulnerabilities when capability is disabled", () => {
+    const deps = createTestDeps({
+      codeNavigationCapability: "disabled",
+      codeNavigationUrl: "https://pkgseer.dev",
+      packageIntelligenceService: createMockPackageIntelligenceService(),
+    });
+
+    const tools = getMcpToolDefinitions(deps);
+    expect(tools.map((tool) => tool.name)).not.toContain(
+      "package_vulnerabilities",
+    );
+  });
+
+  it("advertises package_summary and package_vulnerabilities together (shared predicate)", () => {
+    const deps = createTestDeps({
+      codeNavigationCapability: "enabled",
+      codeNavigationUrl: "https://pkgseer.dev",
+      codeNavigationService: createMockCodeNavigationService(),
+      packageIntelligenceService: createMockPackageIntelligenceService(),
+    });
+
+    const names = getMcpToolDefinitions(deps).map((t) => t.name);
+    if (names.includes("package_summary")) {
+      expect(names).toContain("package_vulnerabilities");
+    }
+  });
 });
 
 describe("startMcpServer", () => {

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -7,6 +7,7 @@ import { dim, highlight, shouldUseColors } from "../shared/colors.js";
 import {
   createFeedbackTool,
   createPackageSummaryTool,
+  createPackageVulnerabilitiesTool,
   createSearchLanguageTool,
   createSearchSymbolsTool,
   createSearchTool,
@@ -37,6 +38,9 @@ export function getMcpToolDefinitions(
 
   if (gateOpen && deps.packageIntelligenceService) {
     tools.push(createPackageSummaryTool(deps.packageIntelligenceService));
+    tools.push(
+      createPackageVulnerabilitiesTool(deps.packageIntelligenceService),
+    );
   }
 
   return tools;

--- a/src/commands/pkg/index.test.ts
+++ b/src/commands/pkg/index.test.ts
@@ -31,6 +31,9 @@ describe("registerPkgCommandGroup", () => {
     expect(
       pkgCommand?.commands.some((command) => command.name() === "info"),
     ).toBe(true);
+    expect(
+      pkgCommand?.commands.some((command) => command.name() === "vulns"),
+    ).toBe(true);
   });
 
   it("registers the pkg command group when override and URL are set", async () => {

--- a/src/commands/pkg/index.ts
+++ b/src/commands/pkg/index.ts
@@ -7,6 +7,7 @@ import {
   isCodeNavigationCliOverrideEnabled,
 } from "../../services/index.js";
 import { registerPkgInfoCommand } from "./info.js";
+import { registerPkgVulnsCommand } from "./vulns.js";
 
 export interface PkgCommandGroupOptions {
   codeNavigationUrl?: string;
@@ -71,4 +72,5 @@ export async function registerPkgCommandGroup(
     );
 
   registerPkgInfoCommand(pkgCommand);
+  registerPkgVulnsCommand(pkgCommand);
 }

--- a/src/commands/pkg/vulns.test.ts
+++ b/src/commands/pkg/vulns.test.ts
@@ -1,0 +1,366 @@
+import { describe, expect, it, mock, spyOn } from "bun:test";
+import {
+  PackageIntelligenceTargetNotFoundError,
+  PackageIntelligenceVersionNotFoundError,
+} from "../../services/index.js";
+import {
+  createMockPackageIntelligenceService,
+  defaultVulnerabilityReport,
+} from "../../services/test-helpers.js";
+import { AuthRequiredError } from "../../shared/require-auth.js";
+import { type PkgVulnsCommandDependencies, pkgVulnsAction } from "./vulns.js";
+
+describe("pkgVulnsAction", () => {
+  const mcpUrl = "https://mcp.githits.com";
+
+  function createDeps(
+    overrides: Partial<PkgVulnsCommandDependencies> = {},
+  ): PkgVulnsCommandDependencies {
+    return {
+      packageIntelligenceService: createMockPackageIntelligenceService(),
+      codeNavigationUrl: "https://pkgseer.dev",
+      hasValidToken: true,
+      mcpUrl,
+      ...overrides,
+    };
+  }
+
+  it("renders the default terminal block via stdout.write", async () => {
+    const writes: string[] = [];
+    const writeSpy = spyOn(process.stdout, "write").mockImplementation(((
+      chunk: string | Uint8Array,
+    ) => {
+      writes.push(
+        typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk),
+      );
+      return true;
+    }) as typeof process.stdout.write);
+
+    await pkgVulnsAction("npm:express", {}, createDeps());
+
+    const combined = writes.join("");
+    expect(combined).toContain("express @ 4.18.0 · npm");
+    expect(combined).toContain("6 known vulnerabilities · latest affected");
+    expect(combined).toContain("MALWARE");
+    expect(combined).toContain("Upgrade to 4.18.2.");
+    writeSpy.mockRestore();
+  });
+
+  it("prints the lean JSON envelope when --json is set", async () => {
+    const logSpy = spyOn(console, "log").mockImplementation(() => {});
+
+    await pkgVulnsAction("npm:express", { json: true }, createDeps());
+
+    const output = logSpy.mock.calls[0]?.[0] as string;
+    const payload = JSON.parse(output);
+    expect(payload.name).toBe("express");
+    expect(payload.summary.total).toBe(6);
+    expect(payload.summary.bySeverity.malware).toBe(1);
+    logSpy.mockRestore();
+  });
+
+  it("passes version from spec to the service", async () => {
+    const packageVulnerabilities = mock(() =>
+      Promise.resolve(defaultVulnerabilityReport),
+    );
+    const service = createMockPackageIntelligenceService({
+      packageVulnerabilities,
+    });
+    const writeSpy = spyOn(process.stdout, "write").mockImplementation(
+      (() => true) as typeof process.stdout.write,
+    );
+
+    await pkgVulnsAction(
+      "npm:express@4.17.0",
+      {},
+      createDeps({ packageIntelligenceService: service }),
+    );
+
+    const calls = packageVulnerabilities.mock.calls as unknown as Array<
+      [{ version?: string }]
+    >;
+    expect(calls[0]?.[0]?.version).toBe("4.17.0");
+    writeSpy.mockRestore();
+  });
+
+  it("passes --severity → minSeverity float on the wire", async () => {
+    const packageVulnerabilities = mock(() =>
+      Promise.resolve(defaultVulnerabilityReport),
+    );
+    const service = createMockPackageIntelligenceService({
+      packageVulnerabilities,
+    });
+    const writeSpy = spyOn(process.stdout, "write").mockImplementation(
+      (() => true) as typeof process.stdout.write,
+    );
+
+    await pkgVulnsAction(
+      "npm:express",
+      { severity: "high" },
+      createDeps({ packageIntelligenceService: service }),
+    );
+
+    const calls = packageVulnerabilities.mock.calls as unknown as Array<
+      [{ minSeverity?: number }]
+    >;
+    expect(calls[0]?.[0]?.minSeverity).toBe(7.0);
+    writeSpy.mockRestore();
+  });
+
+  it("tolerates uppercase --severity input", async () => {
+    const packageVulnerabilities = mock(() =>
+      Promise.resolve(defaultVulnerabilityReport),
+    );
+    const service = createMockPackageIntelligenceService({
+      packageVulnerabilities,
+    });
+    const writeSpy = spyOn(process.stdout, "write").mockImplementation(
+      (() => true) as typeof process.stdout.write,
+    );
+
+    await pkgVulnsAction(
+      "npm:express",
+      { severity: "CRITICAL" },
+      createDeps({ packageIntelligenceService: service }),
+    );
+
+    const calls = packageVulnerabilities.mock.calls as unknown as Array<
+      [{ minSeverity?: number }]
+    >;
+    expect(calls[0]?.[0]?.minSeverity).toBe(9.0);
+    writeSpy.mockRestore();
+  });
+
+  it("passes --include-withdrawn through to the wire", async () => {
+    const packageVulnerabilities = mock(() =>
+      Promise.resolve(defaultVulnerabilityReport),
+    );
+    const service = createMockPackageIntelligenceService({
+      packageVulnerabilities,
+    });
+    const writeSpy = spyOn(process.stdout, "write").mockImplementation(
+      (() => true) as typeof process.stdout.write,
+    );
+
+    await pkgVulnsAction(
+      "npm:express",
+      { includeWithdrawn: true },
+      createDeps({ packageIntelligenceService: service }),
+    );
+
+    const calls = packageVulnerabilities.mock.calls as unknown as Array<
+      [{ includeWithdrawn?: boolean }]
+    >;
+    expect(calls[0]?.[0]?.includeWithdrawn).toBe(true);
+    writeSpy.mockRestore();
+  });
+
+  it("rejects unsupported registry (vcpkg) client-side with bare message", async () => {
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+
+    try {
+      await pkgVulnsAction("vcpkg:foo", {}, createDeps());
+    } catch {
+      // expected exit
+    }
+
+    expect(errorSpy.mock.calls[0]?.[0]).toBe(
+      "pkg vulns only supports npm, pypi, hex, and crates. Got: vcpkg.",
+    );
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it("rejects bad --severity label with INVALID_ARGUMENT", async () => {
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+
+    try {
+      await pkgVulnsAction("npm:express", { severity: "severe" }, createDeps());
+    } catch {
+      // expected
+    }
+
+    const msg = errorSpy.mock.calls[0]?.[0] as string;
+    expect(msg).toContain("Unsupported severity 'severe'");
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it("rejects tag-style versions with an actionable INVALID_ARGUMENT message", async () => {
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+
+    try {
+      await pkgVulnsAction("npm:express@v4.18.0", {}, createDeps());
+    } catch {
+      // expected
+    }
+
+    const msg = errorSpy.mock.calls[0]?.[0] as string;
+    expect(msg).toContain("Invalid version 'v4.18.0'");
+    expect(msg).toContain("without a leading 'v'");
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it("routes service NOT_FOUND through --json error envelope", async () => {
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+
+    const service = createMockPackageIntelligenceService({
+      packageVulnerabilities: mock(() =>
+        Promise.reject(
+          new PackageIntelligenceTargetNotFoundError("Package not found"),
+        ),
+      ),
+    });
+
+    try {
+      await pkgVulnsAction(
+        "npm:ghost",
+        { json: true },
+        createDeps({ packageIntelligenceService: service }),
+      );
+    } catch {
+      // expected
+    }
+
+    const output = errorSpy.mock.calls[0]?.[0] as string;
+    const payload = JSON.parse(output);
+    expect(payload.code).toBe("NOT_FOUND");
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it("enriches VERSION_NOT_FOUND terminal output with package + requested version", async () => {
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+
+    const service = createMockPackageIntelligenceService({
+      packageVulnerabilities: mock(() =>
+        Promise.reject(
+          new PackageIntelligenceVersionNotFoundError(
+            "No matching version found",
+            "npm:lodash",
+            "99.99.99",
+            undefined,
+          ),
+        ),
+      ),
+    });
+
+    try {
+      await pkgVulnsAction(
+        "npm:lodash@99.99.99",
+        {},
+        createDeps({ packageIntelligenceService: service }),
+      );
+    } catch {
+      // expected exit
+    }
+
+    const msg = errorSpy.mock.calls[0]?.[0] as string;
+    expect(msg).toContain("No matching version found");
+    expect(msg).toContain("package:   npm:lodash");
+    expect(msg).toContain("requested: 99.99.99");
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it("includes available-versions sample line when backend returns them", async () => {
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+
+    const service = createMockPackageIntelligenceService({
+      packageVulnerabilities: mock(() =>
+        Promise.reject(
+          new PackageIntelligenceVersionNotFoundError(
+            "No matching version found",
+            "express",
+            "99.0.0",
+            ["4.18.2", "4.18.1", "4.18.0", "4.17.4", "4.17.3", "4.17.2"],
+          ),
+        ),
+      ),
+    });
+
+    try {
+      await pkgVulnsAction(
+        "npm:express@99.0.0",
+        {},
+        createDeps({ packageIntelligenceService: service }),
+      );
+    } catch {
+      // expected exit
+    }
+
+    const msg = errorSpy.mock.calls[0]?.[0] as string;
+    expect(msg).toContain("available: 4.18.2, 4.18.1, 4.18.0, 4.17.4, 4.17.3");
+    expect(msg).toContain("(+1 more)");
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it("throws AuthRequiredError before calling service when unauthenticated", async () => {
+    const logSpy = spyOn(console, "log").mockImplementation(() => {});
+    const packageVulnerabilities = mock(() =>
+      Promise.resolve(defaultVulnerabilityReport),
+    );
+    const service = createMockPackageIntelligenceService({
+      packageVulnerabilities,
+    });
+
+    await expect(
+      pkgVulnsAction(
+        "npm:express",
+        {},
+        createDeps({
+          packageIntelligenceService: service,
+          hasValidToken: false,
+        }),
+      ),
+    ).rejects.toThrow(AuthRequiredError);
+
+    expect(packageVulnerabilities).not.toHaveBeenCalled();
+    logSpy.mockRestore();
+  });
+
+  it("errors when pkgseer URL / service are missing", async () => {
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+
+    try {
+      await pkgVulnsAction(
+        "npm:express",
+        {},
+        createDeps({
+          packageIntelligenceService: undefined,
+          codeNavigationUrl: undefined,
+        }),
+      );
+    } catch {
+      // expected
+    }
+
+    const combined = errorSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(combined).toContain("Package intelligence is not configured");
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+});

--- a/src/commands/pkg/vulns.ts
+++ b/src/commands/pkg/vulns.ts
@@ -1,0 +1,179 @@
+import type { Command } from "commander";
+import { createContainer } from "../../container.js";
+import type { PackageIntelligenceService } from "../../services/index.js";
+import { shouldUseColors } from "../../shared/colors.js";
+import {
+  InvalidPackageSpecError,
+  type MappedError,
+  mapPackageIntelligenceError,
+  parsePackageSpec,
+  requireAuth,
+} from "../../shared/index.js";
+import { buildPackageVulnerabilitiesParams } from "../../shared/package-vulnerabilities-request.js";
+import {
+  buildPackageVulnerabilitiesSuccessPayload,
+  formatPackageVulnerabilitiesTerminal,
+} from "../../shared/package-vulnerabilities-response.js";
+
+export interface PkgVulnsCommandOptions {
+  severity?: string;
+  includeWithdrawn?: boolean;
+  verbose?: boolean;
+  json?: boolean;
+}
+
+export interface PkgVulnsCommandDependencies {
+  packageIntelligenceService: PackageIntelligenceService | undefined;
+  codeNavigationUrl: string | undefined;
+  hasValidToken: boolean;
+  mcpUrl: string;
+}
+
+/**
+ * Core `pkg vulns` action. Accepts `<spec>@<version>` (unlike `pkg
+ * info`, which always returns latest). Version flows through to the
+ * backend; `minSeverity` and `includeWithdrawn` likewise go to the
+ * wire. No client-side filtering — backend is single source of truth.
+ */
+export async function pkgVulnsAction(
+  spec: string,
+  options: PkgVulnsCommandOptions,
+  deps: PkgVulnsCommandDependencies,
+): Promise<void> {
+  requireAuth(deps);
+
+  try {
+    if (!deps.codeNavigationUrl || !deps.packageIntelligenceService) {
+      throw new InvalidPackageSpecError(
+        "Package intelligence is not configured for this environment.",
+      );
+    }
+
+    const parsed = parsePackageSpec(spec);
+    const { params } = buildPackageVulnerabilitiesParams({
+      registry: parsed.registry,
+      packageName: parsed.name,
+      version: parsed.version,
+      minSeverity: options.severity,
+      includeWithdrawn: options.includeWithdrawn,
+    });
+    const report =
+      await deps.packageIntelligenceService.packageVulnerabilities(params);
+
+    if (options.json) {
+      const payload = buildPackageVulnerabilitiesSuccessPayload(report, {
+        requestedVersion: parsed.version,
+      });
+      console.log(JSON.stringify(payload));
+      return;
+    }
+
+    const output = formatPackageVulnerabilitiesTerminal(report, {
+      verbose: options.verbose,
+      useColors: shouldUseColors(),
+      requestedVersion: parsed.version,
+      terminalWidth: process.stdout.columns,
+    });
+    process.stdout.write(output);
+  } catch (error) {
+    handlePkgVulnsCommandError(error, options.json ?? false);
+  }
+}
+
+function handlePkgVulnsCommandError(error: unknown, json: boolean): never {
+  const mapped = mapPackageIntelligenceError(error);
+
+  if (json) {
+    console.error(
+      JSON.stringify({
+        error: mapped.message,
+        code: mapped.code,
+        retryable: mapped.retryable ?? false,
+        ...(mapped.details ? { details: mapped.details } : {}),
+      }),
+    );
+    process.exit(1);
+  }
+
+  console.error(formatVulnsTerminalError(mapped));
+  process.exit(1);
+}
+
+/**
+ * Format the terminal error line. Most codes fall through to the
+ * bare mapped message (matches the `pkg info` handler pattern);
+ * `VERSION_NOT_FOUND` gets an extra detail line echoing what the
+ * user asked for and, when available, the versions the backend does
+ * know about — this is the one case where the bare message
+ * ("No matching version found") omits crucial context.
+ */
+function formatVulnsTerminalError(mapped: MappedError): string {
+  if (mapped.code !== "VERSION_NOT_FOUND") return mapped.message;
+  const detail = mapped.details ?? {};
+  const pkg = typeof detail.package === "string" ? detail.package : undefined;
+  const requested =
+    typeof detail.requestedVersion === "string"
+      ? detail.requestedVersion
+      : undefined;
+  const lines = [mapped.message];
+  if (pkg && requested) {
+    lines.push(`  package:   ${pkg}`);
+    lines.push(`  requested: ${requested}`);
+  } else if (requested) {
+    lines.push(`  requested: ${requested}`);
+  }
+  const rawAvailable = Array.isArray(detail.availableVersions)
+    ? detail.availableVersions
+    : undefined;
+  const available = rawAvailable
+    ?.map((entry) => (typeof entry?.version === "string" ? entry.version : ""))
+    .filter((v): v is string => v.length > 0);
+  if (available && available.length > 0) {
+    const sample = available.slice(0, 5).join(", ");
+    const more = available.length - 5;
+    const suffix = more > 0 ? `, … (+${more} more)` : "";
+    lines.push(`  available: ${sample}${suffix}`);
+  }
+  return lines.join("\n");
+}
+
+const PKG_VULNS_DESCRIPTION = `Show known vulnerabilities for a package. Lists CVE / OSV advisories
+with severity, affected version ranges, fix versions, and suggested
+upgrade paths. Malicious-package advisories are flagged prominently.
+
+Package spec: <registry>:<name>[@<version>]. Supported registries:
+npm, pypi, hex, crates. Omit @<version> to check the latest release.
+
+Severity filter (--severity) and withdrawn-advisory visibility
+(--include-withdrawn) are passed through to the backend; the
+returned count reflects whatever survived the filter.`;
+
+export function registerPkgVulnsCommand(pkgCommand: Command): Command {
+  return pkgCommand
+    .command("vulns")
+    .summary("List known vulnerabilities for a package")
+    .description(PKG_VULNS_DESCRIPTION)
+    .argument("<spec>", "Package spec, e.g. npm:express or npm:express@4.18.0")
+    .option(
+      "-s, --severity <level>",
+      "Only show advisories at or above this severity (low, medium, high, critical). Omit to see all.",
+    )
+    .option(
+      "--include-withdrawn",
+      "Include retracted advisories (default: off)",
+    )
+    .option(
+      "-v, --verbose",
+      "Show aliases, modified/withdrawn dates, and malicious-advisory markers",
+    )
+    .option("--json", "Emit the lean JSON envelope")
+    .action(async (spec: string, options: PkgVulnsCommandOptions) => {
+      const deps = await createContainer();
+      await pkgVulnsAction(spec, options, {
+        packageIntelligenceService: deps.packageIntelligenceService,
+        codeNavigationUrl: deps.codeNavigationUrl,
+        hasValidToken: deps.hasValidToken,
+        mcpUrl: deps.mcpUrl,
+      });
+    });
+}

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -88,8 +88,13 @@ export type {
   PackageSecurityOverview,
   PackageSummary,
   PackageSummaryParams,
+  PackageVersionIdentity,
+  PackageVulnerabilitiesParams,
   QuickstartInfo,
+  VulnerabilityDetail,
   VulnerabilityOverview,
+  VulnerabilityReport,
+  VulnerabilitySecurityDetails,
 } from "./package-intelligence-service.js";
 export {
   MalformedPackageIntelligenceResponseError,
@@ -101,6 +106,7 @@ export {
   PackageIntelligenceServiceImpl,
   PackageIntelligenceTargetNotFoundError,
   PackageIntelligenceValidationError,
+  PackageIntelligenceVersionNotFoundError,
 } from "./package-intelligence-service.js";
 export type {
   CheckboxChoice,

--- a/src/services/package-intelligence-service.test.ts
+++ b/src/services/package-intelligence-service.test.ts
@@ -9,6 +9,7 @@ import {
   PackageIntelligenceServiceImpl,
   PackageIntelligenceTargetNotFoundError,
   PackageIntelligenceValidationError,
+  PackageIntelligenceVersionNotFoundError,
 } from "./package-intelligence-service.js";
 import { createMockTokenProvider } from "./test-helpers.js";
 
@@ -499,5 +500,596 @@ describe("PackageIntelligenceServiceImpl", () => {
       expect(error).toBeInstanceOf(PackageIntelligenceNetworkError);
       expect((error as PackageIntelligenceNetworkError).cause).toBeDefined();
     }
+  });
+});
+
+// --------------------------------------------------------------------
+// packageVulnerabilities
+// --------------------------------------------------------------------
+
+const VULNS_HAPPY_BODY = {
+  data: {
+    packageVulnerabilities: {
+      package: { name: "express", registry: "NPM", version: "4.18.0" },
+      security: {
+        vulnerabilityCount: 2,
+        currentVersionAffected: true,
+        upgradePaths: ["4.18.2"],
+        vulnerabilities: [
+          {
+            osvId: "GHSA-xxxx-xxxx-xxxx",
+            summary: "Open redirect",
+            severityScore: 7.5,
+            severityType: "CVSS_V3",
+            affectedVersionRanges: [">= 4.0.0, < 4.18.2"],
+            fixedInVersions: ["4.18.2"],
+            publishedAt: "2024-06-01T00:00:00Z",
+            modifiedAt: null,
+            withdrawnAt: null,
+            aliases: ["CVE-2024-1234"],
+            isMalicious: false,
+          },
+          {
+            osvId: "GHSA-mmmm-mmmm-mmmm",
+            summary: "Malicious impersonator",
+            severityScore: null,
+            severityType: null,
+            affectedVersionRanges: [">= 4.17.0, < 4.18.1"],
+            fixedInVersions: [],
+            publishedAt: "2024-07-10T00:00:00Z",
+            modifiedAt: null,
+            withdrawnAt: null,
+            aliases: [],
+            isMalicious: true,
+          },
+        ],
+      },
+    },
+  },
+};
+
+describe("PackageIntelligenceServiceImpl.packageVulnerabilities", () => {
+  const ENDPOINT = "https://pkgseer.dev";
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("maps a happy-path response to VulnerabilityReport", async () => {
+    const fetchFn = mock(() => Promise.resolve(jsonResponse(VULNS_HAPPY_BODY)));
+    const service = new PackageIntelligenceServiceImpl(
+      ENDPOINT,
+      createMockTokenProvider(),
+      asFetchFn(fetchFn),
+    );
+
+    const result = await service.packageVulnerabilities({
+      registry: "NPM",
+      packageName: "express",
+    });
+
+    expect(result.package.name).toBe("express");
+    expect(result.package.version).toBe("4.18.0");
+    expect(result.security?.vulnerabilityCount).toBe(2);
+    expect(result.security?.upgradePaths).toEqual(["4.18.2"]);
+    expect(result.security?.vulnerabilities?.[0]?.osvId).toBe(
+      "GHSA-xxxx-xxxx-xxxx",
+    );
+    expect(result.security?.vulnerabilities?.[1]?.isMalicious).toBe(true);
+  });
+
+  it("sends packageVulnerabilities query with wire variables", async () => {
+    let captured: string | undefined;
+    const fetchFn = mock((_url: string, init?: RequestInit) => {
+      captured = init?.body as string;
+      return Promise.resolve(jsonResponse(VULNS_HAPPY_BODY));
+    });
+    const service = new PackageIntelligenceServiceImpl(
+      ENDPOINT,
+      createMockTokenProvider(),
+      asFetchFn(fetchFn),
+    );
+
+    await service.packageVulnerabilities({
+      registry: "NPM",
+      packageName: "express",
+      version: "4.18.0",
+      minSeverity: 7.0,
+      includeWithdrawn: true,
+    });
+
+    expect(captured).toBeDefined();
+    const parsed = JSON.parse(captured ?? "{}");
+    expect(parsed.query).toContain(
+      "packageVulnerabilities(\n    registry: $registry",
+    );
+    expect(parsed.variables).toEqual({
+      registry: "NPM",
+      name: "express",
+      version: "4.18.0",
+      minSeverity: 7.0,
+      includeWithdrawn: true,
+    });
+  });
+
+  it("throws MalformedPackageIntelligenceResponseError when name is null", async () => {
+    const body = {
+      data: {
+        packageVulnerabilities: {
+          package: { name: null, registry: "NPM", version: "1.0.0" },
+          security: null,
+        },
+      },
+    };
+    const fetchFn = mock(() => Promise.resolve(jsonResponse(body)));
+    const service = new PackageIntelligenceServiceImpl(
+      ENDPOINT,
+      createMockTokenProvider(),
+      asFetchFn(fetchFn),
+    );
+
+    await expect(
+      service.packageVulnerabilities({
+        registry: "NPM",
+        packageName: "x",
+      }),
+    ).rejects.toBeInstanceOf(MalformedPackageIntelligenceResponseError);
+  });
+
+  it("throws MalformedPackageIntelligenceResponseError when version is null", async () => {
+    const body = {
+      data: {
+        packageVulnerabilities: {
+          package: { name: "express", version: null },
+          security: null,
+        },
+      },
+    };
+    const fetchFn = mock(() => Promise.resolve(jsonResponse(body)));
+    const service = new PackageIntelligenceServiceImpl(
+      ENDPOINT,
+      createMockTokenProvider(),
+      asFetchFn(fetchFn),
+    );
+
+    await expect(
+      service.packageVulnerabilities({
+        registry: "NPM",
+        packageName: "express",
+      }),
+    ).rejects.toBeInstanceOf(MalformedPackageIntelligenceResponseError);
+  });
+
+  it("handles empty vulnerabilities list (zero-vulns success)", async () => {
+    const body = {
+      data: {
+        packageVulnerabilities: {
+          package: { name: "express", registry: "NPM", version: "4.18.2" },
+          security: {
+            vulnerabilityCount: 0,
+            currentVersionAffected: false,
+            upgradePaths: [],
+            vulnerabilities: [],
+          },
+        },
+      },
+    };
+    const fetchFn = mock(() => Promise.resolve(jsonResponse(body)));
+    const service = new PackageIntelligenceServiceImpl(
+      ENDPOINT,
+      createMockTokenProvider(),
+      asFetchFn(fetchFn),
+    );
+
+    const result = await service.packageVulnerabilities({
+      registry: "NPM",
+      packageName: "express",
+    });
+
+    expect(result.security?.vulnerabilityCount).toBe(0);
+    expect(result.security?.vulnerabilities).toEqual([]);
+  });
+
+  it("classifies GraphQL VERSION_NOT_FOUND as typed error with structured details", async () => {
+    const fetchFn = mock(() =>
+      Promise.resolve(
+        jsonResponse({
+          errors: [
+            {
+              message: "version not found",
+              extensions: {
+                code: "VERSION_NOT_FOUND",
+                package: "npm:express",
+                requested_version: "99.0.0",
+                available_versions: ["4.18.2", "4.18.1"],
+              },
+            },
+          ],
+        }),
+      ),
+    );
+    const service = new PackageIntelligenceServiceImpl(
+      ENDPOINT,
+      createMockTokenProvider(),
+      asFetchFn(fetchFn),
+    );
+
+    try {
+      await service.packageVulnerabilities({
+        registry: "NPM",
+        packageName: "express",
+        version: "99.0.0",
+      });
+      throw new Error("expected typed version error");
+    } catch (error) {
+      expect(error).toBeInstanceOf(PackageIntelligenceVersionNotFoundError);
+      const typed = error as PackageIntelligenceVersionNotFoundError;
+      expect(typed.packageName).toBe("npm:express");
+      expect(typed.requestedVersion).toBe("99.0.0");
+      expect(typed.availableVersions).toEqual(["4.18.2", "4.18.1"]);
+    }
+  });
+
+  it("classifies GraphQL VERSION_NOT_FOUND with empty extensions (backend not wired)", async () => {
+    const fetchFn = mock(() =>
+      Promise.resolve(
+        jsonResponse({
+          errors: [
+            {
+              message: "version not found",
+              extensions: { code: "VERSION_NOT_FOUND" },
+            },
+          ],
+        }),
+      ),
+    );
+    const service = new PackageIntelligenceServiceImpl(
+      ENDPOINT,
+      createMockTokenProvider(),
+      asFetchFn(fetchFn),
+    );
+
+    try {
+      await service.packageVulnerabilities({
+        registry: "NPM",
+        packageName: "express",
+        version: "99.0.0",
+      });
+      throw new Error("expected typed version error");
+    } catch (error) {
+      expect(error).toBeInstanceOf(PackageIntelligenceVersionNotFoundError);
+      const typed = error as PackageIntelligenceVersionNotFoundError;
+      expect(typed.packageName).toBeUndefined();
+      expect(typed.requestedVersion).toBeUndefined();
+      expect(typed.availableVersions).toBeUndefined();
+    }
+  });
+
+  it("promotes generic 'no matching version' backend error to VersionNotFoundError when a version was requested", async () => {
+    // Live backend currently returns the plain message without the
+    // typed extensions.code. We recover the `package` and
+    // `requestedVersion` fields from the caller's params so the CLI /
+    // MCP surfaces can render actionable output.
+    const fetchFn = mock(() =>
+      Promise.resolve(
+        jsonResponse({
+          errors: [{ message: "No matching version found" }],
+        }),
+      ),
+    );
+    const service = new PackageIntelligenceServiceImpl(
+      ENDPOINT,
+      createMockTokenProvider(),
+      asFetchFn(fetchFn),
+    );
+
+    try {
+      await service.packageVulnerabilities({
+        registry: "NPM",
+        packageName: "lodash",
+        version: "99.99.99",
+      });
+      throw new Error("expected typed version error");
+    } catch (error) {
+      expect(error).toBeInstanceOf(PackageIntelligenceVersionNotFoundError);
+      const typed = error as PackageIntelligenceVersionNotFoundError;
+      // Qualified with lowercase registry prefix to match the typed
+      // (backend-sent) VERSION_NOT_FOUND shape — keeps CLI / MCP
+      // output consistent across the two code paths.
+      expect(typed.packageName).toBe("npm:lodash");
+      expect(typed.requestedVersion).toBe("99.99.99");
+      expect(typed.availableVersions).toBeUndefined();
+    }
+  });
+
+  it("does NOT promote to VersionNotFoundError when no version was requested (caller asked for latest)", async () => {
+    const fetchFn = mock(() =>
+      Promise.resolve(
+        jsonResponse({
+          errors: [{ message: "No matching version found" }],
+        }),
+      ),
+    );
+    const service = new PackageIntelligenceServiceImpl(
+      ENDPOINT,
+      createMockTokenProvider(),
+      asFetchFn(fetchFn),
+    );
+
+    try {
+      await service.packageVulnerabilities({
+        registry: "NPM",
+        packageName: "lodash",
+      });
+      throw new Error("expected backend error");
+    } catch (error) {
+      expect(error).not.toBeInstanceOf(PackageIntelligenceVersionNotFoundError);
+    }
+  });
+
+  it("does NOT promote when backend supplies an explicit graphqlCode (INTERNAL_ERROR)", async () => {
+    // Real backend faults that happen to mention "no matching
+    // version" in a joined error string must not have their typed
+    // code / retryability silently flipped. Only messages with no
+    // graphqlCode at all (current production behaviour on
+    // packageVulnerabilities) are eligible for promotion.
+    const fetchFn = mock(() =>
+      Promise.resolve(
+        jsonResponse({
+          errors: [
+            {
+              message: "internal error, no matching version table",
+              extensions: { code: "INTERNAL_ERROR" },
+            },
+          ],
+        }),
+      ),
+    );
+    const service = new PackageIntelligenceServiceImpl(
+      ENDPOINT,
+      createMockTokenProvider(),
+      asFetchFn(fetchFn),
+    );
+
+    try {
+      await service.packageVulnerabilities({
+        registry: "NPM",
+        packageName: "lodash",
+        version: "99.99.99",
+      });
+      throw new Error("expected backend error");
+    } catch (error) {
+      expect(error).not.toBeInstanceOf(PackageIntelligenceVersionNotFoundError);
+      expect(error).toBeInstanceOf(PackageIntelligenceBackendError);
+    }
+  });
+
+  it("classifies GraphQL UNAUTHORIZED (after 2xx) and triggers token refresh", async () => {
+    let callCount = 0;
+    const fetchFn = mock(() => {
+      callCount++;
+      if (callCount === 1) {
+        return Promise.resolve(
+          jsonResponse({
+            errors: [
+              { message: "unauthorized", extensions: { code: "UNAUTHORIZED" } },
+            ],
+          }),
+        );
+      }
+      return Promise.resolve(jsonResponse(VULNS_HAPPY_BODY));
+    });
+    const refreshed = mock(() => Promise.resolve("new-token"));
+    const tokenProvider = createMockTokenProvider({
+      getToken: mock(() => Promise.resolve("old-token")),
+      forceRefresh: refreshed,
+    });
+
+    const service = new PackageIntelligenceServiceImpl(
+      ENDPOINT,
+      tokenProvider,
+      asFetchFn(fetchFn),
+    );
+
+    const result = await service.packageVulnerabilities({
+      registry: "NPM",
+      packageName: "express",
+    });
+
+    expect(refreshed).toHaveBeenCalledTimes(1);
+    expect(result.package.name).toBe("express");
+  });
+
+  it("classifies 403 as PackageIntelligenceAccessError", async () => {
+    const fetchFn = mock(() =>
+      Promise.resolve(jsonResponse({ detail: "no access" }, 403)),
+    );
+    const service = new PackageIntelligenceServiceImpl(
+      ENDPOINT,
+      createMockTokenProvider(),
+      asFetchFn(fetchFn),
+    );
+
+    await expect(
+      service.packageVulnerabilities({ registry: "NPM", packageName: "x" }),
+    ).rejects.toBeInstanceOf(PackageIntelligenceAccessError);
+  });
+
+  it("classifies FEATURE_FLAG_REQUIRED correctly", async () => {
+    const fetchFn = mock(() =>
+      Promise.resolve(
+        jsonResponse({
+          errors: [
+            {
+              message: "flag missing",
+              extensions: { code: "FEATURE_FLAG_REQUIRED" },
+            },
+          ],
+        }),
+      ),
+    );
+    const service = new PackageIntelligenceServiceImpl(
+      ENDPOINT,
+      createMockTokenProvider(),
+      asFetchFn(fetchFn),
+    );
+
+    await expect(
+      service.packageVulnerabilities({ registry: "NPM", packageName: "x" }),
+    ).rejects.toBeInstanceOf(PackageIntelligenceFeatureFlagRequiredError);
+  });
+
+  it("classifies GraphQL NOT_FOUND as PackageIntelligenceTargetNotFoundError", async () => {
+    const fetchFn = mock(() =>
+      Promise.resolve(
+        jsonResponse({
+          errors: [
+            { message: "package not found", extensions: { code: "NOT_FOUND" } },
+          ],
+        }),
+      ),
+    );
+    const service = new PackageIntelligenceServiceImpl(
+      ENDPOINT,
+      createMockTokenProvider(),
+      asFetchFn(fetchFn),
+    );
+
+    await expect(
+      service.packageVulnerabilities({ registry: "NPM", packageName: "ghost" }),
+    ).rejects.toBeInstanceOf(PackageIntelligenceTargetNotFoundError);
+  });
+
+  it("classifies VALIDATION_ERROR as PackageIntelligenceValidationError", async () => {
+    const fetchFn = mock(() =>
+      Promise.resolve(
+        jsonResponse({
+          errors: [
+            {
+              message: "bad input",
+              extensions: { code: "VALIDATION_ERROR" },
+            },
+          ],
+        }),
+      ),
+    );
+    const service = new PackageIntelligenceServiceImpl(
+      ENDPOINT,
+      createMockTokenProvider(),
+      asFetchFn(fetchFn),
+    );
+
+    await expect(
+      service.packageVulnerabilities({ registry: "NPM", packageName: "x" }),
+    ).rejects.toBeInstanceOf(PackageIntelligenceValidationError);
+  });
+
+  it("classifies 5xx as PackageIntelligenceBackendError", async () => {
+    const fetchFn = mock(() =>
+      Promise.resolve(
+        new Response("Server went away", {
+          status: 503,
+          headers: { "Content-Type": "text/plain" },
+        }),
+      ),
+    );
+    const service = new PackageIntelligenceServiceImpl(
+      ENDPOINT,
+      createMockTokenProvider(),
+      asFetchFn(fetchFn),
+    );
+
+    try {
+      await service.packageVulnerabilities({
+        registry: "NPM",
+        packageName: "x",
+      });
+      throw new Error("expected backend error");
+    } catch (error) {
+      expect(error).toBeInstanceOf(PackageIntelligenceBackendError);
+    }
+  });
+
+  it("wraps fetch rejection as PackageIntelligenceNetworkError preserving cause", async () => {
+    const cause = new Error("ENOTFOUND");
+    const fetchFn = mock(() => Promise.reject(cause));
+    const service = new PackageIntelligenceServiceImpl(
+      ENDPOINT,
+      createMockTokenProvider(),
+      asFetchFn(fetchFn),
+    );
+
+    try {
+      await service.packageVulnerabilities({
+        registry: "NPM",
+        packageName: "x",
+      });
+      throw new Error("expected network error");
+    } catch (error) {
+      expect(error).toBeInstanceOf(PackageIntelligenceNetworkError);
+      expect((error as PackageIntelligenceNetworkError).cause).toBeDefined();
+    }
+  });
+
+  it("preserves malicious and withdrawn flags round-trip", async () => {
+    const body = {
+      data: {
+        packageVulnerabilities: {
+          package: { name: "shady", registry: "NPM", version: "1.0.0" },
+          security: {
+            vulnerabilityCount: 2,
+            currentVersionAffected: true,
+            upgradePaths: [],
+            vulnerabilities: [
+              {
+                osvId: "GHSA-mal",
+                summary: "Malicious",
+                severityScore: null,
+                affectedVersionRanges: [">= 1.0.0"],
+                fixedInVersions: [],
+                publishedAt: "2024-01-01T00:00:00Z",
+                modifiedAt: null,
+                withdrawnAt: null,
+                aliases: [],
+                isMalicious: true,
+              },
+              {
+                osvId: "GHSA-wit",
+                summary: "Retracted advisory",
+                severityScore: 6.5,
+                affectedVersionRanges: [">= 1.0.0"],
+                fixedInVersions: ["1.0.1"],
+                publishedAt: "2023-12-01T00:00:00Z",
+                modifiedAt: null,
+                withdrawnAt: "2024-02-01T00:00:00Z",
+                aliases: [],
+                isMalicious: false,
+              },
+            ],
+          },
+        },
+      },
+    };
+    const fetchFn = mock(() => Promise.resolve(jsonResponse(body)));
+    const service = new PackageIntelligenceServiceImpl(
+      ENDPOINT,
+      createMockTokenProvider(),
+      asFetchFn(fetchFn),
+    );
+
+    const result = await service.packageVulnerabilities({
+      registry: "NPM",
+      packageName: "shady",
+    });
+
+    expect(result.security?.vulnerabilities?.[0]?.isMalicious).toBe(true);
+    expect(result.security?.vulnerabilities?.[1]?.withdrawnAt).toBe(
+      "2024-02-01T00:00:00Z",
+    );
   });
 });

--- a/src/services/package-intelligence-service.ts
+++ b/src/services/package-intelligence-service.ts
@@ -1,13 +1,16 @@
 /**
- * Package intelligence service — reads registry metadata, dependency
- * reports, vulnerability overviews, and changelogs from the pkgseer
+ * Package intelligence service — reads registry metadata, vulnerability
+ * reports, dependency reports, and changelogs from the upstream
  * GraphQL endpoint.
  *
  * Wire-level plumbing (URL, headers, POST, transport-error wrapping)
  * lives in `src/shared/pkgseer-graphql.ts`. This service owns:
- * - Domain error classes (`PackageIntelligence*Error`).
+ * - Domain error classes (`PackageIntelligence*Error`) including the
+ *   typed `PackageIntelligenceVersionNotFoundError` for structured
+ *   VERSION_NOT_FOUND responses.
  * - GraphQL-error classification on structured responses.
- * - Zod schema validation for the `PackageSummary` response shape.
+ * - Zod schemas for each query's response shape (packageSummary,
+ *   packageVulnerabilities).
  * - Outer `executeWithTokenRefresh` wrapper so GraphQL-level
  *   `UNAUTHORIZED` errors — classified after the POST — continue to
  *   trigger token refresh.
@@ -84,8 +87,54 @@ export interface PackageSummary {
   latestChangelogs?: ChangelogEntry[];
 }
 
+export interface PackageVulnerabilitiesParams {
+  registry: PkgseerRegistry;
+  packageName: string;
+  /** Optional — backend defaults to latest when omitted. */
+  version?: string;
+  /** Optional CVSS float; backend filters advisories below this score. */
+  minSeverity?: number;
+  /** Optional — backend defaults to false when omitted. */
+  includeWithdrawn?: boolean;
+}
+
+export interface PackageVersionIdentity {
+  name: string;
+  registry?: string;
+  version: string;
+}
+
+export interface VulnerabilityDetail {
+  osvId?: string;
+  summary?: string;
+  severityScore?: number;
+  severityType?: string;
+  affectedVersionRanges?: string[];
+  fixedInVersions?: string[];
+  publishedAt?: string;
+  modifiedAt?: string;
+  withdrawnAt?: string;
+  aliases?: string[];
+  isMalicious?: boolean;
+}
+
+export interface VulnerabilitySecurityDetails {
+  vulnerabilityCount?: number;
+  currentVersionAffected?: boolean;
+  vulnerabilities?: VulnerabilityDetail[];
+  upgradePaths?: string[];
+}
+
+export interface VulnerabilityReport {
+  package: PackageVersionIdentity;
+  security?: VulnerabilitySecurityDetails;
+}
+
 export interface PackageIntelligenceService {
   packageSummary(params: PackageSummaryParams): Promise<PackageSummary>;
+  packageVulnerabilities(
+    params: PackageVulnerabilitiesParams,
+  ): Promise<VulnerabilityReport>;
 }
 
 // --------------------------------------------------------------------
@@ -152,6 +201,27 @@ export class PackageIntelligenceValidationError extends Error {
   constructor(message: string) {
     super(message);
     this.name = "PackageIntelligenceValidationError";
+  }
+}
+
+/**
+ * Raised when the caller asked for a version that the backend has no
+ * record of. Mirrors the code-navigation precedent but narrower:
+ * vulnerability data has no indexing lifecycle, so there is no
+ * `latestIndexed` field. Backend may populate `availableVersions` in
+ * `extensions` for "did you mean" hints — shape is `string[]` because
+ * vulns registries expose plain version strings (no ref / commit
+ * concept).
+ */
+export class PackageIntelligenceVersionNotFoundError extends Error {
+  constructor(
+    message: string,
+    public readonly packageName: string | undefined,
+    public readonly requestedVersion: string | undefined,
+    public readonly availableVersions: string[] | undefined,
+  ) {
+    super(message);
+    this.name = "PackageIntelligenceVersionNotFoundError";
   }
 }
 
@@ -295,6 +365,98 @@ query PackageSummary($registry: Registry!, $name: String!) {
 }`;
 
 // --------------------------------------------------------------------
+// Zod schema + query for packageVulnerabilities
+// --------------------------------------------------------------------
+
+const packageVersionIdentitySchema = z.object({
+  name: z.string().nullable().optional(),
+  registry: z.string().nullable().optional(),
+  version: z.string().nullable().optional(),
+});
+
+const vulnerabilityDetailSchema = z.object({
+  osvId: z.string().nullable().optional(),
+  summary: z.string().nullable().optional(),
+  severityScore: z.number().nullable().optional(),
+  severityType: z.string().nullable().optional(),
+  affectedVersionRanges: z.array(z.string()).nullable().optional(),
+  fixedInVersions: z.array(z.string()).nullable().optional(),
+  publishedAt: z.string().nullable().optional(),
+  modifiedAt: z.string().nullable().optional(),
+  withdrawnAt: z.string().nullable().optional(),
+  aliases: z.array(z.string()).nullable().optional(),
+  isMalicious: z.boolean().nullable().optional(),
+});
+
+const vulnerabilitySecurityDetailsSchema = z
+  .object({
+    vulnerabilityCount: z.number().int().nullable().optional(),
+    currentVersionAffected: z.boolean().nullable().optional(),
+    vulnerabilities: z.array(vulnerabilityDetailSchema).nullable().optional(),
+    upgradePaths: z.array(z.string()).nullable().optional(),
+  })
+  .nullable()
+  .optional();
+
+const vulnerabilityReportResponseSchema = z.object({
+  package: packageVersionIdentitySchema.nullable().optional(),
+  security: vulnerabilitySecurityDetailsSchema,
+});
+
+const vulnerabilitiesGraphQLResponseSchema = z.object({
+  data: z
+    .object({
+      packageVulnerabilities: vulnerabilityReportResponseSchema
+        .nullable()
+        .optional(),
+    })
+    .nullable()
+    .optional(),
+  errors: z.array(graphQLErrorSchema).optional(),
+});
+
+const PACKAGE_VULNERABILITIES_QUERY = `
+query PackageVulnerabilities(
+  $registry: Registry!
+  $name: String!
+  $version: String
+  $minSeverity: Float
+  $includeWithdrawn: Boolean
+) {
+  packageVulnerabilities(
+    registry: $registry
+    name: $name
+    version: $version
+    minSeverity: $minSeverity
+    includeWithdrawn: $includeWithdrawn
+  ) {
+    package {
+      name
+      registry
+      version
+    }
+    security {
+      vulnerabilityCount
+      currentVersionAffected
+      upgradePaths
+      vulnerabilities {
+        osvId
+        summary
+        severityScore
+        severityType
+        affectedVersionRanges
+        fixedInVersions
+        publishedAt
+        modifiedAt
+        withdrawnAt
+        aliases
+        isMalicious
+      }
+    }
+  }
+}`;
+
+// --------------------------------------------------------------------
 // Service implementation
 // --------------------------------------------------------------------
 
@@ -413,6 +575,20 @@ export class PackageIntelligenceServiceImpl
       case "PACKAGE_NOT_FOUND":
         return new PackageIntelligenceTargetNotFoundError(message);
 
+      case "VERSION_NOT_FOUND":
+        return new PackageIntelligenceVersionNotFoundError(
+          message,
+          typeof extensions?.package === "string"
+            ? extensions.package
+            : undefined,
+          typeof extensions?.requested_version === "string"
+            ? extensions.requested_version
+            : undefined,
+          parseVersionList(
+            extensions?.available_versions ?? extensions?.availableVersions,
+          ),
+        );
+
       case "UNSUPPORTED_REGISTRY":
       case "VALIDATION_ERROR":
         return new PackageIntelligenceValidationError(message);
@@ -528,6 +704,123 @@ export class PackageIntelligenceServiceImpl
       latestChangelogs,
     };
   }
+
+  async packageVulnerabilities(
+    params: PackageVulnerabilitiesParams,
+  ): Promise<VulnerabilityReport> {
+    return executeWithTokenRefresh({
+      getToken: () => this.tokenProvider.getToken(),
+      forceRefresh: () => this.tokenProvider.forceRefresh(),
+      shouldRefresh: (error) => error instanceof AuthenticationError,
+      executeWithToken: (token) =>
+        this.executePackageVulnerabilities(token, params),
+    });
+  }
+
+  private async executePackageVulnerabilities(
+    token: string,
+    params: PackageVulnerabilitiesParams,
+  ): Promise<VulnerabilityReport> {
+    let response: PkgseerGraphqlResponse;
+    try {
+      response = await postPkgseerGraphql({
+        endpointUrl: this.endpointUrl,
+        token,
+        query: PACKAGE_VULNERABILITIES_QUERY,
+        variables: {
+          registry: params.registry,
+          name: params.packageName,
+          version: params.version,
+          minSeverity: params.minSeverity,
+          includeWithdrawn: params.includeWithdrawn,
+        },
+        fetchFn: this.fetchFn,
+      });
+    } catch (cause) {
+      if (cause instanceof PkgseerTransportError) {
+        throw new PackageIntelligenceNetworkError(
+          "Could not reach the package intelligence service. Check your connection or set GITHITS_CODE_NAV_URL.",
+          { cause },
+        );
+      }
+      throw cause;
+    }
+
+    if (response.status < 200 || response.status >= 300) {
+      throw this.createHttpError(response);
+    }
+
+    const parsed = vulnerabilitiesGraphQLResponseSchema.safeParse(
+      response.parsedBody,
+    );
+    if (!parsed.success) {
+      throw new MalformedPackageIntelligenceResponseError(
+        "Malformed response from the package-intelligence service.",
+      );
+    }
+
+    if (parsed.data.errors && parsed.data.errors.length > 0) {
+      throw promoteVersionNotFound(
+        this.createGraphQLError(parsed.data.errors),
+        params,
+      );
+    }
+
+    const data = parsed.data.data?.packageVulnerabilities;
+    if (!data) {
+      throw new MalformedPackageIntelligenceResponseError(
+        "Empty response from the package-intelligence service.",
+      );
+    }
+
+    return this.normaliseVulnerabilityReport(data);
+  }
+
+  private normaliseVulnerabilityReport(
+    data: z.infer<typeof vulnerabilityReportResponseSchema>,
+  ): VulnerabilityReport {
+    const name = data.package?.name ?? undefined;
+    const version = data.package?.version ?? undefined;
+    if (!name || !version) {
+      throw new MalformedPackageIntelligenceResponseError(
+        "Vulnerability report response missing required name/version.",
+      );
+    }
+
+    const identity: PackageVersionIdentity = {
+      name,
+      version,
+      registry: data.package?.registry ?? undefined,
+    };
+
+    const security: VulnerabilitySecurityDetails | undefined = data.security
+      ? {
+          vulnerabilityCount: data.security.vulnerabilityCount ?? undefined,
+          currentVersionAffected:
+            data.security.currentVersionAffected ?? undefined,
+          vulnerabilities:
+            data.security.vulnerabilities?.map((vuln) => ({
+              osvId: vuln.osvId ?? undefined,
+              summary: vuln.summary ?? undefined,
+              severityScore: vuln.severityScore ?? undefined,
+              severityType: vuln.severityType ?? undefined,
+              affectedVersionRanges: vuln.affectedVersionRanges ?? undefined,
+              fixedInVersions: vuln.fixedInVersions ?? undefined,
+              publishedAt: vuln.publishedAt ?? undefined,
+              modifiedAt: vuln.modifiedAt ?? undefined,
+              withdrawnAt: vuln.withdrawnAt ?? undefined,
+              aliases: vuln.aliases ?? undefined,
+              isMalicious: vuln.isMalicious ?? undefined,
+            })) ?? undefined,
+          upgradePaths: data.security.upgradePaths ?? undefined,
+        }
+      : undefined;
+
+    return {
+      package: identity,
+      security,
+    };
+  }
 }
 
 function parseDetail(body: string): string | undefined {
@@ -551,4 +844,67 @@ function getPrimaryExtensions(
     }
   }
   return undefined;
+}
+
+/**
+ * Parse a possibly-present list of version strings from an `extensions`
+ * value. Accepts a raw array of strings or returns undefined for
+ * missing/malformed data. Narrower than the code-nav
+ * `availableVersions` parser because vulnerability data has no ref
+ * concept — plain version strings suffice.
+ */
+function parseVersionList(raw: unknown): string[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  const versions: string[] = [];
+  for (const item of raw) {
+    if (typeof item === "string" && item.length > 0) {
+      versions.push(item);
+    }
+  }
+  return versions.length > 0 ? versions : undefined;
+}
+
+/**
+ * Fallback: if the backend returns a generic backend error whose
+ * message matches the well-known "no matching version" phrase and the
+ * caller explicitly requested a version, promote it to the typed
+ * {@link PackageIntelligenceVersionNotFoundError} so downstream
+ * surfaces can render structured, actionable error details.
+ *
+ * TODO(pkgseer-backend): remove this helper once the upstream
+ * `packageVulnerabilities` resolver emits
+ * `extensions.code = "VERSION_NOT_FOUND"` with `package`,
+ * `requested_version`, and `available_versions`. The typed path in
+ * `createGraphQLError` already handles that shape; deleting this
+ * helper + its two fallback-specific service tests will be the only
+ * cleanup needed, and the typed-error parity test will catch any
+ * regression in the structured-details envelope.
+ *
+ * Guard rails:
+ * - Only promotes when `graphqlCode` is absent. Any explicit code
+ *   (including INTERNAL_ERROR, UPSTREAM_ERROR, TIMEOUT, …) is
+ *   respected as-is so we never swallow real backend signalling or
+ *   flip retryability.
+ * - Only promotes when `params.version` is set — if the caller asked
+ *   for "latest", a "no matching version" message can only reflect
+ *   an unrelated upstream condition, not a caller-addressable one.
+ * - `details.package` is qualified with the lowercase registry
+ *   prefix (e.g. `"npm:lodash"`) so CLI / MCP output matches the
+ *   shape produced when the backend sends the typed code.
+ */
+function promoteVersionNotFound(
+  error: Error,
+  params: PackageVulnerabilitiesParams,
+): Error {
+  if (!(error instanceof PackageIntelligenceBackendError)) return error;
+  if (error.graphqlCode !== undefined) return error;
+  if (!params.version) return error;
+  if (!/no matching version/i.test(error.message)) return error;
+  const qualifiedName = `${params.registry.toLowerCase()}:${params.packageName}`;
+  return new PackageIntelligenceVersionNotFoundError(
+    error.message,
+    qualifiedName,
+    params.version,
+    undefined,
+  );
 }

--- a/src/services/test-helpers.ts
+++ b/src/services/test-helpers.ts
@@ -23,6 +23,7 @@ import type { KeyringService } from "./keyring-service.js";
 import type {
   PackageIntelligenceService,
   PackageSummary,
+  VulnerabilityReport,
 } from "./package-intelligence-service.js";
 import type { ConfirmChoice, PromptService } from "./prompt-service.js";
 import type { TokenProvider } from "./token-manager.js";
@@ -297,15 +298,95 @@ export const defaultPackageSummary: PackageSummary = {
 };
 
 /**
- * Creates a mock PackageIntelligenceService. Default `packageSummary`
- * resolves to {@link defaultPackageSummary} — override per-test as
- * needed.
+ * Fully-populated `VulnerabilityReport` fixture. Mixes one malicious
+ * advisory, one critical, one high, one medium with aliases, one low
+ * with a `modifiedAt` that differs from `publishedAt`, and one
+ * null-severity advisory so omission tests have live material to
+ * subtract from.
+ */
+export const defaultVulnerabilityReport: VulnerabilityReport = {
+  package: {
+    name: "express",
+    registry: "NPM",
+    version: "4.18.0",
+  },
+  security: {
+    vulnerabilityCount: 6,
+    currentVersionAffected: true,
+    upgradePaths: ["4.18.2"],
+    vulnerabilities: [
+      {
+        osvId: "GHSA-mmmm-mmmm-mmmm",
+        summary: "Malicious package impersonating express helper",
+        severityScore: 9.8,
+        severityType: "CVSS_V3",
+        affectedVersionRanges: [">= 4.17.0, < 4.18.1"],
+        fixedInVersions: [],
+        publishedAt: "2024-07-10T00:00:00Z",
+        aliases: [],
+        isMalicious: true,
+      },
+      {
+        osvId: "GHSA-cccc-cccc-cccc",
+        summary: "RCE via crafted JSON body",
+        severityScore: 9.2,
+        severityType: "CVSS_V3",
+        affectedVersionRanges: [">= 4.0.0, < 4.18.2"],
+        fixedInVersions: ["4.18.2"],
+        publishedAt: "2024-06-15T00:00:00Z",
+        aliases: ["CVE-2024-4242"],
+      },
+      {
+        osvId: "GHSA-xxxx-xxxx-xxxx",
+        summary: "Open redirect in default error handler",
+        severityScore: 7.5,
+        severityType: "CVSS_V3",
+        affectedVersionRanges: [">= 4.0.0, < 4.18.2"],
+        fixedInVersions: ["4.18.2"],
+        publishedAt: "2024-06-01T00:00:00Z",
+        aliases: ["CVE-2024-1234"],
+      },
+      {
+        osvId: "GHSA-yyyy-yyyy-yyyy",
+        summary: "Prototype pollution via query parser",
+        severityScore: 5.3,
+        severityType: "CVSS_V3",
+        affectedVersionRanges: [">= 4.0.0, < 4.17.4"],
+        fixedInVersions: ["4.17.4"],
+        publishedAt: "2024-03-12T00:00:00Z",
+        modifiedAt: "2024-04-02T00:00:00Z",
+        aliases: ["CVE-2024-5678", "CVE-2024-5679"],
+      },
+      {
+        osvId: "GHSA-zzzz-zzzz-zzzz",
+        summary: "Header injection in res.send",
+        severityScore: 3.2,
+        severityType: "CVSS_V3",
+        affectedVersionRanges: [">= 4.0.0, < 4.17.3"],
+        fixedInVersions: ["4.17.3"],
+        publishedAt: "2024-02-01T00:00:00Z",
+      },
+      {
+        osvId: "GHSA-nnnn-nnnn-nnnn",
+        summary: "Advisory without a CVSS score",
+        publishedAt: "2023-11-20T00:00:00Z",
+      },
+    ],
+  },
+};
+
+/**
+ * Creates a mock PackageIntelligenceService. Defaults resolve to the
+ * fully-populated fixtures; override per-test as needed.
  */
 export function createMockPackageIntelligenceService(
   impl: Partial<PackageIntelligenceService> = {},
 ): PackageIntelligenceService {
   return {
     packageSummary: mock(() => Promise.resolve(defaultPackageSummary)),
+    packageVulnerabilities: mock(() =>
+      Promise.resolve(defaultVulnerabilityReport),
+    ),
     ...impl,
   };
 }

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -65,6 +65,24 @@ export {
   severityLabel,
 } from "./package-summary-response.js";
 export {
+  buildPackageVulnerabilitiesParams,
+  type PackageVulnerabilitiesRequestBuildResult,
+  type PackageVulnerabilitiesRequestInput,
+  SEVERITY_LABEL_TO_CVSS,
+  supportsVulnerabilitiesRegistry,
+  UnsupportedVulnerabilitiesRegistryError,
+} from "./package-vulnerabilities-request.js";
+export {
+  buildPackageVulnerabilitiesSuccessPayload,
+  computeBySeverity,
+  formatPackageVulnerabilitiesTerminal,
+  type LeanAdvisory,
+  type LeanVulnerabilityReport,
+  type LeanVulnerabilitySummary,
+  type VulnSeverityLabel,
+  vulnSeverityLabel,
+} from "./package-vulnerabilities-response.js";
+export {
   isKnownPkgseerRegistryArg,
   knownPkgseerRegistryArgs,
   type PkgseerRegistry,

--- a/src/shared/package-intelligence-error-map.test.ts
+++ b/src/shared/package-intelligence-error-map.test.ts
@@ -9,6 +9,7 @@ import {
   PackageIntelligenceNetworkError,
   PackageIntelligenceTargetNotFoundError,
   PackageIntelligenceValidationError,
+  PackageIntelligenceVersionNotFoundError,
 } from "../services/package-intelligence-service.js";
 import { mapPackageIntelligenceError } from "./package-intelligence-error-map.js";
 
@@ -20,6 +21,40 @@ describe("mapPackageIntelligenceError", () => {
     expect(mapped.code).toBe("NOT_FOUND");
     expect(mapped.retryable).toBe(false);
     expect(mapped.message).toBe("Package not found");
+  });
+
+  it("maps PackageIntelligenceVersionNotFoundError to VERSION_NOT_FOUND with structured details", () => {
+    const mapped = mapPackageIntelligenceError(
+      new PackageIntelligenceVersionNotFoundError(
+        "Version not found",
+        "npm:express",
+        "99.0.0",
+        ["4.18.2", "4.18.1", "4.17.4"],
+      ),
+    );
+    expect(mapped.code).toBe("VERSION_NOT_FOUND");
+    expect(mapped.retryable).toBe(false);
+    expect(mapped.message).toBe("Version not found");
+    expect(mapped.details?.package).toBe("npm:express");
+    expect(mapped.details?.requestedVersion).toBe("99.0.0");
+    expect(mapped.details?.availableVersions).toEqual([
+      { version: "4.18.2", ref: "4.18.2" },
+      { version: "4.18.1", ref: "4.18.1" },
+      { version: "4.17.4", ref: "4.17.4" },
+    ]);
+  });
+
+  it("maps PackageIntelligenceVersionNotFoundError with empty extensions (backend not wired)", () => {
+    const mapped = mapPackageIntelligenceError(
+      new PackageIntelligenceVersionNotFoundError(
+        "Version not found",
+        undefined,
+        undefined,
+        undefined,
+      ),
+    );
+    expect(mapped.code).toBe("VERSION_NOT_FOUND");
+    expect(mapped.details).toBeUndefined();
   });
 
   it("maps PackageIntelligenceValidationError to INVALID_ARGUMENT", () => {

--- a/src/shared/package-intelligence-error-map.ts
+++ b/src/shared/package-intelligence-error-map.ts
@@ -18,6 +18,7 @@ import {
   PackageIntelligenceNetworkError,
   PackageIntelligenceTargetNotFoundError,
   PackageIntelligenceValidationError,
+  PackageIntelligenceVersionNotFoundError,
 } from "../services/package-intelligence-service.js";
 import type {
   MappedError,
@@ -54,6 +55,29 @@ function classify(error: unknown): MappedError {
       code: "NOT_FOUND",
       message: error.message,
       retryable: false,
+    };
+  }
+  if (error instanceof PackageIntelligenceVersionNotFoundError) {
+    const details: MappedErrorDetails = {};
+    if (error.packageName) details.package = error.packageName;
+    if (error.requestedVersion) {
+      details.requestedVersion = error.requestedVersion;
+    }
+    if (error.availableVersions && error.availableVersions.length > 0) {
+      // `availableVersions` on this typed error is `string[]` —
+      // narrower than the code-nav precedent's `{version, ref}[]`
+      // because vulns registries have no ref concept. Match the
+      // shared envelope shape by mapping into `{version}` objects.
+      details.availableVersions = error.availableVersions.map((version) => ({
+        version,
+        ref: version,
+      }));
+    }
+    return {
+      code: "VERSION_NOT_FOUND",
+      message: error.message,
+      retryable: false,
+      details: Object.keys(details).length > 0 ? details : undefined,
     };
   }
   if (error instanceof PackageIntelligenceValidationError) {
@@ -135,9 +159,9 @@ function classifyBackendError(
       return build("RATE_LIMITED", true);
     case "UPSTREAM_ERROR":
       return build("BACKEND_ERROR", true);
-    case "INTERNAL_ERROR":
-    case "UNKNOWN_ERROR":
     default:
+      // INTERNAL_ERROR / UNKNOWN_ERROR / any other / undefined all
+      // route to a non-retryable backend error.
       return build("BACKEND_ERROR", false);
   }
 }

--- a/src/shared/package-vulnerabilities-request.test.ts
+++ b/src/shared/package-vulnerabilities-request.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from "bun:test";
+import {
+  InvalidPackageSpecError,
+  UnsupportedRegistryError,
+} from "./package-spec.js";
+import {
+  buildPackageVulnerabilitiesParams,
+  SEVERITY_LABEL_TO_CVSS,
+  supportsVulnerabilitiesRegistry,
+  UnsupportedVulnerabilitiesRegistryError,
+} from "./package-vulnerabilities-request.js";
+
+describe("buildPackageVulnerabilitiesParams", () => {
+  it("maps lowercase registry to uppercase backend enum", () => {
+    const { params } = buildPackageVulnerabilitiesParams({
+      registry: "npm",
+      packageName: "express",
+    });
+    expect(params.registry).toBe("NPM");
+    expect(params.packageName).toBe("express");
+  });
+
+  it("trims whitespace on packageName and version", () => {
+    const { params } = buildPackageVulnerabilitiesParams({
+      registry: "npm",
+      packageName: "  express  ",
+      version: "  4.18.0  ",
+    });
+    expect(params.packageName).toBe("express");
+    expect(params.version).toBe("4.18.0");
+  });
+
+  it("passes version through when supplied", () => {
+    const { params } = buildPackageVulnerabilitiesParams({
+      registry: "npm",
+      packageName: "express",
+      version: "4.18.0",
+    });
+    expect(params.version).toBe("4.18.0");
+  });
+
+  it("rejects tag-style versions with a leading v", () => {
+    expect(() =>
+      buildPackageVulnerabilitiesParams({
+        registry: "npm",
+        packageName: "express",
+        version: "v4.18.0",
+      }),
+    ).toThrow(InvalidPackageSpecError);
+  });
+
+  it("omits version when not supplied", () => {
+    const { params } = buildPackageVulnerabilitiesParams({
+      registry: "npm",
+      packageName: "express",
+    });
+    expect(params.version).toBeUndefined();
+  });
+
+  it("maps severity labels to CVSS floats (lowercase)", () => {
+    expect(
+      buildPackageVulnerabilitiesParams({
+        registry: "npm",
+        packageName: "express",
+        minSeverity: "low",
+      }).params.minSeverity,
+    ).toBe(0.1);
+    expect(
+      buildPackageVulnerabilitiesParams({
+        registry: "npm",
+        packageName: "express",
+        minSeverity: "medium",
+      }).params.minSeverity,
+    ).toBe(4.0);
+    expect(
+      buildPackageVulnerabilitiesParams({
+        registry: "npm",
+        packageName: "express",
+        minSeverity: "high",
+      }).params.minSeverity,
+    ).toBe(7.0);
+    expect(
+      buildPackageVulnerabilitiesParams({
+        registry: "npm",
+        packageName: "express",
+        minSeverity: "critical",
+      }).params.minSeverity,
+    ).toBe(9.0);
+  });
+
+  it("tolerates uppercase severity input", () => {
+    expect(
+      buildPackageVulnerabilitiesParams({
+        registry: "npm",
+        packageName: "express",
+        minSeverity: "CRITICAL",
+      }).params.minSeverity,
+    ).toBe(9.0);
+    expect(
+      buildPackageVulnerabilitiesParams({
+        registry: "npm",
+        packageName: "express",
+        minSeverity: "  High  ",
+      }).params.minSeverity,
+    ).toBe(7.0);
+  });
+
+  it("rejects unknown severity labels", () => {
+    expect(() =>
+      buildPackageVulnerabilitiesParams({
+        registry: "npm",
+        packageName: "express",
+        minSeverity: "severe",
+      }),
+    ).toThrow(InvalidPackageSpecError);
+  });
+
+  it("passes includeWithdrawn through", () => {
+    const { params } = buildPackageVulnerabilitiesParams({
+      registry: "npm",
+      packageName: "express",
+      includeWithdrawn: true,
+    });
+    expect(params.includeWithdrawn).toBe(true);
+  });
+
+  it("rejects empty packageName", () => {
+    expect(() =>
+      buildPackageVulnerabilitiesParams({ registry: "npm", packageName: "" }),
+    ).toThrow(InvalidPackageSpecError);
+    expect(() =>
+      buildPackageVulnerabilitiesParams({
+        registry: "npm",
+        packageName: "   ",
+      }),
+    ).toThrow(InvalidPackageSpecError);
+  });
+
+  it("rejects totally unknown registries with generic message", () => {
+    try {
+      buildPackageVulnerabilitiesParams({
+        registry: "cargo",
+        packageName: "serde",
+      });
+      throw new Error("expected throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(UnsupportedRegistryError);
+      expect((error as Error).message).toContain("Unsupported registry");
+    }
+  });
+
+  it("rejects known-but-unsupported registries with tool-specific message", () => {
+    const unsupported = ["vcpkg", "zig", "nuget", "maven", "packagist"];
+    for (const registry of unsupported) {
+      try {
+        buildPackageVulnerabilitiesParams({
+          registry,
+          packageName: "x",
+        });
+        throw new Error(`expected throw for ${registry}`);
+      } catch (error) {
+        expect(error).toBeInstanceOf(UnsupportedVulnerabilitiesRegistryError);
+        expect((error as Error).message).toBe(
+          `pkg vulns only supports npm, pypi, hex, and crates. Got: ${registry}.`,
+        );
+      }
+    }
+  });
+
+  it("accepts all four supported registries", () => {
+    const supported = ["npm", "pypi", "hex", "crates"];
+    for (const registry of supported) {
+      expect(() =>
+        buildPackageVulnerabilitiesParams({
+          registry,
+          packageName: "x",
+        }),
+      ).not.toThrow();
+    }
+  });
+});
+
+describe("supportsVulnerabilitiesRegistry", () => {
+  it("accepts the four supported registries", () => {
+    expect(supportsVulnerabilitiesRegistry("NPM")).toBe(true);
+    expect(supportsVulnerabilitiesRegistry("PYPI")).toBe(true);
+    expect(supportsVulnerabilitiesRegistry("HEX")).toBe(true);
+    expect(supportsVulnerabilitiesRegistry("CRATES")).toBe(true);
+  });
+
+  it("rejects the five unsupported registries", () => {
+    expect(supportsVulnerabilitiesRegistry("NUGET")).toBe(false);
+    expect(supportsVulnerabilitiesRegistry("MAVEN")).toBe(false);
+    expect(supportsVulnerabilitiesRegistry("ZIG")).toBe(false);
+    expect(supportsVulnerabilitiesRegistry("VCPKG")).toBe(false);
+    expect(supportsVulnerabilitiesRegistry("PACKAGIST")).toBe(false);
+  });
+});
+
+describe("SEVERITY_LABEL_TO_CVSS", () => {
+  it("covers the four severity labels with CVSS thresholds", () => {
+    expect(SEVERITY_LABEL_TO_CVSS.low).toBe(0.1);
+    expect(SEVERITY_LABEL_TO_CVSS.medium).toBe(4.0);
+    expect(SEVERITY_LABEL_TO_CVSS.high).toBe(7.0);
+    expect(SEVERITY_LABEL_TO_CVSS.critical).toBe(9.0);
+  });
+});

--- a/src/shared/package-vulnerabilities-request.ts
+++ b/src/shared/package-vulnerabilities-request.ts
@@ -1,0 +1,176 @@
+/**
+ * Shared request builder for the `package_vulnerabilities` tool. Both
+ * the CLI command and the MCP tool normalise their inputs through this
+ * module.
+ *
+ * Responsibilities:
+ * - Trim whitespace on `packageName`; reject empty strings with
+ *   `InvalidPackageSpecError`.
+ * - Normalise registry case and validate against the known 9-value
+ *   surface via `pkgseer-registry`; reject unknown registries with
+ *   the generic `UnsupportedRegistryError` message.
+ * - Gate against the vulnerability-query's narrower registry support
+ *   (backend currently supports only npm, pypi, hex, crates). Known-
+ *   but-unsupported registries are rejected client-side with a
+ *   tool-specific message so the backend never sees them. The
+ *   predicate `supportsVulnerabilitiesRegistry` lives here (not in
+ *   `pkgseer-registry.ts`) because it is a tool-specific capability
+ *   matrix, not a registry-taxonomy concern.
+ * - Map `minSeverity` label → CVSS float threshold (backend takes a
+ *   `Float`; CLI/MCP accept a label for discoverability). Uppercase
+ *   input is tolerated.
+ * - Reject tag-style versions with a leading `v` (`v1.2.3`). This
+ *   tool accepts canonical package versions, not git refs; the live
+ *   backend currently answers these with an unhelpful generic error,
+ *   so we fail fast with an actionable client-side message instead.
+ *   TODO(pkgseer-backend): replace this narrow guard with typed,
+ *   ecosystem-aware version validation from the backend. Do not grow
+ *   ad hoc normalization rules here.
+ */
+
+import type { PackageVulnerabilitiesParams } from "../services/index.js";
+import {
+  InvalidPackageSpecError,
+  UnsupportedRegistryError,
+} from "./package-spec.js";
+import {
+  isKnownPkgseerRegistryArg,
+  type PkgseerRegistry,
+  type PkgseerRegistryArg,
+  toPkgseerRegistry,
+} from "./pkgseer-registry.js";
+
+/**
+ * Raised when the caller targets a registry that is unsupported by
+ * the vulnerabilities query specifically (rather than being unknown
+ * to the spec parser). Name-prefix `Unsupported` routes via the
+ * shared classifier to `INVALID_ARGUMENT`. Message is tool-specific
+ * and points the caller at the supported set.
+ */
+export class UnsupportedVulnerabilitiesRegistryError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "UnsupportedVulnerabilitiesRegistryError";
+  }
+}
+
+export type SeverityLabel = "low" | "medium" | "high" | "critical";
+
+export const SEVERITY_LABEL_TO_CVSS: Readonly<Record<SeverityLabel, number>> = {
+  // 0.1 excludes null-severity advisories (backend drops null when any
+  // filter is set) without functionally suppressing `low`-banded
+  // entries. Agents/users rarely want to see a million irrelevant
+  // advisories, but `--severity low` is available for completeness.
+  low: 0.1,
+  medium: 4.0,
+  high: 7.0,
+  critical: 9.0,
+};
+
+const SUPPORTED_VULN_REGISTRIES: ReadonlySet<PkgseerRegistry> = new Set([
+  "NPM",
+  "PYPI",
+  "HEX",
+  "CRATES",
+]);
+
+const SUPPORTED_VULN_REGISTRIES_HUMAN = "npm, pypi, hex, and crates";
+
+/**
+ * Tool-local capability predicate. Only 4 of the 9 registries our
+ * spec parser understands have vulnerability data on the backend.
+ * When a second tool needs per-tool registry restrictions, extract to
+ * a dedicated `pkgseer-capabilities.ts` module.
+ */
+export function supportsVulnerabilitiesRegistry(
+  registry: PkgseerRegistry,
+): boolean {
+  return SUPPORTED_VULN_REGISTRIES.has(registry);
+}
+
+export interface PackageVulnerabilitiesRequestInput {
+  /** Lowercase registry surface value (`npm`, `pypi`, …). */
+  registry: string;
+  /** Raw package name — may carry surrounding whitespace. */
+  packageName: string;
+  /** Optional version string — backend defaults to latest when omitted. */
+  version?: string;
+  /** Optional severity label; uppercase tolerated. */
+  minSeverity?: string;
+  /** Optional flag to include withdrawn advisories. */
+  includeWithdrawn?: boolean;
+}
+
+export interface PackageVulnerabilitiesRequestBuildResult {
+  params: PackageVulnerabilitiesParams;
+}
+
+export function buildPackageVulnerabilitiesParams(
+  input: PackageVulnerabilitiesRequestInput,
+): PackageVulnerabilitiesRequestBuildResult {
+  const trimmedName = input.packageName?.trim() ?? "";
+  if (!trimmedName) {
+    throw new InvalidPackageSpecError("Package name is required.");
+  }
+
+  const normalisedRegistryArg = input.registry?.trim().toLowerCase() ?? "";
+  if (!isKnownPkgseerRegistryArg(normalisedRegistryArg)) {
+    throw new UnsupportedRegistryError(
+      `Unsupported registry '${input.registry}'. Supported: npm, pypi, hex, crates, nuget, maven, zig, vcpkg, packagist.`,
+    );
+  }
+
+  const registry = toPkgseerRegistry(
+    normalisedRegistryArg as PkgseerRegistryArg,
+  );
+  if (!supportsVulnerabilitiesRegistry(registry)) {
+    throw new UnsupportedVulnerabilitiesRegistryError(
+      `pkg vulns only supports ${SUPPORTED_VULN_REGISTRIES_HUMAN}. Got: ${normalisedRegistryArg}.`,
+    );
+  }
+
+  const minSeverity = resolveMinSeverity(input.minSeverity);
+  const trimmedVersion = input.version?.trim();
+  // Temporary guard until the backend returns a typed invalid-version
+  // error with per-ecosystem version semantics.
+  if (trimmedVersion && /^v\d/i.test(trimmedVersion)) {
+    throw new InvalidPackageSpecError(
+      `Invalid version '${trimmedVersion}'. Use the canonical package version without a leading 'v' (for example '4.18.0', not 'v4.18.0').`,
+    );
+  }
+
+  return {
+    params: {
+      registry,
+      packageName: trimmedName,
+      version:
+        trimmedVersion && trimmedVersion.length > 0
+          ? trimmedVersion
+          : undefined,
+      minSeverity,
+      includeWithdrawn: input.includeWithdrawn,
+    },
+  };
+}
+
+function resolveMinSeverity(raw: string | undefined): number | undefined {
+  if (raw === undefined) return undefined;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return undefined;
+  const lower = trimmed.toLowerCase();
+  if (!isSeverityLabel(lower)) {
+    throw new InvalidPackageSpecError(
+      `Unsupported severity '${raw}'. Expected one of: low, medium, high, critical.`,
+    );
+  }
+  return SEVERITY_LABEL_TO_CVSS[lower];
+}
+
+export function isSeverityLabel(value: string): value is SeverityLabel {
+  return (
+    value === "low" ||
+    value === "medium" ||
+    value === "high" ||
+    value === "critical"
+  );
+}

--- a/src/shared/package-vulnerabilities-response.test.ts
+++ b/src/shared/package-vulnerabilities-response.test.ts
@@ -1,0 +1,612 @@
+import { describe, expect, it } from "bun:test";
+import type { VulnerabilityReport } from "../services/index.js";
+import { defaultVulnerabilityReport } from "../services/test-helpers.js";
+import {
+  buildPackageVulnerabilitiesSuccessPayload,
+  compareVersionsAscending,
+  computeBySeverity,
+  formatPackageVulnerabilitiesTerminal,
+  vulnSeverityLabel,
+} from "./package-vulnerabilities-response.js";
+
+function cloneFixture(): VulnerabilityReport {
+  return structuredClone(defaultVulnerabilityReport);
+}
+
+function zeroVulnsFixture(): VulnerabilityReport {
+  return {
+    package: { name: "clean", registry: "NPM", version: "1.0.0" },
+    security: {
+      vulnerabilityCount: 0,
+      currentVersionAffected: false,
+      upgradePaths: [],
+      vulnerabilities: [],
+    },
+  };
+}
+
+describe("vulnSeverityLabel — CVSS banding", () => {
+  it("lands at locked boundaries", () => {
+    expect(vulnSeverityLabel(0.1)).toBe("low");
+    expect(vulnSeverityLabel(3.9)).toBe("low");
+    expect(vulnSeverityLabel(4.0)).toBe("medium");
+    expect(vulnSeverityLabel(6.9)).toBe("medium");
+    expect(vulnSeverityLabel(7.0)).toBe("high");
+    expect(vulnSeverityLabel(8.9)).toBe("high");
+    expect(vulnSeverityLabel(9.0)).toBe("critical");
+    expect(vulnSeverityLabel(10.0)).toBe("critical");
+  });
+
+  it("returns undefined for null / zero / negative", () => {
+    expect(vulnSeverityLabel(undefined)).toBeUndefined();
+    expect(vulnSeverityLabel(null)).toBeUndefined();
+    expect(vulnSeverityLabel(0)).toBeUndefined();
+    expect(vulnSeverityLabel(-1)).toBeUndefined();
+  });
+});
+
+describe("computeBySeverity — partitioning buckets", () => {
+  it("counts malicious advisories only in the malware bucket; buckets partition total", () => {
+    const advisories = cloneFixture().security?.vulnerabilities ?? [];
+    const histogram = computeBySeverity(advisories);
+    expect(histogram).toEqual({
+      malware: 1,
+      critical: 1,
+      high: 1,
+      medium: 1,
+      low: 1,
+      unrated: 1,
+    });
+    // Every advisory lands in exactly one bucket — the sum equals total.
+    const total = defaultVulnerabilityReport.security?.vulnerabilityCount ?? 0;
+    const bucketSum =
+      histogram.malware +
+      histogram.critical +
+      histogram.high +
+      histogram.medium +
+      histogram.low +
+      histogram.unrated;
+    expect(bucketSum).toBe(total);
+  });
+
+  it("malicious + high advisory counts only in malware bucket", () => {
+    const histogram = computeBySeverity([
+      { severityScore: 8.0, isMalicious: true },
+    ]);
+    expect(histogram.malware).toBe(1);
+    expect(histogram.high).toBe(0);
+  });
+
+  it("null-severity non-malicious advisory counts as unrated", () => {
+    const histogram = computeBySeverity([
+      { severityScore: null as unknown as number, isMalicious: false },
+    ]);
+    expect(histogram).toEqual({
+      malware: 0,
+      critical: 0,
+      high: 0,
+      medium: 0,
+      low: 0,
+      unrated: 1,
+    });
+  });
+});
+
+describe("buildPackageVulnerabilitiesSuccessPayload — happy path", () => {
+  it("shapes the full envelope from the default fixture", () => {
+    const payload = buildPackageVulnerabilitiesSuccessPayload(
+      defaultVulnerabilityReport,
+    );
+    expect(payload.registry).toBe("npm");
+    expect(payload.name).toBe("express");
+    expect(payload.version).toBe("4.18.0");
+    expect(payload.summary.total).toBe(6);
+    expect(payload.summary.affected).toBe(true);
+    expect(payload.summary.bySeverity).toEqual({
+      malware: 1,
+      critical: 1,
+      high: 1,
+      medium: 1,
+      low: 1,
+      unrated: 1,
+    });
+    expect(payload.advisories?.length).toBe(6);
+    expect(payload.upgradePaths).toEqual(["4.18.2"]);
+  });
+
+  it("places malicious advisory first in the sorted list", () => {
+    const payload = buildPackageVulnerabilitiesSuccessPayload(
+      defaultVulnerabilityReport,
+    );
+    expect(payload.advisories?.[0]?.isMalicious).toBe(true);
+  });
+
+  it("sorts non-malicious advisories severity desc → date desc → id asc", () => {
+    const payload = buildPackageVulnerabilitiesSuccessPayload(
+      defaultVulnerabilityReport,
+    );
+    const ids = payload.advisories?.map((a) => a.id);
+    // malware first, then critical → high → medium → low → null-severity
+    expect(ids).toEqual([
+      "GHSA-mmmm-mmmm-mmmm", // malware
+      "GHSA-cccc-cccc-cccc", // critical 9.2
+      "GHSA-xxxx-xxxx-xxxx", // high 7.5
+      "GHSA-yyyy-yyyy-yyyy", // medium 5.3
+      "GHSA-zzzz-zzzz-zzzz", // low 3.2
+      "GHSA-nnnn-nnnn-nnnn", // null severity
+    ]);
+  });
+});
+
+describe("buildPackageVulnerabilitiesSuccessPayload — omission rules", () => {
+  it("zero-vulns case strips summary blocks and omits advisories", () => {
+    const payload = buildPackageVulnerabilitiesSuccessPayload(
+      zeroVulnsFixture(),
+    );
+    expect(payload.summary).toEqual({ total: 0 });
+    expect(payload.advisories).toBeUndefined();
+    expect(payload.upgradePaths).toBeUndefined();
+  });
+
+  it("omits empty aliases / fixedIn / affectedRanges arrays", () => {
+    const fixture = cloneFixture();
+    const malware = fixture.security?.vulnerabilities?.[0];
+    if (malware) {
+      malware.aliases = [];
+      malware.fixedInVersions = [];
+    }
+    const payload = buildPackageVulnerabilitiesSuccessPayload(fixture);
+    const lean = payload.advisories?.[0];
+    expect(lean?.aliases).toBeUndefined();
+    expect(lean?.fixedIn).toBeUndefined();
+    expect(lean?.affectedRanges).toEqual([">= 4.17.0, < 4.18.1"]);
+  });
+
+  it("omits modifiedAt when it equals publishedAt", () => {
+    const fixture = cloneFixture();
+    const advisory = fixture.security?.vulnerabilities?.find(
+      (v) => v.osvId === "GHSA-yyyy-yyyy-yyyy",
+    );
+    if (advisory) advisory.modifiedAt = advisory.publishedAt;
+    const payload = buildPackageVulnerabilitiesSuccessPayload(fixture);
+    const lean = payload.advisories?.find(
+      (a) => a.id === "GHSA-yyyy-yyyy-yyyy",
+    );
+    expect(lean?.modifiedAt).toBeUndefined();
+  });
+
+  it("includes modifiedAt only when it differs from publishedAt", () => {
+    const payload = buildPackageVulnerabilitiesSuccessPayload(
+      defaultVulnerabilityReport,
+    );
+    const lean = payload.advisories?.find(
+      (a) => a.id === "GHSA-yyyy-yyyy-yyyy",
+    );
+    expect(lean?.modifiedAt).toBe("2024-04-02");
+    expect(lean?.publishedAt).toBe("2024-03-12");
+  });
+
+  it("omits severity/severityLabel when score is null or non-positive", () => {
+    const payload = buildPackageVulnerabilitiesSuccessPayload(
+      defaultVulnerabilityReport,
+    );
+    const nullSeverity = payload.advisories?.find(
+      (a) => a.id === "GHSA-nnnn-nnnn-nnnn",
+    );
+    expect(nullSeverity?.severity).toBeUndefined();
+    expect(nullSeverity?.severityLabel).toBeUndefined();
+  });
+
+  it("only includes isMalicious when true", () => {
+    const payload = buildPackageVulnerabilitiesSuccessPayload(
+      defaultVulnerabilityReport,
+    );
+    const malware = payload.advisories?.find((a) => a.isMalicious === true);
+    expect(malware?.isMalicious).toBe(true);
+    const regular = payload.advisories?.find(
+      (a) => a.id === "GHSA-xxxx-xxxx-xxxx",
+    );
+    expect(regular?.isMalicious).toBeUndefined();
+  });
+
+  it("includes withdrawnAt when set; withdrawn advisories sink to the bottom", () => {
+    const fixture = cloneFixture();
+    const advisory = fixture.security?.vulnerabilities?.find(
+      (v) => v.osvId === "GHSA-yyyy-yyyy-yyyy",
+    );
+    if (advisory) advisory.withdrawnAt = "2024-05-01T00:00:00Z";
+    const payload = buildPackageVulnerabilitiesSuccessPayload(fixture);
+    const lean = payload.advisories?.find(
+      (a) => a.id === "GHSA-yyyy-yyyy-yyyy",
+    );
+    expect(lean?.withdrawnAt).toBe("2024-05-01");
+    // Withdrawn should be at the bottom of the list.
+    expect(payload.advisories?.[payload.advisories.length - 1]?.id).toBe(
+      "GHSA-yyyy-yyyy-yyyy",
+    );
+  });
+
+  it("omits upgradePaths when empty", () => {
+    const fixture = cloneFixture();
+    if (fixture.security) fixture.security.upgradePaths = [];
+    const payload = buildPackageVulnerabilitiesSuccessPayload(fixture);
+    expect(payload.upgradePaths).toBeUndefined();
+  });
+});
+
+describe("buildPackageVulnerabilitiesSuccessPayload — requestedVersion echo", () => {
+  it("omits requestedVersion when caller supplied none", () => {
+    const payload = buildPackageVulnerabilitiesSuccessPayload(
+      defaultVulnerabilityReport,
+    );
+    expect(payload.requestedVersion).toBeUndefined();
+  });
+
+  it("omits requestedVersion when caller and backend match exactly", () => {
+    const payload = buildPackageVulnerabilitiesSuccessPayload(
+      defaultVulnerabilityReport,
+      { requestedVersion: "4.18.0" },
+    );
+    expect(payload.requestedVersion).toBeUndefined();
+  });
+
+  it("surfaces requestedVersion on any non-empty divergence, including v-prefix forms", () => {
+    // Unlike `search_symbols` (which normalises `v`-prefixed refs
+    // via `isTrivialRefDifference`), the vulnerabilities query takes
+    // a version string, not a git ref. `v4.18.0` is a tag
+    // convention; no registry accepts it as a canonical version, so
+    // surfacing the divergence here points at a real caller mistake
+    // rather than masking it.
+    const payload = buildPackageVulnerabilitiesSuccessPayload(
+      defaultVulnerabilityReport,
+      { requestedVersion: "v4.18.0" },
+    );
+    expect(payload.requestedVersion).toBe("v4.18.0");
+  });
+
+  it("includes requestedVersion on non-trivial mismatch", () => {
+    const payload = buildPackageVulnerabilitiesSuccessPayload(
+      defaultVulnerabilityReport,
+      { requestedVersion: "4.17" },
+    );
+    expect(payload.requestedVersion).toBe("4.17");
+  });
+
+  it("partition invariant: bucket sum equals vulnerabilities.length (and summary.total when backend is consistent)", () => {
+    // Client-side guarantee: the six buckets partition
+    // `security.vulnerabilities[]`. In the default fixture the
+    // backend also keeps `vulnerabilityCount` in sync with the list
+    // length, so the sum additionally matches `summary.total` — the
+    // visible CLI / MCP reconciliation users see.
+    const payload = buildPackageVulnerabilitiesSuccessPayload(
+      defaultVulnerabilityReport,
+    );
+    const buckets = payload.summary.bySeverity ?? {};
+    const sum =
+      (buckets.malware ?? 0) +
+      (buckets.critical ?? 0) +
+      (buckets.high ?? 0) +
+      (buckets.medium ?? 0) +
+      (buckets.low ?? 0) +
+      (buckets.unrated ?? 0);
+    const returnedCount =
+      defaultVulnerabilityReport.security?.vulnerabilities?.length ?? 0;
+    expect(sum).toBe(returnedCount);
+    expect(sum).toBe(payload.summary.total);
+  });
+});
+
+describe("formatPackageVulnerabilitiesTerminal", () => {
+  it("renders zero-vulns hot path as header + one summary body line", () => {
+    const output = formatPackageVulnerabilitiesTerminal(zeroVulnsFixture(), {
+      useColors: false,
+    });
+    expect(output).toBe("clean @ 1.0.0 · npm\nNo known vulnerabilities.\n");
+  });
+
+  it("renders default terminal block with header, summary, breakdown, advisories, footer", () => {
+    const output = formatPackageVulnerabilitiesTerminal(
+      defaultVulnerabilityReport,
+      { useColors: false },
+    );
+    expect(output).toContain("express @ 4.18.0 · npm");
+    expect(output).toContain("6 known vulnerabilities · latest affected");
+    expect(output).toContain("MALWARE");
+    expect(output).toContain("GHSA-mmmm-mmmm-mmmm");
+    expect(output).toContain("Upgrade to 4.18.2.");
+  });
+
+  it("shows MALWARE · crit combined label for malicious + severe advisory", () => {
+    const fixture = cloneFixture();
+    if (fixture.security?.vulnerabilities?.[0]) {
+      fixture.security.vulnerabilities[0].severityScore = 9.5;
+    }
+    const output = formatPackageVulnerabilitiesTerminal(fixture, {
+      useColors: false,
+    });
+    expect(output).toContain("MALWARE · critical");
+  });
+
+  it("omits breakdown line when total is 1", () => {
+    const fixture = cloneFixture();
+    if (fixture.security) {
+      fixture.security.vulnerabilityCount = 1;
+      fixture.security.vulnerabilities =
+        fixture.security.vulnerabilities?.slice(2, 3) ?? []; // keep one high CVE
+    }
+    const output = formatPackageVulnerabilitiesTerminal(fixture, {
+      useColors: false,
+    });
+    expect(output).toContain("1 known vulnerability");
+    expect(output).not.toContain("1 high");
+  });
+
+  it("appends (requested X) line when requestedVersion fires", () => {
+    const output = formatPackageVulnerabilitiesTerminal(
+      defaultVulnerabilityReport,
+      { useColors: false, requestedVersion: "4.17" },
+    );
+    expect(output).toContain("(requested 4.17)");
+  });
+
+  it("appends (requested vX.Y.Z) line when caller used a `v`-prefixed form (tag ≠ version)", () => {
+    const output = formatPackageVulnerabilitiesTerminal(
+      defaultVulnerabilityReport,
+      { useColors: false, requestedVersion: "v4.18.0" },
+    );
+    expect(output).toContain("(requested v4.18.0)");
+  });
+
+  it("renders Upgrade options: A, B, C. for multiple paths", () => {
+    const fixture = cloneFixture();
+    if (fixture.security) {
+      fixture.security.upgradePaths = ["4.17.4", "4.18.2"];
+    }
+    const output = formatPackageVulnerabilitiesTerminal(fixture, {
+      useColors: false,
+    });
+    expect(output).toContain("Upgrade options: 4.17.4, 4.18.2.");
+  });
+
+  it("omits upgrade footer when no paths", () => {
+    const fixture = cloneFixture();
+    if (fixture.security) fixture.security.upgradePaths = [];
+    const output = formatPackageVulnerabilitiesTerminal(fixture, {
+      useColors: false,
+    });
+    expect(output).not.toContain("Upgrade");
+  });
+
+  it("verbose adds aliases, severity, published/modified rows where applicable", () => {
+    const output = formatPackageVulnerabilitiesTerminal(
+      defaultVulnerabilityReport,
+      { useColors: false, verbose: true },
+    );
+    expect(output).toContain("aliases");
+    expect(output).toContain("CVE-2024-5678, CVE-2024-5679");
+    expect(output).toContain("severity");
+    expect(output).toContain("7.5 (CVSS)");
+    expect(output).toContain("modified");
+    expect(output).toContain("2024-04-02");
+    expect(output).toContain("malicious");
+  });
+
+  it("no-color output contains no ANSI escape sequences", () => {
+    const output = formatPackageVulnerabilitiesTerminal(
+      defaultVulnerabilityReport,
+      { useColors: false, verbose: true },
+    );
+    expect(output).not.toContain("\x1b[");
+  });
+
+  it("breakdown line includes unrated bucket so the sum reconciles with total", () => {
+    const output = formatPackageVulnerabilitiesTerminal(
+      defaultVulnerabilityReport,
+      { useColors: false },
+    );
+    // Fixture has 6 advisories: 1 malware, 1 crit, 1 high, 1 medium, 1 low,
+    // 1 unrated. Breakdown line must enumerate all six to match the total.
+    expect(output).toMatch(
+      /1 MALWARE · 1 crit · 1 high · 1 medium · 1 low · 1 unrated/,
+    );
+  });
+
+  it("truncates long affected-range lists in compact mode with a +N more hint", () => {
+    const fixture = cloneFixture();
+    const advisory = fixture.security?.vulnerabilities?.[1]; // GHSA-cccc critical
+    if (advisory) {
+      advisory.affectedVersionRanges = [
+        "==1.0.0",
+        "==1.0.1",
+        "==1.0.2",
+        "==1.0.3",
+        "==1.0.4",
+        "==1.0.5",
+        "==1.0.6",
+      ];
+    }
+    const output = formatPackageVulnerabilitiesTerminal(fixture, {
+      useColors: false,
+    });
+    // First 4 ranges shown; the remaining 3 collapse into the hint.
+    expect(output).toContain(
+      "affected ==1.0.0, ==1.0.1, ==1.0.2, ==1.0.3, … (+3 more; use -v)",
+    );
+    expect(output).not.toContain("==1.0.4,");
+  });
+
+  it("verbose mode shows every affected range without truncation", () => {
+    const fixture = cloneFixture();
+    const advisory = fixture.security?.vulnerabilities?.[1];
+    if (advisory) {
+      advisory.affectedVersionRanges = [
+        "==1.0.0",
+        "==1.0.1",
+        "==1.0.2",
+        "==1.0.3",
+        "==1.0.4",
+        "==1.0.5",
+      ];
+    }
+    const output = formatPackageVulnerabilitiesTerminal(fixture, {
+      useColors: false,
+      verbose: true,
+    });
+    expect(output).toContain("==1.0.4, ==1.0.5");
+    expect(output).not.toContain("+2 more");
+  });
+
+  it("singular vulnerability noun when total is 1", () => {
+    const fixture = cloneFixture();
+    if (fixture.security) {
+      fixture.security.vulnerabilityCount = 1;
+      fixture.security.vulnerabilities =
+        fixture.security.vulnerabilities?.slice(2, 3) ?? [];
+    }
+    const output = formatPackageVulnerabilitiesTerminal(fixture, {
+      useColors: false,
+    });
+    expect(output).toContain("1 known vulnerability ·");
+  });
+});
+
+describe("compareVersionsAscending — semver-ish display ordering", () => {
+  it("orders base versions numerically across major/minor/patch", () => {
+    const input = ["4.20.0", "3.11.0", "4.5.0", "5.0.0", "4.19.2"];
+    const sorted = input.slice().sort(compareVersionsAscending);
+    expect(sorted).toEqual(["3.11.0", "4.5.0", "4.19.2", "4.20.0", "5.0.0"]);
+  });
+
+  it("places pre-release suffixes below the matching base version", () => {
+    const input = ["4.0.0", "4.0.0-rc1", "4.0.0-alpha.1", "3.11.0"];
+    const sorted = input.slice().sort(compareVersionsAscending);
+    expect(sorted).toEqual(["3.11.0", "4.0.0-alpha.1", "4.0.0-rc1", "4.0.0"]);
+  });
+
+  it("recovers exotic strings via lex fallback without throwing", () => {
+    const input = ["abc", "1.2.3", "zzz", "0.1.0"];
+    const sorted = input.slice().sort(compareVersionsAscending);
+    // Unparseable segments parse to 0, so "abc" and "zzz" both look
+    // like 0.0.0 numerically; lex tiebreak gives stable ordering.
+    expect(sorted[0]).toBe("abc");
+    expect(sorted.includes("1.2.3")).toBe(true);
+    expect(sorted.includes("0.1.0")).toBe(true);
+  });
+});
+
+describe("upgrade-path display ordering", () => {
+  it("sorts upgradePaths ascending and dedupes", () => {
+    const fixture = structuredClone(defaultVulnerabilityReport);
+    if (fixture.security) {
+      // Matches the express-like shape the live backend produces —
+      // advisory iteration order mixes majors and pre-releases.
+      fixture.security.upgradePaths = [
+        "4.19.2",
+        "5.0.0-beta.3",
+        "3.11.0",
+        "4.5.0",
+        "4.20.0",
+        "5.0.0",
+        "4.0.0-rc1",
+        "4.19.2", // duplicate — should be stripped
+      ];
+    }
+    const payload = buildPackageVulnerabilitiesSuccessPayload(fixture);
+    expect(payload.upgradePaths).toEqual([
+      "3.11.0",
+      "4.0.0-rc1",
+      "4.5.0",
+      "4.19.2",
+      "4.20.0",
+      "5.0.0-beta.3",
+      "5.0.0",
+    ]);
+  });
+});
+
+describe("placeholder summary stripping", () => {
+  it("drops literal 'No summary available' from JSON and terminal output", () => {
+    const fixture = structuredClone(defaultVulnerabilityReport);
+    const target = fixture.security?.vulnerabilities?.find(
+      (v) => v.osvId === "GHSA-nnnn-nnnn-nnnn",
+    );
+    if (target) target.summary = "No summary available";
+    const payload = buildPackageVulnerabilitiesSuccessPayload(fixture);
+    const lean = payload.advisories?.find(
+      (a) => a.id === "GHSA-nnnn-nnnn-nnnn",
+    );
+    expect(lean?.summary).toBeUndefined();
+
+    const terminal = formatPackageVulnerabilitiesTerminal(fixture, {
+      useColors: false,
+    });
+    expect(terminal).not.toContain("No summary available");
+  });
+
+  it("preserves real summaries (only the placeholder is stripped)", () => {
+    const payload = buildPackageVulnerabilitiesSuccessPayload(
+      defaultVulnerabilityReport,
+    );
+    const lean = payload.advisories?.find(
+      (a) => a.id === "GHSA-cccc-cccc-cccc",
+    );
+    expect(lean?.summary).toBe("RCE via crafted JSON body");
+  });
+});
+
+describe("unrated severity column", () => {
+  it("fills the severity gutter for null-CVSS non-malicious advisories", () => {
+    const output = formatPackageVulnerabilitiesTerminal(
+      defaultVulnerabilityReport,
+      { useColors: false },
+    );
+    // The fixture's null-severity advisory (GHSA-nnnn) used to render
+    // with a blank severity column. It now reads "unrated", matching
+    // the header-breakdown vocabulary.
+    expect(output).toMatch(/unrated\s+GHSA-nnnn-nnnn-nnnn/);
+  });
+});
+
+describe("affected-range cap adapts to terminal width", () => {
+  function buildManyRangesFixture(rangeCount: number): VulnerabilityReport {
+    const fixture = structuredClone(defaultVulnerabilityReport);
+    const advisory = fixture.security?.vulnerabilities?.[1]; // critical CVE
+    if (advisory) {
+      advisory.affectedVersionRanges = Array.from(
+        { length: rangeCount },
+        (_, i) => `==1.${i}.0`,
+      );
+    }
+    return fixture;
+  }
+
+  it("narrow terminal (≤119 cols) caps at 4 ranges", () => {
+    const output = formatPackageVulnerabilitiesTerminal(
+      buildManyRangesFixture(10),
+      { useColors: false, terminalWidth: 80 },
+    );
+    expect(output).toContain("==1.0.0, ==1.1.0, ==1.2.0, ==1.3.0, …");
+    expect(output).toContain("(+6 more; use -v)");
+    expect(output).not.toContain("==1.4.0");
+  });
+
+  it("wide terminal (120–159 cols) caps at 6 ranges", () => {
+    const output = formatPackageVulnerabilitiesTerminal(
+      buildManyRangesFixture(10),
+      { useColors: false, terminalWidth: 120 },
+    );
+    expect(output).toContain(
+      "==1.0.0, ==1.1.0, ==1.2.0, ==1.3.0, ==1.4.0, ==1.5.0",
+    );
+    expect(output).toContain("(+4 more; use -v)");
+  });
+
+  it("ultrawide terminal (≥160 cols) caps at 8 ranges", () => {
+    const output = formatPackageVulnerabilitiesTerminal(
+      buildManyRangesFixture(10),
+      { useColors: false, terminalWidth: 160 },
+    );
+    expect(output).toContain("(+2 more; use -v)");
+    expect(output).not.toContain("(+4 more");
+  });
+});

--- a/src/shared/package-vulnerabilities-response.ts
+++ b/src/shared/package-vulnerabilities-response.ts
@@ -1,0 +1,686 @@
+/**
+ * Hand-crafted response envelope for the `package_vulnerabilities`
+ * tool. Shared by CLI `--json` output and MCP `content[0].text`. The
+ * terminal formatter is CLI-only.
+ *
+ * Key design commitments (locked in the plan):
+ * - Backend is the single source of truth for counts. `minSeverity`
+ *   and `includeWithdrawn` are passed through on the wire; the
+ *   backend returns a filter-aware `vulnerabilityCount`. The builder
+ *   does no filtering of its own.
+ * - Malware bucket is disjoint from severity bands. `summary.bySeverity`
+ *   carries a `malware` key counting `isMalicious === true` advisories;
+ *   severity bands count non-malicious advisories only. Non-malicious
+ *   advisories with no CVSS score fall into a disjoint `unrated`
+ *   bucket so every returned advisory is accounted for. The buckets
+ *   always partition `security.vulnerabilities[]`; their sum equals
+ *   `summary.total` whenever the backend keeps its `vulnerabilityCount`
+ *   and `vulnerabilities[]` in sync (the expected case on all shipped
+ *   registries). The builder does not re-derive `total` from the array
+ *   length because `vulnerabilityCount` is filter-aware and may
+ *   legitimately exceed the returned list in paginated futures.
+ * - `requestedVersion` surfaces whenever the backend-resolved
+ *   `version` differs from the caller's (trimmed) input. `v`-prefix
+ *   normalisation that `search_symbols` does via
+ *   `isTrivialRefDifference` is intentionally *not* applied here:
+ *   the `v4.17.0` form is a git-tag convention, not a version-string
+ *   convention — no supported registry (npm, PyPI, Hex, Crates)
+ *   accepts it as a canonical version, so the backend will reject
+ *   it rather than resolve it to `4.17.0`. Masking that error
+ *   would hide a real caller mistake.
+ * - `modifiedAt` is included only when it differs from `publishedAt`.
+ * - Sort order: malware bucket first; within a bucket, severity desc,
+ *   then `publishedAt` desc, then `osvId` asc (deterministic
+ *   tiebreaker). Withdrawn advisories bucket below all active.
+ */
+
+import type {
+  VulnerabilityDetail,
+  VulnerabilityReport,
+} from "../services/index.js";
+import { colorize, dim } from "./colors.js";
+import { toIsoDate } from "./format-date.js";
+import { toPkgseerRegistryLowercase } from "./pkgseer-registry.js";
+
+export type VulnSeverityLabel = "critical" | "high" | "medium" | "low";
+
+/**
+ * Buckets that partition {@link LeanVulnerabilitySummary.total}. Malware
+ * is disjoint from CVSS bands; `unrated` holds non-malicious advisories
+ * with no CVSS score so the breakdown reconciles with the total.
+ */
+export type VulnBucket = "malware" | VulnSeverityLabel | "unrated";
+
+export interface LeanAdvisory {
+  id?: string;
+  aliases?: string[];
+  summary?: string;
+  severity?: number;
+  severityLabel?: VulnSeverityLabel;
+  affectedRanges?: string[];
+  fixedIn?: string[];
+  publishedAt?: string;
+  modifiedAt?: string;
+  withdrawnAt?: string;
+  isMalicious?: boolean;
+}
+
+export interface LeanVulnerabilitySummary {
+  total: number;
+  affected?: boolean;
+  bySeverity?: Partial<Record<VulnBucket, number>>;
+}
+
+export interface LeanVulnerabilityReport {
+  registry: string;
+  name: string;
+  version: string;
+  requestedVersion?: string;
+  summary: LeanVulnerabilitySummary;
+  advisories?: LeanAdvisory[];
+  upgradePaths?: string[];
+}
+
+export interface BuildVulnerabilitiesPayloadOptions {
+  /** Raw caller-supplied version string (pre-normalisation). */
+  requestedVersion?: string;
+}
+
+/**
+ * Build the lean envelope from a validated {@link VulnerabilityReport}.
+ * Pure, deterministic — no clock, no env reads.
+ */
+export function buildPackageVulnerabilitiesSuccessPayload(
+  report: VulnerabilityReport,
+  options: BuildVulnerabilitiesPayloadOptions = {},
+): LeanVulnerabilityReport {
+  const pkg = report.package;
+  const security = report.security;
+  const total = security?.vulnerabilityCount ?? 0;
+
+  const payload: LeanVulnerabilityReport = {
+    registry: lowerRegistry(pkg.registry),
+    name: pkg.name,
+    version: pkg.version,
+    summary: buildSummary(total, security),
+  };
+
+  const requestedEcho = deriveRequestedVersion(
+    options.requestedVersion,
+    pkg.version,
+  );
+  if (requestedEcho !== undefined) {
+    payload.requestedVersion = requestedEcho;
+  }
+
+  if (total > 0) {
+    const sortedAdvisories = sortAdvisories(
+      (security?.vulnerabilities ?? []).map(buildAdvisory),
+    );
+    if (sortedAdvisories.length > 0) {
+      payload.advisories = sortedAdvisories;
+    }
+  }
+
+  const upgradePaths = security?.upgradePaths;
+  if (upgradePaths && upgradePaths.length > 0) {
+    // Ascending semver-ish order (pre-releases sort below their base
+    // version) so the CLI footer reads `Upgrade options: 3.11.0, 4.5.0,
+    // 4.19.2, …` — presenting the minimum-churn upgrade first. Without
+    // this sort the backend's advisory-iteration order produced
+    // jarring mixes like `3.11.0, 4.5.0, 4.20.0, 5.0.0, 4.0.0-rc1`.
+    const unique = Array.from(new Set(upgradePaths));
+    unique.sort(compareVersionsAscending);
+    payload.upgradePaths = unique;
+  }
+
+  return payload;
+}
+
+/**
+ * Stable, locale-independent version compare used to sort upgrade
+ * paths. Handles semver-ish `MAJOR.MINOR.PATCH[-pre]` shapes which
+ * covers every vulnerability-capable registry (npm, PyPI, Hex,
+ * Crates) well enough for display ordering. Unparseable segments
+ * fall back to lexicographic compare so exotic strings never crash
+ * the pipeline.
+ */
+export function compareVersionsAscending(a: string, b: string): number {
+  const pa = parseVersionForSort(a);
+  const pb = parseVersionForSort(b);
+  const len = Math.max(pa.main.length, pb.main.length);
+  for (let i = 0; i < len; i++) {
+    const diff = (pa.main[i] ?? 0) - (pb.main[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  // Base versions equal. Pre-release sorts below the clean release
+  // (matches semver: 4.0.0-rc1 < 4.0.0).
+  if (pa.pre === undefined && pb.pre === undefined) return 0;
+  if (pa.pre === undefined) return 1;
+  if (pb.pre === undefined) return -1;
+  return pa.pre < pb.pre ? -1 : pa.pre > pb.pre ? 1 : 0;
+}
+
+function parseVersionForSort(v: string): { main: number[]; pre?: string } {
+  const [mainStr, ...preParts] = v.split("-");
+  const pre = preParts.length > 0 ? preParts.join("-") : undefined;
+  const main = (mainStr ?? "").split(".").map((segment) => {
+    const n = Number.parseInt(segment, 10);
+    return Number.isFinite(n) ? n : 0;
+  });
+  return { main, pre };
+}
+
+// --------------------------------------------------------------------
+// Summary
+// --------------------------------------------------------------------
+
+function buildSummary(
+  total: number,
+  security: VulnerabilityReport["security"],
+): LeanVulnerabilitySummary {
+  const summary: LeanVulnerabilitySummary = { total };
+  if (total === 0) return summary;
+
+  if (typeof security?.currentVersionAffected === "boolean") {
+    summary.affected = security.currentVersionAffected;
+  }
+
+  const bySeverity = computeBySeverity(security?.vulnerabilities ?? []);
+  const anyCounted = Object.values(bySeverity).some((n) => n > 0);
+  if (anyCounted) {
+    const trimmed: Partial<Record<VulnBucket, number>> = {};
+    // Preserve insertion order so JSON output is deterministic and
+    // matches the terminal breakdown line order.
+    for (const key of BUCKET_ORDER) {
+      const n = bySeverity[key];
+      if (n > 0) trimmed[key] = n;
+    }
+    summary.bySeverity = trimmed;
+  }
+
+  return summary;
+}
+
+/**
+ * Partitioning histogram: every advisory lands in exactly one bucket.
+ * Malicious advisories count under `malware`; non-malicious advisories
+ * with a positive CVSS score count under their band; non-malicious
+ * advisories with no score count under `unrated`.
+ */
+export function computeBySeverity(
+  advisories: readonly VulnerabilityDetail[],
+): Record<VulnBucket, number> {
+  const histogram: Record<VulnBucket, number> = {
+    malware: 0,
+    critical: 0,
+    high: 0,
+    medium: 0,
+    low: 0,
+    unrated: 0,
+  };
+  for (const advisory of advisories) {
+    if (advisory.isMalicious === true) {
+      histogram.malware += 1;
+      continue;
+    }
+    const label = vulnSeverityLabel(advisory.severityScore);
+    if (label !== undefined) {
+      histogram[label] += 1;
+    } else {
+      histogram.unrated += 1;
+    }
+  }
+  return histogram;
+}
+
+const BUCKET_ORDER: readonly VulnBucket[] = [
+  "malware",
+  "critical",
+  "high",
+  "medium",
+  "low",
+  "unrated",
+];
+
+export function vulnSeverityLabel(
+  score: number | null | undefined,
+): VulnSeverityLabel | undefined {
+  if (typeof score !== "number" || score <= 0) return undefined;
+  if (score >= 9) return "critical";
+  if (score >= 7) return "high";
+  if (score >= 4) return "medium";
+  return "low";
+}
+
+// --------------------------------------------------------------------
+// Advisory shaping
+// --------------------------------------------------------------------
+
+function buildAdvisory(advisory: VulnerabilityDetail): LeanAdvisory {
+  const lean: LeanAdvisory = {};
+  if (advisory.osvId) lean.id = advisory.osvId;
+  if (advisory.aliases && advisory.aliases.length > 0) {
+    lean.aliases = advisory.aliases.slice();
+  }
+  if (advisory.summary && !isPlaceholderSummary(advisory.summary)) {
+    lean.summary = advisory.summary;
+  }
+
+  if (
+    typeof advisory.severityScore === "number" &&
+    advisory.severityScore > 0
+  ) {
+    lean.severity = advisory.severityScore;
+    const label = vulnSeverityLabel(advisory.severityScore);
+    if (label !== undefined) lean.severityLabel = label;
+  }
+
+  if (
+    advisory.affectedVersionRanges &&
+    advisory.affectedVersionRanges.length > 0
+  ) {
+    lean.affectedRanges = advisory.affectedVersionRanges.slice();
+  }
+  if (advisory.fixedInVersions && advisory.fixedInVersions.length > 0) {
+    lean.fixedIn = advisory.fixedInVersions.slice();
+  }
+
+  const publishedAt = toIsoDate(advisory.publishedAt);
+  if (publishedAt) lean.publishedAt = publishedAt;
+
+  const modifiedAt = toIsoDate(advisory.modifiedAt);
+  if (modifiedAt && modifiedAt !== publishedAt) {
+    lean.modifiedAt = modifiedAt;
+  }
+
+  const withdrawnAt = toIsoDate(advisory.withdrawnAt);
+  if (withdrawnAt) lean.withdrawnAt = withdrawnAt;
+
+  if (advisory.isMalicious === true) {
+    lean.isMalicious = true;
+  }
+
+  return lean;
+}
+
+// --------------------------------------------------------------------
+// Sort
+// --------------------------------------------------------------------
+
+const SEVERITY_RANK: Readonly<Record<VulnSeverityLabel, number>> = {
+  critical: 4,
+  high: 3,
+  medium: 2,
+  low: 1,
+};
+
+function sortAdvisories(advisories: LeanAdvisory[]): LeanAdvisory[] {
+  return advisories.slice().sort(compareAdvisories);
+}
+
+function compareAdvisories(a: LeanAdvisory, b: LeanAdvisory): number {
+  // 1. Active advisories come before withdrawn.
+  const aWithdrawn = a.withdrawnAt !== undefined;
+  const bWithdrawn = b.withdrawnAt !== undefined;
+  if (aWithdrawn !== bWithdrawn) return aWithdrawn ? 1 : -1;
+
+  // 2. Malicious advisories float to the top of their bucket.
+  const aMalware = a.isMalicious === true;
+  const bMalware = b.isMalicious === true;
+  if (aMalware !== bMalware) return aMalware ? -1 : 1;
+
+  // 3. Severity descending.
+  const aRank = a.severityLabel ? SEVERITY_RANK[a.severityLabel] : 0;
+  const bRank = b.severityLabel ? SEVERITY_RANK[b.severityLabel] : 0;
+  if (aRank !== bRank) return bRank - aRank;
+
+  // 4. publishedAt descending (most recent first).
+  const aDate = a.publishedAt ?? "";
+  const bDate = b.publishedAt ?? "";
+  if (aDate !== bDate) return aDate < bDate ? 1 : -1;
+
+  // 5. Final deterministic tiebreaker: osvId ascending.
+  const aId = a.id ?? "";
+  const bId = b.id ?? "";
+  if (aId !== bId) return aId < bId ? -1 : 1;
+  return 0;
+}
+
+// --------------------------------------------------------------------
+// Version-echo derivation
+// --------------------------------------------------------------------
+
+function deriveRequestedVersion(
+  requested: string | undefined,
+  resolved: string,
+): string | undefined {
+  if (requested === undefined) return undefined;
+  const trimmed = requested.trim();
+  if (trimmed.length === 0) return undefined;
+  // Any non-empty divergence from the resolved version surfaces as
+  // `requestedVersion`. No `v`-prefix suppression: a registry that
+  // accepts a version-only input never treats `v4.17.0` as a valid
+  // canonical version — the `v` prefix is a git-tag convention, not
+  // a semver/PEP 440/Cargo version. If the backend resolved to
+  // something different, that divergence is a real signal the caller
+  // should see.
+  if (trimmed === resolved) return undefined;
+  return trimmed;
+}
+
+// --------------------------------------------------------------------
+// Registry lowering
+// --------------------------------------------------------------------
+
+function lowerRegistry(value: string | undefined): string {
+  if (!value) return "";
+  const upper = value.toUpperCase();
+  try {
+    // biome-ignore lint/suspicious/noExplicitAny: boundary guard
+    return toPkgseerRegistryLowercase(upper as any);
+  } catch {
+    return value.toLowerCase();
+  }
+}
+
+// --------------------------------------------------------------------
+// Terminal formatter (CLI-only; MCP never invokes this)
+// --------------------------------------------------------------------
+
+export interface FormatVulnerabilitiesTerminalOptions {
+  verbose?: boolean;
+  useColors?: boolean;
+  requestedVersion?: string;
+  /**
+   * Terminal width in columns. Used to decide how many
+   * affected-version ranges to show before collapsing into a
+   * `(+N more)` hint. Defaults to a conservative 80 when the caller
+   * doesn't know (tests, piped output).
+   */
+  terminalWidth?: number;
+}
+
+export function formatPackageVulnerabilitiesTerminal(
+  report: VulnerabilityReport,
+  options: FormatVulnerabilitiesTerminalOptions = {},
+): string {
+  const payload = buildPackageVulnerabilitiesSuccessPayload(report, {
+    requestedVersion: options.requestedVersion,
+  });
+  const useColors = options.useColors ?? false;
+  const verbose = options.verbose ?? false;
+
+  const headerLine = formatHeader(payload, useColors);
+  const requestedLine = payload.requestedVersion
+    ? dim(`(requested ${payload.requestedVersion})`, useColors)
+    : undefined;
+
+  if (payload.summary.total === 0) {
+    const lines = [headerLine];
+    if (requestedLine) lines.push(requestedLine);
+    lines.push("No known vulnerabilities.");
+    return `${lines.join("\n")}\n`;
+  }
+
+  const blocks: string[] = [];
+  const headerBlock: string[] = [headerLine];
+  if (requestedLine) headerBlock.push(requestedLine);
+  headerBlock.push(formatSummaryLine(payload, useColors));
+  const breakdown = formatBreakdownLine(payload.summary, useColors);
+  if (breakdown) headerBlock.push(breakdown);
+  blocks.push(headerBlock.join("\n"));
+
+  if (payload.advisories && payload.advisories.length > 0) {
+    const rangeLimit = resolveAffectedRangesLimit(options.terminalWidth);
+    blocks.push(
+      formatAdvisoryList(payload.advisories, verbose, useColors, rangeLimit),
+    );
+  }
+
+  const upgradeFooter = formatUpgradeFooter(payload.upgradePaths);
+  if (upgradeFooter) blocks.push(upgradeFooter);
+
+  return `${blocks.join("\n\n")}\n`;
+}
+
+function formatHeader(
+  payload: LeanVulnerabilityReport,
+  useColors: boolean,
+): string {
+  const name = colorize(payload.name, "bold", useColors);
+  return `${name} @ ${payload.version} · ${payload.registry}`;
+}
+
+function formatSummaryLine(
+  payload: LeanVulnerabilityReport,
+  useColors: boolean,
+): string {
+  const n = payload.summary.total;
+  const noun = n === 1 ? "vulnerability" : "vulnerabilities";
+  const base = `${n} known ${noun}`;
+  // Colour reflects caller risk: yellow/warn when the latest version
+  // is affected; plain text when clean (so "latest clean" doesn't
+  // read as a caution signal).
+  if (payload.summary.affected === true) {
+    return colorize(`${base} · latest affected`, "yellow", useColors);
+  }
+  if (payload.summary.affected === false) {
+    return `${base} · latest clean`;
+  }
+  return base;
+}
+
+function formatBreakdownLine(
+  summary: LeanVulnerabilitySummary,
+  useColors: boolean,
+): string | undefined {
+  // One-advisory case doesn't need a breakdown.
+  if (summary.total <= 1) return undefined;
+  const bucket = summary.bySeverity;
+  if (!bucket) return undefined;
+  const labels: Record<VulnBucket, string> = {
+    malware: "MALWARE",
+    critical: "crit",
+    high: "high",
+    medium: "medium",
+    low: "low",
+    unrated: "unrated",
+  };
+  const parts: string[] = [];
+  for (const key of BUCKET_ORDER) {
+    const count = bucket[key];
+    if (typeof count === "number" && count > 0) {
+      const segment = `${count} ${labels[key]}`;
+      parts.push(
+        key === "malware" ? colorize(segment, "red", useColors) : segment,
+      );
+    }
+  }
+  if (parts.length === 0) return undefined;
+  return `  ${parts.join(" · ")}`;
+}
+
+// --------------------------------------------------------------------
+// Advisory rendering
+// --------------------------------------------------------------------
+
+function formatAdvisoryList(
+  advisories: LeanAdvisory[],
+  verbose: boolean,
+  useColors: boolean,
+  rangeLimit: number,
+): string {
+  const labelWidth = Math.max(
+    ...advisories.map((a) => severityColumnLabel(a).length),
+  );
+  const lines: string[] = [];
+  for (const advisory of advisories) {
+    lines.push(
+      ...formatAdvisoryLines(
+        advisory,
+        labelWidth,
+        verbose,
+        useColors,
+        rangeLimit,
+      ),
+    );
+    lines.push("");
+  }
+  return lines.join("\n").trimEnd();
+}
+
+function severityColumnLabel(advisory: LeanAdvisory): string {
+  if (advisory.isMalicious === true) {
+    if (advisory.severityLabel) return `MALWARE · ${advisory.severityLabel}`;
+    return "MALWARE";
+  }
+  // Filling the column with "unrated" (dim) when the advisory has no
+  // CVSS score beats an empty gutter — users immediately see the
+  // advisory is present, just unbanded, rather than wondering why
+  // the severity column is blank. Matches the header breakdown
+  // label so the two surfaces share vocabulary.
+  return advisory.severityLabel ?? "unrated";
+}
+
+/**
+ * Backend (OSV upstream, in particular) occasionally ships a literal
+ * "No summary available" string where a real summary would go. Strip
+ * it so the terminal row doesn't render a non-informative sentence
+ * and the JSON envelope doesn't leak a placeholder string to
+ * agents. Absence of the field is the signal.
+ */
+function isPlaceholderSummary(summary: string): boolean {
+  return /^\s*no summary available\s*$/i.test(summary);
+}
+
+function severityColumnColor(
+  advisory: LeanAdvisory,
+  useColors: boolean,
+  padded: string,
+): string {
+  if (!useColors) return padded;
+  if (advisory.withdrawnAt !== undefined) return dim(padded, useColors);
+  if (advisory.isMalicious === true) {
+    return `${colorize(padded, "red", useColors)}`;
+  }
+  switch (advisory.severityLabel) {
+    case "critical":
+      return colorize(padded, "red", useColors);
+    case "high":
+      return colorize(padded, "yellow", useColors);
+    case "medium":
+      return colorize(padded, "yellow", useColors);
+    case "low":
+      return dim(padded, useColors);
+    default:
+      // Unrated advisories (no CVSS score) — the label was filled in
+      // by severityColumnLabel; render it dim so it visually ranks
+      // below banded rows.
+      return dim(padded, useColors);
+  }
+}
+
+function formatAdvisoryLines(
+  advisory: LeanAdvisory,
+  labelWidth: number,
+  verbose: boolean,
+  useColors: boolean,
+  rangeLimit: number,
+): string[] {
+  const rawLabel = severityColumnLabel(advisory);
+  const padded = rawLabel.padEnd(labelWidth);
+  const colouredLabel = severityColumnColor(advisory, useColors, padded);
+
+  const parts: string[] = [colouredLabel];
+  if (advisory.id) parts.push(advisory.id);
+  if (advisory.publishedAt) parts.push(advisory.publishedAt);
+  if (advisory.summary) parts.push(advisory.summary);
+
+  const lines: string[] = [`  ${parts.join("  ")}`];
+
+  // Compact detail rows — indented 4 spaces so they "hang" under the
+  // advisory headline.
+  const detailWidth = verbose ? 12 : 8;
+  const pushRow = (label: string, value: string) => {
+    lines.push(`    ${label.padEnd(detailWidth)} ${value}`);
+  };
+  if (advisory.affectedRanges && advisory.affectedRanges.length > 0) {
+    pushRow(
+      "affected",
+      formatRangeList(advisory.affectedRanges, verbose, useColors, rangeLimit),
+    );
+  }
+  if (advisory.fixedIn && advisory.fixedIn.length > 0) {
+    pushRow("fixed in", advisory.fixedIn.join(", "));
+  }
+
+  if (verbose) {
+    if (advisory.aliases && advisory.aliases.length > 0) {
+      pushRow("aliases", advisory.aliases.join(", "));
+    }
+    if (typeof advisory.severity === "number") {
+      pushRow("severity", `${advisory.severity} (CVSS)`);
+    }
+    if (advisory.publishedAt) {
+      pushRow("published", advisory.publishedAt);
+    }
+    if (advisory.modifiedAt) {
+      pushRow("modified", advisory.modifiedAt);
+    }
+    if (advisory.withdrawnAt) {
+      pushRow("withdrawn", advisory.withdrawnAt);
+    }
+    if (advisory.isMalicious === true) {
+      pushRow("malicious", "yes");
+    }
+  }
+
+  return lines;
+}
+
+/**
+ * Cap the displayed affected-range list in compact mode so long-history
+ * packages (e.g. `requests`) don't drown the advisory headline. Verbose
+ * mode shows the full list — operators auditing a specific CVE still
+ * get it with `-v`. JSON output is never truncated (machine consumers
+ * need the full list).
+ */
+function formatRangeList(
+  ranges: string[],
+  verbose: boolean,
+  useColors: boolean,
+  limit: number,
+): string {
+  if (verbose || ranges.length <= limit) {
+    return ranges.join(", ");
+  }
+  const shown = ranges.slice(0, limit).join(", ");
+  const hiddenCount = ranges.length - limit;
+  const hint = dim(`… (+${hiddenCount} more; use -v)`, useColors);
+  return `${shown}, ${hint}`;
+}
+
+/**
+ * Adaptive cap: wider terminals accommodate more ranges before the
+ * row wraps awkwardly. These thresholds are empirical — 80 cols is
+ * the lowest common default; ≥120 is a typical modern terminal; a
+ * few ultrawide rigs justify more. Chosen to keep most rows on a
+ * single visual line without truncating the advisory ID column.
+ */
+function resolveAffectedRangesLimit(terminalWidth: number | undefined): number {
+  const cols = typeof terminalWidth === "number" ? terminalWidth : 80;
+  if (cols >= 160) return 8;
+  if (cols >= 120) return 6;
+  return 4;
+}
+
+// --------------------------------------------------------------------
+// Upgrade footer
+// --------------------------------------------------------------------
+
+function formatUpgradeFooter(paths: string[] | undefined): string | undefined {
+  if (!paths || paths.length === 0) return undefined;
+  if (paths.length === 1) return `Upgrade to ${paths[0]}.`;
+  return `Upgrade options: ${paths.join(", ")}.`;
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,5 +1,6 @@
 export { createFeedbackTool } from "./feedback.js";
 export { createPackageSummaryTool } from "./package-summary.js";
+export { createPackageVulnerabilitiesTool } from "./package-vulnerabilities.js";
 export { createSearchTool } from "./search.js";
 export { createSearchLanguageTool } from "./search-language.js";
 export { createSearchSymbolsTool } from "./search-symbols.js";

--- a/src/tools/package-vulnerabilities-parity.test.ts
+++ b/src/tools/package-vulnerabilities-parity.test.ts
@@ -1,0 +1,425 @@
+// PARITY TEST — enforces rule IDs from docs/implementation/mcp-cli-parity.md:
+//   PARITY-JSON-KEYS       CLI --json output and MCP text payload parse to
+//                          deepEqual JSON objects for equivalent inputs.
+//   PARITY-ERROR-ENVELOPE  Both surfaces emit { error, code, retryable,
+//                          details? } on every error path; MCP error text is
+//                          always valid JSON.
+//
+// Assertion policy (locked in the P2 plan; matches shipped
+// search_symbols / package_summary precedent):
+//   - Service-sourced success and error fixtures use `toEqual`: both
+//     surfaces route through the same classifier / envelope builder,
+//     so envelopes are byte-identical.
+//   - `INVALID_ARGUMENT` fixture uses `toMatchObject`: CLI rejects
+//     unsupported registries in `buildPackageVulnerabilitiesParams`
+//     (via `parsePackageSpec` for the first leg, then
+//     `supportsVulnerabilitiesRegistry`); MCP rejects in the same
+//     builder via the in-handler pattern. Same envelope shape,
+//     potentially surface-specific error text.
+//
+// Fixture count: ten (eight `toEqual` + two `toMatchObject`).
+
+import { describe, expect, it, mock, spyOn } from "bun:test";
+import {
+  type PkgVulnsCommandDependencies,
+  pkgVulnsAction,
+} from "../commands/pkg/vulns.js";
+import type { VulnerabilityReport } from "../services/index.js";
+import {
+  PackageIntelligenceBackendError,
+  PackageIntelligenceTargetNotFoundError,
+  PackageIntelligenceVersionNotFoundError,
+} from "../services/index.js";
+import {
+  createMockPackageIntelligenceService,
+  defaultVulnerabilityReport,
+} from "../services/test-helpers.js";
+import { createPackageVulnerabilitiesTool } from "./package-vulnerabilities.js";
+
+function cliDeps(
+  overrides: Partial<PkgVulnsCommandDependencies> = {},
+): PkgVulnsCommandDependencies {
+  return {
+    packageIntelligenceService: createMockPackageIntelligenceService(),
+    codeNavigationUrl: "https://pkgseer.dev",
+    hasValidToken: true,
+    mcpUrl: "https://mcp.example.com",
+    ...overrides,
+  };
+}
+
+async function cliJson(
+  spec: string,
+  options: Parameters<typeof pkgVulnsAction>[1] = {},
+  deps: PkgVulnsCommandDependencies = cliDeps(),
+): Promise<unknown> {
+  const logSpy = spyOn(console, "log").mockImplementation(() => {});
+  const errSpy = spyOn(console, "error").mockImplementation(() => {});
+  const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+    throw new Error("process.exit");
+  });
+  try {
+    try {
+      await pkgVulnsAction(spec, { ...options, json: true }, deps);
+    } catch {
+      // CLI error paths call process.exit — caught.
+    }
+    const fromLog = logSpy.mock.calls[0]?.[0] as string | undefined;
+    const fromErr = errSpy.mock.calls[0]?.[0] as string | undefined;
+    const raw = fromLog ?? fromErr;
+    return raw ? JSON.parse(raw) : undefined;
+  } finally {
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+    exitSpy.mockRestore();
+  }
+}
+
+async function mcpJson(
+  args: {
+    registry: string;
+    package_name: string;
+    version?: string;
+    min_severity?: string;
+    include_withdrawn?: boolean;
+  },
+  packageVulnerabilitiesMock?: () => Promise<VulnerabilityReport>,
+): Promise<{ json: unknown; isError: boolean | undefined }> {
+  const service = createMockPackageIntelligenceService(
+    packageVulnerabilitiesMock
+      ? { packageVulnerabilities: packageVulnerabilitiesMock as never }
+      : {},
+  );
+  const tool = createPackageVulnerabilitiesTool(service);
+  const result = await tool.handler(args, {});
+  const text = result.content[0]?.text ?? "";
+  return { json: JSON.parse(text), isError: result.isError };
+}
+
+function zeroVulnsReport(): VulnerabilityReport {
+  return {
+    package: { name: "clean", registry: "NPM", version: "1.0.0" },
+    security: {
+      vulnerabilityCount: 0,
+      currentVersionAffected: false,
+      upgradePaths: [],
+      vulnerabilities: [],
+    },
+  };
+}
+
+describe("package_vulnerabilities parity", () => {
+  it("PARITY-JSON-KEYS: happy path CLI === MCP", async () => {
+    const cli = await cliJson("npm:express");
+    const { json, isError } = await mcpJson({
+      registry: "npm",
+      package_name: "express",
+    });
+    expect(isError).toBeUndefined();
+    expect(cli).toEqual(json);
+  });
+
+  it("PARITY-JSON-KEYS: zero-vulns hot path CLI === MCP", async () => {
+    const zeroFn = mock(() => Promise.resolve(zeroVulnsReport()));
+    const cli = await cliJson(
+      "npm:clean",
+      {},
+      cliDeps({
+        packageIntelligenceService: createMockPackageIntelligenceService({
+          packageVulnerabilities: zeroFn as never,
+        }),
+      }),
+    );
+    const { json } = await mcpJson(
+      { registry: "npm", package_name: "clean" },
+      zeroFn as never,
+    );
+    expect(cli).toEqual(json);
+  });
+
+  it("PARITY-JSON-KEYS: filtered success CLI === MCP", async () => {
+    // Simulate the backend returning a filter-aware count: only the
+    // high and critical advisories (2 total) plus the malware one
+    // (included because a null severity + isMalicious still counts
+    // as malware, not below-threshold) — a filter typically returns
+    // just banded advisories above the threshold.
+    const sourceAdvisories =
+      defaultVulnerabilityReport.security?.vulnerabilities ?? [];
+    const critAdvisory = sourceAdvisories[1];
+    const highAdvisory = sourceAdvisories[2];
+    if (!critAdvisory || !highAdvisory) {
+      throw new Error(
+        "fixture setup: expected at least 3 advisories in default report",
+      );
+    }
+    const filteredReport: VulnerabilityReport = {
+      package: { name: "express", registry: "NPM", version: "4.18.0" },
+      security: {
+        vulnerabilityCount: 2,
+        currentVersionAffected: true,
+        upgradePaths: ["4.18.2"],
+        vulnerabilities: [critAdvisory, highAdvisory],
+      },
+    };
+    const fn = mock(() => Promise.resolve(filteredReport));
+    const cli = await cliJson(
+      "npm:express",
+      { severity: "high" },
+      cliDeps({
+        packageIntelligenceService: createMockPackageIntelligenceService({
+          packageVulnerabilities: fn as never,
+        }),
+      }),
+    );
+    const { json } = await mcpJson(
+      { registry: "npm", package_name: "express", min_severity: "high" },
+      fn as never,
+    );
+    expect(cli).toEqual(json);
+  });
+
+  it("PARITY-JSON-KEYS: versioned success (caller and backend match) CLI === MCP", async () => {
+    const fn = mock(() => Promise.resolve(defaultVulnerabilityReport));
+    const cli = await cliJson(
+      "npm:express@4.18.0",
+      {},
+      cliDeps({
+        packageIntelligenceService: createMockPackageIntelligenceService({
+          packageVulnerabilities: fn as never,
+        }),
+      }),
+    );
+    const { json } = await mcpJson(
+      { registry: "npm", package_name: "express", version: "4.18.0" },
+      fn as never,
+    );
+    expect(cli).toEqual(json);
+    // Both surfaces should omit requestedVersion.
+    expect(
+      (cli as { requestedVersion?: string }).requestedVersion,
+    ).toBeUndefined();
+  });
+
+  it("PARITY-JSON-KEYS: versioned real diff surfaces requestedVersion on both surfaces", async () => {
+    // Fixture where the backend resolves a "4.17" tag to concrete
+    // "4.17.2"; the requestedVersion echoes the caller's input.
+    const resolvedReport: VulnerabilityReport = {
+      package: { name: "express", registry: "NPM", version: "4.17.2" },
+      security: {
+        vulnerabilityCount: 0,
+        currentVersionAffected: false,
+        upgradePaths: [],
+        vulnerabilities: [],
+      },
+    };
+    const fn = mock(() => Promise.resolve(resolvedReport));
+    const cli = await cliJson(
+      "npm:express@4.17",
+      {},
+      cliDeps({
+        packageIntelligenceService: createMockPackageIntelligenceService({
+          packageVulnerabilities: fn as never,
+        }),
+      }),
+    );
+    const { json } = await mcpJson(
+      { registry: "npm", package_name: "express", version: "4.17" },
+      fn as never,
+    );
+    expect(cli).toEqual(json);
+    expect((cli as { requestedVersion?: string }).requestedVersion).toBe(
+      "4.17",
+    );
+  });
+
+  it("PARITY-ERROR-ENVELOPE: NOT_FOUND CLI === MCP", async () => {
+    const error = new PackageIntelligenceTargetNotFoundError(
+      "Package 'npm:ghost' not found.",
+    );
+    const fn = mock(() => Promise.reject(error));
+    const cli = await cliJson(
+      "npm:ghost",
+      {},
+      cliDeps({
+        packageIntelligenceService: createMockPackageIntelligenceService({
+          packageVulnerabilities: fn as never,
+        }),
+      }),
+    );
+    const { json, isError } = await mcpJson(
+      { registry: "npm", package_name: "ghost" },
+      fn as never,
+    );
+    expect(isError).toBe(true);
+    expect(cli).toEqual(json);
+    expect(cli).toEqual({
+      error: "Package 'npm:ghost' not found.",
+      code: "NOT_FOUND",
+      retryable: false,
+    });
+  });
+
+  it("PARITY-ERROR-ENVELOPE: VERSION_NOT_FOUND with structured details CLI === MCP", async () => {
+    const error = new PackageIntelligenceVersionNotFoundError(
+      "Version 99.0.0 not found",
+      "npm:express",
+      "99.0.0",
+      ["4.18.2", "4.18.1"],
+    );
+    const fn = mock(() => Promise.reject(error));
+    const cli = await cliJson(
+      "npm:express@99.0.0",
+      {},
+      cliDeps({
+        packageIntelligenceService: createMockPackageIntelligenceService({
+          packageVulnerabilities: fn as never,
+        }),
+      }),
+    );
+    const { json } = await mcpJson(
+      { registry: "npm", package_name: "express", version: "99.0.0" },
+      fn as never,
+    );
+    expect(cli).toEqual(json);
+    expect(cli).toMatchObject({
+      code: "VERSION_NOT_FOUND",
+      retryable: false,
+      details: {
+        package: "npm:express",
+        requestedVersion: "99.0.0",
+        availableVersions: [
+          { version: "4.18.2", ref: "4.18.2" },
+          { version: "4.18.1", ref: "4.18.1" },
+        ],
+      },
+    });
+  });
+
+  it("PARITY-ERROR-ENVELOPE: BACKEND_ERROR (TIMEOUT) CLI === MCP", async () => {
+    const error = new PackageIntelligenceBackendError(
+      "upstream timed out",
+      504,
+      "TIMEOUT",
+    );
+    const fn = mock(() => Promise.reject(error));
+    const cli = await cliJson(
+      "npm:express",
+      {},
+      cliDeps({
+        packageIntelligenceService: createMockPackageIntelligenceService({
+          packageVulnerabilities: fn as never,
+        }),
+      }),
+    );
+    const { json, isError } = await mcpJson(
+      { registry: "npm", package_name: "express" },
+      fn as never,
+    );
+    expect(isError).toBe(true);
+    expect(cli).toEqual(json);
+    expect(cli).toMatchObject({
+      code: "TIMEOUT",
+      retryable: true,
+      error: "upstream timed out",
+    });
+  });
+
+  it("PARITY-ERROR-ENVELOPE: INVALID_ARGUMENT (unsupported registry) — shape match via toMatchObject", async () => {
+    // CLI: parsePackageSpec accepts vcpkg (it's a known registry),
+    // then buildPackageVulnerabilitiesParams rejects via the tool-
+    // local predicate. MCP: schema is permissive; the same builder
+    // runs in-handler and rejects. Same envelope shape, identical
+    // error text because the message is a literal string in the
+    // builder.
+    const cli = await cliJson("vcpkg:foo");
+    const { json, isError } = await mcpJson({
+      registry: "vcpkg",
+      package_name: "foo",
+    });
+
+    expect(isError).toBe(true);
+    expect(cli).toMatchObject({
+      code: "INVALID_ARGUMENT",
+      retryable: false,
+      error: expect.any(String),
+    });
+    expect(json).toMatchObject({
+      code: "INVALID_ARGUMENT",
+      retryable: false,
+      error: expect.any(String),
+    });
+    expect(Object.keys(cli as object).sort()).toEqual(
+      Object.keys(json as object).sort(),
+    );
+  });
+
+  it("PARITY-ERROR-ENVELOPE: INVALID_ARGUMENT (tag-style version) — shape match via toMatchObject", async () => {
+    const cli = await cliJson("npm:express@v4.18.0");
+    const { json, isError } = await mcpJson({
+      registry: "npm",
+      package_name: "express",
+      version: "v4.18.0",
+    });
+
+    expect(isError).toBe(true);
+    expect(cli).toMatchObject({
+      code: "INVALID_ARGUMENT",
+      retryable: false,
+      error: expect.any(String),
+    });
+    expect(json).toMatchObject({
+      code: "INVALID_ARGUMENT",
+      retryable: false,
+      error: expect.any(String),
+    });
+    expect(Object.keys(cli as object).sort()).toEqual(
+      Object.keys(json as object).sort(),
+    );
+  });
+
+  it("PARITY-PERMISSIVE-SCHEMA: uppercase min_severity input is tolerated on both surfaces (envelope parity)", async () => {
+    // Permissive schema + in-handler validation means uppercase
+    // severity input flows through buildPackageVulnerabilitiesParams
+    // on both surfaces. CLI: parses via resolveMinSeverity. MCP:
+    // schema is z.string(), validation delegated to the builder.
+    // Both should succeed and emit the same success envelope; no
+    // raw Zod error surfaces on either side.
+    const fn = mock(() => Promise.resolve(defaultVulnerabilityReport));
+    const cli = await cliJson(
+      "npm:express",
+      { severity: "CRITICAL" },
+      cliDeps({
+        packageIntelligenceService: createMockPackageIntelligenceService({
+          packageVulnerabilities: fn as never,
+        }),
+      }),
+    );
+    const { json, isError } = await mcpJson(
+      { registry: "npm", package_name: "express", min_severity: "CRITICAL" },
+      fn as never,
+    );
+    expect(isError).toBeUndefined();
+    expect(cli).toEqual(json);
+  });
+
+  it("PARITY-PERMISSIVE-SCHEMA: invalid min_severity label produces INVALID_ARGUMENT envelope on both surfaces", async () => {
+    // "severe" is not a known label. Both surfaces should reject
+    // via the in-handler builder with a structured envelope; neither
+    // should surface a raw Zod error.
+    const cli = await cliJson("npm:express", { severity: "severe" });
+    const { json, isError } = await mcpJson({
+      registry: "npm",
+      package_name: "express",
+      min_severity: "severe",
+    });
+    expect(isError).toBe(true);
+    expect(cli).toMatchObject({
+      code: "INVALID_ARGUMENT",
+      retryable: false,
+    });
+    expect(json).toMatchObject({
+      code: "INVALID_ARGUMENT",
+      retryable: false,
+    });
+  });
+});

--- a/src/tools/package-vulnerabilities.test.ts
+++ b/src/tools/package-vulnerabilities.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it, mock } from "bun:test";
+import { PackageIntelligenceTargetNotFoundError } from "../services/index.js";
+import {
+  createMockPackageIntelligenceService,
+  defaultVulnerabilityReport,
+} from "../services/test-helpers.js";
+import { createPackageVulnerabilitiesTool } from "./package-vulnerabilities.js";
+
+function parseText(result: { content: Array<{ text: string }> }): unknown {
+  return JSON.parse(result.content[0]?.text ?? "");
+}
+
+describe("createPackageVulnerabilitiesTool — metadata", () => {
+  it("registers the correct tool name, description, and schema keys", () => {
+    const tool = createPackageVulnerabilitiesTool(
+      createMockPackageIntelligenceService(),
+    );
+    expect(tool.name).toBe("package_vulnerabilities");
+    expect(tool.description).toContain("npm, PyPI, Hex, or");
+    expect(Object.keys(tool.schema).sort()).toEqual([
+      "include_withdrawn",
+      "min_severity",
+      "package_name",
+      "registry",
+      "version",
+    ]);
+    expect(tool.annotations?.readOnlyHint).toBe(true);
+  });
+});
+
+describe("createPackageVulnerabilitiesTool — happy path", () => {
+  it("calls service.packageVulnerabilities with normalised params", async () => {
+    const packageVulnerabilities = mock(() =>
+      Promise.resolve(defaultVulnerabilityReport),
+    );
+    const service = createMockPackageIntelligenceService({
+      packageVulnerabilities,
+    });
+    const tool = createPackageVulnerabilitiesTool(service);
+
+    await tool.handler(
+      {
+        registry: "npm",
+        package_name: "express",
+        version: "4.18.0",
+        min_severity: "high",
+        include_withdrawn: true,
+      },
+      {},
+    );
+
+    const calls = packageVulnerabilities.mock.calls as unknown as Array<
+      [
+        {
+          registry: string;
+          packageName: string;
+          version?: string;
+          minSeverity?: number;
+          includeWithdrawn?: boolean;
+        },
+      ]
+    >;
+    expect(calls[0]?.[0]?.registry).toBe("NPM");
+    expect(calls[0]?.[0]?.packageName).toBe("express");
+    expect(calls[0]?.[0]?.version).toBe("4.18.0");
+    expect(calls[0]?.[0]?.minSeverity).toBe(7.0);
+    expect(calls[0]?.[0]?.includeWithdrawn).toBe(true);
+  });
+
+  it("returns JSON-stringified lean envelope on success", async () => {
+    const tool = createPackageVulnerabilitiesTool(
+      createMockPackageIntelligenceService(),
+    );
+    const result = await tool.handler(
+      { registry: "npm", package_name: "express" },
+      {},
+    );
+    expect(result.isError).toBeUndefined();
+    const payload = parseText(result) as Record<string, unknown>;
+    expect(payload.registry).toBe("npm");
+    expect(payload.name).toBe("express");
+    expect(payload.version).toBe("4.18.0");
+    expect((payload.summary as { total: number }).total).toBe(6);
+  });
+
+  it("surfaces requestedVersion when caller passes a real-diff version", async () => {
+    const tool = createPackageVulnerabilitiesTool(
+      createMockPackageIntelligenceService(),
+    );
+    const result = await tool.handler(
+      { registry: "npm", package_name: "express", version: "4.17" },
+      {},
+    );
+    const payload = parseText(result) as { requestedVersion?: string };
+    expect(payload.requestedVersion).toBe("4.17");
+  });
+
+  it("rejects tag-style versions with INVALID_ARGUMENT", async () => {
+    const tool = createPackageVulnerabilitiesTool(
+      createMockPackageIntelligenceService(),
+    );
+    const result = await tool.handler(
+      { registry: "npm", package_name: "express", version: "v4.18.0" },
+      {},
+    );
+    expect(result.isError).toBe(true);
+    const payload = parseText(result) as { code: string; error: string };
+    expect(payload.code).toBe("INVALID_ARGUMENT");
+    expect(payload.error).toContain("without a leading 'v'");
+  });
+});
+
+describe("createPackageVulnerabilitiesTool — validation errors via in-handler builder", () => {
+  it("returns INVALID_ARGUMENT envelope for unsupported registry (vcpkg)", async () => {
+    const tool = createPackageVulnerabilitiesTool(
+      createMockPackageIntelligenceService(),
+    );
+    const result = await tool.handler(
+      { registry: "vcpkg", package_name: "foo" },
+      {},
+    );
+    expect(result.isError).toBe(true);
+    const payload = parseText(result) as {
+      code: string;
+      retryable: boolean;
+      error: string;
+    };
+    expect(payload.code).toBe("INVALID_ARGUMENT");
+    expect(payload.retryable).toBe(false);
+    expect(payload.error).toBe(
+      "pkg vulns only supports npm, pypi, hex, and crates. Got: vcpkg.",
+    );
+  });
+
+  it("returns INVALID_ARGUMENT envelope for truly unknown registry", async () => {
+    const tool = createPackageVulnerabilitiesTool(
+      createMockPackageIntelligenceService(),
+    );
+    const result = await tool.handler(
+      { registry: "cargo", package_name: "serde" },
+      {},
+    );
+    expect(result.isError).toBe(true);
+    const payload = parseText(result) as { code: string; error: string };
+    expect(payload.code).toBe("INVALID_ARGUMENT");
+    expect(payload.error.toLowerCase()).toContain("unsupported registry");
+  });
+
+  it("returns INVALID_ARGUMENT envelope for empty package_name", async () => {
+    const tool = createPackageVulnerabilitiesTool(
+      createMockPackageIntelligenceService(),
+    );
+    const result = await tool.handler(
+      { registry: "npm", package_name: "" },
+      {},
+    );
+    expect(result.isError).toBe(true);
+    const payload = parseText(result) as { code: string };
+    expect(payload.code).toBe("INVALID_ARGUMENT");
+  });
+});
+
+describe("createPackageVulnerabilitiesTool — service errors", () => {
+  it("classifies PackageIntelligenceTargetNotFoundError as NOT_FOUND envelope", async () => {
+    const service = createMockPackageIntelligenceService({
+      packageVulnerabilities: mock(() =>
+        Promise.reject(
+          new PackageIntelligenceTargetNotFoundError("Package not found"),
+        ),
+      ),
+    });
+    const tool = createPackageVulnerabilitiesTool(service);
+    const result = await tool.handler(
+      { registry: "npm", package_name: "ghost" },
+      {},
+    );
+    expect(result.isError).toBe(true);
+    const payload = parseText(result) as { code: string };
+    expect(payload.code).toBe("NOT_FOUND");
+  });
+
+  it("classifies unexpected Error as UNKNOWN", async () => {
+    const service = createMockPackageIntelligenceService({
+      packageVulnerabilities: mock(() => Promise.reject(new Error("boom"))),
+    });
+    const tool = createPackageVulnerabilitiesTool(service);
+    const result = await tool.handler(
+      { registry: "npm", package_name: "express" },
+      {},
+    );
+    expect(result.isError).toBe(true);
+    const payload = parseText(result) as { code: string };
+    expect(payload.code).toBe("UNKNOWN");
+  });
+});

--- a/src/tools/package-vulnerabilities.ts
+++ b/src/tools/package-vulnerabilities.ts
@@ -1,0 +1,98 @@
+import { z } from "zod";
+import type { PackageIntelligenceService } from "../services/index.js";
+import { mapPackageIntelligenceError } from "../shared/package-intelligence-error-map.js";
+import { buildPackageVulnerabilitiesParams } from "../shared/package-vulnerabilities-request.js";
+import { buildPackageVulnerabilitiesSuccessPayload } from "../shared/package-vulnerabilities-response.js";
+import { type ToolDefinition, textResult } from "./types.js";
+
+export interface PackageVulnerabilitiesArgs {
+  registry: string;
+  package_name: string;
+  version?: string;
+  min_severity?: string;
+  include_withdrawn?: boolean;
+}
+
+/**
+ * Permissive schema by design — in-handler validation via
+ * `buildPackageVulnerabilitiesParams` is the single validation path
+ * for both CLI and MCP. Matches shipped `search_symbols` /
+ * `package_summary` pattern: raw Zod errors never surface to agents.
+ */
+const schema = {
+  registry: z
+    .string()
+    .describe(
+      "Package registry. Vulnerability data available on npm, pypi, hex, and crates only.",
+    ),
+  package_name: z
+    .string()
+    .describe("Package name (scoped names ok: @types/node)."),
+  version: z
+    .string()
+    .optional()
+    .describe("Specific version to check. Defaults to latest when omitted."),
+  min_severity: z
+    .string()
+    .optional()
+    .describe(
+      "Only return advisories at or above this severity (`low`, `medium`, `high`, `critical`; uppercase tolerated). Omit to see all, including null-severity advisories.",
+    ),
+  include_withdrawn: z
+    .boolean()
+    .optional()
+    .describe("Include retracted advisories (default: false)."),
+};
+
+const DESCRIPTION =
+  "Check known vulnerabilities for a package on npm, PyPI, Hex, or " +
+  "Crates (other registries are not yet supported for vulnerability " +
+  "data). Returns a count summary, each advisory with OSV ID, " +
+  "severity, affected ranges and fix versions, plus suggested " +
+  "upgrade paths. Pass `version` to inspect a specific release; " +
+  "otherwise the latest is checked. Use `min_severity` to filter to " +
+  "a threshold (`low`, `medium`, `high`, `critical`) and " +
+  "`include_withdrawn` to also see retracted advisories.";
+
+export function createPackageVulnerabilitiesTool(
+  service: PackageIntelligenceService,
+): ToolDefinition<PackageVulnerabilitiesArgs, typeof schema> {
+  return {
+    name: "package_vulnerabilities",
+    description: DESCRIPTION,
+    schema,
+    annotations: { readOnlyHint: true },
+    handler: async (args) => {
+      try {
+        const { params } = buildPackageVulnerabilitiesParams({
+          registry: args.registry,
+          packageName: args.package_name,
+          version: args.version,
+          minSeverity: args.min_severity,
+          includeWithdrawn: args.include_withdrawn,
+        });
+        const report = await service.packageVulnerabilities(params);
+        const payload = buildPackageVulnerabilitiesSuccessPayload(report, {
+          requestedVersion: args.version,
+        });
+        return textResult(JSON.stringify(payload));
+      } catch (error) {
+        const mapped = mapPackageIntelligenceError(error);
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({
+                error: mapped.message,
+                code: mapped.code,
+                retryable: mapped.retryable ?? false,
+                ...(mapped.details ? { details: mapped.details } : {}),
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Adds the `package_vulnerabilities` MCP tool and `githits pkg vulns` CLI command behind the existing `code_navigation` capability gate. Both surfaces share a single request builder, envelope builder, and error classifier; a parity test asserts `toEqual` JSON across the two surfaces for every service-sourced fixture.

## Surface

- **`githits pkg vulns <spec>`** — CLI listing known CVE / OSV advisories with severity, affected ranges, fix versions, and upgrade paths. Supports `@version` in the spec (unlike `pkg info`), plus `--severity low|medium|high|critical` (uppercase tolerated), `--include-withdrawn`, `--verbose`, `--json`.
- **`package_vulnerabilities`** — MCP tool with the same lean envelope. Permissive Zod schema, validation in-handler via `buildPackageVulnerabilitiesParams`. Advertised in the MCP server-level instructions under the package-tools section, gated on `packageIntelligenceService`.

The zero-vulns happy path renders as a single-line summary body (`No known vulnerabilities.`) to keep agent token usage minimal on the common case.

## Design choices

- **Server-side filtering.** `--severity` maps to a CVSS float on the wire; `--include-withdrawn` passes through. The backend returns a filter-aware `vulnerabilityCount`, so `summary.total` reflects whatever survived the filter. No client-side filtering, no dual-summary block.
- **Partitioning `bySeverity` buckets.** Every returned advisory lands in exactly one of `malware` / `critical` / `high` / `medium` / `low` / `unrated`. The client-side guarantee is `MALWARE + crit + high + medium + low + unrated = advisories.length`, so the header breakdown always reconciles with the total — even on RUSTSEC / PYSEC where unbanded advisories are common.
- **Canonical versions only.** Tag-style refs with a leading `v` (e.g. `v4.18.0`) are rejected client-side with `INVALID_ARGUMENT` before the backend call. The `v` prefix is a git-tag convention, not a canonical version on any supported registry; proper ecosystem-aware version parsing belongs in the backend, not in ad hoc CLI normalisation rules.
- **Typed `VERSION_NOT_FOUND`.** When the backend emits `extensions.code = "VERSION_NOT_FOUND"` with structured fields, the classifier surfaces `details: { package, requestedVersion, availableVersions[] }`. The CLI terminal error expands this into `package:` / `requested:` / `available:` detail lines so users see the mistake and the alternatives. A narrow message-string fallback promotes generic `BackendError`s with matching text to the typed error while the backend catches up; it's guarded to only fire when no `graphqlCode` is present, so real server faults never have their retryability flipped.
- **Registry coverage.** Only npm, PyPI, Hex, and Crates have vulnerability data. The other five known registries are rejected client-side with `pkg vulns only supports npm, pypi, hex, and crates. Got: ${registry}.` before the backend call.
- **Malware marker.** Advisories with `isMalicious: true` render with a red/bold `MALWARE` column (optionally combined as `MALWARE · crit` when both flags are set) and sort to the top of the advisory list regardless of CVSS score. The malware count in the breakdown line is always coloured red.
- **Shared helper scope.** The envelope builder is shared between CLI `--json` and MCP `content[0].text`; the terminal formatter is CLI-only (MCP always emits JSON). Documented in `mcp-cli-parity.md`.

## Terminal UX refinements

- `latest affected` is the only yellow token in the summary line; `latest clean` stays plain so it doesn't read as a caution.
- Unrated advisories render with a dim `unrated` label in the severity gutter rather than an empty column.
- Affected-range lists adapt to terminal width: 4 entries on narrow (≤119 cols), 6 on standard-wide (120–159), 8 on ultrawide (≥160). The remainder collapses into a dim `… (+N more; use -v)` hint. Verbose shows every range. JSON is never truncated — machine consumers get the full list.
- Upgrade options are de-duplicated and sorted ascending by semver-ish comparison (pre-releases rank below their matching base release), so the footer presents the minimum-churn upgrade first.
- Literal `No summary available` placeholders from upstream are stripped from both the JSON envelope and the terminal row — absence of `summary` is the signal.

## Tests

- `bun test` — 810 pass, 0 fail, 1784 `expect()` calls.
- `bun run typecheck` / `bun run build` / `bun run lint` — clean.
- Parity fixtures: happy, zero-vulns, filtered success, versioned-match, `v`-prefixed (rejected client-side), versioned real-diff, `NOT_FOUND`, `VERSION_NOT_FOUND` with structured details, `BACKEND_ERROR`, plus `INVALID_ARGUMENT` fixtures for unsupported registry and invalid severity label.
- Live-verified against production pkgseer across npm, PyPI, Crates, Hex, scoped-npm, and MCP stdio.

## Test plan

- [x] `bun test` passes
- [x] `bun run typecheck` clean
- [x] `bun run build` clean
- [x] `bun run lint` clean
- [x] `pkg vulns` scenarios smoked against a token with `code_navigation` capability (happy, zero-vulns, version pin, malware fixture, severity filter, withdrawn toggle, tag-style rejection, scoped-npm name, registry rejection)
- [x] MCP `tools/list` shows `package_vulnerabilities` under an open-gate token, absent under a gate-closed token
- [x] MCP server-level `instructions` include the `package_vulnerabilities` bullet under an open-gate token
- [x] `pkg vulns --help` renders under an open-gate token