### PR TITLE
Make example language optional

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -11,12 +11,12 @@ Find code examples from open source repositories.
 **Parameters:**
 
 - `query` (string, required) - natural language description of what you need
-- `language` (string, required) - programming language name (use `search_language` to verify)
+- `language` (string, optional) - programming language name; omit it to let GitHits infer the language from the query
 - `license_mode` (string, optional) - one of `strict` (default), `yolo`, or `custom`
 
 ### search_language
 
-Look up supported programming language names. Use this before calling `get_example` to get the correct language identifier.
+Look up supported programming language names. Use this before calling `get_example` only when you need to force a specific language and the exact name is uncertain.
 
 **Parameters:**
 
@@ -60,7 +60,7 @@ Do not use `get_example` for:
 
 ## How to Search Well
 
-- Call `search_language` first to confirm the correct language name before calling `get_example`
+- Pass `language` only when you need to force a specific language; call `search_language` first if the exact language name is uncertain
 - Formulate queries as natural language questions (e.g., "How to stream responses with the Vercel AI SDK in Next.js")
 - Include specific error messages, library names, or API names when relevant
 - Keep queries focused: 3-4 technical terms maximum

--- a/commands/example.md
+++ b/commands/example.md
@@ -6,16 +6,17 @@ description: Search for canonical code examples from open source via GitHits
 
 Search for code examples using GitHits for the query: "$ARGUMENTS"
 
-Use the GitHits MCP `get_example` tool with the user's query. The tool requires two
-parameters:
+Use the GitHits MCP `get_example` tool with the user's query.
+
+Required parameter:
 
 - **query**: The user's search query, formulated in natural language.
-- **language**: The programming language. If the language is unclear from
-  context, use the `search_language` tool first to find the correct language
-  name.
 
-Optional parameter:
+Optional parameters:
 
+- **language**: The programming language. Omit it to let GitHits infer the
+  language from the query. If you need to force a specific language and the
+  exact name is uncertain, use the `search_language` tool first.
 - **license_mode**: `"strict"` (default, excludes copyleft), `"yolo"` (all
   licenses), or `"custom"` (user's blocklist).
 

--- a/commands/help.md
+++ b/commands/help.md
@@ -28,9 +28,9 @@ context summary:
 This plugin connects to the GitHits MCP server and always exposes three core tools:
 
 - **get_example** — Find code examples by describing what you need in natural
-  language. Requires `query` and `language` parameters.
-- **search_language** — Look up supported programming language names before
-  searching.
+  language. Requires `query`; `language` is optional and inferred when omitted.
+- **search_language** — Look up supported programming language names when you
+  need to force a specific language.
 - **feedback** — Rate a search result to improve future quality.
 
 Additional indexed dependency/package tools such as `search`, `package_summary`,

--- a/commands/search.md
+++ b/commands/search.md
@@ -8,16 +8,17 @@ Use GitHits example search for the query: "$ARGUMENTS"
 
 This slash command is the older alias for `/githits:example`.
 
-Use the GitHits MCP `get_example` tool with the user's query. The tool requires two
-parameters:
+Use the GitHits MCP `get_example` tool with the user's query.
+
+Required parameter:
 
 - **query**: The user's search query, formulated in natural language.
-- **language**: The programming language. If the language is unclear from
-  context, use the `search_language` tool first to find the correct language
-  name.
 
-Optional parameter:
+Optional parameters:
 
+- **language**: The programming language. Omit it to let GitHits infer the
+  language from the query. If you need to force a specific language and the
+  exact name is uncertain, use the `search_language` tool first.
 - **license_mode**: `"strict"` (default, excludes copyleft), `"yolo"` (all
   licenses), or `"custom"` (user's blocklist).
 

--- a/docs/implementation/cli-commands.md
+++ b/docs/implementation/cli-commands.md
@@ -9,7 +9,7 @@ The CLI exposes three always-on top-level commands: `example`, `languages`, and 
 | Command | Required Args | Options | Description |
 |---|---|---|---|
 | `init` | — | `-y, --yes`, `--skip-login` | Authenticate and set up MCP server for coding agents |
-| `example <query>` | `-l, --lang <language>` | `--license <mode>`, `--explain`, `--json` | Search for code examples |
+| `example <query>` | `<query>` | `-l, --lang <language>`, `--license <mode>`, `--explain`, `--json` | Search for code examples |
 | `search <query>` | `--in <target>` | `--source <source>`, `--kind <kind>`, `--category <category>`, `--path-prefix <prefix>`, `--intent <intent>`, `--public`, `--name <name>`, `--lang <language>`, `--allow-partial`, `--limit <n>`, `--offset <n>`, `--wait <seconds>`, `--json` | Unified indexed search across dependency/repository code, docs, and symbols |
 | `search-status <search-ref>` | `<search-ref>` | `--json` | Check progress, fetch partial hits, or fetch final results for a prior unified search |
 | `languages [query]` | — | `--json` | List or filter supported languages |
@@ -41,13 +41,14 @@ The command uses `createContainer()` lazily for the login step. Tool detection a
 ### `githits example`
 
 ```
+githits example "how to use express middleware"
 githits example "how to use express middleware" --lang javascript
 githits example "async file reading" -l python --license yolo
 githits example "react hooks patterns" -l typescript --explain
 githits example "react hooks patterns" -l typescript --json
 ```
 
-Default output is markdown (the API response). With `--explain`, an AI-generated explanation is included alongside the code example. With `--json`, output is `{ "result": "<markdown>", "solution_id": "<uuid>" }` (`solution_id` is omitted only if the markdown lacks a solution URL — pass it back to `feedback`). The MCP `get_example` tool always sends `include_explanation: false` since LLMs don't need the extra context.
+Default output is markdown (the API response). `--lang` is optional; when omitted, the backend infers the language from the query. With `--explain`, an AI-generated explanation is included alongside the code example. With `--json`, output is `{ "result": "<markdown>", "solution_id": "<uuid>" }` (`solution_id` is omitted only if the markdown lacks a solution URL — pass it back to `feedback`). The MCP `get_example` tool always sends `include_explanation: false` since LLMs don't need the extra context.
 
 ### `githits search`
 

--- a/docs/implementation/tools.md
+++ b/docs/implementation/tools.md
@@ -19,7 +19,7 @@ Both expose the same tools with identical names, parameters, and descriptions. T
 
 | Tool | Parameters | Description |
 |---|---|---|
-| `get_example` | `query`, `language`, `license_mode?` | Search for canonical code examples. Returns markdown-formatted results. |
+| `get_example` | `query`, `language?`, `license_mode?` | Search for canonical code examples. Returns markdown-formatted results. If `language` is omitted, the backend infers it from the query. |
 | `search_language` | `query` | Find supported programming language names before searching. |
 | `feedback` | `solution_id`, `accepted`, `feedback_text?` | Submit feedback on a search result to improve quality. |
 | `search` | `query`, `target?`, `targets?`, `sources?`, `category?`, `kind?`, `path_prefix?`, `file_intent?`, `public_only?`, `name?`, `language?`, `allow_partial_results?`, `limit?`, `offset?`, `wait_timeout_ms?` | Unified indexed dependency/repository discovery search across code, docs, and symbols. Omit `file_intent` to search across all intents; set it only when you want to narrow results, and note that some sources may ignore it and report that in `sourceStatus`. Prefer `sources:["symbol"]` for symbol-shaped unified search. Complete-by-default; set `allow_partial_results: true` to receive available partial hits while indexing continues. |

--- a/plugins/claude/commands/example.md
+++ b/plugins/claude/commands/example.md
@@ -6,16 +6,17 @@ description: Search for canonical code examples from open source via GitHits
 
 Search for code examples using GitHits for the query: "$ARGUMENTS"
 
-Use the GitHits MCP `get_example` tool with the user's query. The tool requires two
-parameters:
+Use the GitHits MCP `get_example` tool with the user's query.
+
+Required parameter:
 
 - **query**: The user's search query, formulated in natural language.
-- **language**: The programming language. If the language is unclear from
-  context, use the `search_language` tool first to find the correct language
-  name.
 
-Optional parameter:
+Optional parameters:
 
+- **language**: The programming language. Omit it to let GitHits infer the
+  language from the query. If you need to force a specific language and the
+  exact name is uncertain, use the `search_language` tool first.
 - **license_mode**: `"strict"` (default, excludes copyleft), `"yolo"` (all
   licenses), or `"custom"` (user's blocklist).
 

--- a/plugins/claude/commands/help.md
+++ b/plugins/claude/commands/help.md
@@ -28,9 +28,9 @@ context summary:
 This plugin connects to the GitHits MCP server and always exposes three core tools:
 
 - **get_example** — Find code examples by describing what you need in natural
-  language. Requires `query` and `language` parameters.
-- **search_language** — Look up supported programming language names before
-  searching.
+  language. Requires `query`; `language` is optional and inferred when omitted.
+- **search_language** — Look up supported programming language names when you
+  need to force a specific language.
 - **feedback** — Rate a search result to improve future quality.
 
 Additional indexed dependency/package tools such as `search`, `package_summary`,

--- a/plugins/claude/commands/search.md
+++ b/plugins/claude/commands/search.md
@@ -8,16 +8,17 @@ Use GitHits example search for the query: "$ARGUMENTS"
 
 This slash command is the older alias for `/githits:example`.
 
-Use the GitHits MCP `get_example` tool with the user's query. The tool requires two
-parameters:
+Use the GitHits MCP `get_example` tool with the user's query.
+
+Required parameter:
 
 - **query**: The user's search query, formulated in natural language.
-- **language**: The programming language. If the language is unclear from
-  context, use the `search_language` tool first to find the correct language
-  name.
 
-Optional parameter:
+Optional parameters:
 
+- **language**: The programming language. Omit it to let GitHits infer the
+  language from the query. If you need to force a specific language and the
+  exact name is uncertain, use the `search_language` tool first.
 - **license_mode**: `"strict"` (default, excludes copyleft), `"yolo"` (all
   licenses), or `"custom"` (user's blocklist).
 

--- a/plugins/claude/skills/search/SKILL.md
+++ b/plugins/claude/skills/search/SKILL.md
@@ -28,7 +28,8 @@ Authentication:
 Guidelines:
 
 - Prefer existing search context if it already answers the problem.
-- Use `search_language` first when language naming is uncertain.
+- Pass `language` only when you need to force a specific language; use
+  `search_language` first if the exact language name is uncertain.
 - Use `get_example` for one focused example-search question at a time.
 - When the task is about indexed dependency or repository internals and the
   capability-gated tools are available, prefer unified `search` instead of

--- a/skills/search/SKILL.md
+++ b/skills/search/SKILL.md
@@ -28,7 +28,8 @@ Authentication:
 Guidelines:
 
 - Prefer existing search context if it already answers the problem.
-- Use `search_language` first when language naming is uncertain.
+- Pass `language` only when you need to force a specific language; use
+  `search_language` first if the exact language name is uncertain.
 - Use `get_example` for one focused example-search question at a time.
 - When the task is about indexed dependency or repository internals and the
   capability-gated tools are available, prefer unified `search` instead of

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -61,7 +61,7 @@ Getting started:
   githits init                         Set up MCP for your coding agents
   githits login                        Authenticate with your GitHits account
   githits mcp                          Show MCP setup instructions
-  githits example "query" -l python    Get code examples
+  githits example "query"              Get code examples
 
 Learn more at https://githits.com
 Docs: https://app.githits.com/docs/
@@ -84,7 +84,6 @@ registerLanguagesCommand(program);
 registerFeedbackCommand(program);
 const argv = process.argv.slice(2);
 const registrationArgv = stripRootRegistrationOptions(argv);
-const helpInvocation = isHelpInvocation(registrationArgv);
 const shouldLoadGatedHelpRegistration =
   needsGatedHelpRegistration(registrationArgv);
 const helpRegistrationOptions = shouldLoadGatedHelpRegistration

--- a/src/commands/example.test.ts
+++ b/src/commands/example.test.ts
@@ -39,6 +39,24 @@ describe("exampleAction", () => {
     consoleSpy.mockRestore();
   });
 
+  it("calls service without language when --lang is omitted", async () => {
+    const searchFn = mock(() => Promise.resolve("result"));
+    const deps = createDeps({
+      githitsService: createMockGitHitsService({ search: searchFn }),
+    });
+    const consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+
+    await exampleAction("hello world", {}, deps);
+
+    expect(searchFn).toHaveBeenCalledWith({
+      query: "hello world",
+      language: undefined,
+      licenseMode: undefined,
+      includeExplanation: undefined,
+    });
+    consoleSpy.mockRestore();
+  });
+
   it("outputs JSON when --json flag provided", async () => {
     const consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 

--- a/src/commands/example.ts
+++ b/src/commands/example.ts
@@ -4,7 +4,7 @@ import { extractSolutionId } from "../shared/extract-solution-id.js";
 import { AuthRequiredError, requireAuth } from "../shared/require-auth.js";
 
 export interface ExampleOptions {
-  lang: string;
+  lang?: string;
   license?: "strict" | "yolo" | "custom";
   explain?: boolean;
   json?: boolean;
@@ -53,6 +53,7 @@ const EXAMPLE_DESCRIPTION = `Get verified, canonical code examples from global o
 For dependency, package, or repository source search, use \`githits search\` instead.
 
 Examples:
+  githits example "how to use express middleware"
   githits example "how to use express middleware" --lang javascript
   githits example "async file reading" -l python --license yolo
   githits example "react hooks patterns" -l typescript --explain
@@ -64,7 +65,10 @@ export function registerExampleCommand(program: Command) {
     .summary("Get code examples from global open source")
     .description(EXAMPLE_DESCRIPTION)
     .argument("<query>", "Natural language example-search query")
-    .requiredOption("-l, --lang <language>", "Programming language")
+    .option(
+      "-l, --lang <language>",
+      "Optional programming language; omitted values are inferred by GitHits",
+    )
     .addOption(
       new Option("--license <mode>", "License filter mode")
         .choices(["strict", "yolo", "custom"])

--- a/src/commands/mcp-instructions.ts
+++ b/src/commands/mcp-instructions.ts
@@ -17,7 +17,7 @@ import type { Dependencies } from "../container.js";
 
 const CORE_BLOCK = `GitHits surfaces verified, canonical code examples from global open source. Use it when you're stuck, the user is frustrated by repeated failed attempts, you need up-to-date API usage, or the user mentions GitHits.
 
-Workflow: call \`search_language\` first if the language name is uncertain → call \`get_example\` with one focused question → send \`feedback\` on the returned solution_id so quality improves. Each search addresses a single issue; reuse context from prior results before re-searching.`;
+Workflow: call \`get_example\` with one focused question, optionally passing \`language\` when the desired language is known; call \`search_language\` first only if you need to force a language and the exact name is uncertain. Send \`feedback\` on the returned solution_id so quality improves. Each search addresses a single issue; reuse context from prior results before re-searching.`;
 
 const PACKAGE_TOOLS_PREAMBLE = `Package tools work with third-party dependency source plus registry metadata. Use them when a stack trace points into a dependency, you need to verify how a library actually works, or you're evaluating whether to add or upgrade a package.
 

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -24,6 +24,7 @@ import {
   createSearchStatusTool,
   createSearchTool,
   type ToolDefinition,
+  type ZodRawShape,
 } from "../tools/index.js";
 import {
   buildMcpInstructions,
@@ -35,35 +36,56 @@ import {
  */
 export function getMcpToolDefinitions(
   deps: Dependencies,
-): ToolDefinition<any, any>[] {
-  const tools: ToolDefinition<any, any>[] = [
-    createGetExampleTool(deps.githitsService),
-    createSearchLanguageTool(deps.githitsService),
-    createFeedbackTool(deps.githitsService),
+): ToolDefinition<unknown>[] {
+  const tools: ToolDefinition<unknown>[] = [
+    eraseTool(createGetExampleTool(deps.githitsService)),
+    eraseTool(createSearchLanguageTool(deps.githitsService)),
+    eraseTool(createFeedbackTool(deps.githitsService)),
   ];
 
   const gateOpen = isPackageToolsCapabilityOpen(deps);
 
   if (gateOpen && deps.codeNavigationService) {
-    tools.push(createSearchTool(deps.codeNavigationService));
-    tools.push(createSearchStatusTool(deps.codeNavigationService));
-    tools.push(createListFilesTool(deps.codeNavigationService));
-    tools.push(createReadFileTool(deps.codeNavigationService));
-    tools.push(createGrepRepoTool(deps.codeNavigationService));
+    tools.push(eraseTool(createSearchTool(deps.codeNavigationService)));
+    tools.push(eraseTool(createSearchStatusTool(deps.codeNavigationService)));
+    tools.push(eraseTool(createListFilesTool(deps.codeNavigationService)));
+    tools.push(eraseTool(createReadFileTool(deps.codeNavigationService)));
+    tools.push(eraseTool(createGrepRepoTool(deps.codeNavigationService)));
   }
 
   if (gateOpen && deps.packageIntelligenceService) {
-    tools.push(createListPackageDocsTool(deps.packageIntelligenceService));
-    tools.push(createReadPackageDocTool(deps.packageIntelligenceService));
-    tools.push(createPackageSummaryTool(deps.packageIntelligenceService));
     tools.push(
-      createPackageVulnerabilitiesTool(deps.packageIntelligenceService),
+      eraseTool(createListPackageDocsTool(deps.packageIntelligenceService)),
     );
-    tools.push(createPackageDependenciesTool(deps.packageIntelligenceService));
-    tools.push(createPackageChangelogTool(deps.packageIntelligenceService));
+    tools.push(
+      eraseTool(createReadPackageDocTool(deps.packageIntelligenceService)),
+    );
+    tools.push(
+      eraseTool(createPackageSummaryTool(deps.packageIntelligenceService)),
+    );
+    tools.push(
+      eraseTool(
+        createPackageVulnerabilitiesTool(deps.packageIntelligenceService),
+      ),
+    );
+    tools.push(
+      eraseTool(createPackageDependenciesTool(deps.packageIntelligenceService)),
+    );
+    tools.push(
+      eraseTool(createPackageChangelogTool(deps.packageIntelligenceService)),
+    );
   }
 
   return tools;
+}
+
+function eraseTool<TArgs, TSchema extends ZodRawShape>(
+  tool: ToolDefinition<TArgs, TSchema>,
+): ToolDefinition<unknown> {
+  return {
+    ...tool,
+    handler: (args, extra) => tool.handler(args as TArgs, extra),
+  };
 }
 
 /**

--- a/src/services/code-navigation-service.test.ts
+++ b/src/services/code-navigation-service.test.ts
@@ -11,15 +11,8 @@ import {
   CodeNavigationBackendError,
   CodeNavigationFileNotFoundError,
   CodeNavigationIndexingError,
-  CodeNavigationNetworkError,
   CodeNavigationServiceImpl,
-  CodeNavigationTargetNotFoundError,
-  CodeNavigationUnresolvableError,
-  CodeNavigationValidationError,
-  CodeNavigationVersionNotFoundError,
-  MalformedCodeNavigationResponseError,
 } from "./code-navigation-service.js";
-import { AuthenticationError } from "./githits-service.js";
 import { createMockTokenProvider } from "./test-helpers.js";
 
 function mockFetch(impl: () => Promise<Response>) {

--- a/src/services/githits-service.test.ts
+++ b/src/services/githits-service.test.ts
@@ -79,6 +79,16 @@ describe("GitHitsServiceImpl", () => {
       expect(body.license_mode).toBe("yolo");
     });
 
+    it("omits language from JSON when not provided", async () => {
+      const fn = mockFetch(() => Promise.resolve(new Response("result")));
+
+      await service.search({ query: "test" });
+
+      const call = fn.mock.calls[0] as unknown as [string, RequestInit];
+      const body = JSON.parse(call[1].body as string);
+      expect(body).not.toHaveProperty("language");
+    });
+
     it("passes include_explanation when set", async () => {
       const fn = mockFetch(() => Promise.resolve(new Response("result")));
 

--- a/src/services/githits-service.ts
+++ b/src/services/githits-service.ts
@@ -44,7 +44,7 @@ export interface Language {
  */
 export interface SearchParams {
   query: string;
-  language: string;
+  language?: string;
   licenseMode?: "strict" | "yolo" | "custom";
   includeExplanation?: boolean;
 }

--- a/src/shared/package-intelligence-error-map.test.ts
+++ b/src/shared/package-intelligence-error-map.test.ts
@@ -189,13 +189,12 @@ describe("mapPackageIntelligenceError — debug emissions", () => {
     process.env.GITHITS_DEBUG = "pkg-intel";
     stderrLines = [];
     originalWrite = process.stderr.write.bind(process.stderr);
-    // biome-ignore lint/suspicious/noExplicitAny: test-only monkeypatch
     process.stderr.write = ((chunk: string | Uint8Array) => {
       stderrLines.push(
         typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk),
       );
       return true;
-    }) as any;
+    }) as typeof process.stderr.write;
   });
 
   afterEach(() => {

--- a/src/shared/pkgseer-graphql.test.ts
+++ b/src/shared/pkgseer-graphql.test.ts
@@ -250,13 +250,12 @@ describe("postPkgseerGraphql", () => {
     const stderrLines: string[] = [];
     const originalWrite = process.stderr.write.bind(process.stderr);
     // Capture stderr for the duration of the call.
-    // biome-ignore lint/suspicious/noExplicitAny: test-only monkeypatch
     process.stderr.write = ((chunk: string | Uint8Array) => {
       stderrLines.push(
         typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk),
       );
       return true;
-    }) as any;
+    }) as typeof process.stderr.write;
 
     try {
       const fetchFn = mock(() => Promise.reject(new Error("ENOTFOUND")));

--- a/src/shared/unified-search-response.ts
+++ b/src/shared/unified-search-response.ts
@@ -1,7 +1,6 @@
 import type {
   UnifiedSearchCompleted,
   UnifiedSearchHit,
-  UnifiedSearchIncomplete,
   UnifiedSearchOutcome,
   UnifiedSearchParams,
   UnifiedSearchProgress,

--- a/src/tools/get-example.test.ts
+++ b/src/tools/get-example.test.ts
@@ -34,6 +34,21 @@ describe("getExampleTool", () => {
     });
   });
 
+  it("allows language to be omitted", async () => {
+    const searchFn = mock(() => Promise.resolve("result"));
+    const service = createMockGitHitsService({ search: searchFn });
+    const tool = createGetExampleTool(service);
+
+    await tool.handler({ query: "test" }, {});
+
+    expect(searchFn).toHaveBeenCalledWith({
+      query: "test",
+      language: undefined,
+      licenseMode: undefined,
+      includeExplanation: false,
+    });
+  });
+
   it("returns error result on service failure", async () => {
     const service = createMockGitHitsService({
       search: mock(() => Promise.reject(new Error("Network error"))),

--- a/src/tools/get-example.ts
+++ b/src/tools/get-example.ts
@@ -6,7 +6,7 @@ import { type ToolDefinition, textResult } from "./types.js";
 
 interface GetExampleArgs {
   query: string;
-  language: string;
+  language?: string;
   license_mode?: "strict" | "yolo" | "custom";
 }
 
@@ -20,8 +20,9 @@ const schema = {
   language: z
     .string()
     .min(1)
+    .optional()
     .describe(
-      "Programming language. Use search_language first if the exact name is uncertain.",
+      "Optional programming language. If omitted, GitHits tries to infer it automatically. Use search_language first only when you need to force a specific language and the exact name is uncertain.",
     ),
   license_mode: z
     .enum(["strict", "yolo", "custom"])

--- a/src/tools/grep-repo.ts
+++ b/src/tools/grep-repo.ts
@@ -38,11 +38,6 @@ export interface GrepRepoArgs {
   wait_timeout_ms?: number;
 }
 
-const pathSelectorSchema = z.object({
-  kind: z.enum(["exact", "prefix", "glob"]),
-  value: z.string(),
-});
-
 const schema = {
   target: codeTargetSchema,
   pattern: z.string().describe(GREP_REPO_PATTERN_NOTE),

--- a/src/tools/package-summary-parity.test.ts
+++ b/src/tools/package-summary-parity.test.ts
@@ -28,10 +28,7 @@ import {
   PackageIntelligenceBackendError,
   PackageIntelligenceTargetNotFoundError,
 } from "../services/index.js";
-import {
-  createMockPackageIntelligenceService,
-  defaultPackageSummary,
-} from "../services/test-helpers.js";
+import { createMockPackageIntelligenceService } from "../services/test-helpers.js";
 import { createPackageSummaryTool } from "./package-summary.js";
 
 function cliDeps(


### PR DESCRIPTION
## Summary
- Make `get_example` and `githits example` accept omitted language so production can infer it from the query.
- Update REST request typing/serialization, MCP instructions, CLI/plugin docs, and packaged agent guidance for optional language.
- Add regression coverage for omitted language and clean existing lint warnings surfaced during verification.

## Verification
- `bun test`
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run build`
- Production smoke test: `GITHITS_API_URL="https://api.githits.com" bun run dev example "how to read a JSON file in Python" --json`

## Review
- Code reviewer: no findings. Residual risk noted: no Commander-level parse test or MCP registration/schema assertion for optional language.