### PR TITLE
[codex] release 0.1.10

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "GitHits plugins for Claude Code - code examples from global open source",
-    "version": "0.1.9"
+    "version": "0.1.10"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Code examples from global open source for developers and AI assistants",
   "author": {
     "name": "GitHits"

--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Code examples from global open source for developers and AI assistants",
   "author": {
     "name": "GitHits"

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Code examples from global open source for developers and AI assistants.",
   "mcpServers": {
     "githits": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "githits",
   "description": "CLI companion for GitHits - code examples from global open source for developers and AI assistants",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "type": "module",
   "files": [
     "dist",

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Code examples from global open source for developers and AI assistants",
   "author": {
     "name": "GitHits"


### PR DESCRIPTION
## Summary
- bump the CLI package version from `0.1.9` to `0.1.10`
- keep all published plugin and marketplace manifests aligned with the package version
- prepare the next patch release for the existing GitHub release workflow

## Why
The release workflow keys off `package.json` version and tag existence. This patch bump is required to produce the next GitHub release and npm publish.

## Impact
- release metadata stays consistent across npm, Open Plugin, Claude marketplace, and Gemini extension surfaces
- merging this PR to `main` enables the existing release workflow to create `v0.1.10`

## Validation
- `bun install --frozen-lockfile`
- `bun test`
- `bun run build`
