### PR TITLE
feat: streamline auth flow for remote commands

### DIFF
--- a/src/commands/feedback.test.ts
+++ b/src/commands/feedback.test.ts
@@ -1,18 +1,13 @@
 import { describe, expect, it, mock, spyOn } from "bun:test";
 import { createMockGitHitsService } from "../services/test-helpers.js";
-import { AuthRequiredError } from "../shared/require-auth.js";
 import { type FeedbackDependencies, feedbackAction } from "./feedback.js";
 
 describe("feedbackAction", () => {
-  const mcpUrl = "https://mcp.githits.com";
-
   function createDeps(
     overrides: Partial<FeedbackDependencies> = {},
   ): FeedbackDependencies {
     return {
       githitsService: createMockGitHitsService(),
-      hasValidToken: true,
-      mcpUrl,
       ...overrides,
     };
   }
@@ -130,17 +125,6 @@ describe("feedbackAction", () => {
     expect(exitSpy).toHaveBeenCalledWith(1);
     errorSpy.mockRestore();
     exitSpy.mockRestore();
-  });
-
-  it("throws AuthRequiredError on auth failure", async () => {
-    const consoleSpy = spyOn(console, "log").mockImplementation(() => {});
-    const deps = createDeps({ hasValidToken: false });
-
-    await expect(
-      feedbackAction("abc-123", { accept: true }, deps),
-    ).rejects.toThrow(AuthRequiredError);
-
-    consoleSpy.mockRestore();
   });
 
   it("catches service error and exits with message", async () => {

--- a/src/commands/feedback.ts
+++ b/src/commands/feedback.ts
@@ -1,7 +1,6 @@
 import { type Command, Option } from "commander";
-import { createContainer } from "../container.js";
 import type { GitHitsService } from "../services/githits-service.js";
-import { AuthRequiredError, requireAuth } from "../shared/require-auth.js";
+import { withAuthenticatedAction } from "./shared.js";
 
 export interface FeedbackOptions {
   accept?: boolean;
@@ -12,8 +11,6 @@ export interface FeedbackOptions {
 
 export interface FeedbackDependencies {
   githitsService: GitHitsService;
-  hasValidToken: boolean;
-  mcpUrl: string;
 }
 
 /**
@@ -24,8 +21,6 @@ export async function feedbackAction(
   options: FeedbackOptions,
   deps: FeedbackDependencies,
 ): Promise<void> {
-  requireAuth(deps);
-
   if (!options.accept && !options.reject) {
     console.error("Error: Specify either --accept or --reject.");
     process.exit(1);
@@ -79,13 +74,5 @@ export function registerFeedbackCommand(program: Command) {
     .addOption(new Option("--reject", "Mark as unhelpful").conflicts("accept"))
     .option("-m, --message <text>", "Feedback explanation")
     .option("--json", "Output as JSON for piping")
-    .action(async (solutionId: string, options: FeedbackOptions) => {
-      try {
-        const deps = await createContainer();
-        await feedbackAction(solutionId, options, deps);
-      } catch (error) {
-        if (error instanceof AuthRequiredError) process.exit(1);
-        throw error;
-      }
-    });
+    .action(withAuthenticatedAction(feedbackAction));
 }

--- a/src/commands/languages.test.ts
+++ b/src/commands/languages.test.ts
@@ -1,18 +1,13 @@
 import { describe, expect, it, mock, spyOn } from "bun:test";
 import { createMockGitHitsService } from "../services/test-helpers.js";
-import { AuthRequiredError } from "../shared/require-auth.js";
 import { type LanguagesDependencies, languagesAction } from "./languages.js";
 
 describe("languagesAction", () => {
-  const mcpUrl = "https://mcp.githits.com";
-
   function createDeps(
     overrides: Partial<LanguagesDependencies> = {},
   ): LanguagesDependencies {
     return {
       githitsService: createMockGitHitsService(),
-      hasValidToken: true,
-      mcpUrl,
       ...overrides,
     };
   }
@@ -88,17 +83,6 @@ describe("languagesAction", () => {
 
     const output = consoleSpy.mock.calls[0]?.[0] as string;
     expect(JSON.parse(output)).toEqual([]);
-    consoleSpy.mockRestore();
-  });
-
-  it("throws AuthRequiredError on auth failure", async () => {
-    const consoleSpy = spyOn(console, "log").mockImplementation(() => {});
-    const deps = createDeps({ hasValidToken: false });
-
-    await expect(languagesAction(undefined, {}, deps)).rejects.toThrow(
-      AuthRequiredError,
-    );
-
     consoleSpy.mockRestore();
   });
 

--- a/src/commands/languages.ts
+++ b/src/commands/languages.ts
@@ -1,12 +1,11 @@
 import type { Command } from "commander";
-import { createContainer } from "../container.js";
 import type { GitHitsService } from "../services/githits-service.js";
 import { colorize, dim, shouldUseColors } from "../shared/colors.js";
 import {
   filterLanguages,
   type LanguageMatch,
 } from "../shared/language-filter.js";
-import { AuthRequiredError, requireAuth } from "../shared/require-auth.js";
+import { withAuthenticatedAction } from "./shared.js";
 
 export interface LanguagesOptions {
   json?: boolean;
@@ -14,8 +13,6 @@ export interface LanguagesOptions {
 
 export interface LanguagesDependencies {
   githitsService: GitHitsService;
-  hasValidToken: boolean;
-  mcpUrl: string;
 }
 
 /**
@@ -26,8 +23,6 @@ export async function languagesAction(
   options: LanguagesOptions,
   deps: LanguagesDependencies,
 ): Promise<void> {
-  requireAuth(deps);
-
   try {
     const allLanguages = await deps.githitsService.getLanguages();
 
@@ -76,13 +71,5 @@ export function registerLanguagesCommand(program: Command) {
     .description(LANGUAGES_DESCRIPTION)
     .argument("[query]", "Filter by name, display name, or alias")
     .option("--json", "Output as JSON for piping")
-    .action(async (query: string | undefined, options: LanguagesOptions) => {
-      try {
-        const deps = await createContainer();
-        await languagesAction(query, options, deps);
-      } catch (error) {
-        if (error instanceof AuthRequiredError) process.exit(1);
-        throw error;
-      }
-    });
+    .action(withAuthenticatedAction(languagesAction));
 }

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -25,39 +25,20 @@ export interface LoginDependencies {
   mcpUrl: string;
 }
 
+export interface PerformLoginOptions {
+  browser?: boolean;
+  port?: number;
+}
+
 /**
- * Core login logic, separated for testability.
+ * Core OAuth PKCE login flow. Returns true on success, false on failure.
+ * Does not call process.exit — callers decide how to handle failure.
  */
-export async function loginAction(
-  options: LoginOptions,
+export async function performLogin(
   deps: LoginDependencies,
-): Promise<void> {
+  options: PerformLoginOptions = {},
+): Promise<boolean> {
   const { authService, authStorage, browserService, mcpUrl } = deps;
-
-  // Validate port if provided
-  if (
-    options.port !== undefined &&
-    (Number.isNaN(options.port) || options.port < 1 || options.port > 65535)
-  ) {
-    console.error("Invalid port number. Must be between 1 and 65535.");
-    process.exit(1);
-  }
-
-  // Check if already logged in
-  const existing = await authStorage.loadTokens(mcpUrl);
-  if (existing && !options.force) {
-    const isExpired =
-      existing.expiresAt && new Date(existing.expiresAt) < new Date();
-    if (!isExpired) {
-      console.log("Already logged in.\n");
-      console.log(`  Environment: ${mcpUrl}\n`);
-      console.log("To re-authenticate, use `githits login --force`.");
-      return;
-    }
-    console.log("Token expired. Starting new login...\n");
-  } else if (existing && options.force) {
-    console.log("Re-authenticating (--force flag)...\n");
-  }
 
   // Step 1: Discover OAuth endpoints
   console.log("Discovering OAuth endpoints...");
@@ -69,12 +50,9 @@ export async function loginAction(
   let redirectUri: string;
 
   if (client) {
-    // Reuse the stored redirect URI to match the DCR registration.
-    // If user specified --port, use that and re-register if needed.
     if (options.port) {
       redirectUri = `http://127.0.0.1:${options.port}/callback`;
       if (redirectUri !== client.redirectUri) {
-        // Port changed - need to re-register
         console.log("Registering CLI client with new port...");
         const registration = await authService.registerClient({
           registrationEndpoint: metadata.registrationEndpoint,
@@ -90,7 +68,6 @@ export async function loginAction(
       }
       port = options.port;
     } else {
-      // Extract port from stored redirect URI
       redirectUri = client.redirectUri;
       const storedUrl = new URL(redirectUri);
       port = Number(storedUrl.port) || randomPort();
@@ -154,19 +131,17 @@ export async function loginAction(
   } catch (error) {
     if (timeoutId) clearTimeout(timeoutId);
     if (error instanceof Error) {
-      console.log(`${error.message}.\n`);
-      console.log("Run `githits login` to try again.");
+      console.error(`${error.message}.`);
     }
-    process.exit(1);
+    return false;
   }
 
   // Step 7: Handle callback outcome
   if (callback.type !== "success") {
-    console.log(`${callback.message}\n`);
-    console.log("Run `githits login` to try again.");
+    console.error(callback.message);
     // Let the callback server finish sending the error page to the browser
     await new Promise((r) => setTimeout(r, 2000));
-    process.exit(1);
+    return false;
   }
 
   // Step 8: Exchange code for tokens
@@ -184,10 +159,9 @@ export async function loginAction(
     });
   } catch (error) {
     console.error(
-      `Failed to complete authentication: ${error instanceof Error ? error.message : error}\n`,
+      `Failed to complete authentication: ${error instanceof Error ? error.message : error}`,
     );
-    console.log("Run `githits login` to try again.");
-    process.exit(1);
+    return false;
   }
 
   // Step 9: Save tokens
@@ -201,12 +175,60 @@ export async function loginAction(
     createdAt: new Date().toISOString(),
   });
 
-  // Success message
   const hours = Math.round(tokenResponse.expiresIn / 3600);
   console.log("Logged in successfully.\n");
   console.log(`  Environment: ${mcpUrl}`);
-  console.log(`  Token expires in: ${hours} hour${hours !== 1 ? "s" : ""}`);
-  console.log("\nYou're ready to use githits with your AI assistant.");
+  console.log(`  Token expires in: ${hours} hour${hours !== 1 ? "s" : ""}\n`);
+
+  return true;
+}
+
+/**
+ * Core login command logic, separated for testability.
+ * Wraps performLogin with CLI-specific behavior (already-logged-in check, process.exit).
+ */
+export async function loginAction(
+  options: LoginOptions,
+  deps: LoginDependencies,
+): Promise<void> {
+  const { authStorage, mcpUrl } = deps;
+
+  // Validate port if provided
+  if (
+    options.port !== undefined &&
+    (Number.isNaN(options.port) || options.port < 1 || options.port > 65535)
+  ) {
+    console.error("Invalid port number. Must be between 1 and 65535.");
+    process.exit(1);
+  }
+
+  // Check if already logged in
+  const existing = await authStorage.loadTokens(mcpUrl);
+  if (existing && !options.force) {
+    const isExpired =
+      existing.expiresAt && new Date(existing.expiresAt) < new Date();
+    if (!isExpired) {
+      console.log("Already logged in.\n");
+      console.log(`  Environment: ${mcpUrl}\n`);
+      console.log("To re-authenticate, use `githits login --force`.");
+      return;
+    }
+    console.log("Token expired. Starting new login...\n");
+  } else if (existing && options.force) {
+    console.log("Re-authenticating (--force flag)...\n");
+  }
+
+  const success = await performLogin(deps, {
+    browser: options.browser,
+    port: options.port,
+  });
+
+  if (!success) {
+    console.log("\nRun `githits login` to try again.");
+    process.exit(1);
+  }
+
+  console.log("You're ready to use githits with your AI assistant.");
 }
 
 const LOGIN_DESCRIPTION = `Authenticate with your GitHits account via browser.

--- a/src/commands/mcp.test.ts
+++ b/src/commands/mcp.test.ts
@@ -11,6 +11,8 @@ import { AuthRequiredError } from "../shared/require-auth.js";
 import { createMcpServer, startMcpServer } from "./mcp.js";
 
 function createTestDeps(overrides: Partial<Dependencies> = {}): Dependencies {
+  const githitsService = createMockGitHitsService();
+
   return {
     authStorage: createMockAuthStorage(),
     authService: createMockAuthService(),
@@ -21,7 +23,12 @@ function createTestDeps(overrides: Partial<Dependencies> = {}): Dependencies {
     apiToken: "test-token",
     hasValidToken: true,
     envApiToken: undefined,
-    githitsService: createMockGitHitsService(),
+    githitsService,
+    refreshAuth: async () => ({
+      apiToken: "test-token",
+      hasValidToken: true,
+      githitsService,
+    }),
     ...overrides,
   };
 }

--- a/src/commands/search.test.ts
+++ b/src/commands/search.test.ts
@@ -1,18 +1,13 @@
 import { describe, expect, it, mock, spyOn } from "bun:test";
 import { createMockGitHitsService } from "../services/test-helpers.js";
-import { AuthRequiredError } from "../shared/require-auth.js";
 import { type SearchDependencies, searchAction } from "./search.js";
 
 describe("searchAction", () => {
-  const mcpUrl = "https://mcp.githits.com";
-
   function createDeps(
     overrides: Partial<SearchDependencies> = {},
   ): SearchDependencies {
     return {
       githitsService: createMockGitHitsService(),
-      hasValidToken: true,
-      mcpUrl,
       ...overrides,
     };
   }
@@ -78,17 +73,6 @@ describe("searchAction", () => {
     const output = consoleSpy.mock.calls[0]?.[0] as string;
     const parsed = JSON.parse(output);
     expect(parsed.result).toContain("# Example");
-    consoleSpy.mockRestore();
-  });
-
-  it("throws AuthRequiredError on auth failure", async () => {
-    const consoleSpy = spyOn(console, "log").mockImplementation(() => {});
-    const deps = createDeps({ hasValidToken: false });
-
-    await expect(
-      searchAction("test", { lang: "python" }, deps),
-    ).rejects.toThrow(AuthRequiredError);
-
     consoleSpy.mockRestore();
   });
 

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -1,7 +1,6 @@
 import { type Command, Option } from "commander";
-import { createContainer } from "../container.js";
 import type { GitHitsService } from "../services/githits-service.js";
-import { AuthRequiredError, requireAuth } from "../shared/require-auth.js";
+import { withAuthenticatedAction } from "./shared.js";
 
 export interface SearchOptions {
   lang: string;
@@ -12,8 +11,6 @@ export interface SearchOptions {
 
 export interface SearchDependencies {
   githitsService: GitHitsService;
-  hasValidToken: boolean;
-  mcpUrl: string;
 }
 
 /**
@@ -24,8 +21,6 @@ export async function searchAction(
   options: SearchOptions,
   deps: SearchDependencies,
 ): Promise<void> {
-  requireAuth(deps);
-
   try {
     const result = await deps.githitsService.search({
       query,
@@ -77,13 +72,5 @@ export function registerSearchCommand(program: Command) {
     )
     .option("--explain", "Include AI-generated explanation")
     .option("--json", "Output as JSON for piping")
-    .action(async (query: string, options: SearchOptions) => {
-      try {
-        const deps = await createContainer();
-        await searchAction(query, options, deps);
-      } catch (error) {
-        if (error instanceof AuthRequiredError) process.exit(1);
-        throw error;
-      }
-    });
+    .action(withAuthenticatedAction(searchAction));
 }

--- a/src/commands/shared.test.ts
+++ b/src/commands/shared.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it, mock, spyOn } from "bun:test";
+import type { Dependencies } from "../container.js";
+import {
+  createMockAuthService,
+  createMockAuthStorage,
+  createMockBrowserService,
+  createMockFileSystemService,
+  createMockGitHitsService,
+} from "../services/test-helpers.js";
+import { AuthRequiredError } from "../shared/require-auth.js";
+import {
+  createAuthenticatedDependencies,
+  withAuthenticatedAction,
+} from "./shared.js";
+
+function createDeps(overrides: Partial<Dependencies> = {}): Dependencies {
+  return {
+    authStorage: createMockAuthStorage(),
+    authService: createMockAuthService(),
+    browserService: createMockBrowserService(),
+    fileSystemService: createMockFileSystemService(),
+    mcpUrl: "https://mcp.githits.com",
+    apiUrl: "https://api.githits.com",
+    apiToken: undefined,
+    hasValidToken: false,
+    envApiToken: undefined,
+    githitsService: createMockGitHitsService(),
+    refreshAuth: mock(async () => ({
+      apiToken: "fresh-token",
+      hasValidToken: true,
+      githitsService: createMockGitHitsService(),
+    })),
+    ...overrides,
+  };
+}
+
+function withTty<T>(
+  stdinIsTTY: boolean,
+  stdoutIsTTY: boolean,
+  run: () => Promise<T>,
+): Promise<T> {
+  const stdinDescriptor = Object.getOwnPropertyDescriptor(
+    process.stdin,
+    "isTTY",
+  );
+  const stdoutDescriptor = Object.getOwnPropertyDescriptor(
+    process.stdout,
+    "isTTY",
+  );
+
+  Object.defineProperty(process.stdin, "isTTY", {
+    configurable: true,
+    value: stdinIsTTY,
+  });
+  Object.defineProperty(process.stdout, "isTTY", {
+    configurable: true,
+    value: stdoutIsTTY,
+  });
+
+  return run().finally(() => {
+    if (stdinDescriptor) {
+      Object.defineProperty(process.stdin, "isTTY", stdinDescriptor);
+    }
+    if (stdoutDescriptor) {
+      Object.defineProperty(process.stdout, "isTTY", stdoutDescriptor);
+    }
+  });
+}
+
+describe("createAuthenticatedDependencies", () => {
+  it("returns existing dependencies when token is already valid", async () => {
+    const deps = createDeps({
+      hasValidToken: true,
+      apiToken: "existing-token",
+    });
+    const login = mock(async () => true);
+
+    const result = await createAuthenticatedDependencies(deps, login);
+
+    expect(result).toBe(deps);
+    expect(login).not.toHaveBeenCalled();
+    expect(deps.refreshAuth).not.toHaveBeenCalled();
+  });
+
+  it("falls back to requireAuth in non-interactive mode", async () => {
+    const deps = createDeps();
+    const consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+    const login = mock(async () => true);
+
+    await expect(
+      withTty(false, false, () => createAuthenticatedDependencies(deps, login)),
+    ).rejects.toThrow(AuthRequiredError);
+
+    expect(login).not.toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  it("runs login flow and refreshes dependencies in interactive mode", async () => {
+    const refreshedService = createMockGitHitsService();
+    const deps = createDeps({
+      refreshAuth: mock(async () => ({
+        apiToken: "fresh-token",
+        hasValidToken: true,
+        githitsService: refreshedService,
+      })),
+    });
+    const consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+    const login = mock(async () => true);
+
+    const result = await withTty(true, true, () =>
+      createAuthenticatedDependencies(deps, login),
+    );
+
+    expect(login).toHaveBeenCalledWith(deps);
+    expect(deps.refreshAuth).toHaveBeenCalledTimes(1);
+    expect(result.apiToken).toBe("fresh-token");
+    expect(result.hasValidToken).toBe(true);
+    expect(result.githitsService).toBe(refreshedService);
+    consoleSpy.mockRestore();
+  });
+
+  it("throws when interactive login fails", async () => {
+    const deps = createDeps();
+    const consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+    const login = mock(async () => false);
+
+    await expect(
+      withTty(true, true, () => createAuthenticatedDependencies(deps, login)),
+    ).rejects.toThrow(AuthRequiredError);
+
+    const output = consoleSpy.mock.calls.map((call) => call[0]).join("\n");
+    expect(output).toContain("Not authenticated. Starting login...");
+    expect(output).toContain("npx githits@latest login");
+    expect(deps.refreshAuth).not.toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+});
+
+describe("withAuthenticatedAction", () => {
+  it("passes only business args and injects dependencies last", async () => {
+    const deps = createDeps({
+      hasValidToken: true,
+      apiToken: "existing-token",
+    });
+    const action = mock(
+      async (
+        query: string,
+        options: { json?: boolean },
+        resolvedDeps: Dependencies,
+      ) => {
+        expect(query).toBe("search term");
+        expect(options).toEqual({ json: true });
+        expect(resolvedDeps).toBe(deps);
+      },
+    );
+
+    const wrapped = withAuthenticatedAction(action, {
+      createDeps: async () => deps,
+      authenticateDeps: async (inputDeps) => inputDeps,
+    });
+
+    await wrapped("search term", { json: true }, { opts: () => ({}) });
+
+    expect(action).toHaveBeenCalledTimes(1);
+    expect(action).toHaveBeenCalledWith("search term", { json: true }, deps);
+  });
+});

--- a/src/commands/shared.ts
+++ b/src/commands/shared.ts
@@ -1,0 +1,59 @@
+import { createContainer, type Dependencies } from "../container.js";
+import {
+  AuthRequiredError,
+  printAuthInstructions,
+  requireAuth,
+} from "../shared/require-auth.js";
+import { performLogin } from "./login.js";
+
+export async function createAuthenticatedDependencies(
+  deps: Dependencies,
+  login: typeof performLogin = performLogin,
+): Promise<Dependencies> {
+  if (deps.hasValidToken) {
+    return deps;
+  }
+
+  if (!process.stdin.isTTY || !process.stdout.isTTY) {
+    requireAuth(deps);
+  }
+
+  console.log("Not authenticated. Starting login...\n");
+
+  const success = await login(deps);
+  if (!success) {
+    console.log("");
+    printAuthInstructions();
+    throw new AuthRequiredError("Authentication failed");
+  }
+
+  const refreshed = await deps.refreshAuth();
+  return { ...deps, ...refreshed };
+}
+
+export function withAuthenticatedAction<TArgs extends unknown[]>(
+  action: (...args: [...TArgs, Dependencies]) => Promise<void>,
+  options: {
+    createDeps?: () => Promise<Dependencies>;
+    authenticateDeps?: (deps: Dependencies) => Promise<Dependencies>;
+  } = {},
+): (...args: unknown[]) => Promise<void> {
+  const createDeps = options.createDeps ?? createContainer;
+  const authenticateDeps =
+    options.authenticateDeps ?? createAuthenticatedDependencies;
+
+  return async (...args: unknown[]) => {
+    try {
+      const deps = await createDeps();
+      const authenticatedDeps = await authenticateDeps(deps);
+      const actionArgs = args.slice(0, Math.max(action.length - 1, 0)) as TArgs;
+      await action(...actionArgs, authenticatedDeps);
+    } catch (error) {
+      if (error instanceof AuthRequiredError) {
+        process.exit(1);
+      }
+
+      throw error;
+    }
+  };
+}

--- a/src/container.ts
+++ b/src/container.ts
@@ -79,6 +79,12 @@ export interface Dependencies {
   envApiToken: string | undefined;
   /** GitHits REST API service */
   githitsService: GitHitsService;
+  /** Re-resolve token and service after login. Returns updated auth fields. */
+  refreshAuth: () => Promise<{
+    apiToken: string | undefined;
+    hasValidToken: boolean;
+    githitsService: GitHitsService;
+  }>;
 }
 
 /**
@@ -96,6 +102,7 @@ export async function createContainer(): Promise<Dependencies> {
   // Check for env API token first
   const envToken = getEnvApiToken();
   if (envToken) {
+    const githitsService = new GitHitsServiceImpl(apiUrl, envToken);
     return {
       authStorage,
       authService,
@@ -106,13 +113,28 @@ export async function createContainer(): Promise<Dependencies> {
       apiToken: envToken,
       hasValidToken: true,
       envApiToken: envToken,
-      githitsService: new GitHitsServiceImpl(apiUrl, envToken),
+      githitsService,
+      refreshAuth: async () => ({
+        apiToken: envToken,
+        hasValidToken: true,
+        githitsService,
+      }),
     };
   }
 
   // Create token manager for stored auth with auto-refresh
   const tokenManager = new TokenManager({ authService, authStorage, mcpUrl });
   const apiToken = await tokenManager.getToken();
+
+  const refreshAuth = async () => {
+    const freshManager = new TokenManager({ authService, authStorage, mcpUrl });
+    const freshToken = await freshManager.getToken();
+    return {
+      apiToken: freshToken,
+      hasValidToken: freshToken !== undefined,
+      githitsService: new RefreshingGitHitsService(apiUrl, freshManager),
+    };
+  };
 
   return {
     authStorage,
@@ -125,5 +147,6 @@ export async function createContainer(): Promise<Dependencies> {
     hasValidToken: apiToken !== undefined,
     envApiToken: undefined,
     githitsService: new RefreshingGitHitsService(apiUrl, tokenManager),
+    refreshAuth,
   };
 }

--- a/src/shared/require-auth.test.ts
+++ b/src/shared/require-auth.test.ts
@@ -19,6 +19,7 @@ describe("requireAuth", () => {
     const output = consoleSpy.mock.calls.map((c) => c[0]).join("\n");
     expect(output).toContain("Authentication required");
     expect(output).toContain("githits login");
+    expect(output).toContain("npx githits@latest login");
     consoleSpy.mockRestore();
   });
 

--- a/src/shared/require-auth.ts
+++ b/src/shared/require-auth.ts
@@ -9,9 +9,16 @@ export class AuthRequiredError extends Error {
   }
 }
 
+export function printAuthInstructions(): void {
+  console.log("To authenticate:");
+  console.log("  githits login");
+  console.log("  npx githits@latest login\n");
+  console.log("Or set GITHITS_API_TOKEN environment variable.");
+}
+
 /**
  * Print friendly message when auth is missing and throw AuthRequiredError.
- * Shared between MCP server startup and CLI commands.
+ * Used for non-interactive contexts (MCP server) where auto-login is not possible.
  *
  * @param context - Optional context appended to the message (e.g., "to start MCP server")
  * @throws AuthRequiredError - Always throws when hasValidToken is false
@@ -33,9 +40,7 @@ export function requireAuth(
     console.log("  You're using a custom environment.\n");
   }
 
-  console.log("To authenticate:");
-  console.log("  githits login\n");
-  console.log("Or set GITHITS_API_TOKEN environment variable.");
+  printAuthInstructions();
 
   throw new AuthRequiredError(`Authentication required${suffix}`);
 }


### PR DESCRIPTION
## Summary
- automatically trigger the interactive login flow for remote CLI commands when no stored token is available
- centralize authenticated command setup in a shared wrapper instead of wiring auth into each command separately
- reuse the login flow for first-run onboarding while keeping non-interactive contexts on the existing auth-required path

## Testing
- bun test
- bun test src/shared/require-auth.test.ts src/commands/shared.test.ts
- bun run typecheck
