### PR TITLE
fix(init): verify setup outcomes and report failed tools

### DIFF
--- a/src/commands/init/agent-definitions.test.ts
+++ b/src/commands/init/agent-definitions.test.ts
@@ -618,6 +618,7 @@ describe("getSetupConfig", () => {
       expect(config.commands[0]!.command).toBe("gemini");
       expect(config.commands[0]!.args).toContain("extensions");
       expect(config.commands[0]!.args).toContain("install");
+      expect(config.commands[0]!.args).toContain("--consent");
       expect(config.commands[0]!.args).toContain(
         "https://github.com/githits-com/githits-cli",
       );
@@ -804,6 +805,7 @@ describe("scanAgents", () => {
   function createScanMocks(opts: {
     detectedDirs: string[];
     configFiles?: Record<string, string>;
+    existingFiles?: string[];
     execResults?: Record<string, ExecResult | Error>;
   }) {
     const fs = createMockFileSystemService({
@@ -818,6 +820,9 @@ describe("scanAgents", () => {
         }
         throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
       }),
+      exists: mock(async (path: string) =>
+        (opts.existingFiles ?? []).includes(path),
+      ),
     });
     const execService = createMockExecService({
       exec: mock(async (cmd: string, args: string[]) => {
@@ -878,6 +883,35 @@ describe("scanAgents", () => {
       true,
     );
     expect(result.needsSetup.some((a) => a.id === "claude-code")).toBe(false);
+  });
+
+  it("categorizes gemini CLI as alreadyConfigured for config check outputs", async () => {
+    const lookupCmd = lookupCommandFor();
+    const outputs = ["", "configured\n", "extension settings\n"];
+
+    for (const output of outputs) {
+      const { fs, execService } = createScanMocks({
+        detectedDirs: [],
+        execResults: {
+          [`${lookupCmd} gemini`]: {
+            exitCode: 0,
+            stdout: "/usr/bin/gemini\n",
+            stderr: "",
+          },
+          "gemini extensions config githits": {
+            exitCode: 0,
+            stdout: output,
+            stderr: "",
+          },
+        },
+      });
+
+      const result = await scanAgents(agentDefinitions, fs, execService);
+      expect(result.alreadyConfigured.some((a) => a.id === "gemini-cli")).toBe(
+        true,
+      );
+      expect(result.needsSetup.some((a) => a.id === "gemini-cli")).toBe(false);
+    }
   });
 
   it("categorizes CLI agent as needsSetup when check command does not match", async () => {
@@ -1146,7 +1180,7 @@ describe("scanAgents", () => {
         stdout: "/usr/bin/gemini\n",
         stderr: "",
       },
-      "gemini extensions list": {
+      "gemini extensions config githits": {
         exitCode: 0,
         stdout: "githits-cli\n",
         stderr: "",
@@ -1332,7 +1366,7 @@ describe("scanAgents", () => {
             },
             "claude plugin list": enoent,
             "codex mcp list": enoent,
-            "gemini extensions list": enoent,
+            "gemini extensions config githits": enoent,
           },
         });
         const result = await scanAgents(agentDefinitions, fs, execService);
@@ -1342,6 +1376,79 @@ describe("scanAgents", () => {
         expect(result.needsSetup.some((a) => a.id === "codex-cli")).toBe(true);
         expect(result.needsSetup.some((a) => a.id === "gemini-cli")).toBe(true);
         expect(result.alreadyConfigured).toHaveLength(0);
+      });
+
+      it("gemini falls back to filesystem when config probe is unavailable", async () => {
+        const enoent = Object.assign(new Error("spawn ENOENT"), {
+          code: "ENOENT",
+        });
+        const { fs, execService } = createScanMocks({
+          detectedDirs: ["/home/test/.gemini/extensions/githits"],
+          existingFiles: [
+            "/home/test/.gemini/extensions/githits/gemini-extension.json",
+          ],
+          execResults: {
+            [`${whichCmd} gemini`]: {
+              exitCode: 0,
+              stdout: "/usr/bin/gemini\n",
+              stderr: "",
+            },
+            "gemini extensions config githits": enoent,
+          },
+        });
+        const result = await scanAgents(agentDefinitions, fs, execService);
+        expect(
+          result.alreadyConfigured.some((a) => a.id === "gemini-cli"),
+        ).toBe(true);
+        expect(result.needsSetup.some((a) => a.id === "gemini-cli")).toBe(
+          false,
+        );
+      });
+
+      it("gemini config probe reports not installed as needsSetup", async () => {
+        const { fs, execService } = createScanMocks({
+          detectedDirs: [],
+          execResults: {
+            [`${whichCmd} gemini`]: {
+              exitCode: 0,
+              stdout: "/usr/bin/gemini\n",
+              stderr: "",
+            },
+            "gemini extensions config githits": {
+              exitCode: 0,
+              stdout: "",
+              stderr: 'Extension "githits" is not installed.\n',
+            },
+          },
+        });
+        const result = await scanAgents(agentDefinitions, fs, execService);
+        expect(result.needsSetup.some((a) => a.id === "gemini-cli")).toBe(true);
+      });
+
+      it("gemini does not use filesystem fallback when probe explicitly reports not installed", async () => {
+        const { fs, execService } = createScanMocks({
+          detectedDirs: ["/home/test/.gemini/extensions/githits"],
+          existingFiles: [
+            "/home/test/.gemini/extensions/githits/gemini-extension.json",
+          ],
+          execResults: {
+            [`${whichCmd} gemini`]: {
+              exitCode: 0,
+              stdout: "/usr/bin/gemini\n",
+              stderr: "",
+            },
+            "gemini extensions config githits": {
+              exitCode: 0,
+              stdout: "",
+              stderr: 'Extension "githits" is not installed.\n',
+            },
+          },
+        });
+        const result = await scanAgents(agentDefinitions, fs, execService);
+        expect(result.needsSetup.some((a) => a.id === "gemini-cli")).toBe(true);
+        expect(
+          result.alreadyConfigured.some((a) => a.id === "gemini-cli"),
+        ).toBe(false);
       });
     });
   }

--- a/src/commands/init/agent-definitions.ts
+++ b/src/commands/init/agent-definitions.ts
@@ -3,8 +3,8 @@ import type { ExecService } from "../../services/exec-service.js";
 import type { FileSystemService } from "../../services/index.js";
 import {
   type CliCheckCommand,
+  getCliCheckStatus,
   isAlreadyConfigured,
-  isCliAlreadyConfigured,
 } from "./setup-handlers.js";
 
 /** A single CLI command step (command + arguments). */
@@ -301,17 +301,35 @@ const geminiCli: AgentDefinition = {
         args: [
           "extensions",
           "install",
+          "--consent",
           "https://github.com/githits-com/githits-cli",
         ],
       },
     ],
     checkCommand: {
       command: "gemini",
-      args: ["extensions", "list"],
-      configuredPattern: /githits/i,
+      args: ["extensions", "config", "githits"],
+      // `gemini extensions list` can return empty output in non-interactive
+      // environments. `extensions config githits` is a deterministic probe:
+      // stderr includes "not installed" when missing.
+      notConfiguredPattern: /not installed/i,
+      requireExitCodeZero: true,
     },
   }),
 };
+
+async function isGeminiExtensionInstalledFromFilesystem(
+  fs: FileSystemService,
+): Promise<boolean> {
+  const extensionManifestPath = fs.joinPath(
+    fs.getHomeDir(),
+    ".gemini",
+    "extensions",
+    "githits",
+    "gemini-extension.json",
+  );
+  return fs.exists(extensionManifestPath);
+}
 
 /** Google Antigravity: detected by ~/.gemini/antigravity/ directory */
 const googleAntigravity: AgentDefinition = {
@@ -472,10 +490,18 @@ export async function scanAgents(
       // CLI agent — try checkCommand if available
       const config = agent.getSetupConfig(fs);
       if (config.method === "cli" && config.checkCommand) {
-        const configured = await isCliAlreadyConfigured(
+        const checkStatus = await getCliCheckStatus(
           config.checkCommand,
           execService,
         );
+        let configured = checkStatus === "configured";
+        if (!configured && agent.id === "gemini-cli") {
+          // Only use filesystem fallback when the CLI probe itself failed.
+          // If Gemini explicitly reports "not installed", do not override it.
+          if (checkStatus === "probe_failed") {
+            configured = await isGeminiExtensionInstalledFromFilesystem(fs);
+          }
+        }
         if (configured) {
           result.alreadyConfigured.push(agent);
         } else {

--- a/src/commands/init/init.test.ts
+++ b/src/commands/init/init.test.ts
@@ -269,8 +269,8 @@ describe("initAction", () => {
       },
     );
 
-    // 4 binary detections + 1 check + 2 setup commands = 7 exec calls
-    expect(execService.exec).toHaveBeenCalledTimes(7);
+    // 4 binary detections + 1 check + 2 setup commands + 2 post-setup verification calls = 9
+    expect(execService.exec).toHaveBeenCalledTimes(9);
     expect(execService.exec).toHaveBeenCalledWith("claude", expect.any(Array));
   });
 
@@ -418,6 +418,134 @@ describe("initAction", () => {
     // Both should be attempted
     expect(execService.exec).toHaveBeenCalled();
     expect(fs.atomicWriteFile).toHaveBeenCalled();
+
+    const logCalls = getLogOutput();
+    expect(
+      logCalls.some((msg) => msg.includes("Setup completed with errors")),
+    ).toBe(true);
+    expect(logCalls.some((msg) => msg.includes("Done! GitHits is ready"))).toBe(
+      false,
+    );
+    expect(logCalls.some((msg) => msg.includes("- Claude Code:"))).toBe(true);
+  });
+
+  it("treats Gemini already-installed setup output as already configured", async () => {
+    const lookupCmd = lookupCommandFor();
+    const fs = createFsWithDetection([]);
+    const promptService = createMockPromptService({
+      confirm3: mock(() => Promise.resolve("yes" as ConfirmChoice)),
+    });
+    const execService = createMockExecService({
+      exec: mock((cmd: string, args: string[]) => {
+        const key = `${cmd} ${args.join(" ")}`;
+        if (key === `${lookupCmd} gemini`) {
+          return Promise.resolve({
+            exitCode: 0,
+            stdout: "/usr/bin/gemini\n",
+            stderr: "",
+          });
+        }
+        if (key === "gemini extensions config githits") {
+          return Promise.resolve({
+            exitCode: 0,
+            stdout: "",
+            stderr: "",
+          });
+        }
+        if (
+          key ===
+          "gemini extensions install --consent https://github.com/githits-com/githits-cli"
+        ) {
+          return Promise.resolve({
+            exitCode: 1,
+            stdout: "",
+            stderr:
+              'Extension "githits" is already installed. Please uninstall it first.\n',
+          });
+        }
+        return Promise.resolve({ exitCode: 1, stdout: "", stderr: "" });
+      }),
+    });
+
+    await initAction(
+      {},
+      {
+        fileSystemService: fs,
+        promptService,
+        execService,
+        createLoginDeps: createAlreadyAuthLoginDeps(),
+      },
+    );
+
+    const logCalls = getLogOutput();
+    expect(
+      logCalls.some(
+        (msg) =>
+          msg.includes("Gemini CLI") && msg.includes("already configured"),
+      ),
+    ).toBe(true);
+    expect(logCalls.some((msg) => msg.includes("failed to configure"))).toBe(
+      false,
+    );
+  });
+
+  it("marks Gemini setup as failed when install does not actually configure extension", async () => {
+    const lookupCmd = lookupCommandFor();
+    const fs = createFsWithDetection([]);
+    const promptService = createMockPromptService({
+      confirm3: mock(() => Promise.resolve("yes" as ConfirmChoice)),
+    });
+    const execService = createMockExecService({
+      exec: mock((cmd: string, args: string[]) => {
+        const key = `${cmd} ${args.join(" ")}`;
+        if (key === `${lookupCmd} gemini`) {
+          return Promise.resolve({
+            exitCode: 0,
+            stdout: "/usr/bin/gemini\n",
+            stderr: "",
+          });
+        }
+        if (key === "gemini extensions config githits") {
+          return Promise.resolve({
+            exitCode: 0,
+            stdout: "",
+            stderr: 'Extension "githits" is not installed.\n',
+          });
+        }
+        if (
+          key ===
+          "gemini extensions install --consent https://github.com/githits-com/githits-cli"
+        ) {
+          return Promise.resolve({
+            exitCode: 0,
+            stdout: "Do you want to continue? [Y/n]: ",
+            stderr: "",
+          });
+        }
+        return Promise.resolve({ exitCode: 1, stdout: "", stderr: "" });
+      }),
+    });
+
+    await initAction(
+      {},
+      {
+        fileSystemService: fs,
+        promptService,
+        execService,
+        createLoginDeps: createAlreadyAuthLoginDeps(),
+      },
+    );
+
+    const logCalls = getLogOutput();
+    expect(
+      logCalls.some((msg) =>
+        msg.includes("Gemini installation did not complete"),
+      ),
+    ).toBe(true);
+    expect(logCalls.some((msg) => msg.includes("failed to configure"))).toBe(
+      true,
+    );
+    expect(logCalls.some((msg) => msg.includes("- Gemini CLI:"))).toBe(true);
   });
 
   it("does not attempt Gemini setup when only .gemini directory exists", async () => {

--- a/src/commands/init/init.ts
+++ b/src/commands/init/init.ts
@@ -45,8 +45,31 @@ export interface InitDependencies {
 
 /** Tracks per-agent setup outcome for the summary */
 interface AgentOutcome {
+  id: string;
   name: string;
   status: "success" | "already_configured" | "failed" | "skipped";
+  message?: string;
+}
+
+async function verifyAgentConfigured(
+  agent: (typeof agentDefinitions)[number],
+  fileSystemService: FileSystemService,
+  execService: ExecService,
+): Promise<{ ok: boolean; message?: string }> {
+  const postCheck = await scanAgents([agent], fileSystemService, execService);
+  if (postCheck.alreadyConfigured.some((a) => a.id === agent.id)) {
+    return { ok: true };
+  }
+  if (postCheck.needsSetup.some((a) => a.id === agent.id)) {
+    return {
+      ok: false,
+      message: `${agent.name} verification failed: not configured after setup.`,
+    };
+  }
+  return {
+    ok: false,
+    message: `${agent.name} verification failed: agent not detected after setup.`,
+  };
 }
 
 /**
@@ -182,7 +205,7 @@ export async function initAction(
       }
 
       if (choice === "no") {
-        outcomes.push({ name: agent.name, status: "skipped" });
+        outcomes.push({ id: agent.id, name: agent.name, status: "skipped" });
         console.log();
         continue;
       }
@@ -192,13 +215,36 @@ export async function initAction(
     }
 
     // Execute setup
-    const result =
+    let result =
       config.method === "cli"
         ? await executeCliSetup(config, execService)
         : await executeConfigFileSetup(config, fileSystemService);
 
+    if (result.status === "success" || result.status === "already_configured") {
+      const verification = await verifyAgentConfigured(
+        agent,
+        fileSystemService,
+        execService,
+      );
+      if (!verification.ok) {
+        result = {
+          status: "failed",
+          message:
+            agent.id === "gemini-cli"
+              ? "Gemini installation did not complete. Retry, or run: gemini extensions install --consent https://github.com/githits-com/githits-cli"
+              : (verification.message ??
+                `${agent.name} verification failed after setup.`),
+        };
+      }
+    }
+
     // Record and display outcome
-    outcomes.push({ name: agent.name, status: result.status });
+    outcomes.push({
+      id: agent.id,
+      name: agent.name,
+      status: result.status,
+      message: result.status === "failed" ? result.message : undefined,
+    });
 
     if (result.status === "success") {
       console.log(`    ${success(`${agent.name} configured`, useColors)}\n`);
@@ -219,10 +265,10 @@ export async function initAction(
   const failed = outcomes.filter((o) => o.status === "failed").length;
   const skipped = outcomes.filter((o) => o.status === "skipped").length;
 
-  if (configured > 0 || alreadyDone > 0) {
-    console.log("  Done! GitHits is ready.");
-  } else if (failed > 0) {
+  if (failed > 0) {
     console.log("  Setup completed with errors.");
+  } else if (configured > 0 || alreadyDone > 0) {
+    console.log("  Done! GitHits is ready.");
   } else if (skipped > 0) {
     console.log("  Setup skipped.");
   }
@@ -231,6 +277,11 @@ export async function initAction(
     console.log(
       `  ${failed} agent${failed !== 1 ? "s" : ""} failed to configure.`,
     );
+    for (const outcome of outcomes.filter((o) => o.status === "failed")) {
+      console.log(
+        `    - ${outcome.name}: ${outcome.message ?? "Unknown error"}`,
+      );
+    }
   }
   if (skipped > 0) {
     console.log(`  ${skipped} agent${skipped !== 1 ? "s" : ""} skipped.`);

--- a/src/commands/init/setup-handlers.test.ts
+++ b/src/commands/init/setup-handlers.test.ts
@@ -9,6 +9,7 @@ import {
   executeCliSetup,
   executeConfigFileSetup,
   formatSetupPreview,
+  getCliCheckStatus,
   isAlreadyConfigured,
   isCliAlreadyConfigured,
   mergeServerConfig,
@@ -186,6 +187,102 @@ describe("isCliAlreadyConfigured", () => {
       ),
     });
     expect(await isCliAlreadyConfigured(check, execService)).toBe(true);
+  });
+
+  it("supports negative-only checks via notConfiguredPattern", async () => {
+    const negativeOnlyCheck: CliCheckCommand = {
+      command: "gemini",
+      args: ["extensions", "config", "githits"],
+      notConfiguredPattern: /not installed/i,
+      requireExitCodeZero: true,
+    };
+
+    const installedExec = createMockExecService({
+      exec: mock(() =>
+        Promise.resolve({
+          exitCode: 0,
+          stdout: "",
+          stderr: "",
+        }),
+      ),
+    });
+    expect(await isCliAlreadyConfigured(negativeOnlyCheck, installedExec)).toBe(
+      true,
+    );
+
+    const missingExec = createMockExecService({
+      exec: mock(() =>
+        Promise.resolve({
+          exitCode: 0,
+          stdout: "",
+          stderr: 'Extension "githits" is not installed.\n',
+        }),
+      ),
+    });
+    expect(await isCliAlreadyConfigured(negativeOnlyCheck, missingExec)).toBe(
+      false,
+    );
+  });
+
+  it("returns false for negative-only checks when requireExitCodeZero is set and command fails", async () => {
+    const negativeOnlyCheck: CliCheckCommand = {
+      command: "gemini",
+      args: ["extensions", "config", "githits"],
+      notConfiguredPattern: /not installed/i,
+      requireExitCodeZero: true,
+    };
+    const execService = createMockExecService({
+      exec: mock(() =>
+        Promise.resolve({
+          exitCode: 1,
+          stdout: "",
+          stderr: "",
+        }),
+      ),
+    });
+    expect(await isCliAlreadyConfigured(negativeOnlyCheck, execService)).toBe(
+      false,
+    );
+  });
+});
+
+describe("getCliCheckStatus", () => {
+  it("returns not_configured when notConfiguredPattern matches", async () => {
+    const check: CliCheckCommand = {
+      command: "gemini",
+      args: ["extensions", "config", "githits"],
+      notConfiguredPattern: /not installed/i,
+      requireExitCodeZero: true,
+    };
+    const execService = createMockExecService({
+      exec: mock(() =>
+        Promise.resolve({
+          exitCode: 0,
+          stdout: "",
+          stderr: 'Extension "githits" is not installed.\n',
+        }),
+      ),
+    });
+    expect(await getCliCheckStatus(check, execService)).toBe("not_configured");
+  });
+
+  it("returns probe_failed when requireExitCodeZero is set and command fails", async () => {
+    const check: CliCheckCommand = {
+      command: "gemini",
+      args: ["extensions", "config", "githits"],
+      notConfiguredPattern: /not installed/i,
+      requireExitCodeZero: true,
+    };
+    const execService = createMockExecService({
+      exec: mock(() =>
+        Promise.resolve({
+          exitCode: 1,
+          stdout: "",
+          stderr: "",
+        }),
+      ),
+    });
+    expect(await getCliCheckStatus(check, execService)).toBe("probe_failed");
   });
 });
 
@@ -532,6 +629,21 @@ describe("executeCliSetup", () => {
           exitCode: 0,
           stdout: "Server GitHits already added\n",
           stderr: "",
+        }),
+      ),
+    });
+    const result = await executeCliSetup(singleStepSetup, execService);
+    expect(result.status).toBe("already_configured");
+  });
+
+  it("detects already-installed on non-zero exit (gemini pattern)", async () => {
+    const execService = createMockExecService({
+      exec: mock(() =>
+        Promise.resolve({
+          exitCode: 1,
+          stdout: "",
+          stderr:
+            'Extension "githits" is already installed. Please uninstall it first.\n',
         }),
       ),
     });

--- a/src/commands/init/setup-handlers.ts
+++ b/src/commands/init/setup-handlers.ts
@@ -12,9 +12,21 @@ export interface CliCheckCommand {
   command: string;
   /** Command arguments (e.g., ["plugin", "list"]) */
   args: string[];
-  /** Pattern to search for in combined stdout+stderr. If found, agent is configured. */
-  configuredPattern: RegExp;
+  /**
+   * Pattern to search for in combined stdout+stderr. If found, agent is configured.
+   * Optional when using a negative-only check via notConfiguredPattern.
+   */
+  configuredPattern?: RegExp;
+  /**
+   * Pattern indicating the agent is definitely not configured.
+   * Checked before configuredPattern.
+   */
+  notConfiguredPattern?: RegExp;
+  /** Require exitCode=0 for the check command to be considered valid. */
+  requireExitCodeZero?: boolean;
 }
+
+export type CliCheckStatus = "configured" | "not_configured" | "probe_failed";
 
 /** Result of merging server config into an existing config file */
 export type MergeResult =
@@ -186,12 +198,37 @@ export async function isCliAlreadyConfigured(
   check: CliCheckCommand,
   execService: ExecService,
 ): Promise<boolean> {
+  return (await getCliCheckStatus(check, execService)) === "configured";
+}
+
+/**
+ * Check CLI configuration status with tri-state output so callers can
+ * distinguish a definitive "not configured" from probe failures.
+ */
+export async function getCliCheckStatus(
+  check: CliCheckCommand,
+  execService: ExecService,
+): Promise<CliCheckStatus> {
   try {
     const result = await execService.exec(check.command, check.args);
+    if (check.requireExitCodeZero && result.exitCode !== 0) {
+      return "probe_failed";
+    }
     const combined = `${result.stdout} ${result.stderr}`;
-    return check.configuredPattern.test(combined);
+    if (check.notConfiguredPattern?.test(combined)) {
+      return "not_configured";
+    }
+    if (check.configuredPattern) {
+      return check.configuredPattern.test(combined)
+        ? "configured"
+        : "not_configured";
+    }
+    if (check.notConfiguredPattern) {
+      return "configured";
+    }
+    return "not_configured";
   } catch {
-    return false;
+    return "probe_failed";
   }
 }
 
@@ -200,6 +237,7 @@ const ALREADY_EXISTS_PATTERNS = [
   /already exists/i,
   /already configured/i,
   /already added/i,
+  /extension\s+"githits"\s+is\s+already\s+installed/i,
 ];
 
 /** Check if CLI output indicates the server is already configured */


### PR DESCRIPTION
## Summary

This PR fixes false-positive `githits init` success reporting by requiring post-setup verification before an agent is marked configured. It also hardens Gemini CLI installation and detection in non-interactive flows so install prompts and ambiguous probe output do not silently pass.

## Changes

### Files Changed
- `src/commands/init/init.ts` - adds unified post-setup verification for attempted agents, switches summary to failure-first precedence, and lists failed tools with explicit reasons.
- `src/commands/init/agent-definitions.ts` - updates Gemini install command to use `--consent`, switches Gemini configured check to `extensions config githits`, and limits filesystem fallback to probe-failure cases.
- `src/commands/init/setup-handlers.ts` - adds tri-state CLI check status (`configured`/`not_configured`/`probe_failed`) and narrows "already installed" classification to the Gemini GitHits message.
- `src/commands/init/init.test.ts` - adds regression coverage for failure-first summary behavior and explicit failed-tool output.
- `src/commands/init/agent-definitions.test.ts` - adds coverage for Gemini config-probe variants and fallback behavior.
- `src/commands/init/setup-handlers.test.ts` - adds coverage for tri-state checks and Gemini already-installed output handling.

### Files Added
- None.

### Architecture / Structure
- Introduces a unified verification step in init orchestration so setup success is determined by actual configured state, not command exit code alone.

## Verification

### Automated Checks
- [x] `bun run typecheck`
- [x] `bun run format:check`
- [x] `bun run lint` *(passes with existing repo warnings unrelated to this change)*
- [x] `bun run build`
- [x] `bun test`

### Manual Verification
- [x] `gemini extensions uninstall githits`
- [x] `gemini extensions list --debug` shows no extensions installed
- [x] `bun run ./src/cli.ts init --skip-login` runs `gemini extensions install --consent ...`
- [x] `gemini extensions list --debug` shows `githits (0.1.8)` installed
- [x] rerun `bun run ./src/cli.ts init --skip-login` reports `Gemini CLI — already configured`

### Related Issues
- None.
