### PR TITLE
Improve CLI timing diagnostics and auth overhead

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ githits code ...       Dependency source inspection: search, files, read, grep
 | `GITHITS_API_URL` | Override REST API URL | `https://api.githits.com` |
 | `GITHITS_CODE_NAV_URL` | Override package/source service URL | environment-specific |
 | `GITHITS_CODE_NAVIGATION` | Expose hidden `pkg` / `code` command groups locally | — |
+| `GITHITS_TELEMETRY` | Emit end-of-run timing spans to stderr for local profiling | — |
 
 ## Manual Setup
 

--- a/docs/implementation/cli-commands.md
+++ b/docs/implementation/cli-commands.md
@@ -351,6 +351,10 @@ All commands support two output modes:
 
 - **`--no-color`** — Disables colored output by setting `NO_COLOR=1` env var via a root-level `preAction` hook. All downstream `shouldUseColors()` calls pick it up automatically.
 
+## Runtime Diagnostics
+
+- **`GITHITS_TELEMETRY=1`** — Emits an end-of-run timing summary to stderr without polluting normal stdout. Current spans cover gated command registration, startup auth lookup, container creation, token loading/refresh, and the outbound API/package-intelligence request.
+
 ## Key Reference Files
 
 | File | Purpose |

--- a/docs/implementation/config.md
+++ b/docs/implementation/config.md
@@ -53,6 +53,7 @@ Package/source access is different from the REST endpoints above:
 | `GITHITS_CODE_NAV_URL` | Override package/source service URL | `http://localhost:4000` |
 | `GITHITS_API_TOKEN` | API token for authentication | `ghi-abc123...` |
 | `GITHITS_CODE_NAVIGATION` | Override capability gate and expose hidden `code` / `pkg` CLI groups locally | `1` |
+| `GITHITS_TELEMETRY` | Emit end-of-run timing spans to stderr for local profiling | `1` |
 
 ## Local Storage
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,18 +13,44 @@ import {
   registerPkgCommandGroup,
   registerSearchCommand,
 } from "./commands/index.js";
+import {
+  endTelemetrySpan,
+  flushTelemetry,
+  isTelemetryEnabled,
+  startTelemetrySpan,
+  withTelemetrySpan,
+} from "./shared/index.js";
 
 const program = new Command();
+const commandSpans = new WeakMap<
+  Command,
+  ReturnType<typeof startTelemetrySpan>
+>();
+
+if (isTelemetryEnabled()) {
+  process.once("exit", (exitCode) => {
+    flushTelemetry(exitCode);
+  });
+}
 
 program
   .name("githits")
   .description("Code examples from global open source for your AI assistant")
   .version(version)
   .option("--no-color", "Disable colored output")
-  .hook("preAction", (thisCommand) => {
+  .hook("preAction", (thisCommand, actionCommand) => {
     if (thisCommand.opts().color === false) {
       process.env.NO_COLOR = "1";
     }
+
+    const command = actionCommand ?? thisCommand;
+    commandSpans.set(
+      command,
+      startTelemetrySpan(getTelemetryCommandName(command)),
+    );
+  })
+  .hook("postAction", (_thisCommand, actionCommand) => {
+    endTelemetrySpan(commandSpans.get(actionCommand));
   })
   .addHelpText(
     "after",
@@ -56,10 +82,14 @@ registerLanguagesCommand(program);
 registerFeedbackCommand(program);
 const argv = process.argv.slice(2);
 if (shouldEagerLoadGatedCommandGroup(argv, "code")) {
-  await registerCodeCommandGroup(program);
+  await withTelemetrySpan("cli.register.code-group", () =>
+    registerCodeCommandGroup(program),
+  );
 }
 if (shouldEagerLoadGatedCommandGroup(argv, "pkg")) {
-  await registerPkgCommandGroup(program);
+  await withTelemetrySpan("cli.register.pkg-group", () =>
+    registerPkgCommandGroup(program),
+  );
 }
 
 // Auth status as subcommand of `auth`
@@ -69,7 +99,7 @@ const authCommand = program
   .description("Manage authentication with GitHits.");
 registerAuthStatusCommand(authCommand);
 
-await program.parseAsync();
+await withTelemetrySpan("cli.parse", () => program.parseAsync());
 
 /**
  * Argv-sniff optimisation for gated command groups. Returns `true`
@@ -90,4 +120,19 @@ function shouldEagerLoadGatedCommandGroup(
     firstArg === "--help" ||
     firstArg === "-h"
   );
+}
+
+function getTelemetryCommandName(command: Command): string {
+  const names: string[] = [];
+  let current: Command | null = command;
+
+  while (current) {
+    const name = current.name();
+    if (name && name !== "githits") {
+      names.unshift(name);
+    }
+    current = current.parent ?? null;
+  }
+
+  return `command.${names.join(".")}`;
 }

--- a/src/container.ts
+++ b/src/container.ts
@@ -31,6 +31,10 @@ import {
   type TokenProvider,
   WINDOWS_MAX_ENTRY_SIZE,
 } from "./services/index.js";
+import {
+  withTelemetrySpan,
+  withTelemetrySpanSync,
+} from "./shared/telemetry.js";
 
 /**
  * Create an AuthStorage instance, preferring keychain with file-based fallback.
@@ -38,37 +42,41 @@ import {
  * unavailable (no daemon, access denied), falls back to file storage with a warning.
  */
 function createAuthStorage(fileSystemService: FileSystemService): AuthStorage {
-  const fileStorage = new AuthStorageImpl(fileSystemService);
+  return withTelemetrySpanSync("container.create-auth-storage", () => {
+    const fileStorage = new AuthStorageImpl(fileSystemService);
 
-  try {
-    const rawKeyring = new KeyringServiceImpl();
-    // Windows Credential Manager limits entries to 2560 UTF-16 chars.
-    // Wrap with chunking decorator to split large values across multiple entries.
-    const keyring =
-      process.platform === "win32"
-        ? new ChunkingKeyringService(rawKeyring, WINDOWS_MAX_ENTRY_SIZE)
-        : rawKeyring;
-    // Probe keychain availability with a write+delete cycle.
-    // Use timestamp + random suffix to avoid probe key collisions.
-    // Probe value "probe" is 5 chars, passes through the chunking wrapper unchanged.
-    const probeKey = `__probe_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
-    keyring.setPassword("githits", probeKey, "probe");
     try {
-      keyring.deletePassword("githits", probeKey);
-    } catch {
-      // Orphaned probe entry — keychain is operational (write succeeded)
-      // but delete failed. The tiny entry is harmless; proceed with keychain.
-    }
+      const rawKeyring = new KeyringServiceImpl();
+      // Windows Credential Manager limits entries to 2560 UTF-16 chars.
+      // Wrap with chunking decorator to split large values across multiple entries.
+      const keyring =
+        process.platform === "win32"
+          ? new ChunkingKeyringService(rawKeyring, WINDOWS_MAX_ENTRY_SIZE)
+          : rawKeyring;
+      withTelemetrySpanSync("container.keychain-probe", () => {
+        // Probe keychain availability with a write+delete cycle.
+        // Use timestamp + random suffix to avoid probe key collisions.
+        // Probe value "probe" is 5 chars, passes through the chunking wrapper unchanged.
+        const probeKey = `__probe_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+        keyring.setPassword("githits", probeKey, "probe");
+        try {
+          keyring.deletePassword("githits", probeKey);
+        } catch {
+          // Orphaned probe entry — keychain is operational (write succeeded)
+          // but delete failed. The tiny entry is harmless; proceed with keychain.
+        }
+      });
 
-    const keychainStorage = new KeychainAuthStorage(keyring);
-    return new MigratingAuthStorage(keychainStorage, fileStorage);
-  } catch (error) {
-    if (!(error instanceof KeychainUnavailableError)) throw error;
-    console.error(
-      "Warning: System keychain unavailable. Falling back to file-based credential storage.",
-    );
-    return fileStorage;
-  }
+      const keychainStorage = new KeychainAuthStorage(keyring);
+      return new MigratingAuthStorage(keychainStorage, fileStorage);
+    } catch (error) {
+      if (!(error instanceof KeychainUnavailableError)) throw error;
+      console.error(
+        "Warning: System keychain unavailable. Falling back to file-based credential storage.",
+      );
+      return fileStorage;
+    }
+  });
 }
 
 /**
@@ -118,24 +126,57 @@ function createStaticTokenProvider(token: string): TokenProvider {
  * Async because token resolution requires reading stored auth.
  */
 export async function createContainer(): Promise<Dependencies> {
-  const mcpUrl = getMcpUrl();
-  const apiUrl = getApiUrl();
-  const codeNavigationUrl = getCodeNavigationUrl();
-  const codeNavigationCliOverrideEnabled = isCodeNavigationCliOverrideEnabled();
-  const fileSystemService = new FileSystemServiceImpl();
-  const authStorage = createAuthStorage(fileSystemService);
-  const authService = new AuthServiceImpl();
-  const browserService = new BrowserServiceImpl();
+  return withTelemetrySpan("container.create", async () => {
+    const mcpUrl = getMcpUrl();
+    const apiUrl = getApiUrl();
+    const codeNavigationUrl = getCodeNavigationUrl();
+    const codeNavigationCliOverrideEnabled =
+      isCodeNavigationCliOverrideEnabled();
+    const fileSystemService = new FileSystemServiceImpl();
+    const authStorage = createAuthStorage(fileSystemService);
+    const authService = new AuthServiceImpl();
+    const browserService = new BrowserServiceImpl();
 
-  // Check for env API token first
-  const envToken = getEnvApiToken();
-  if (envToken) {
-    const tokenProvider = createStaticTokenProvider(envToken);
+    // Check for env API token first
+    const envToken = getEnvApiToken();
+    if (envToken) {
+      const tokenProvider = createStaticTokenProvider(envToken);
+      const codeNavigationService = codeNavigationUrl
+        ? new CodeNavigationServiceImpl(codeNavigationUrl, tokenProvider)
+        : undefined;
+      const packageIntelligenceService = codeNavigationUrl
+        ? new PackageIntelligenceServiceImpl(codeNavigationUrl, tokenProvider)
+        : undefined;
+
+      return {
+        authStorage,
+        authService,
+        browserService,
+        fileSystemService,
+        mcpUrl,
+        apiUrl,
+        apiToken: envToken,
+        hasValidToken: true,
+        envApiToken: envToken,
+        codeNavigationCapability: getCodeNavigationCapability(envToken),
+        codeNavigationCliOverrideEnabled,
+        codeNavigationUrl,
+        codeNavigationService,
+        packageIntelligenceService,
+        githitsService: new GitHitsServiceImpl(apiUrl, envToken),
+      };
+    }
+
+    // Create token manager for stored auth with auto-refresh
+    const tokenManager = new TokenManager({ authService, authStorage, mcpUrl });
+    const apiToken = await withTelemetrySpan("container.token.get", () =>
+      tokenManager.getToken(),
+    );
     const codeNavigationService = codeNavigationUrl
-      ? new CodeNavigationServiceImpl(codeNavigationUrl, tokenProvider)
+      ? new CodeNavigationServiceImpl(codeNavigationUrl, tokenManager)
       : undefined;
     const packageIntelligenceService = codeNavigationUrl
-      ? new PackageIntelligenceServiceImpl(codeNavigationUrl, tokenProvider)
+      ? new PackageIntelligenceServiceImpl(codeNavigationUrl, tokenManager)
       : undefined;
 
     return {
@@ -145,45 +186,17 @@ export async function createContainer(): Promise<Dependencies> {
       fileSystemService,
       mcpUrl,
       apiUrl,
-      apiToken: envToken,
-      hasValidToken: true,
-      envApiToken: envToken,
-      codeNavigationCapability: getCodeNavigationCapability(envToken),
+      apiToken,
+      hasValidToken: apiToken !== undefined,
+      envApiToken: undefined,
+      codeNavigationCapability: getCodeNavigationCapability(apiToken),
       codeNavigationCliOverrideEnabled,
       codeNavigationUrl,
       codeNavigationService,
       packageIntelligenceService,
-      githitsService: new GitHitsServiceImpl(apiUrl, envToken),
+      githitsService: new RefreshingGitHitsService(apiUrl, tokenManager),
     };
-  }
-
-  // Create token manager for stored auth with auto-refresh
-  const tokenManager = new TokenManager({ authService, authStorage, mcpUrl });
-  const apiToken = await tokenManager.getToken();
-  const codeNavigationService = codeNavigationUrl
-    ? new CodeNavigationServiceImpl(codeNavigationUrl, tokenManager)
-    : undefined;
-  const packageIntelligenceService = codeNavigationUrl
-    ? new PackageIntelligenceServiceImpl(codeNavigationUrl, tokenManager)
-    : undefined;
-
-  return {
-    authStorage,
-    authService,
-    browserService,
-    fileSystemService,
-    mcpUrl,
-    apiUrl,
-    apiToken,
-    hasValidToken: apiToken !== undefined,
-    envApiToken: undefined,
-    codeNavigationCapability: getCodeNavigationCapability(apiToken),
-    codeNavigationCliOverrideEnabled,
-    codeNavigationUrl,
-    codeNavigationService,
-    packageIntelligenceService,
-    githitsService: new RefreshingGitHitsService(apiUrl, tokenManager),
-  };
+  });
 }
 
 /**
@@ -203,47 +216,54 @@ export interface StartupCodeNavigationRegistrationState {
  * Resolves CLI registration state without triggering token refresh.
  */
 export async function resolveStartupCodeNavigationRegistrationState(): Promise<StartupCodeNavigationRegistrationState> {
-  const envToken = getEnvApiToken();
-  if (envToken) {
-    return {
-      capability: getCodeNavigationCapability(envToken),
-      expiredStoredAuth: false,
-    };
-  }
+  return withTelemetrySpan(
+    "startup.resolve-code-nav-registration-state",
+    async () => {
+      const envToken = getEnvApiToken();
+      if (envToken) {
+        return {
+          capability: getCodeNavigationCapability(envToken),
+          expiredStoredAuth: false,
+        };
+      }
 
-  const tokens = await loadStartupTokens(getMcpUrl());
-  if (tokens?.expiresAt && new Date(tokens.expiresAt) < new Date()) {
-    return { capability: "unknown", expiredStoredAuth: true };
-  }
+      const tokens = await loadStartupTokens(getMcpUrl());
+      if (tokens?.expiresAt && new Date(tokens.expiresAt) < new Date()) {
+        return { capability: "unknown", expiredStoredAuth: true };
+      }
 
-  return {
-    capability: getCodeNavigationCapability(tokens?.accessToken),
-    expiredStoredAuth: false,
-  };
+      return {
+        capability: getCodeNavigationCapability(tokens?.accessToken),
+        expiredStoredAuth: false,
+      };
+    },
+  );
 }
 
 async function loadStartupTokens(mcpUrl: string): Promise<TokenData | null> {
-  const fileSystemService = new FileSystemServiceImpl();
-  const fileStorage = new AuthStorageImpl(fileSystemService);
+  return withTelemetrySpan("startup.load-tokens", async () => {
+    const fileSystemService = new FileSystemServiceImpl();
+    const fileStorage = new AuthStorageImpl(fileSystemService);
 
-  try {
-    // Avoid createAuthStorage() here: command registration/help should stay read-only
-    // and must not trigger the keychain probe write+delete cycle or migration writes.
-    const rawKeyring = new KeyringServiceImpl();
-    const keyring =
-      process.platform === "win32"
-        ? new ChunkingKeyringService(rawKeyring, WINDOWS_MAX_ENTRY_SIZE)
-        : rawKeyring;
-    const keychainStorage = new KeychainAuthStorage(keyring);
-    const keychainTokens = await keychainStorage.loadTokens(mcpUrl);
-    if (keychainTokens) {
-      return keychainTokens;
+    try {
+      // Avoid createAuthStorage() here: command registration/help should stay read-only
+      // and must not trigger the keychain probe write+delete cycle or migration writes.
+      const rawKeyring = new KeyringServiceImpl();
+      const keyring =
+        process.platform === "win32"
+          ? new ChunkingKeyringService(rawKeyring, WINDOWS_MAX_ENTRY_SIZE)
+          : rawKeyring;
+      const keychainStorage = new KeychainAuthStorage(keyring);
+      const keychainTokens = await keychainStorage.loadTokens(mcpUrl);
+      if (keychainTokens) {
+        return keychainTokens;
+      }
+    } catch (error) {
+      if (!(error instanceof KeychainUnavailableError)) {
+        throw error;
+      }
     }
-  } catch (error) {
-    if (!(error instanceof KeychainUnavailableError)) {
-      throw error;
-    }
-  }
 
-  return fileStorage.loadTokens(mcpUrl);
+    return fileStorage.loadTokens(mcpUrl);
+  });
 }

--- a/src/container.ts
+++ b/src/container.ts
@@ -38,44 +38,26 @@ import {
 
 /**
  * Create an AuthStorage instance, preferring keychain with file-based fallback.
- * Probes keychain availability with a write+delete test. If the keychain is
- * unavailable (no daemon, access denied), falls back to file storage with a warning.
+ * Falls back to file storage only if a real keychain operation fails.
  */
 function createAuthStorage(fileSystemService: FileSystemService): AuthStorage {
   return withTelemetrySpanSync("container.create-auth-storage", () => {
     const fileStorage = new AuthStorageImpl(fileSystemService);
 
-    try {
-      const rawKeyring = new KeyringServiceImpl();
-      // Windows Credential Manager limits entries to 2560 UTF-16 chars.
-      // Wrap with chunking decorator to split large values across multiple entries.
-      const keyring =
-        process.platform === "win32"
-          ? new ChunkingKeyringService(rawKeyring, WINDOWS_MAX_ENTRY_SIZE)
-          : rawKeyring;
-      withTelemetrySpanSync("container.keychain-probe", () => {
-        // Probe keychain availability with a write+delete cycle.
-        // Use timestamp + random suffix to avoid probe key collisions.
-        // Probe value "probe" is 5 chars, passes through the chunking wrapper unchanged.
-        const probeKey = `__probe_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
-        keyring.setPassword("githits", probeKey, "probe");
-        try {
-          keyring.deletePassword("githits", probeKey);
-        } catch {
-          // Orphaned probe entry — keychain is operational (write succeeded)
-          // but delete failed. The tiny entry is harmless; proceed with keychain.
-        }
-      });
-
-      const keychainStorage = new KeychainAuthStorage(keyring);
-      return new MigratingAuthStorage(keychainStorage, fileStorage);
-    } catch (error) {
-      if (!(error instanceof KeychainUnavailableError)) throw error;
+    const rawKeyring = new KeyringServiceImpl();
+    // Windows Credential Manager limits entries to 2560 UTF-16 chars.
+    // Wrap with chunking decorator to split large values across multiple entries.
+    const keyring =
+      process.platform === "win32"
+        ? new ChunkingKeyringService(rawKeyring, WINDOWS_MAX_ENTRY_SIZE)
+        : rawKeyring;
+    const keychainStorage = new KeychainAuthStorage(keyring);
+    return new MigratingAuthStorage(keychainStorage, fileStorage, (error) => {
+      if (!(error instanceof KeychainUnavailableError)) return;
       console.error(
         "Warning: System keychain unavailable. Falling back to file-based credential storage.",
       );
-      return fileStorage;
-    }
+    });
   });
 }
 

--- a/src/services/githits-service.ts
+++ b/src/services/githits-service.ts
@@ -1,5 +1,6 @@
 import { version } from "../../package.json";
 import { buildClientHeaders } from "../shared/request-headers.js";
+import { withTelemetrySpan } from "../shared/telemetry.js";
 
 /**
  * Error thrown when the API returns 401 Unauthorized.
@@ -89,52 +90,58 @@ export class GitHitsServiceImpl implements GitHitsService {
   ) {}
 
   async search(params: SearchParams): Promise<string> {
-    const response = await fetch(`${this.apiUrl}/search`, {
-      method: "POST",
-      headers: this.headers(),
-      body: JSON.stringify({
-        query: params.query,
-        language: params.language,
-        license_mode: params.licenseMode ?? "strict",
-        include_explanation: params.includeExplanation ?? false,
-      }),
+    return withTelemetrySpan("githits.search.request", async () => {
+      const response = await fetch(`${this.apiUrl}/search`, {
+        method: "POST",
+        headers: this.headers(),
+        body: JSON.stringify({
+          query: params.query,
+          language: params.language,
+          license_mode: params.licenseMode ?? "strict",
+          include_explanation: params.includeExplanation ?? false,
+        }),
+      });
+
+      if (!response.ok) {
+        throw await this.createError(response);
+      }
+
+      return response.text();
     });
-
-    if (!response.ok) {
-      throw await this.createError(response);
-    }
-
-    return response.text();
   }
 
   async getLanguages(): Promise<Language[]> {
-    const response = await fetch(`${this.apiUrl}/languages`, {
-      headers: this.headers(),
+    return withTelemetrySpan("githits.languages.request", async () => {
+      const response = await fetch(`${this.apiUrl}/languages`, {
+        headers: this.headers(),
+      });
+
+      if (!response.ok) {
+        throw await this.createError(response);
+      }
+
+      return response.json() as Promise<Language[]>;
     });
-
-    if (!response.ok) {
-      throw await this.createError(response);
-    }
-
-    return response.json() as Promise<Language[]>;
   }
 
   async submitFeedback(params: FeedbackParams): Promise<FeedbackResult> {
-    const response = await fetch(`${this.apiUrl}/feedbacks`, {
-      method: "POST",
-      headers: this.headers(),
-      body: JSON.stringify({
-        solution_id: params.solutionId,
-        accepted: params.accepted,
-        feedback_text: params.feedbackText ?? null,
-      }),
+    return withTelemetrySpan("githits.feedback.request", async () => {
+      const response = await fetch(`${this.apiUrl}/feedbacks`, {
+        method: "POST",
+        headers: this.headers(),
+        body: JSON.stringify({
+          solution_id: params.solutionId,
+          accepted: params.accepted,
+          feedback_text: params.feedbackText ?? null,
+        }),
+      });
+
+      if (!response.ok) {
+        throw await this.createError(response);
+      }
+
+      return { success: true, message: "Feedback submitted successfully" };
     });
-
-    if (!response.ok) {
-      throw await this.createError(response);
-    }
-
-    return { success: true, message: "Feedback submitted successfully" };
   }
 
   private headers(): Record<string, string> {

--- a/src/services/migrating-auth-storage.test.ts
+++ b/src/services/migrating-auth-storage.test.ts
@@ -60,9 +60,9 @@ describe("MigratingAuthStorage", () => {
       });
       const storage = new MigratingAuthStorage(primary, legacy);
 
-      await expect(storage.loadTokens(BASE_URL)).rejects.toThrow(
-        KeychainUnavailableError,
-      );
+      const result = await storage.loadTokens(BASE_URL);
+
+      expect(result).toEqual(tokenData);
       expect(legacy.clearTokens).not.toHaveBeenCalled();
     });
 
@@ -96,6 +96,21 @@ describe("MigratingAuthStorage", () => {
       expect(primary.saveTokens).toHaveBeenCalledWith(BASE_URL, tokenData);
       expect(legacy.saveTokens).not.toHaveBeenCalled();
     });
+
+    it("falls back to legacy when primary save fails with keychain unavailable", async () => {
+      const tokenData = createValidTokenData();
+      const primary = createMockAuthStorage({
+        saveTokens: mock(() =>
+          Promise.reject(new KeychainUnavailableError("keychain locked")),
+        ),
+      });
+      const legacy = createMockAuthStorage();
+      const storage = new MigratingAuthStorage(primary, legacy);
+
+      await storage.saveTokens(BASE_URL, tokenData);
+
+      expect(legacy.saveTokens).toHaveBeenCalledWith(BASE_URL, tokenData);
+    });
   });
 
   describe("clearTokens", () => {
@@ -119,13 +134,11 @@ describe("MigratingAuthStorage", () => {
       const legacy = createMockAuthStorage();
       const storage = new MigratingAuthStorage(primary, legacy);
 
-      await expect(storage.clearTokens(BASE_URL)).rejects.toThrow(
-        KeychainUnavailableError,
-      );
+      await storage.clearTokens(BASE_URL);
       expect(legacy.clearTokens).toHaveBeenCalledWith(BASE_URL);
     });
 
-    it("propagates primary error when both primary and legacy throw", async () => {
+    it("swallows keychain-unavailable primary clear errors even when legacy clear also throws", async () => {
       const primaryError = new KeychainUnavailableError("keychain locked");
       const primary = createMockAuthStorage({
         clearTokens: mock(() => Promise.reject(primaryError)),
@@ -135,8 +148,7 @@ describe("MigratingAuthStorage", () => {
       });
       const storage = new MigratingAuthStorage(primary, legacy);
 
-      // Primary error takes precedence; legacy error is swallowed
-      await expect(storage.clearTokens(BASE_URL)).rejects.toBe(primaryError);
+      await storage.clearTokens(BASE_URL);
     });
   });
 
@@ -190,9 +202,9 @@ describe("MigratingAuthStorage", () => {
       });
       const storage = new MigratingAuthStorage(primary, legacy);
 
-      await expect(storage.loadClient(BASE_URL)).rejects.toThrow(
-        KeychainUnavailableError,
-      );
+      const result = await storage.loadClient(BASE_URL);
+
+      expect(result).toEqual(defaultClientRegistration);
       expect(legacy.clearClient).not.toHaveBeenCalled();
     });
 
@@ -229,6 +241,23 @@ describe("MigratingAuthStorage", () => {
       );
       expect(legacy.saveClient).not.toHaveBeenCalled();
     });
+
+    it("falls back to legacy when primary client save fails with keychain unavailable", async () => {
+      const primary = createMockAuthStorage({
+        saveClient: mock(() =>
+          Promise.reject(new KeychainUnavailableError("keychain locked")),
+        ),
+      });
+      const legacy = createMockAuthStorage();
+      const storage = new MigratingAuthStorage(primary, legacy);
+
+      await storage.saveClient(BASE_URL, defaultClientRegistration);
+
+      expect(legacy.saveClient).toHaveBeenCalledWith(
+        BASE_URL,
+        defaultClientRegistration,
+      );
+    });
   });
 
   describe("clearClient", () => {
@@ -252,13 +281,11 @@ describe("MigratingAuthStorage", () => {
       const legacy = createMockAuthStorage();
       const storage = new MigratingAuthStorage(primary, legacy);
 
-      await expect(storage.clearClient(BASE_URL)).rejects.toThrow(
-        KeychainUnavailableError,
-      );
+      await storage.clearClient(BASE_URL);
       expect(legacy.clearClient).toHaveBeenCalledWith(BASE_URL);
     });
 
-    it("propagates primary error when both primary and legacy throw", async () => {
+    it("swallows keychain-unavailable primary client clear errors even when legacy clear also throws", async () => {
       const primaryError = new KeychainUnavailableError("keychain locked");
       const primary = createMockAuthStorage({
         clearClient: mock(() => Promise.reject(primaryError)),
@@ -268,8 +295,7 @@ describe("MigratingAuthStorage", () => {
       });
       const storage = new MigratingAuthStorage(primary, legacy);
 
-      // Primary error takes precedence; legacy error is swallowed
-      await expect(storage.clearClient(BASE_URL)).rejects.toBe(primaryError);
+      await storage.clearClient(BASE_URL);
     });
   });
 
@@ -287,18 +313,13 @@ describe("MigratingAuthStorage", () => {
       });
       const storage = new MigratingAuthStorage(primary, legacy);
 
-      // Token migration fails
-      await expect(storage.loadTokens(BASE_URL)).rejects.toThrow(
-        KeychainUnavailableError,
-      );
+      const tokenResult = await storage.loadTokens(BASE_URL);
+      expect(tokenResult).toEqual(tokenData);
 
       // Client migration succeeds independently
       const client = await storage.loadClient(BASE_URL);
       expect(client).toEqual(defaultClientRegistration);
-      expect(primary.saveClient).toHaveBeenCalledWith(
-        BASE_URL,
-        defaultClientRegistration,
-      );
+      expect(primary.saveClient).not.toHaveBeenCalled();
     });
   });
 
@@ -311,6 +332,46 @@ describe("MigratingAuthStorage", () => {
       const storage = new MigratingAuthStorage(primary, legacy);
 
       expect(storage.getStorageLocation()).toBe("System keychain (githits)");
+    });
+
+    it("switches to legacy storage location after primary keychain failure", async () => {
+      const primary = createMockAuthStorage({
+        loadTokens: mock(() =>
+          Promise.reject(new KeychainUnavailableError("keychain locked")),
+        ),
+        getStorageLocation: mock(() => "System keychain (githits)"),
+      });
+      const legacy = createMockAuthStorage({
+        getStorageLocation: mock(() => "/mock/.githits"),
+      });
+      const storage = new MigratingAuthStorage(primary, legacy);
+
+      await storage.loadTokens(BASE_URL);
+
+      expect(storage.getStorageLocation()).toBe("/mock/.githits");
+    });
+
+    it("warns only once when the primary keychain becomes unavailable", async () => {
+      const onPrimaryUnavailable = mock(() => {});
+      const primary = createMockAuthStorage({
+        loadTokens: mock(() =>
+          Promise.reject(new KeychainUnavailableError("keychain locked")),
+        ),
+        loadClient: mock(() =>
+          Promise.reject(new KeychainUnavailableError("keychain locked")),
+        ),
+      });
+      const legacy = createMockAuthStorage();
+      const storage = new MigratingAuthStorage(
+        primary,
+        legacy,
+        onPrimaryUnavailable,
+      );
+
+      await storage.loadTokens(BASE_URL);
+      await storage.loadClient(BASE_URL);
+
+      expect(onPrimaryUnavailable).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/services/migrating-auth-storage.ts
+++ b/src/services/migrating-auth-storage.ts
@@ -3,6 +3,7 @@ import type {
   ClientRegistration,
   TokenData,
 } from "./auth-storage.js";
+import { KeychainUnavailableError } from "./keyring-service.js";
 
 /**
  * AuthStorage decorator that migrates credentials from a legacy (file-based)
@@ -13,51 +14,77 @@ import type {
  * 2. Check legacy → if found, write to primary → delete from legacy → return it
  * 3. Both empty → return null
  *
- * Ordering guarantee: primary write must succeed before legacy entry is deleted.
- * If primary write fails, legacy entry is kept intact and the error propagates.
- *
- * Saves always go to primary only. Clears hit both (idempotent).
+ * If the primary keychain becomes unavailable at runtime, the storage falls back
+ * to the legacy backend for the lifetime of the process and stops attempting
+ * migrations.
  */
 export class MigratingAuthStorage implements AuthStorage {
+  private primaryAvailable = true;
+  private warnedOnPrimaryFailure = false;
+
   constructor(
     private readonly primary: AuthStorage,
     private readonly legacy: AuthStorage,
+    private readonly onPrimaryUnavailable: (
+      error: KeychainUnavailableError,
+    ) => void = () => {},
   ) {}
 
   async loadTokens(baseUrl: string): Promise<TokenData | null> {
-    const tokens = await this.primary.loadTokens(baseUrl);
-    if (tokens) return tokens;
+    if (this.primaryAvailable) {
+      try {
+        const tokens = await this.primary.loadTokens(baseUrl);
+        if (tokens) return tokens;
+      } catch (error) {
+        if (!this.handlePrimaryFailure(error)) throw error;
+      }
+    }
 
     const legacyTokens = await this.legacy.loadTokens(baseUrl);
-    if (legacyTokens) {
-      // Primary write must succeed before we attempt to remove from legacy.
-      // If primary write fails, the error propagates and legacy stays intact.
+    if (!legacyTokens) return null;
+    if (!this.primaryAvailable) return legacyTokens;
+
+    try {
       await this.primary.saveTokens(baseUrl, legacyTokens);
-      try {
-        await this.legacy.clearTokens(baseUrl);
-      } catch {
-        // Non-fatal: legacy entry persists but primary is now authoritative.
-        // Next load will return from primary, skipping migration entirely.
-      }
+    } catch (error) {
+      if (!this.handlePrimaryFailure(error)) throw error;
       return legacyTokens;
     }
 
-    return null;
+    try {
+      await this.legacy.clearTokens(baseUrl);
+    } catch {
+      // Non-fatal: legacy entry persists but primary is now authoritative.
+      // Next load will return from primary, skipping migration entirely.
+    }
+    return legacyTokens;
   }
 
   async saveTokens(baseUrl: string, data: TokenData): Promise<void> {
-    await this.primary.saveTokens(baseUrl, data);
+    if (this.primaryAvailable) {
+      try {
+        await this.primary.saveTokens(baseUrl, data);
+        return;
+      } catch (error) {
+        if (!this.handlePrimaryFailure(error)) throw error;
+      }
+    }
+
+    await this.legacy.saveTokens(baseUrl, data);
   }
 
   async clearTokens(baseUrl: string): Promise<void> {
     let primaryError: unknown;
-    try {
-      await this.primary.clearTokens(baseUrl);
-    } catch (error) {
-      primaryError = error;
+    if (this.primaryAvailable) {
+      try {
+        await this.primary.clearTokens(baseUrl);
+      } catch (error) {
+        if (!this.handlePrimaryFailure(error)) {
+          primaryError = error;
+        }
+      }
     }
-    // Always attempt legacy clear regardless of primary result.
-    // Legacy failure is non-fatal — the primary error (if any) takes precedence.
+
     try {
       await this.legacy.clearTokens(baseUrl);
     } catch {
@@ -67,37 +94,60 @@ export class MigratingAuthStorage implements AuthStorage {
   }
 
   async loadClient(baseUrl: string): Promise<ClientRegistration | null> {
-    const client = await this.primary.loadClient(baseUrl);
-    if (client) return client;
+    if (this.primaryAvailable) {
+      try {
+        const client = await this.primary.loadClient(baseUrl);
+        if (client) return client;
+      } catch (error) {
+        if (!this.handlePrimaryFailure(error)) throw error;
+      }
+    }
 
     const legacyClient = await this.legacy.loadClient(baseUrl);
-    if (legacyClient) {
+    if (!legacyClient) return null;
+    if (!this.primaryAvailable) return legacyClient;
+
+    try {
       await this.primary.saveClient(baseUrl, legacyClient);
-      try {
-        await this.legacy.clearClient(baseUrl);
-      } catch {
-        // Non-fatal: legacy entry persists but primary is now authoritative.
-        // Next load will return from primary, skipping migration entirely.
-      }
+    } catch (error) {
+      if (!this.handlePrimaryFailure(error)) throw error;
       return legacyClient;
     }
 
-    return null;
+    try {
+      await this.legacy.clearClient(baseUrl);
+    } catch {
+      // Non-fatal: legacy entry persists but primary is now authoritative.
+      // Next load will return from primary, skipping migration entirely.
+    }
+    return legacyClient;
   }
 
   async saveClient(baseUrl: string, data: ClientRegistration): Promise<void> {
-    await this.primary.saveClient(baseUrl, data);
+    if (this.primaryAvailable) {
+      try {
+        await this.primary.saveClient(baseUrl, data);
+        return;
+      } catch (error) {
+        if (!this.handlePrimaryFailure(error)) throw error;
+      }
+    }
+
+    await this.legacy.saveClient(baseUrl, data);
   }
 
   async clearClient(baseUrl: string): Promise<void> {
     let primaryError: unknown;
-    try {
-      await this.primary.clearClient(baseUrl);
-    } catch (error) {
-      primaryError = error;
+    if (this.primaryAvailable) {
+      try {
+        await this.primary.clearClient(baseUrl);
+      } catch (error) {
+        if (!this.handlePrimaryFailure(error)) {
+          primaryError = error;
+        }
+      }
     }
-    // Always attempt legacy clear regardless of primary result.
-    // Legacy failure is non-fatal — the primary error (if any) takes precedence.
+
     try {
       await this.legacy.clearClient(baseUrl);
     } catch {
@@ -107,6 +157,21 @@ export class MigratingAuthStorage implements AuthStorage {
   }
 
   getStorageLocation(): string {
-    return this.primary.getStorageLocation();
+    return this.primaryAvailable
+      ? this.primary.getStorageLocation()
+      : this.legacy.getStorageLocation();
+  }
+
+  private handlePrimaryFailure(error: unknown): boolean {
+    if (!(error instanceof KeychainUnavailableError)) {
+      return false;
+    }
+
+    this.primaryAvailable = false;
+    if (!this.warnedOnPrimaryFailure) {
+      this.warnedOnPrimaryFailure = true;
+      this.onPrimaryUnavailable(error);
+    }
+    return true;
   }
 }

--- a/src/services/package-intelligence-service.ts
+++ b/src/services/package-intelligence-service.ts
@@ -23,6 +23,7 @@ import {
   postPkgseerGraphql,
 } from "../shared/pkgseer-graphql.js";
 import type { PkgseerRegistry } from "../shared/pkgseer-registry.js";
+import { withTelemetrySpan } from "../shared/telemetry.js";
 import { executeWithTokenRefresh } from "./execute-with-token-refresh.js";
 import { AuthenticationError } from "./githits-service.js";
 import { promoteGenericVersionNotFound } from "./promote-version-not-found.js";
@@ -1013,12 +1014,14 @@ export class PackageIntelligenceServiceImpl
   ) {}
 
   async packageSummary(params: PackageSummaryParams): Promise<PackageSummary> {
-    return executeWithTokenRefresh({
-      getToken: () => this.tokenProvider.getToken(),
-      forceRefresh: () => this.tokenProvider.forceRefresh(),
-      shouldRefresh: (error) => error instanceof AuthenticationError,
-      executeWithToken: (token) => this.executePackageSummary(token, params),
-    });
+    return withTelemetrySpan("pkg-intel.summary.request", () =>
+      executeWithTokenRefresh({
+        getToken: () => this.tokenProvider.getToken(),
+        forceRefresh: () => this.tokenProvider.forceRefresh(),
+        shouldRefresh: (error) => error instanceof AuthenticationError,
+        executeWithToken: (token) => this.executePackageSummary(token, params),
+      }),
+    );
   }
 
   private async executePackageSummary(
@@ -1251,13 +1254,15 @@ export class PackageIntelligenceServiceImpl
   async packageVulnerabilities(
     params: PackageVulnerabilitiesParams,
   ): Promise<VulnerabilityReport> {
-    return executeWithTokenRefresh({
-      getToken: () => this.tokenProvider.getToken(),
-      forceRefresh: () => this.tokenProvider.forceRefresh(),
-      shouldRefresh: (error) => error instanceof AuthenticationError,
-      executeWithToken: (token) =>
-        this.executePackageVulnerabilities(token, params),
-    });
+    return withTelemetrySpan("pkg-intel.vulnerabilities.request", () =>
+      executeWithTokenRefresh({
+        getToken: () => this.tokenProvider.getToken(),
+        forceRefresh: () => this.tokenProvider.forceRefresh(),
+        shouldRefresh: (error) => error instanceof AuthenticationError,
+        executeWithToken: (token) =>
+          this.executePackageVulnerabilities(token, params),
+      }),
+    );
   }
 
   private async executePackageVulnerabilities(
@@ -1368,13 +1373,15 @@ export class PackageIntelligenceServiceImpl
   async packageDependencies(
     params: PackageDependenciesParams,
   ): Promise<DependencyReport> {
-    return executeWithTokenRefresh({
-      getToken: () => this.tokenProvider.getToken(),
-      forceRefresh: () => this.tokenProvider.forceRefresh(),
-      shouldRefresh: (error) => error instanceof AuthenticationError,
-      executeWithToken: (token) =>
-        this.executePackageDependencies(token, params),
-    });
+    return withTelemetrySpan("pkg-intel.dependencies.request", () =>
+      executeWithTokenRefresh({
+        getToken: () => this.tokenProvider.getToken(),
+        forceRefresh: () => this.tokenProvider.forceRefresh(),
+        shouldRefresh: (error) => error instanceof AuthenticationError,
+        executeWithToken: (token) =>
+          this.executePackageDependencies(token, params),
+      }),
+    );
   }
 
   private async executePackageDependencies(
@@ -1566,12 +1573,15 @@ export class PackageIntelligenceServiceImpl
   async packageChangelog(
     params: PackageChangelogParams,
   ): Promise<ChangelogReport> {
-    return executeWithTokenRefresh({
-      getToken: () => this.tokenProvider.getToken(),
-      forceRefresh: () => this.tokenProvider.forceRefresh(),
-      shouldRefresh: (error) => error instanceof AuthenticationError,
-      executeWithToken: (token) => this.executePackageChangelog(token, params),
-    });
+    return withTelemetrySpan("pkg-intel.changelog.request", () =>
+      executeWithTokenRefresh({
+        getToken: () => this.tokenProvider.getToken(),
+        forceRefresh: () => this.tokenProvider.forceRefresh(),
+        shouldRefresh: (error) => error instanceof AuthenticationError,
+        executeWithToken: (token) =>
+          this.executePackageChangelog(token, params),
+      }),
+    );
   }
 
   private async executePackageChangelog(

--- a/src/services/token-manager.test.ts
+++ b/src/services/token-manager.test.ts
@@ -383,5 +383,32 @@ describe("TokenManager", () => {
       expect(result).toBeUndefined();
       expect(authStorage.clearTokens).toHaveBeenCalledWith(MCP_URL);
     });
+
+    it("resets createdAt on refresh so a fresh token is not immediately refreshed again", async () => {
+      const tokenData = createValidTokenData({
+        createdAt: new Date(Date.now() - 58 * 60_000).toISOString(),
+        expiresAt: new Date(Date.now() + 2 * 60_000).toISOString(),
+      });
+      const refreshMock = mock(() => Promise.resolve(defaultTokenResponse));
+      const authStorage = createMockAuthStorage({
+        loadTokens: mock(() => Promise.resolve(tokenData)),
+        loadClient: mock(() => Promise.resolve(defaultClientRegistration)),
+      });
+      const manager = new TokenManager({
+        authService: createMockAuthService({
+          refreshAccessToken: refreshMock,
+        }),
+        authStorage,
+        mcpUrl: MCP_URL,
+      });
+
+      const refreshed = await manager.getToken();
+      const second = await manager.getToken();
+
+      expect(refreshed).toBe(defaultTokenResponse.accessToken);
+      expect(second).toBe(defaultTokenResponse.accessToken);
+      expect(refreshMock).toHaveBeenCalledTimes(1);
+      expect(authStorage.saveTokens).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/src/services/token-manager.ts
+++ b/src/services/token-manager.ts
@@ -205,7 +205,10 @@ export class TokenManager implements TokenProvider {
         expiresAt: new Date(
           Date.now() + response.expiresIn * 1000,
         ).toISOString(),
-        createdAt: tokens.createdAt,
+        // Refresh starts a new token lifetime window. Keeping the
+        // original createdAt makes a freshly refreshed token look
+        // permanently near expiry, which triggers immediate re-refresh.
+        createdAt: new Date().toISOString(),
       };
 
       await withTelemetrySpan("token-manager.save-tokens", () =>

--- a/src/services/token-manager.ts
+++ b/src/services/token-manager.ts
@@ -1,3 +1,4 @@
+import { withTelemetrySpan } from "../shared/telemetry.js";
 import type { AuthService, TokenResponse } from "./auth-service.js";
 import type { AuthStorage, TokenData } from "./auth-storage.js";
 
@@ -92,41 +93,48 @@ export class TokenManager implements TokenProvider {
   }
 
   async getToken(): Promise<string | undefined> {
-    // Load from storage on first call
-    if (!this.cachedToken) {
-      this.cachedToken = await this.authStorage.loadTokens(this.mcpUrl);
-      if (!this.cachedToken) return undefined;
-    }
+    return withTelemetrySpan("token-manager.get-token", async () => {
+      // Load from storage on first call
+      if (!this.cachedToken) {
+        this.cachedToken = await withTelemetrySpan(
+          "token-manager.load-tokens",
+          () => this.authStorage.loadTokens(this.mcpUrl),
+        );
+        if (!this.cachedToken) return undefined;
+      }
 
-    const currentToken = this.cachedToken.accessToken;
-    const { expired, shouldRefresh } = shouldRefreshToken(
-      this.cachedToken,
-      PROACTIVE_REFRESH_RATIO,
-      new Date(),
-    );
+      const currentToken = this.cachedToken.accessToken;
+      const { expired, shouldRefresh } = shouldRefreshToken(
+        this.cachedToken,
+        PROACTIVE_REFRESH_RATIO,
+        new Date(),
+      );
 
-    if (!shouldRefresh) {
-      return currentToken;
-    }
+      if (!shouldRefresh) {
+        return currentToken;
+      }
 
-    // Attempt refresh (coalesced if already in-flight)
-    const refreshedToken = await this.doRefresh();
+      // Attempt refresh (coalesced if already in-flight)
+      const refreshedToken = await this.doRefresh();
 
-    if (refreshedToken) {
-      return refreshedToken;
-    }
+      if (refreshedToken) {
+        return refreshedToken;
+      }
 
-    // Proactive refresh failed but token still valid — return current token
-    if (!expired) {
-      return currentToken;
-    }
+      // Proactive refresh failed but token still valid — return current token
+      if (!expired) {
+        return currentToken;
+      }
 
-    // Token expired and refresh failed
-    return undefined;
+      // Token expired and refresh failed
+      return undefined;
+    });
   }
 
   async forceRefresh(): Promise<string | undefined> {
-    return this.doRefresh();
+    return withTelemetrySpan("token-manager.force-refresh", () =>
+      this.doRefresh(),
+    );
   }
 
   /**
@@ -146,45 +154,65 @@ export class TokenManager implements TokenProvider {
   }
 
   private async executeRefresh(): Promise<string | undefined> {
-    const tokens =
-      this.cachedToken ?? (await this.authStorage.loadTokens(this.mcpUrl));
-    if (!tokens) return undefined;
+    return withTelemetrySpan("token-manager.refresh", async () => {
+      const tokens =
+        this.cachedToken ??
+        (await withTelemetrySpan("token-manager.load-tokens", () =>
+          this.authStorage.loadTokens(this.mcpUrl),
+        ));
+      if (!tokens) return undefined;
 
-    const client = await this.authStorage.loadClient(this.mcpUrl);
-    if (!client) return undefined;
+      const client = await withTelemetrySpan("token-manager.load-client", () =>
+        this.authStorage.loadClient(this.mcpUrl),
+      );
+      if (!client) return undefined;
 
-    let response: TokenResponse;
-    try {
-      const metadata = await this.authService.discoverEndpoints(this.mcpUrl);
-      response = await this.authService.refreshAccessToken({
-        tokenEndpoint: metadata.tokenEndpoint,
-        clientId: client.clientId,
-        clientSecret: client.clientSecret,
-        refreshToken: tokens.refreshToken,
-      });
-    } catch {
-      // Only clear tokens if they are actually expired.
-      // If refresh was proactive (token still valid), leave storage intact
-      // so subsequent calls can still serve the current token.
-      const isExpired = tokens.expiresAt
-        ? new Date() >= new Date(tokens.expiresAt)
-        : false;
-      if (isExpired) {
-        this.cachedToken = null;
-        await this.authStorage.clearTokens(this.mcpUrl);
+      let response: TokenResponse;
+      try {
+        const metadata = await withTelemetrySpan(
+          "token-manager.discover-endpoints",
+          () => this.authService.discoverEndpoints(this.mcpUrl),
+        );
+        response = await withTelemetrySpan(
+          "token-manager.refresh-access-token",
+          () =>
+            this.authService.refreshAccessToken({
+              tokenEndpoint: metadata.tokenEndpoint,
+              clientId: client.clientId,
+              clientSecret: client.clientSecret,
+              refreshToken: tokens.refreshToken,
+            }),
+        );
+      } catch {
+        // Only clear tokens if they are actually expired.
+        // If refresh was proactive (token still valid), leave storage intact
+        // so subsequent calls can still serve the current token.
+        const isExpired = tokens.expiresAt
+          ? new Date() >= new Date(tokens.expiresAt)
+          : false;
+        if (isExpired) {
+          this.cachedToken = null;
+          await withTelemetrySpan("token-manager.clear-tokens", () =>
+            this.authStorage.clearTokens(this.mcpUrl),
+          );
+        }
+        return undefined;
       }
-      return undefined;
-    }
 
-    const newTokenData: TokenData = {
-      accessToken: response.accessToken,
-      refreshToken: response.refreshToken,
-      expiresAt: new Date(Date.now() + response.expiresIn * 1000).toISOString(),
-      createdAt: tokens.createdAt,
-    };
+      const newTokenData: TokenData = {
+        accessToken: response.accessToken,
+        refreshToken: response.refreshToken,
+        expiresAt: new Date(
+          Date.now() + response.expiresIn * 1000,
+        ).toISOString(),
+        createdAt: tokens.createdAt,
+      };
 
-    await this.authStorage.saveTokens(this.mcpUrl, newTokenData);
-    this.cachedToken = newTokenData;
-    return response.accessToken;
+      await withTelemetrySpan("token-manager.save-tokens", () =>
+        this.authStorage.saveTokens(this.mcpUrl, newTokenData),
+      );
+      this.cachedToken = newTokenData;
+      return response.accessToken;
+    });
   }
 }

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -124,3 +124,15 @@ export {
   type SearchSymbolsQueryEcho,
   type SearchSymbolsSuccessPayload,
 } from "./search-symbols-response.js";
+export {
+  endTelemetrySpan,
+  flushTelemetry,
+  isTelemetryEnabled,
+  resetTelemetryCollectorForTests,
+  startTelemetrySpan,
+  type TelemetryAttributes,
+  TelemetryCollector,
+  type TelemetrySpanHandle,
+  withTelemetrySpan,
+  withTelemetrySpanSync,
+} from "./telemetry.js";

--- a/src/shared/telemetry.test.ts
+++ b/src/shared/telemetry.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "bun:test";
+import {
+  flushTelemetry,
+  isTelemetryEnabled,
+  resetTelemetryCollectorForTests,
+  startTelemetrySpan,
+  withTelemetrySpan,
+} from "./telemetry.js";
+
+describe("telemetry", () => {
+  it("recognises the opt-in env flag", () => {
+    expect(isTelemetryEnabled({ GITHITS_TELEMETRY: "1" })).toBe(true);
+    expect(isTelemetryEnabled({ GITHITS_TELEMETRY: "true" })).toBe(true);
+    expect(isTelemetryEnabled({ GITHITS_TELEMETRY: "0" })).toBe(false);
+    expect(isTelemetryEnabled({})).toBe(false);
+  });
+
+  it("flushes spans as a summary at exit", () => {
+    const writes: string[] = [];
+    let nowMs = 0;
+
+    resetTelemetryCollectorForTests({
+      env: { GITHITS_TELEMETRY: "1" },
+      now: () => nowMs,
+      write: (text) => writes.push(text),
+    });
+
+    const span = startTelemetrySpan("container.create", { area: "startup" });
+    nowMs = 37;
+    expect(span).toBeDefined();
+    flushTelemetry(0);
+
+    const report = writes.join("");
+    expect(report).toContain("[githits telemetry]");
+    expect(report).toContain("exit: 0");
+    expect(report).toContain("total: 37.0ms");
+    expect(report).toContain(
+      "container.create: 37.0ms (start +0.0ms, ended-at-exit, area=startup)",
+    );
+  });
+
+  it("marks failed spans without suppressing the error", async () => {
+    const writes: string[] = [];
+    let nowMs = 0;
+
+    resetTelemetryCollectorForTests({
+      env: { GITHITS_TELEMETRY: "1" },
+      now: () => nowMs,
+      write: (text) => writes.push(text),
+    });
+
+    await expect(
+      withTelemetrySpan("pkg-intel.dependencies.request", async () => {
+        nowMs = 12;
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+
+    nowMs = 20;
+    flushTelemetry(1);
+
+    const report = writes.join("");
+    expect(report).toContain("exit: 1");
+    expect(report).toContain(
+      "pkg-intel.dependencies.request: 12.0ms (start +0.0ms, error=true)",
+    );
+  });
+});

--- a/src/shared/telemetry.ts
+++ b/src/shared/telemetry.ts
@@ -1,0 +1,240 @@
+import { writeSync } from "node:fs";
+
+export type TelemetryAttributeValue = string | number | boolean;
+
+export interface TelemetryAttributes {
+  [key: string]: TelemetryAttributeValue | undefined;
+}
+
+export interface TelemetrySpanHandle {
+  id: number;
+}
+
+interface MutableTelemetrySpan {
+  id: number;
+  name: string;
+  startMs: number;
+  endMs?: number;
+  attributes?: TelemetryAttributes;
+  endedAtExit?: boolean;
+}
+
+export interface TelemetryCollectorOptions {
+  env?: Record<string, string | undefined>;
+  now?: () => number;
+  write?: (text: string) => void;
+}
+
+const ENABLED_VALUES = new Set(["1", "true", "yes", "on"]);
+
+export function isTelemetryEnabled(
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  const raw = env.GITHITS_TELEMETRY?.trim().toLowerCase();
+  if (!raw) return false;
+  return ENABLED_VALUES.has(raw);
+}
+
+export class TelemetryCollector {
+  private readonly enabled: boolean;
+  private readonly now: () => number;
+  private readonly write: (text: string) => void;
+  private readonly sessionStartMs: number;
+  private readonly spans: MutableTelemetrySpan[] = [];
+  private readonly activeSpans = new Map<number, MutableTelemetrySpan>();
+  private nextId = 1;
+  private flushed = false;
+
+  constructor(options: TelemetryCollectorOptions = {}) {
+    this.enabled = isTelemetryEnabled(options.env);
+    this.now = options.now ?? (() => globalThis.performance.now());
+    this.write =
+      options.write ?? ((text: string) => writeSync(process.stderr.fd, text));
+    this.sessionStartMs = this.now();
+  }
+
+  isEnabled(): boolean {
+    return this.enabled;
+  }
+
+  startSpan(
+    name: string,
+    attributes?: TelemetryAttributes,
+  ): TelemetrySpanHandle | undefined {
+    if (!this.enabled) return undefined;
+
+    const span: MutableTelemetrySpan = {
+      id: this.nextId++,
+      name,
+      startMs: this.now(),
+      attributes: sanitiseAttributes(attributes),
+    };
+
+    this.spans.push(span);
+    this.activeSpans.set(span.id, span);
+    return { id: span.id };
+  }
+
+  endSpan(
+    handle: TelemetrySpanHandle | undefined,
+    attributes?: TelemetryAttributes,
+  ): void {
+    if (!this.enabled || !handle) return;
+
+    const span = this.activeSpans.get(handle.id);
+    if (!span || span.endMs !== undefined) return;
+
+    span.endMs = this.now();
+    span.attributes = mergeAttributes(span.attributes, attributes);
+    this.activeSpans.delete(handle.id);
+  }
+
+  flush(exitCode: number = 0): void {
+    if (!this.enabled || this.flushed) return;
+
+    const nowMs = this.now();
+    for (const span of this.activeSpans.values()) {
+      if (span.endMs !== undefined) continue;
+      span.endMs = nowMs;
+      span.endedAtExit = true;
+    }
+    this.activeSpans.clear();
+
+    this.write(
+      formatTelemetryReport(this.spans, this.sessionStartMs, nowMs, exitCode),
+    );
+    this.flushed = true;
+  }
+}
+
+export async function withTelemetrySpan<T>(
+  name: string,
+  operation: () => Promise<T>,
+  attributes?: TelemetryAttributes,
+): Promise<T> {
+  const handle = telemetryCollector.startSpan(name, attributes);
+  try {
+    const result = await operation();
+    telemetryCollector.endSpan(handle);
+    return result;
+  } catch (error) {
+    telemetryCollector.endSpan(handle, { error: true });
+    throw error;
+  }
+}
+
+export function withTelemetrySpanSync<T>(
+  name: string,
+  operation: () => T,
+  attributes?: TelemetryAttributes,
+): T {
+  const handle = telemetryCollector.startSpan(name, attributes);
+  try {
+    const result = operation();
+    telemetryCollector.endSpan(handle);
+    return result;
+  } catch (error) {
+    telemetryCollector.endSpan(handle, { error: true });
+    throw error;
+  }
+}
+
+export function startTelemetrySpan(
+  name: string,
+  attributes?: TelemetryAttributes,
+): TelemetrySpanHandle | undefined {
+  return telemetryCollector.startSpan(name, attributes);
+}
+
+export function endTelemetrySpan(
+  handle: TelemetrySpanHandle | undefined,
+  attributes?: TelemetryAttributes,
+): void {
+  telemetryCollector.endSpan(handle, attributes);
+}
+
+export function flushTelemetry(exitCode: number = 0): void {
+  telemetryCollector.flush(exitCode);
+}
+
+export function resetTelemetryCollectorForTests(
+  options: TelemetryCollectorOptions = {},
+): void {
+  telemetryCollector = new TelemetryCollector(options);
+}
+
+let telemetryCollector = new TelemetryCollector();
+
+function sanitiseAttributes(
+  attributes?: TelemetryAttributes,
+): TelemetryAttributes | undefined {
+  if (!attributes) return undefined;
+
+  const entries = Object.entries(attributes).filter(
+    ([, value]) => value !== undefined,
+  );
+  if (entries.length === 0) return undefined;
+  return Object.fromEntries(entries);
+}
+
+function mergeAttributes(
+  initial?: TelemetryAttributes,
+  extra?: TelemetryAttributes,
+): TelemetryAttributes | undefined {
+  if (!initial && !extra) return undefined;
+  return sanitiseAttributes({
+    ...(initial ?? {}),
+    ...(extra ?? {}),
+  });
+}
+
+function formatTelemetryReport(
+  spans: MutableTelemetrySpan[],
+  sessionStartMs: number,
+  sessionEndMs: number,
+  exitCode: number,
+): string {
+  const lines = [
+    "[githits telemetry]",
+    `exit: ${exitCode}`,
+    `total: ${formatMs(sessionEndMs - sessionStartMs)}`,
+  ];
+
+  const orderedSpans = [...spans].sort((left, right) => {
+    if (left.startMs !== right.startMs) {
+      return left.startMs - right.startMs;
+    }
+    return left.id - right.id;
+  });
+
+  for (const span of orderedSpans) {
+    const endMs = span.endMs ?? sessionEndMs;
+    const details = [`start +${formatMs(span.startMs - sessionStartMs)}`];
+
+    if (span.endedAtExit) {
+      details.push("ended-at-exit");
+    }
+
+    const attrs = formatAttributes(span.attributes);
+    if (attrs) {
+      details.push(attrs);
+    }
+
+    lines.push(
+      `- ${span.name}: ${formatMs(endMs - span.startMs)} (${details.join(", ")})`,
+    );
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+function formatAttributes(attributes?: TelemetryAttributes): string {
+  if (!attributes) return "";
+  return Object.entries(attributes)
+    .map(([key, value]) => `${key}=${String(value)}`)
+    .join(" ");
+}
+
+function formatMs(value: number): string {
+  return `${value.toFixed(1)}ms`;
+}


### PR DESCRIPTION
## Summary
- add opt-in CLI timing telemetry behind `GITHITS_TELEMETRY=1`
- reduce local auth overhead by removing eager keychain probe work and improving keychain fallback behavior
- avoid immediate repeat token refreshes after a successful refresh

## Verification
- bun test src/shared/telemetry.test.ts src/services/token-manager.test.ts src/services/githits-service.test.ts src/services/package-intelligence-service.test.ts
- bun test src/services/migrating-auth-storage.test.ts src/services/token-manager.test.ts
- bun run build