### PR TITLE
feat(mcp): add server-level instructions

### DIFF
--- a/docs/implementation/tools.md
+++ b/docs/implementation/tools.md
@@ -43,6 +43,19 @@ Both expose the same tools with identical names, parameters, and descriptions. T
 
 `package_summary` shares its envelope builder, terminal formatter, and error classifier with the CLI `githits pkg info` command via `src/shared/package-summary-request.ts`, `src/shared/package-summary-response.ts`, and `src/shared/package-intelligence-error-map.ts`. The parity test (`src/tools/package-summary-parity.test.ts`) asserts `toEqual` between CLI `--json` and MCP `content[0].text` for service-sourced fixtures, and `toMatchObject` for the `INVALID_ARGUMENT` fixture where surface-specific error text is acceptable.
 
+## Server instructions
+
+The MCP server advertises a short, cross-tool orientation via the protocol's server-level `instructions` field. This is distinct from per-tool `description` text: instructions cover rationale, workflow glue, and decisions that span multiple tools, while per-tool descriptions remain the source of truth for arguments, output shape, and tool-specific constraints.
+
+`src/commands/mcp-instructions.ts` owns two sections:
+
+- **Core block** — always loaded. Introduces GitHits and the `search` / `search_language` / `feedback` workflow.
+- **Package-tools block** — appended when `isPackageToolsCapabilityOpen(deps)` is true. Contains a preamble plus one bullet per package tool whose backing service is actually wired, so half-open service configurations never advertise a tool that was not registered.
+
+`isPackageToolsCapabilityOpen` is the single source of truth for whether package tools should surface in the current session. Both `getMcpToolDefinitions` and `buildMcpInstructions` import it so tool registration and the instruction text cannot drift.
+
+When adding a new package tool, extend the composer with a one-line bullet (`\`tool_name\` — one-sentence purpose`) in the same PR that registers the tool, and gate the bullet on the tool's backing service. Keep the bullet terse; argument and response detail belong in the tool's `description`. `mcp-instructions.test.ts` enforces both directions of the mention↔registration invariant across gate-open, gate-closed, and half-open scenarios.
+
 ## Entry Points
 
 The `githits mcp` command has two modes:
@@ -50,7 +63,7 @@ The `githits mcp` command has two modes:
 - **`githits mcp`** (no subcommand) — Detects TTY. When run interactively, shows setup instructions for configuring AI assistants. When run via stdio (non-TTY), starts the MCP server.
 - **`githits mcp start`** — Always starts the MCP server. Use this in MCP configuration files.
 
-Both paths call `requireAuth()` before starting the server. See `src/commands/mcp.ts` for the TTY detection logic.
+The MCP server starts without a synchronous auth check; auth errors surface per-tool-call inside each tool's handler. See `src/commands/mcp.ts` for the TTY detection logic.
 
 ## Architecture
 

--- a/src/commands/mcp-instructions.test.ts
+++ b/src/commands/mcp-instructions.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, it } from "bun:test";
+import type { Dependencies } from "../container.js";
+import {
+  createMockAuthService,
+  createMockAuthStorage,
+  createMockBrowserService,
+  createMockCodeNavigationService,
+  createMockFileSystemService,
+  createMockGitHitsService,
+  createMockPackageIntelligenceService,
+} from "../services/test-helpers.js";
+import { getMcpToolDefinitions } from "./mcp.js";
+import {
+  buildMcpInstructions,
+  isPackageToolsCapabilityOpen,
+} from "./mcp-instructions.js";
+
+function createTestDeps(overrides: Partial<Dependencies> = {}): Dependencies {
+  return {
+    authStorage: createMockAuthStorage(),
+    authService: createMockAuthService(),
+    browserService: createMockBrowserService(),
+    fileSystemService: createMockFileSystemService(),
+    mcpUrl: "https://mcp.githits.com",
+    apiUrl: "https://api.githits.com",
+    apiToken: "test-token",
+    hasValidToken: true,
+    envApiToken: undefined,
+    codeNavigationCapability: "disabled",
+    codeNavigationCliOverrideEnabled: false,
+    codeNavigationUrl: undefined,
+    codeNavigationService: undefined,
+    packageIntelligenceService: undefined,
+    githitsService: createMockGitHitsService(),
+    ...overrides,
+  };
+}
+
+/**
+ * Tool names this CLI knows how to register. Each is separately
+ * probed by the mention↔registration invariant so the composer
+ * cannot advertise a tool that `getMcpToolDefinitions` omits for
+ * the same deps.
+ */
+const KNOWN_TOOLS = [
+  "search",
+  "search_language",
+  "feedback",
+  "search_symbols",
+  "package_summary",
+] as const;
+
+function mentionedTools(instructions: string): Set<string> {
+  const mentioned = new Set<string>();
+  for (const name of KNOWN_TOOLS) {
+    if (instructions.includes(`\`${name}\``)) {
+      mentioned.add(name);
+    }
+  }
+  return mentioned;
+}
+
+function registeredTools(deps: Dependencies): Set<string> {
+  return new Set(getMcpToolDefinitions(deps).map((tool) => tool.name));
+}
+
+describe("isPackageToolsCapabilityOpen", () => {
+  it("is true when capability is enabled", () => {
+    const deps = createTestDeps({ codeNavigationCapability: "enabled" });
+    expect(isPackageToolsCapabilityOpen(deps)).toBe(true);
+  });
+
+  it("is false when capability is disabled", () => {
+    const deps = createTestDeps({ codeNavigationCapability: "disabled" });
+    expect(isPackageToolsCapabilityOpen(deps)).toBe(false);
+  });
+
+  it("is true when capability unknown but env token provides opaque grant", () => {
+    const deps = createTestDeps({
+      codeNavigationCapability: "unknown",
+      envApiToken: "ghi-opaque-token",
+    });
+    expect(isPackageToolsCapabilityOpen(deps)).toBe(true);
+  });
+
+  it("is false when capability unknown and no env token", () => {
+    const deps = createTestDeps({
+      codeNavigationCapability: "unknown",
+      envApiToken: undefined,
+    });
+    expect(isPackageToolsCapabilityOpen(deps)).toBe(false);
+  });
+});
+
+describe("buildMcpInstructions", () => {
+  it("returns only the core block when gate is closed", () => {
+    const deps = createTestDeps();
+    const instructions = buildMcpInstructions(deps);
+
+    expect(instructions).toContain("GitHits surfaces verified");
+    expect(instructions).toContain("search_language");
+    expect(instructions).toContain("feedback");
+    expect(instructions).not.toContain("Package tools");
+    expect(instructions).not.toContain("package_summary");
+    expect(instructions).not.toContain("search_symbols");
+  });
+
+  it("returns core + package-tools section when capability enabled and both services wired", () => {
+    const deps = createTestDeps({
+      codeNavigationCapability: "enabled",
+      codeNavigationUrl: "https://nav.example.com",
+      codeNavigationService: createMockCodeNavigationService(),
+      packageIntelligenceService: createMockPackageIntelligenceService(),
+    });
+    const instructions = buildMcpInstructions(deps);
+
+    expect(instructions).toContain("GitHits surfaces verified");
+    expect(instructions).toContain("Package tools");
+    expect(instructions).toContain("`package_summary`");
+    expect(instructions).toContain("`search_symbols`");
+  });
+
+  it("keeps the core block first when both sections are present", () => {
+    const deps = createTestDeps({
+      codeNavigationCapability: "enabled",
+      codeNavigationService: createMockCodeNavigationService(),
+      packageIntelligenceService: createMockPackageIntelligenceService(),
+    });
+    const instructions = buildMcpInstructions(deps);
+
+    const coreIdx = instructions.indexOf("GitHits surfaces verified");
+    const gatedIdx = instructions.indexOf("Package tools");
+    expect(coreIdx).toBeGreaterThanOrEqual(0);
+    expect(gatedIdx).toBeGreaterThan(coreIdx);
+  });
+
+  it("omits the package-tools section when capability enabled but no services wired", () => {
+    const deps = createTestDeps({
+      codeNavigationCapability: "enabled",
+      codeNavigationService: undefined,
+      packageIntelligenceService: undefined,
+    });
+    const instructions = buildMcpInstructions(deps);
+
+    expect(instructions).not.toContain("Package tools");
+  });
+
+  it("half-open: only code navigation service wired → mentions search_symbols but not package_summary", () => {
+    const deps = createTestDeps({
+      codeNavigationCapability: "enabled",
+      codeNavigationService: createMockCodeNavigationService(),
+      packageIntelligenceService: undefined,
+    });
+    const instructions = buildMcpInstructions(deps);
+
+    expect(instructions).toContain("Package tools");
+    expect(instructions).toContain("`search_symbols`");
+    expect(instructions).not.toContain("`package_summary`");
+    // The decision tip is still meaningful — it contrasts search
+    // with search_symbols, both of which are registered.
+    expect(instructions).toContain("natural-language example questions");
+  });
+
+  it("half-open: only package intelligence service wired → mentions package_summary but not search_symbols", () => {
+    const deps = createTestDeps({
+      codeNavigationCapability: "enabled",
+      codeNavigationService: undefined,
+      packageIntelligenceService: createMockPackageIntelligenceService(),
+    });
+    const instructions = buildMcpInstructions(deps);
+
+    expect(instructions).toContain("Package tools");
+    expect(instructions).toContain("`package_summary`");
+    expect(instructions).not.toContain("`search_symbols`");
+    // The decision tip references search_symbols, so it must not
+    // appear when search_symbols isn't registered.
+    expect(instructions).not.toContain("natural-language example questions");
+  });
+
+  describe("mention↔registration invariant", () => {
+    const scenarios: { label: string; overrides: Partial<Dependencies> }[] = [
+      { label: "gate closed", overrides: {} },
+      {
+        label: "gate open, no services wired",
+        overrides: { codeNavigationCapability: "enabled" },
+      },
+      {
+        label: "gate open, only code navigation service",
+        overrides: {
+          codeNavigationCapability: "enabled",
+          codeNavigationService: createMockCodeNavigationService(),
+        },
+      },
+      {
+        label: "gate open, only package intelligence service",
+        overrides: {
+          codeNavigationCapability: "enabled",
+          packageIntelligenceService: createMockPackageIntelligenceService(),
+        },
+      },
+      {
+        label: "gate open, both services",
+        overrides: {
+          codeNavigationCapability: "enabled",
+          codeNavigationService: createMockCodeNavigationService(),
+          packageIntelligenceService: createMockPackageIntelligenceService(),
+        },
+      },
+      {
+        label: "opaque env token, both services",
+        overrides: {
+          codeNavigationCapability: "unknown",
+          envApiToken: "ghi-opaque-token",
+          codeNavigationService: createMockCodeNavigationService(),
+          packageIntelligenceService: createMockPackageIntelligenceService(),
+        },
+      },
+    ];
+
+    for (const { label, overrides } of scenarios) {
+      it(`${label}: every mentioned tool is registered, and every package tool registered is mentioned`, () => {
+        const deps = createTestDeps(overrides);
+        const mentioned = mentionedTools(buildMcpInstructions(deps));
+        const registered = registeredTools(deps);
+
+        // Forward: no ghost mentions.
+        for (const name of mentioned) {
+          expect(registered.has(name)).toBe(true);
+        }
+        // Reverse: every package tool that is registered must also
+        // be mentioned in the composed instructions. Core tools
+        // (search/search_language/feedback) are exempt — the core
+        // block narrates the workflow rather than bulleting them
+        // individually, so `search_language` and `feedback` won't
+        // appear in backtick form.
+        const packageTools = ["search_symbols", "package_summary"];
+        for (const name of packageTools) {
+          if (registered.has(name)) {
+            expect(mentioned.has(name)).toBe(true);
+          }
+        }
+      });
+    }
+  });
+});

--- a/src/commands/mcp-instructions.ts
+++ b/src/commands/mcp-instructions.ts
@@ -1,0 +1,92 @@
+import type { Dependencies } from "../container.js";
+
+/**
+ * Server-level MCP instructions.
+ *
+ * The MCP `instructions` field gives clients a short, cross-tool
+ * orientation for the server — rationale, workflow glue, and
+ * relationships that the per-tool descriptions cannot cover on
+ * their own. Per upstream guidance it should stay terse: anything
+ * that belongs to a single tool lives in that tool's description.
+ *
+ * Composition mirrors tool registration in `mcp.ts`. Each bullet is
+ * emitted only when its backing service is wired, so MCP clients
+ * never see guidance for a tool that isn't registered in the
+ * current session.
+ */
+
+const CORE_BLOCK = `GitHits surfaces verified, canonical code examples from global open source. Use it when you're stuck, the user is frustrated by repeated failed attempts, you need up-to-date API usage, or the user mentions GitHits.
+
+Workflow: call \`search_language\` first if the language name is uncertain → call \`search\` with one focused question → send \`feedback\` on the returned solution_id so quality improves. Each search addresses a single issue; reuse context from prior results before re-searching.`;
+
+const PACKAGE_TOOLS_PREAMBLE = `Package tools work with third-party dependency source and registry metadata. Use them when a stack trace points into a dependency, you need to verify how a library actually works, or you're evaluating a package.
+
+Package spec: \`registry:name[@version]\`.`;
+
+const PACKAGE_SUMMARY_BULLET =
+  "- `package_summary` — instant package overview.";
+
+const SEARCH_SYMBOLS_BULLET =
+  "- `search_symbols` — text search across a dependency's source. On an INDEXING response, retry with a larger `wait_timeout_ms` (up to 60000).";
+
+const SEARCH_VS_SYMBOLS_TIP =
+  "Prefer `search` for natural-language example questions; prefer `search_symbols` for exact-token lookups inside a specific package.";
+
+/**
+ * Whether the MCP session should register and describe package tools.
+ *
+ * Narrower than the CLI gate by design: agents must not see tools
+ * or guidance that would silently fail, so a bare `unknown`
+ * capability (no env token to probe further) keeps the gate closed.
+ *
+ * Single source of truth — tool registration in `mcp.ts` and the
+ * package-tools fragment in `buildMcpInstructions` must share this
+ * predicate to prevent drift between what's advertised and what's
+ * documented.
+ */
+export function isPackageToolsCapabilityOpen(deps: Dependencies): boolean {
+  return (
+    deps.codeNavigationCapability === "enabled" ||
+    (deps.codeNavigationCapability === "unknown" &&
+      deps.envApiToken !== undefined)
+  );
+}
+
+/**
+ * Build the server-level instructions string for the current session.
+ *
+ * Emits the core block unconditionally. Appends a package-tools
+ * section composed of a preamble plus one bullet per service that
+ * is actually wired. Mirrors `getMcpToolDefinitions` so the
+ * instructions never reference a tool that isn't registered, even
+ * in half-open states where only one service is available.
+ */
+export function buildMcpInstructions(deps: Dependencies): string {
+  const sections = [CORE_BLOCK];
+
+  if (!isPackageToolsCapabilityOpen(deps)) {
+    return sections.join("\n\n");
+  }
+
+  const bullets: string[] = [];
+  if (deps.packageIntelligenceService) {
+    bullets.push(PACKAGE_SUMMARY_BULLET);
+  }
+  if (deps.codeNavigationService) {
+    bullets.push(SEARCH_SYMBOLS_BULLET);
+  }
+
+  if (bullets.length === 0) {
+    return sections.join("\n\n");
+  }
+
+  const parts = [PACKAGE_TOOLS_PREAMBLE, bullets.join("\n")];
+  // The decision tip contrasts `search` with `search_symbols`, so
+  // it is only meaningful when the latter is actually registered.
+  if (deps.codeNavigationService) {
+    parts.push(SEARCH_VS_SYMBOLS_TIP);
+  }
+
+  sections.push(parts.join("\n\n"));
+  return sections.join("\n\n");
+}

--- a/src/commands/mcp.test.ts
+++ b/src/commands/mcp.test.ts
@@ -45,6 +45,22 @@ describe("createMcpServer", () => {
     expect(server).toBeDefined();
   });
 
+  it("creates server with instructions wired in the gate-open state", () => {
+    // Exercises the composer through createMcpServer so any breakage
+    // in the instructions pipeline (composer import, SDK options
+    // shape) surfaces here even though the SDK hides `instructions`
+    // behind a private field.
+    const deps = createTestDeps({
+      codeNavigationCapability: "enabled",
+      codeNavigationUrl: "https://pkgseer.dev",
+      codeNavigationService: createMockCodeNavigationService(),
+      packageIntelligenceService: createMockPackageIntelligenceService(),
+    });
+    const server = createMcpServer(deps);
+
+    expect(server).toBeDefined();
+  });
+
   it("adds search_symbols when capability is enabled", () => {
     const deps = createTestDeps({
       codeNavigationCapability: "enabled",

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -12,6 +12,10 @@ import {
   createSearchTool,
   type ToolDefinition,
 } from "../tools/index.js";
+import {
+  buildMcpInstructions,
+  isPackageToolsCapabilityOpen,
+} from "./mcp-instructions.js";
 
 /**
  * Returns the MCP tools enabled for the current startup state.
@@ -25,19 +29,13 @@ export function getMcpToolDefinitions(
     createFeedbackTool(deps.githitsService),
   ];
 
-  // MCP capability predicate for pkgseer-backed tools. Narrower than
-  // the CLI gate by design — agents must not see tools that would
-  // silently fail. Shared with `search_symbols` below.
-  const pkgseerCapabilityOpen =
-    deps.codeNavigationCapability === "enabled" ||
-    (deps.codeNavigationCapability === "unknown" &&
-      deps.envApiToken !== undefined);
+  const gateOpen = isPackageToolsCapabilityOpen(deps);
 
-  if (pkgseerCapabilityOpen && deps.codeNavigationService) {
+  if (gateOpen && deps.codeNavigationService) {
     tools.push(createSearchSymbolsTool(deps.codeNavigationService));
   }
 
-  if (pkgseerCapabilityOpen && deps.packageIntelligenceService) {
+  if (gateOpen && deps.packageIntelligenceService) {
     tools.push(createPackageSummaryTool(deps.packageIntelligenceService));
   }
 
@@ -48,10 +46,15 @@ export function getMcpToolDefinitions(
  * Creates the MCP server with injected dependencies.
  */
 export function createMcpServer(deps: Dependencies): McpServer {
-  const server = new McpServer({
-    name: "githits",
-    version,
-  });
+  const server = new McpServer(
+    {
+      name: "githits",
+      version,
+    },
+    {
+      instructions: buildMcpInstructions(deps),
+    },
+  );
 
   const tools = getMcpToolDefinitions(deps);
 


### PR DESCRIPTION
## Summary

- The CLI MCP server was constructed without server-level `instructions`, leaving agents with no cross-tool orientation — only isolated per-tool descriptions. This PR supplies a terse, composable instructions string via the protocol's `ServerOptions.instructions` field.
- A core block (always loaded) introduces the `search` / `search_language` / `feedback` workflow. A package-tools section is appended when the capability predicate is open, with each bullet individually gated on its backing service so half-open configurations never advertise an unregistered tool.
- Tool registration and instruction composition now import a single `isPackageToolsCapabilityOpen` predicate, eliminating drift between what the server advertises and what it documents. Future package-tool PRs extend the composer with one bullet gated on the new service.

## Design notes

- **Token efficiency.** Content is gate-conditional, cross-tool only, and avoids duplicating argument/output guidance that lives in each tool's `description`. Combined gate-open footprint is ~180 tokens; gate-closed is ~95 tokens.
- **Mention↔registration invariant.** `mcp-instructions.test.ts` asserts both directions (mentioned-implies-registered, and registered-package-tool-implies-mentioned) across six scenarios covering gate-closed, gate-open, both half-open service configurations, and the opaque-token path.
- **Stale doc fix (in-place).** `docs/implementation/tools.md` claimed both MCP entry points called `requireAuth()`, which no longer matches the actual code path. Corrected alongside the new Server-instructions section since the doc was already open for the same change.

## Test plan

- [x] `bun test` — 690 pass, 0 fail (was 685 before)
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — no new findings (pre-existing `noExplicitAny` warnings on `getMcpToolDefinitions` untouched)
- [x] Codex reviewer pass with blocker-fix iteration
- [x] Manual: `createMcpServer(deps)` constructs successfully in gate-closed and gate-open deps fixtures