### PR TITLE
chore: rename TODO(backend) markers to drop internal-repo names

### DIFF
--- a/docs/implementation/mcp-cli-parity.md
+++ b/docs/implementation/mcp-cli-parity.md
@@ -354,7 +354,7 @@ When a new tool lands with both MCP and CLI surfaces:
 - **`metadata` dropped.** `ChangelogEntry.metadata` is backend
   `GenericJSON`; v1 envelope drops it entirely rather than
   guessing at its shape. Revisit via agent feedback
-  (`TODO(pkgseer-backend)` anchor on the service type).
+  (`TODO(backend)` anchor on the service type).
 - **`source: null` promoted to `NOT_FOUND`.** The service layer
   promotes the null-source case to a typed
   `PackageIntelligenceChangelogSourceNotFoundError` which the

--- a/src/services/package-intelligence-service.ts
+++ b/src/services/package-intelligence-service.ts
@@ -339,7 +339,7 @@ export interface ChangelogEntryDetail {
   body?: string;
   htmlUrl?: string;
   publishedAt?: string;
-  /** TODO(pkgseer-backend): surface when shape is documented. */
+  /** TODO(backend): surface when shape is documented. */
   metadata?: UntypedGenericJSON;
 }
 

--- a/src/services/promote-version-not-found.ts
+++ b/src/services/promote-version-not-found.ts
@@ -11,7 +11,7 @@
  * promotes it to the typed {@link PackageIntelligenceVersionNotFoundError}
  * so downstream surfaces can render structured, actionable error details.
  *
- * TODO(pkgseer-backend): remove once the upstream resolvers all emit
+ * TODO(backend): remove once the upstream resolvers all emit
  * the typed `extensions.code = "VERSION_NOT_FOUND"` payload. The typed
  * path in `createGraphQLError` already handles the structured shape;
  * deleting this helper plus its fallback-specific service tests will

--- a/src/shared/package-changelog-response.ts
+++ b/src/shared/package-changelog-response.ts
@@ -39,7 +39,7 @@
  *   version / date / URL timeline.
  * - **`metadata` dropped from envelope.** Source-specific opaque
  *   JSON; live-smoke observations will inform a typed passthrough
- *   later. TODO(pkgseer-backend) marker in the service types.
+ *   later. TODO(backend) marker in the service types.
  */
 
 import type { ChangelogReport } from "../services/index.js";

--- a/src/shared/package-vulnerabilities-request.ts
+++ b/src/shared/package-vulnerabilities-request.ts
@@ -23,7 +23,7 @@
  *   tool accepts canonical package versions, not git refs; the live
  *   backend currently answers these with an unhelpful generic error,
  *   so we fail fast with an actionable client-side message instead.
- *   TODO(pkgseer-backend): replace this narrow guard with typed,
+ *   TODO(backend): replace this narrow guard with typed,
  *   ecosystem-aware version validation from the backend. Do not grow
  *   ad hoc normalization rules here.
  */


### PR DESCRIPTION
## Summary

Five \`TODO(…)\` markers across the pkg-intel surface used an internal repository name as the anchor (\`TODO(internal-repo-name): …\`). Since \`githits-cli\` is a public repository, those anchors leak internal project structure on every file view.

Rename all five to generic \`TODO(backend)\` — no behaviour change, no semantic loss. Each TODO already describes what backend work is needed inline; the anchor was just a grep-token.

## Files touched

- \`src/shared/package-changelog-response.ts\`
- \`src/shared/package-vulnerabilities-request.ts\`
- \`src/services/package-intelligence-service.ts\`
- \`src/services/promote-version-not-found.ts\`
- \`docs/implementation/mcp-cli-parity.md\`

## Testing

- \`bun test\`: 1326 pass
- Typecheck / lint / build clean
- No behaviour change — pure comment rename

## Test plan

- [x] \`bun test\` passes
- [x] No remaining \`internal-repo-name\` references in src/ or docs/
- [x] Typecheck / lint / build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)