### PR TITLE
fix(init): enforce canonical MCP local config

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "GitHits plugins for Claude Code - code examples from global open source",
-    "version": "0.1.10"
+    "version": "0.1.11"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Code examples from global open source for developers and AI assistants",
   "author": {
     "name": "GitHits"

--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Code examples from global open source for developers and AI assistants",
   "author": {
     "name": "GitHits"

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Code examples from global open source for developers and AI assistants.",
   "mcpServers": {
     "githits": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "githits",
   "description": "CLI companion for GitHits - code examples from global open source for developers and AI assistants",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "type": "module",
   "files": [
     "dist",

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Code examples from global open source for developers and AI assistants",
   "author": {
     "name": "GitHits"

--- a/src/commands/init/agent-definitions.test.ts
+++ b/src/commands/init/agent-definitions.test.ts
@@ -367,7 +367,7 @@ describe("getSetupConfig", () => {
     }
   });
 
-  it("cursor returns config-file setup with native url", () => {
+  it("cursor returns config-file setup with npm MCP command", () => {
     const fs = createMockFileSystemService({
       getHomeDir: mock(() => "/home/test"),
       joinPath: mock((...segments: string[]) => segments.join("/")),
@@ -379,12 +379,14 @@ describe("getSetupConfig", () => {
       expect(config.configPath).toBe("/home/test/.cursor/mcp.json");
       expect(config.serversKey).toBe("mcpServers");
       expect(config.serverName).toBe("GitHits");
-      expect(config.serverConfig).toHaveProperty("url");
-      expect(config.serverConfig).not.toHaveProperty("command");
+      expect(config.serverConfig).toEqual({
+        command: "npx",
+        args: ["-y", "githits@latest", "mcp", "start"],
+      });
     }
   });
 
-  it("windsurf returns config-file setup with native serverUrl", () => {
+  it("windsurf returns config-file setup with npm MCP command", () => {
     const fs = createMockFileSystemService({
       getHomeDir: mock(() => "/home/test"),
       joinPath: mock((...segments: string[]) => segments.join("/")),
@@ -398,12 +400,14 @@ describe("getSetupConfig", () => {
       );
       expect(config.serversKey).toBe("mcpServers");
       expect(config.serverName).toBe("GitHits");
-      expect(config.serverConfig).toHaveProperty("serverUrl");
-      expect(config.serverConfig).not.toHaveProperty("command");
+      expect(config.serverConfig).toEqual({
+        command: "npx",
+        args: ["-y", "githits@latest", "mcp", "start"],
+      });
     }
   });
 
-  it("claude-desktop returns config-file setup with mcp-remote", () => {
+  it("claude-desktop returns config-file setup with npm MCP command", () => {
     const fs = createMockFileSystemService({
       getHomeDir: mock(() => "/home/test"),
       joinPath: mock((...segments: string[]) => segments.join("/")),
@@ -415,9 +419,10 @@ describe("getSetupConfig", () => {
       expect(config.configPath).toContain("claude_desktop_config.json");
       expect(config.serversKey).toBe("mcpServers");
       expect(config.serverName).toBe("GitHits");
-      expect(config.serverConfig).toHaveProperty("command", "npx");
-      const args = config.serverConfig.args as string[];
-      expect(args).toContain("mcp-remote");
+      expect(config.serverConfig).toEqual({
+        command: "npx",
+        args: ["-y", "githits@latest", "mcp", "start"],
+      });
     }
   });
 
@@ -539,7 +544,7 @@ describe("getSetupConfig", () => {
     }
   });
 
-  it("codex-cli returns CLI setup with npm/stdio command", () => {
+  it("codex-cli returns CLI setup with npm MCP command", () => {
     const fs = createMockFileSystemService();
     const agent = agentDefinitions.find((a) => a.id === "codex-cli")!;
     const config = agent.getSetupConfig(fs);
@@ -549,12 +554,13 @@ describe("getSetupConfig", () => {
       expect(config.commands[0]!.command).toBe("codex");
       expect(config.commands[0]!.args).toContain("mcp");
       expect(config.commands[0]!.args).toContain("add");
-      expect(config.commands[0]!.args).toContain("githits");
+      expect(config.commands[0]!.args).toContain("npx");
       expect(config.commands[0]!.args).toContain("githits@latest");
+      expect(config.commands[0]!.args).toContain("githits");
     }
   });
 
-  it("vscode returns config-file setup with servers key and http type", () => {
+  it("vscode returns config-file setup with servers key and npm MCP command", () => {
     const originalPlatform = process.platform;
     Object.defineProperty(process, "platform", {
       value: "darwin",
@@ -575,8 +581,8 @@ describe("getSetupConfig", () => {
         expect(config.serversKey).toBe("servers");
         expect(config.serverName).toBe("GitHits");
         expect(config.serverConfig).toEqual({
-          url: "https://mcp.githits.com",
-          type: "http",
+          command: "npx",
+          args: ["-y", "githits@latest", "mcp", "start"],
         });
       }
     } finally {
@@ -587,7 +593,7 @@ describe("getSetupConfig", () => {
     }
   });
 
-  it("cline returns config-file setup with streamableHttp type", () => {
+  it("cline returns config-file setup with npm MCP command", () => {
     const fs = createMockFileSystemService({
       getHomeDir: mock(() => "/home/test"),
       joinPath: mock((...segments: string[]) => segments.join("/")),
@@ -602,8 +608,8 @@ describe("getSetupConfig", () => {
       expect(config.serversKey).toBe("mcpServers");
       expect(config.serverName).toBe("GitHits");
       expect(config.serverConfig).toEqual({
-        url: "https://mcp.githits.com",
-        type: "streamableHttp",
+        command: "npx",
+        args: ["-y", "githits@latest", "mcp", "start"],
       });
     }
   });
@@ -625,7 +631,7 @@ describe("getSetupConfig", () => {
     }
   });
 
-  it("google-antigravity returns config-file setup with serverUrl", () => {
+  it("google-antigravity returns config-file setup with npm MCP command", () => {
     const fs = createMockFileSystemService({
       getHomeDir: mock(() => "/home/test"),
       joinPath: mock((...segments: string[]) => segments.join("/")),
@@ -640,7 +646,8 @@ describe("getSetupConfig", () => {
       expect(config.serversKey).toBe("mcpServers");
       expect(config.serverName).toBe("GitHits");
       expect(config.serverConfig).toEqual({
-        serverUrl: "https://mcp.githits.com",
+        command: "npx",
+        args: ["-y", "githits@latest", "mcp", "start"],
       });
     }
   });
@@ -701,7 +708,7 @@ describe("getSetupConfig", () => {
     }
   });
 
-  it("claude-desktop is the only config-file agent using mcp-remote", () => {
+  it("all config-file agents use npm githits@latest mcp start command", () => {
     const fs = createMockFileSystemService({
       getHomeDir: mock(() => "/home/test"),
       joinPath: mock((...segments: string[]) => segments.join("/")),
@@ -712,43 +719,18 @@ describe("getSetupConfig", () => {
     for (const agent of configFileAgents) {
       const config = agent.getSetupConfig(fs);
       if (config.method === "config-file") {
-        if (agent.id === "claude-desktop") {
-          expect(config.serverConfig).toHaveProperty("command", "npx");
-          const args = config.serverConfig.args as string[];
-          expect(args).toContain("mcp-remote");
+        if (agent.id === "opencode") {
+          expect(config.serverConfig).toEqual({
+            type: "local",
+            command: ["npx", "-y", "githits@latest", "mcp", "start"],
+            enabled: true,
+          });
         } else {
-          // No agent other than claude-desktop should use mcp-remote
-          const args = config.serverConfig.args;
-          if (Array.isArray(args)) {
-            expect(args).not.toContain("mcp-remote");
-          }
+          expect(config.serverConfig).toEqual({
+            command: "npx",
+            args: ["-y", "githits@latest", "mcp", "start"],
+          });
         }
-      }
-    }
-  });
-
-  it("uses GITHITS_MCP_URL env var when set", () => {
-    const originalUrl = process.env.GITHITS_MCP_URL;
-    process.env.GITHITS_MCP_URL = "https://staging.mcp.example.com";
-    try {
-      const fs = createMockFileSystemService({
-        getHomeDir: mock(() => "/home/test"),
-        joinPath: mock((...segments: string[]) => segments.join("/")),
-      });
-      // Check a config-file agent
-      const cursor = agentDefinitions.find((a) => a.id === "cursor")!;
-      const cursorConfig = cursor.getSetupConfig(fs);
-      if (cursorConfig.method === "config-file") {
-        expect(cursorConfig.serverConfig).toHaveProperty(
-          "url",
-          "https://staging.mcp.example.com",
-        );
-      }
-    } finally {
-      if (originalUrl !== undefined) {
-        process.env.GITHITS_MCP_URL = originalUrl;
-      } else {
-        delete process.env.GITHITS_MCP_URL;
       }
     }
   });
@@ -843,7 +825,12 @@ describe("scanAgents", () => {
       detectedDirs: ["/home/test/.cursor"],
       configFiles: {
         "/home/test/.cursor/mcp.json": JSON.stringify({
-          mcpServers: { GitHits: { url: "https://mcp.githits.com" } },
+          mcpServers: {
+            GitHits: {
+              command: "npx",
+              args: ["-y", "githits@latest", "mcp", "start"],
+            },
+          },
         }),
       },
     });
@@ -1031,7 +1018,12 @@ describe("scanAgents", () => {
       detectedDirs: ["/home/test/.cursor", "/home/test/.codeium/windsurf"],
       configFiles: {
         "/home/test/.cursor/mcp.json": JSON.stringify({
-          mcpServers: { GitHits: { url: "https://mcp.githits.com" } },
+          mcpServers: {
+            GitHits: {
+              command: "npx",
+              args: ["-y", "githits@latest", "mcp", "start"],
+            },
+          },
         }),
       },
       execResults: {
@@ -1113,18 +1105,36 @@ describe("scanAgents", () => {
     // Config files for all config-file agents with GitHits configured
     const allConfiguredFiles: Record<string, string> = {
       "/home/test/.cursor/mcp.json": JSON.stringify({
-        mcpServers: { GitHits: { url: "https://mcp.githits.com" } },
+        mcpServers: {
+          GitHits: {
+            command: "npx",
+            args: ["-y", "githits@latest", "mcp", "start"],
+          },
+        },
       }),
       "/home/test/.codeium/windsurf/mcp_config.json": JSON.stringify({
-        mcpServers: { GitHits: { serverUrl: "https://mcp.githits.com" } },
+        mcpServers: {
+          GitHits: {
+            command: "npx",
+            args: ["-y", "githits@latest", "mcp", "start"],
+          },
+        },
       }),
       [`${vscodePath}/User/mcp.json`]: JSON.stringify({
-        servers: { GitHits: { url: "https://mcp.githits.com", type: "http" } },
+        servers: {
+          GitHits: {
+            command: "npx",
+            args: ["-y", "githits@latest", "mcp", "start"],
+          },
+        },
       }),
       "/home/test/.cline/data/settings/cline_mcp_settings.json": JSON.stringify(
         {
           mcpServers: {
-            GitHits: { url: "https://mcp.githits.com", type: "streamableHttp" },
+            GitHits: {
+              command: "npx",
+              args: ["-y", "githits@latest", "mcp", "start"],
+            },
           },
         },
       ),
@@ -1132,12 +1142,17 @@ describe("scanAgents", () => {
         mcpServers: {
           GitHits: {
             command: "npx",
-            args: ["-y", "mcp-remote", "https://mcp.githits.com"],
+            args: ["-y", "githits@latest", "mcp", "start"],
           },
         },
       }),
       "/home/test/.gemini/antigravity/mcp_config.json": JSON.stringify({
-        mcpServers: { GitHits: { serverUrl: "https://mcp.githits.com" } },
+        mcpServers: {
+          GitHits: {
+            command: "npx",
+            args: ["-y", "githits@latest", "mcp", "start"],
+          },
+        },
       }),
       [`${opencodePath}/opencode.json`]: JSON.stringify({
         mcp: {
@@ -1294,11 +1309,21 @@ describe("scanAgents", () => {
           ],
           configFiles: {
             "/home/test/.cursor/mcp.json": JSON.stringify({
-              mcpServers: { GitHits: { url: "https://mcp.githits.com" } },
+              mcpServers: {
+                GitHits: {
+                  command: "npx",
+                  args: ["-y", "githits@latest", "mcp", "start"],
+                },
+              },
             }),
             [`${claudeDesktopPath}/claude_desktop_config.json`]: JSON.stringify(
               {
-                mcpServers: { GitHits: { command: "npx" } },
+                mcpServers: {
+                  GitHits: {
+                    command: "npx",
+                    args: ["-y", "githits@latest", "mcp", "start"],
+                  },
+                },
               },
             ),
           },

--- a/src/commands/init/agent-definitions.ts
+++ b/src/commands/init/agent-definitions.ts
@@ -1,4 +1,3 @@
-import { getMcpUrl } from "../../services/config.js";
 import type { ExecService } from "../../services/exec-service.js";
 import type { FileSystemService } from "../../services/index.js";
 import {
@@ -43,6 +42,14 @@ export interface ConfigFileSetup {
 }
 
 export type SetupConfig = CliSetup | ConfigFileSetup;
+
+const GITHITS_SERVER_NAME = "GitHits";
+const GITHITS_MCP_COMMAND = "npx";
+const GITHITS_MCP_ARGS = ["-y", "githits@latest", "mcp", "start"] as const;
+const GITHITS_MCP_INVOCATION = [
+  GITHITS_MCP_COMMAND,
+  ...GITHITS_MCP_ARGS,
+] as const;
 
 /** How an agent is considered present on the machine. */
 type DetectionMethod = "binary" | "path";
@@ -134,7 +141,7 @@ const claudeCode: AgentDefinition = {
   }),
 };
 
-/** Cursor: detected by ~/.cursor/ directory, configured via mcp.json with native OAuth */
+/** Cursor: detected by ~/.cursor/ directory, configured via npm MCP command */
 const cursor: AgentDefinition = {
   name: "Cursor",
   id: "cursor",
@@ -145,14 +152,17 @@ const cursor: AgentDefinition = {
     method: "config-file",
     configPath: fs.joinPath(fs.getHomeDir(), ".cursor", "mcp.json"),
     serversKey: "mcpServers",
-    serverName: "GitHits",
-    serverConfig: { url: getMcpUrl() },
+    serverName: GITHITS_SERVER_NAME,
+    serverConfig: {
+      command: GITHITS_MCP_COMMAND,
+      args: [...GITHITS_MCP_ARGS],
+    },
   }),
 };
 
 /**
  * Windsurf: detected by ~/.codeium/windsurf/ directory.
- * Uses native serverUrl (no mcp-remote needed).
+ * Uses npm MCP command.
  */
 const windsurf: AgentDefinition = {
   name: "Windsurf",
@@ -169,12 +179,15 @@ const windsurf: AgentDefinition = {
       "mcp_config.json",
     ),
     serversKey: "mcpServers",
-    serverName: "GitHits",
-    serverConfig: { serverUrl: getMcpUrl() },
+    serverName: GITHITS_SERVER_NAME,
+    serverConfig: {
+      command: GITHITS_MCP_COMMAND,
+      args: [...GITHITS_MCP_ARGS],
+    },
   }),
 };
 
-/** Claude Desktop: detected by platform-specific Claude directory, uses mcp-remote */
+/** Claude Desktop: detected by platform-specific Claude directory, uses npm MCP command */
 const claudeDesktop: AgentDefinition = {
   name: "Claude Desktop",
   id: "claude-desktop",
@@ -200,10 +213,10 @@ const claudeDesktop: AgentDefinition = {
       method: "config-file",
       configPath: fs.joinPath(appData, "claude_desktop_config.json"),
       serversKey: "mcpServers",
-      serverName: "GitHits",
+      serverName: GITHITS_SERVER_NAME,
       serverConfig: {
-        command: "npx",
-        args: ["-y", "mcp-remote", getMcpUrl()],
+        command: GITHITS_MCP_COMMAND,
+        args: [...GITHITS_MCP_ARGS],
       },
     };
   },
@@ -221,17 +234,7 @@ const codexCli: AgentDefinition = {
     commands: [
       {
         command: "codex",
-        args: [
-          "mcp",
-          "add",
-          "githits",
-          "--",
-          "npx",
-          "-y",
-          "githits@latest",
-          "mcp",
-          "start",
-        ],
+        args: ["mcp", "add", "githits", "--", ...GITHITS_MCP_INVOCATION],
       },
     ],
     checkCommand: {
@@ -242,7 +245,7 @@ const codexCli: AgentDefinition = {
   }),
 };
 
-/** VS Code / Copilot: detected by platform-specific Code directory, uses native HTTP */
+/** VS Code / Copilot: detected by platform-specific Code directory, uses npm MCP command */
 const vscode: AgentDefinition = {
   name: "VS Code / Copilot",
   id: "vscode",
@@ -258,13 +261,16 @@ const vscode: AgentDefinition = {
       method: "config-file",
       configPath: fs.joinPath(appData, "User", "mcp.json"),
       serversKey: "servers",
-      serverName: "GitHits",
-      serverConfig: { url: getMcpUrl(), type: "http" },
+      serverName: GITHITS_SERVER_NAME,
+      serverConfig: {
+        command: GITHITS_MCP_COMMAND,
+        args: [...GITHITS_MCP_ARGS],
+      },
     };
   },
 };
 
-/** Cline: detected by ~/.cline/ directory, uses streamable HTTP */
+/** Cline: detected by ~/.cline/ directory, uses npm MCP command */
 const cline: AgentDefinition = {
   name: "Cline",
   id: "cline",
@@ -281,8 +287,11 @@ const cline: AgentDefinition = {
       "cline_mcp_settings.json",
     ),
     serversKey: "mcpServers",
-    serverName: "GitHits",
-    serverConfig: { url: getMcpUrl(), type: "streamableHttp" },
+    serverName: GITHITS_SERVER_NAME,
+    serverConfig: {
+      command: GITHITS_MCP_COMMAND,
+      args: [...GITHITS_MCP_ARGS],
+    },
   }),
 };
 
@@ -347,8 +356,11 @@ const googleAntigravity: AgentDefinition = {
       "mcp_config.json",
     ),
     serversKey: "mcpServers",
-    serverName: "GitHits",
-    serverConfig: { serverUrl: getMcpUrl() },
+    serverName: GITHITS_SERVER_NAME,
+    serverConfig: {
+      command: GITHITS_MCP_COMMAND,
+      args: [...GITHITS_MCP_ARGS],
+    },
   }),
 };
 
@@ -371,10 +383,10 @@ const openCode: AgentDefinition = {
           )
         : fs.joinPath(fs.getHomeDir(), ".config", "opencode", "opencode.json"),
     serversKey: "mcp",
-    serverName: "GitHits",
+    serverName: GITHITS_SERVER_NAME,
     serverConfig: {
       type: "local",
-      command: ["npx", "-y", "githits@latest", "mcp", "start"],
+      command: [...GITHITS_MCP_INVOCATION],
       enabled: true,
     },
   }),

--- a/src/commands/init/init.test.ts
+++ b/src/commands/init/init.test.ts
@@ -115,7 +115,12 @@ describe("initAction", () => {
     // Cursor detected AND already configured
     const fs = createFsWithDetection(["/home/test/.cursor"], {
       "/home/test/.cursor/mcp.json": JSON.stringify({
-        mcpServers: { GitHits: { url: "https://mcp.githits.com" } },
+        mcpServers: {
+          GitHits: {
+            command: "npx",
+            args: ["-y", "githits@latest", "mcp", "start"],
+          },
+        },
       }),
     });
     const promptService = createMockPromptService();
@@ -146,7 +151,12 @@ describe("initAction", () => {
       ["/home/test/.cursor", "/home/test/.codeium/windsurf"],
       {
         "/home/test/.cursor/mcp.json": JSON.stringify({
-          mcpServers: { GitHits: { url: "https://mcp.githits.com" } },
+          mcpServers: {
+            GitHits: {
+              command: "npx",
+              args: ["-y", "githits@latest", "mcp", "start"],
+            },
+          },
         }),
       },
     );
@@ -185,7 +195,12 @@ describe("initAction", () => {
     // Detect Claude Code (CLI) and Cursor (config-file), both configured
     const fs = createFsWithDetection(["/home/test/.cursor"], {
       "/home/test/.cursor/mcp.json": JSON.stringify({
-        mcpServers: { GitHits: { url: "https://mcp.githits.com" } },
+        mcpServers: {
+          GitHits: {
+            command: "npx",
+            args: ["-y", "githits@latest", "mcp", "start"],
+          },
+        },
       }),
     });
     const execService = createMockExecService({
@@ -362,7 +377,12 @@ describe("initAction", () => {
   it("--yes with all agents already configured shows nothing to do", async () => {
     const fs = createFsWithDetection(["/home/test/.cursor"], {
       "/home/test/.cursor/mcp.json": JSON.stringify({
-        mcpServers: { GitHits: { url: "https://mcp.githits.com" } },
+        mcpServers: {
+          GitHits: {
+            command: "npx",
+            args: ["-y", "githits@latest", "mcp", "start"],
+          },
+        },
       }),
     });
 
@@ -378,6 +398,104 @@ describe("initAction", () => {
 
     const logCalls = getLogOutput();
     expect(logCalls.some((msg) => msg.includes("Nothing to do"))).toBe(true);
+  });
+
+  it("treats equivalent local npx @latest configs as already configured", async () => {
+    const fs = createFsWithDetection(["/home/test/.cursor"], {
+      "/home/test/.cursor/mcp.json": JSON.stringify({
+        mcpServers: {
+          GitHits: {
+            command: "npx",
+            args: ["-y", "githits@latest", "mcp", "start"],
+          },
+        },
+      }),
+    });
+
+    await initAction(
+      { yes: true },
+      {
+        fileSystemService: fs,
+        promptService: createMockPromptService(),
+        execService: createMockExecService(),
+        createLoginDeps: createAlreadyAuthLoginDeps(),
+      },
+    );
+
+    expect(fs.atomicWriteFile).not.toHaveBeenCalled();
+    const logCalls = getLogOutput();
+    expect(logCalls.some((msg) => msg.includes("Nothing to do"))).toBe(true);
+  });
+
+  it("migrates non-@latest local config to @latest", async () => {
+    const fs = createFsWithDetection(["/home/test/.cursor"], {
+      "/home/test/.cursor/mcp.json": JSON.stringify({
+        mcpServers: {
+          GitHits: {
+            command: "npx",
+            args: ["-y", "githits", "mcp", "start"],
+          },
+        },
+      }),
+    });
+
+    await initAction(
+      { yes: true },
+      {
+        fileSystemService: fs,
+        promptService: createMockPromptService(),
+        execService: createMockExecService(),
+        createLoginDeps: createAlreadyAuthLoginDeps(),
+      },
+    );
+
+    expect(fs.atomicWriteFile).toHaveBeenCalledTimes(1);
+    const written = (fs.atomicWriteFile as ReturnType<typeof mock>).mock
+      .calls[0]![1] as string;
+    const parsed = JSON.parse(written);
+    expect(parsed.mcpServers.GitHits).toEqual({
+      command: "npx",
+      args: ["-y", "githits@latest", "mcp", "start"],
+    });
+  });
+
+  it("cleans duplicate lowercase githits entry during setup", async () => {
+    const fs = createFsWithDetection(["/home/test/.cline"], {
+      "/home/test/.cline/data/settings/cline_mcp_settings.json": JSON.stringify(
+        {
+          mcpServers: {
+            githits: {
+              command: "npx",
+              args: ["-y", "githits@latest", "mcp", "start"],
+            },
+            GitHits: {
+              command: "npx",
+              args: ["-y", "githits", "mcp", "start"],
+            },
+          },
+        },
+      ),
+    });
+
+    await initAction(
+      { yes: true },
+      {
+        fileSystemService: fs,
+        promptService: createMockPromptService(),
+        execService: createMockExecService(),
+        createLoginDeps: createAlreadyAuthLoginDeps(),
+      },
+    );
+
+    expect(fs.atomicWriteFile).toHaveBeenCalledTimes(1);
+    const written = (fs.atomicWriteFile as ReturnType<typeof mock>).mock
+      .calls[0]![1] as string;
+    const parsed = JSON.parse(written);
+    expect(parsed.mcpServers.GitHits).toEqual({
+      command: "npx",
+      args: ["-y", "githits@latest", "mcp", "start"],
+    });
+    expect(parsed.mcpServers.githits).toBeUndefined();
   });
 
   it("continues to next agent when one fails", async () => {

--- a/src/commands/init/setup-handlers.test.ts
+++ b/src/commands/init/setup-handlers.test.ts
@@ -22,6 +22,12 @@ function expectAdded(result: MergeResult): string {
   return result.content;
 }
 
+function expectUpdated(result: MergeResult): string {
+  expect(result.status).toBe("updated");
+  if (result.status !== "updated") throw new Error("unreachable");
+  return result.content;
+}
+
 /** Assert that a MergeResult is "parse_error" and return its error */
 function expectParseError(result: MergeResult): string {
   expect(result.status).toBe("parse_error");
@@ -37,12 +43,20 @@ describe("isAlreadyConfigured", () => {
     configPath: "/home/test/.cursor/mcp.json",
     serversKey: "mcpServers",
     serverName: "GitHits",
-    serverConfig: { url: "https://mcp.githits.com/" },
+    serverConfig: {
+      command: "npx",
+      args: ["-y", "githits@latest", "mcp", "start"],
+    },
   };
 
   it("returns true when config file contains the server entry", async () => {
     const existing = JSON.stringify({
-      mcpServers: { GitHits: { url: "https://mcp.githits.com/" } },
+      mcpServers: {
+        GitHits: {
+          command: "npx",
+          args: ["-y", "githits@latest", "mcp", "start"],
+        },
+      },
     });
     const fs = createMockFileSystemService({
       readFile: mock(() => Promise.resolve(existing)),
@@ -50,8 +64,113 @@ describe("isAlreadyConfigured", () => {
     expect(await isAlreadyConfigured(configSetup, fs)).toBe(true);
   });
 
+  it("returns false when GitHits exists with legacy remote shape", async () => {
+    const existing = JSON.stringify({
+      mcpServers: { GitHits: { url: "https://mcp.githits.com" } },
+    });
+    const fs = createMockFileSystemService({
+      readFile: mock(() => Promise.resolve(existing)),
+    });
+    expect(await isAlreadyConfigured(configSetup, fs)).toBe(false);
+  });
+
+  it("returns true when config uses equivalent npx @latest invocation", async () => {
+    const existing = JSON.stringify({
+      mcpServers: {
+        GitHits: {
+          command: "npx",
+          args: ["-y", "githits@latest", "mcp", "start"],
+        },
+      },
+    });
+    const fs = createMockFileSystemService({
+      readFile: mock(() => Promise.resolve(existing)),
+    });
+    expect(await isAlreadyConfigured(configSetup, fs)).toBe(true);
+  });
+
+  it("returns false when config uses npx without @latest", async () => {
+    const existing = JSON.stringify({
+      mcpServers: {
+        GitHits: {
+          command: "npx",
+          args: ["-y", "githits", "mcp", "start"],
+        },
+      },
+    });
+    const fs = createMockFileSystemService({
+      readFile: mock(() => Promise.resolve(existing)),
+    });
+    expect(await isAlreadyConfigured(configSetup, fs)).toBe(false);
+  });
+
+  it("returns false when config uses direct githits invocation", async () => {
+    const existing = JSON.stringify({
+      mcpServers: {
+        GitHits: {
+          command: "githits",
+          args: ["mcp", "start"],
+        },
+      },
+    });
+    const fs = createMockFileSystemService({
+      readFile: mock(() => Promise.resolve(existing)),
+    });
+    expect(await isAlreadyConfigured(configSetup, fs)).toBe(false);
+  });
+
+  it("returns false when local command is mixed with legacy remote url", async () => {
+    const existing = JSON.stringify({
+      mcpServers: {
+        GitHits: {
+          command: "npx",
+          args: ["-y", "githits@latest", "mcp", "start"],
+          url: "https://mcp.githits.com",
+        },
+      },
+    });
+    const fs = createMockFileSystemService({
+      readFile: mock(() => Promise.resolve(existing)),
+    });
+    expect(await isAlreadyConfigured(configSetup, fs)).toBe(false);
+  });
+
   it("returns false when config file exists but server entry is missing", async () => {
     const existing = JSON.stringify({ mcpServers: { Other: {} } });
+    const fs = createMockFileSystemService({
+      readFile: mock(() => Promise.resolve(existing)),
+    });
+    expect(await isAlreadyConfigured(configSetup, fs)).toBe(false);
+  });
+
+  it("returns false when only lowercase githits key exists", async () => {
+    const existing = JSON.stringify({
+      mcpServers: {
+        githits: {
+          command: "npx",
+          args: ["-y", "githits@latest", "mcp", "start"],
+        },
+      },
+    });
+    const fs = createMockFileSystemService({
+      readFile: mock(() => Promise.resolve(existing)),
+    });
+    expect(await isAlreadyConfigured(configSetup, fs)).toBe(false);
+  });
+
+  it("returns false when both GitHits and githits keys are present", async () => {
+    const existing = JSON.stringify({
+      mcpServers: {
+        GitHits: {
+          command: "npx",
+          args: ["-y", "githits@latest", "mcp", "start"],
+        },
+        githits: {
+          command: "npx",
+          args: ["-y", "githits@latest", "mcp", "start"],
+        },
+      },
+    });
     const fs = createMockFileSystemService({
       readFile: mock(() => Promise.resolve(existing)),
     });
@@ -87,10 +206,18 @@ describe("isAlreadyConfigured", () => {
       configPath: "/home/test/.vscode/mcp.json",
       serversKey: "servers",
       serverName: "GitHits",
-      serverConfig: { url: "https://mcp.githits.com/", type: "http" },
+      serverConfig: {
+        command: "npx",
+        args: ["-y", "githits@latest", "mcp", "start"],
+      },
     };
     const existing = JSON.stringify({
-      servers: { GitHits: { url: "https://mcp.githits.com/", type: "http" } },
+      servers: {
+        GitHits: {
+          command: "npx",
+          args: ["-y", "githits@latest", "mcp", "start"],
+        },
+      },
     });
     const fs = createMockFileSystemService({
       readFile: mock(() => Promise.resolve(existing)),
@@ -107,7 +234,7 @@ describe("isAlreadyConfigured", () => {
 
   it("handles BOM prefix", async () => {
     const bom = "\uFEFF";
-    const existing = `${bom}${JSON.stringify({ mcpServers: { GitHits: {} } })}`;
+    const existing = `${bom}${JSON.stringify({ mcpServers: { GitHits: { command: "npx", args: ["-y", "githits@latest", "mcp", "start"] } } })}`;
     const fs = createMockFileSystemService({
       readFile: mock(() => Promise.resolve(existing)),
     });
@@ -291,7 +418,7 @@ describe("getCliCheckStatus", () => {
 describe("mergeServerConfig", () => {
   const serverConfig = {
     command: "npx",
-    args: ["-y", "mcp-remote", "https://mcp.githits.com"],
+    args: ["-y", "githits@latest", "mcp", "start"],
   };
 
   it("adds server to empty string input", () => {
@@ -359,10 +486,13 @@ describe("mergeServerConfig", () => {
     expect(parsed.someOtherSetting).toBe(true);
   });
 
-  it("returns already_configured when server exists", () => {
+  it("returns already_configured when server value already matches", () => {
     const existing = JSON.stringify({
       mcpServers: {
-        GitHits: { command: "old-cmd" },
+        GitHits: {
+          command: "npx",
+          args: ["-y", "githits@latest", "mcp", "start"],
+        },
       },
     });
     const result = mergeServerConfig(
@@ -372,6 +502,148 @@ describe("mergeServerConfig", () => {
       serverConfig,
     );
     expect(result.status).toBe("already_configured");
+  });
+
+  it("returns updated when server exists with different value", () => {
+    const existing = JSON.stringify({
+      mcpServers: {
+        GitHits: { url: "https://mcp.githits.com" },
+      },
+    });
+    const result = mergeServerConfig(
+      existing,
+      "mcpServers",
+      "GitHits",
+      serverConfig,
+    );
+    const content = expectUpdated(result);
+    const parsed = JSON.parse(content);
+    expect(parsed.mcpServers.GitHits).toEqual(serverConfig);
+  });
+
+  it("returns updated and normalizes lowercase githits key to GitHits", () => {
+    const existing = JSON.stringify({
+      mcpServers: {
+        githits: {
+          command: "npx",
+          args: ["-y", "githits@latest", "mcp", "start"],
+        },
+      },
+    });
+    const result = mergeServerConfig(
+      existing,
+      "mcpServers",
+      "GitHits",
+      serverConfig,
+    );
+    const content = expectUpdated(result);
+    const parsed = JSON.parse(content);
+    expect(parsed.mcpServers.GitHits).toEqual(serverConfig);
+    expect(parsed.mcpServers.githits).toBeUndefined();
+  });
+
+  it("returns updated and removes duplicate case-variant keys", () => {
+    const existing = JSON.stringify({
+      mcpServers: {
+        GitHits: {
+          command: "npx",
+          args: ["-y", "githits@latest", "mcp", "start"],
+        },
+        githits: {
+          command: "npx",
+          args: ["-y", "githits@latest", "mcp", "start"],
+        },
+      },
+    });
+    const result = mergeServerConfig(
+      existing,
+      "mcpServers",
+      "GitHits",
+      serverConfig,
+    );
+    const content = expectUpdated(result);
+    const parsed = JSON.parse(content);
+    expect(parsed.mcpServers.GitHits).toEqual(serverConfig);
+    expect(parsed.mcpServers.githits).toBeUndefined();
+  });
+
+  it("returns already_configured for equivalent npx invocation", () => {
+    const existing = JSON.stringify({
+      mcpServers: {
+        GitHits: {
+          command: "npx",
+          args: ["-y", "githits@latest", "mcp", "start"],
+        },
+      },
+    });
+    const result = mergeServerConfig(
+      existing,
+      "mcpServers",
+      "GitHits",
+      serverConfig,
+    );
+    expect(result.status).toBe("already_configured");
+  });
+
+  it("returns updated for npx command missing @latest", () => {
+    const existing = JSON.stringify({
+      mcpServers: {
+        GitHits: {
+          command: "npx",
+          args: ["-y", "githits", "mcp", "start"],
+        },
+      },
+    });
+    const result = mergeServerConfig(
+      existing,
+      "mcpServers",
+      "GitHits",
+      serverConfig,
+    );
+    const content = expectUpdated(result);
+    const parsed = JSON.parse(content);
+    expect(parsed.mcpServers.GitHits).toEqual(serverConfig);
+  });
+
+  it("returns updated for direct githits command", () => {
+    const existing = JSON.stringify({
+      mcpServers: {
+        GitHits: {
+          command: "githits",
+          args: ["mcp", "start"],
+        },
+      },
+    });
+    const result = mergeServerConfig(
+      existing,
+      "mcpServers",
+      "GitHits",
+      serverConfig,
+    );
+    const content = expectUpdated(result);
+    const parsed = JSON.parse(content);
+    expect(parsed.mcpServers.GitHits).toEqual(serverConfig);
+  });
+
+  it("returns updated when equivalent command also has legacy remote fields", () => {
+    const existing = JSON.stringify({
+      mcpServers: {
+        GitHits: {
+          command: "npx",
+          args: ["-y", "githits@latest", "mcp", "start"],
+          url: "https://mcp.githits.com",
+        },
+      },
+    });
+    const result = mergeServerConfig(
+      existing,
+      "mcpServers",
+      "GitHits",
+      serverConfig,
+    );
+    const content = expectUpdated(result);
+    const parsed = JSON.parse(content);
+    expect(parsed.mcpServers.GitHits).toEqual(serverConfig);
   });
 
   it("returns parse_error for malformed JSON", () => {
@@ -464,7 +736,10 @@ describe("mergeServerConfig", () => {
   });
 
   it("works with 'servers' key for VS Code config", () => {
-    const vscodeConfig = { url: "https://mcp.githits.com", type: "http" };
+    const vscodeConfig = {
+      command: "npx",
+      args: ["-y", "githits@latest", "mcp", "start"],
+    };
     const result = mergeServerConfig("{}", "servers", "GitHits", vscodeConfig);
     const content = expectAdded(result);
     const parsed = JSON.parse(content);
@@ -514,12 +789,15 @@ describe("formatSetupPreview", () => {
       configPath: "/home/test/.cursor/mcp.json",
       serversKey: "mcpServers",
       serverName: "GitHits",
-      serverConfig: { url: "https://mcp.githits.com/" },
+      serverConfig: {
+        command: "npx",
+        args: ["-y", "githits@latest", "mcp", "start"],
+      },
     };
     const preview = formatSetupPreview(setup);
     expect(preview).toContain("Will add to /home/test/.cursor/mcp.json:");
     expect(preview).toContain('"GitHits"');
-    expect(preview).toContain('"url"');
+    expect(preview).toContain('"command"');
   });
 });
 
@@ -701,7 +979,10 @@ describe("executeConfigFileSetup", () => {
     configPath: "/home/test/.cursor/mcp.json",
     serversKey: "mcpServers",
     serverName: "GitHits",
-    serverConfig: { url: "https://mcp.githits.com/" },
+    serverConfig: {
+      command: "npx",
+      args: ["-y", "githits@latest", "mcp", "start"],
+    },
   };
 
   it("creates new config when file does not exist", async () => {
@@ -749,9 +1030,66 @@ describe("executeConfigFileSetup", () => {
     expect(parsed.mcpServers.GitHits).toEqual(configSetup.serverConfig);
   });
 
-  it("returns already_configured when GitHits already present", async () => {
+  it("returns already_configured when GitHits already matches desired config", async () => {
     const existing = JSON.stringify({
-      mcpServers: { GitHits: { command: "old" } },
+      mcpServers: {
+        GitHits: {
+          command: "npx",
+          args: ["-y", "githits@latest", "mcp", "start"],
+        },
+      },
+    });
+    const atomicWrite = mock((_path: string, _content: string) =>
+      Promise.resolve(),
+    );
+    const fs = createMockFileSystemService({
+      readFile: mock(() => Promise.resolve(existing)),
+      getDirname: mock(() => "/home/test/.cursor"),
+      ensureDir: mock(() => Promise.resolve()),
+      atomicWriteFile: atomicWrite,
+    });
+
+    const result = await executeConfigFileSetup(configSetup, fs);
+    expect(result.status).toBe("already_configured");
+    expect(atomicWrite).not.toHaveBeenCalled();
+  });
+
+  it("migrates legacy remote config to local CLI command", async () => {
+    const existing = JSON.stringify({
+      mcpServers: { GitHits: { url: "https://mcp.githits.com" } },
+    });
+    const atomicWrite = mock((_path: string, _content: string) =>
+      Promise.resolve(),
+    );
+    const fs = createMockFileSystemService({
+      readFile: mock(() => Promise.resolve(existing)),
+      getDirname: mock(() => "/home/test/.cursor"),
+      ensureDir: mock(() => Promise.resolve()),
+      atomicWriteFile: atomicWrite,
+    });
+
+    const result = await executeConfigFileSetup(configSetup, fs);
+    expect(result.status).toBe("success");
+    expect(atomicWrite).toHaveBeenCalledTimes(1);
+    const firstCall = atomicWrite.mock.calls[0];
+    expect(firstCall).toBeDefined();
+    const writtenContent = firstCall?.[1];
+    expect(typeof writtenContent).toBe("string");
+    if (typeof writtenContent !== "string") {
+      throw new Error("Expected written config content");
+    }
+    const parsed = JSON.parse(writtenContent);
+    expect(parsed.mcpServers.GitHits).toEqual(configSetup.serverConfig);
+  });
+
+  it("does not rewrite equivalent npx local config", async () => {
+    const existing = JSON.stringify({
+      mcpServers: {
+        GitHits: {
+          command: "npx",
+          args: ["-y", "githits@latest", "mcp", "start"],
+        },
+      },
     });
     const atomicWrite = mock(() => Promise.resolve());
     const fs = createMockFileSystemService({
@@ -764,6 +1102,34 @@ describe("executeConfigFileSetup", () => {
     const result = await executeConfigFileSetup(configSetup, fs);
     expect(result.status).toBe("already_configured");
     expect(atomicWrite).not.toHaveBeenCalled();
+  });
+
+  it("treats opencode-style npx array command as equivalent local config", async () => {
+    const opencodeSetup: ConfigFileSetup = {
+      method: "config-file",
+      configPath: "/home/test/.config/opencode/opencode.json",
+      serversKey: "mcp",
+      serverName: "GitHits",
+      serverConfig: {
+        type: "local",
+        command: ["npx", "-y", "githits@latest", "mcp", "start"],
+        enabled: true,
+      },
+    };
+    const existing = JSON.stringify({
+      mcp: {
+        GitHits: {
+          type: "local",
+          command: ["npx", "-y", "githits@latest", "mcp", "start"],
+          enabled: true,
+        },
+      },
+    });
+    const fs = createMockFileSystemService({
+      readFile: mock(() => Promise.resolve(existing)),
+    });
+
+    expect(await isAlreadyConfigured(opencodeSetup, fs)).toBe(true);
   });
 
   it("returns failed on malformed JSON without writing", async () => {

--- a/src/commands/init/setup-handlers.ts
+++ b/src/commands/init/setup-handlers.ts
@@ -30,9 +30,170 @@ export type CliCheckStatus = "configured" | "not_configured" | "probe_failed";
 
 /** Result of merging server config into an existing config file */
 export type MergeResult =
-  | { status: "added"; content: string }
+  | { status: "added" | "updated"; content: string }
   | { status: "already_configured" }
   | { status: "parse_error"; error: string };
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function deepEqual(left: unknown, right: unknown): boolean {
+  if (Object.is(left, right)) {
+    return true;
+  }
+
+  if (Array.isArray(left) && Array.isArray(right)) {
+    if (left.length !== right.length) {
+      return false;
+    }
+    for (let i = 0; i < left.length; i++) {
+      if (!deepEqual(left[i], right[i])) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  if (isPlainObject(left) && isPlainObject(right)) {
+    const leftKeys = Object.keys(left).sort();
+    const rightKeys = Object.keys(right).sort();
+    if (!deepEqual(leftKeys, rightKeys)) {
+      return false;
+    }
+    for (const key of leftKeys) {
+      if (!deepEqual(left[key], right[key])) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  return false;
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return (
+    Array.isArray(value) && value.every((item) => typeof item === "string")
+  );
+}
+
+function isGitHitsPackageToken(token: string): boolean {
+  return token.toLowerCase() === "githits@latest";
+}
+
+function isLocalGitHitsInvocation(invocation: string[]): boolean {
+  if (invocation.length === 5) {
+    const [command, yesFlag, packageToken, subcommand, action] = invocation;
+    return (
+      command === "npx" &&
+      yesFlag === "-y" &&
+      typeof packageToken === "string" &&
+      isGitHitsPackageToken(packageToken) &&
+      subcommand === "mcp" &&
+      action === "start"
+    );
+  }
+
+  return false;
+}
+
+function extractInvocation(config: unknown): string[] | null {
+  if (!isPlainObject(config)) {
+    return null;
+  }
+
+  const command = config.command;
+  if (typeof command === "string") {
+    const args = config.args;
+    if (!isStringArray(args)) {
+      return null;
+    }
+    return [command, ...args];
+  }
+
+  if (isStringArray(command)) {
+    return [...command];
+  }
+
+  return null;
+}
+
+function nonCommandFieldsEqual(
+  existing: Record<string, unknown>,
+  expected: Record<string, unknown>,
+): boolean {
+  for (const [key, value] of Object.entries(expected)) {
+    if (key === "command" || key === "args") {
+      continue;
+    }
+    if (!deepEqual(existing[key], value)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function hasLegacyRemoteIndicators(
+  existing: Record<string, unknown>,
+  expected: Record<string, unknown>,
+): boolean {
+  if ("url" in existing || "serverUrl" in existing) {
+    return true;
+  }
+
+  if (
+    "type" in existing &&
+    !("type" in expected) &&
+    (existing.type === "http" || existing.type === "streamableHttp")
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+function isEquivalentConfiguredValue(
+  existing: unknown,
+  expected: Record<string, unknown>,
+): boolean {
+  if (deepEqual(existing, expected)) {
+    return true;
+  }
+
+  if (!isPlainObject(existing)) {
+    return false;
+  }
+
+  const expectedInvocation = extractInvocation(expected);
+  const existingInvocation = extractInvocation(existing);
+  if (!expectedInvocation || !existingInvocation) {
+    return false;
+  }
+
+  if (
+    !isLocalGitHitsInvocation(expectedInvocation) ||
+    !isLocalGitHitsInvocation(existingInvocation)
+  ) {
+    return false;
+  }
+
+  if (hasLegacyRemoteIndicators(existing, expected)) {
+    return false;
+  }
+
+  return nonCommandFieldsEqual(existing, expected);
+}
+
+function getMatchingServerKeys(
+  servers: Record<string, unknown>,
+  serverName: string,
+): string[] {
+  const normalizedTarget = serverName.toLowerCase();
+  return Object.keys(servers).filter(
+    (key) => key.toLowerCase() === normalizedTarget,
+  );
+}
 
 /** Result of executing a setup operation */
 export interface SetupResult {
@@ -108,15 +269,25 @@ export function mergeServerConfig(
 
   // Check if already configured
   const serversObj = servers as Record<string, unknown>;
-  if (serverName in serversObj) {
+  const matchingKeys = getMatchingServerKeys(serversObj, serverName);
+  if (
+    matchingKeys.length === 1 &&
+    matchingKeys[0] === serverName &&
+    isEquivalentConfiguredValue(serversObj[serverName], serverConfig)
+  ) {
     return { status: "already_configured" };
   }
 
-  // Add server entry
+  // Add or migrate server entry; collapse case-variant duplicates.
+  for (const key of matchingKeys) {
+    delete serversObj[key];
+  }
+
+  const hadExisting = matchingKeys.length > 0;
   serversObj[serverName] = serverConfig;
 
   return {
-    status: "added",
+    status: hadExisting ? "updated" : "added",
     content: `${JSON.stringify(config, null, 2)}\n`,
   };
 }
@@ -183,7 +354,16 @@ export async function isAlreadyConfigured(
       return false;
     }
 
-    return config.serverName in servers;
+    const serversObj = servers as Record<string, unknown>;
+    const matchingKeys = getMatchingServerKeys(serversObj, config.serverName);
+    if (matchingKeys.length !== 1 || matchingKeys[0] !== config.serverName) {
+      return false;
+    }
+
+    return isEquivalentConfiguredValue(
+      serversObj[config.serverName],
+      config.serverConfig,
+    );
   } catch {
     return false;
   }
@@ -376,7 +556,7 @@ export async function executeConfigFileSetup(
       };
     }
 
-    // Atomic write — result.status is "added" here (other statuses returned above)
+    // Atomic write — result.status is "added" or "updated" here
     await fs.atomicWriteFile(setup.configPath, result.content);
 
     return { status: "success", message: "Configured successfully" };


### PR DESCRIPTION
## Summary

This PR standardizes `githits init` output so every config-file integration uses the canonical local MCP invocation `npx -y githits@latest mcp start`. It also makes init migrations deterministic by upgrading legacy remote/non-canonical entries and collapsing case-variant `GitHits` keys, so repeated init runs are idempotent and predictable.

## Changes

### Files Changed
- `src/commands/init/agent-definitions.ts` - centralizes canonical GitHits command/server constants and updates all config-file agent definitions to emit canonical local MCP configuration.
- `src/commands/init/setup-handlers.ts` - adds equivalence/migration logic for canonical local invocations, rejects legacy remote indicators as "already configured", and normalizes duplicate case-variant server keys during merge.
- `src/commands/init/agent-definitions.test.ts` - updates expected setup outputs across agents and validates canonical command usage.
- `src/commands/init/setup-handlers.test.ts` - expands coverage for migration/idempotency paths (legacy remote -> local canonical, missing `@latest`, direct `githits`, duplicate key cleanup, and OpenCode array-command equivalence).
- `src/commands/init/init.test.ts` - adds end-to-end init behavior checks ensuring canonical config is treated as configured and non-canonical entries are upgraded.

### Files Added
- None.

## Verification

### Automated Checks
- [x] `bun run typecheck`
- [x] `bun run build`
- [x] `bun test`
- [x] `bun run lint` (passes with existing repo-level warnings unrelated to this PR)
- [ ] `bun run format:check` (blocked by existing local-only `.claude/settings.local.json` formatting mismatch outside PR scope)

### Manual Verification
- [x] Ran `githits init` and inspected per-tool local configs for Cursor, Windsurf, Claude Desktop, VS Code, Cline, Google Antigravity, and OpenCode.
- [x] Confirmed canonical `npx -y githits@latest mcp start` entries were written.
- [x] Confirmed CLI integrations are configured after init for Claude plugin/marketplace and Codex MCP server.

### Related Issues
- None.