### PR TITLE
[codex] Improve search match highlighting

### DIFF
--- a/src/commands/code/grep.test.ts
+++ b/src/commands/code/grep.test.ts
@@ -91,7 +91,7 @@ describe("pkgGrepAction", () => {
     const output = writes.join("");
     expect(output).toContain("src/index.js\n4:module.exports = ");
     expect(output).toContain(
-      "\u001b[1m\u001b[36mrequire\u001b[0m('./lib/express');",
+      "\u001b[1m\u001b[33mrequire\u001b[0m('./lib/express');",
     );
     expect(output).not.toContain(
       "src/index.js:4:module.exports = require('./lib/express');",

--- a/src/commands/search.test.ts
+++ b/src/commands/search.test.ts
@@ -420,9 +420,12 @@ describe("searchAction", () => {
       );
 
       const output = String(consoleSpy.mock.calls[0]?.[0]);
-      expect(output).toContain("\u001b[1m\u001b[36mmiddleware\u001b[0m");
+      expect(output).toContain("\u001b[1m\u001b[33mmiddleware\u001b[0m");
       expect(output).toContain(
-        "function \u001b[1m\u001b[36mrouter\u001b[0m(req, res, next) { ... }",
+        "\u001b[1m\u001b[36mlib/\u001b[0m\u001b[1m\u001b[33mrouter\u001b[0m\u001b[1m\u001b[36m/index.js:42-57\u001b[0m",
+      );
+      expect(output).toContain(
+        "function \u001b[1m\u001b[33mrouter\u001b[0m(req, res, next) { ... }",
       );
     } finally {
       consoleSpy.mockRestore();
@@ -483,7 +486,7 @@ describe("searchAction", () => {
       const output = String(consoleSpy.mock.calls[0]?.[0]);
       expect(output).toContain("  line 1");
       expect(output).toContain(
-        `  ${"\u001b[1m\u001b[36m"}line 2${"\u001b[0m"}`,
+        `  ${"\u001b[1m\u001b[33m"}line 2${"\u001b[0m"}`,
       );
     } finally {
       consoleSpy.mockRestore();

--- a/src/commands/search.test.ts
+++ b/src/commands/search.test.ts
@@ -441,6 +441,40 @@ describe("searchAction", () => {
     }
   });
 
+  it("prefers longer overlapping query terms for location highlights", async () => {
+    const consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+    const originalIsTTY = process.stdout.isTTY;
+    const noColor = process.env.NO_COLOR;
+    try {
+      delete process.env.NO_COLOR;
+      Object.defineProperty(process.stdout, "isTTY", {
+        value: true,
+        configurable: true,
+      });
+
+      await searchAction("route router", { in: ["npm:express"] }, createDeps());
+
+      const output = String(consoleSpy.mock.calls[0]?.[0]);
+      expect(output).toContain(
+        "\u001b[1m\u001b[36mlib/\u001b[0m\u001b[1m\u001b[33mrouter\u001b[0m\u001b[1m\u001b[36m/index.js:42-57\u001b[0m",
+      );
+      expect(output).not.toContain(
+        "\u001b[1m\u001b[33mroute\u001b[0m\u001b[1m\u001b[36mr/index.js",
+      );
+    } finally {
+      consoleSpy.mockRestore();
+      Object.defineProperty(process.stdout, "isTTY", {
+        value: originalIsTTY,
+        configurable: true,
+      });
+      if (noColor === undefined) {
+        delete process.env.NO_COLOR;
+      } else {
+        process.env.NO_COLOR = noColor;
+      }
+    }
+  });
+
   it("preserves CRLF-based summary highlight offsets", async () => {
     const consoleSpy = spyOn(console, "log").mockImplementation(() => {});
     const originalIsTTY = process.stdout.isTTY;

--- a/src/commands/search.test.ts
+++ b/src/commands/search.test.ts
@@ -674,8 +674,40 @@ describe("searchStatusAction", () => {
     const payload = JSON.parse(String(consoleSpy.mock.calls[0]?.[0]));
     expect(payload.completed).toBe(true);
     expect(payload.searchRef).toBe("search-ref-123");
+    expect(payload.result.query.raw).toBe("router middleware");
     expect(payload.result.results).toHaveLength(1);
     expect(payload).not.toHaveProperty("query.raw");
     consoleSpy.mockRestore();
+  });
+
+  it("renders location term highlights for completed search-status results", async () => {
+    const consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+    const originalIsTTY = process.stdout.isTTY;
+    const noColor = process.env.NO_COLOR;
+    try {
+      delete process.env.NO_COLOR;
+      Object.defineProperty(process.stdout, "isTTY", {
+        value: true,
+        configurable: true,
+      });
+
+      await searchStatusAction("search-ref-123", {}, createDeps());
+
+      const output = String(consoleSpy.mock.calls[0]?.[0]);
+      expect(output).toContain(
+        "\u001b[1m\u001b[36mlib/\u001b[0m\u001b[1m\u001b[33mrouter\u001b[0m\u001b[1m\u001b[36m/index.js:42-57\u001b[0m",
+      );
+    } finally {
+      consoleSpy.mockRestore();
+      Object.defineProperty(process.stdout, "isTTY", {
+        value: originalIsTTY,
+        configurable: true,
+      });
+      if (noColor === undefined) {
+        delete process.env.NO_COLOR;
+      } else {
+        process.env.NO_COLOR = noColor;
+      }
+    }
   });
 });

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -11,6 +11,7 @@ import {
   buildUnifiedSearchSuccessPayload,
   dim,
   highlight,
+  highlightMatch,
   highlightRanges,
   InvalidArgumentError,
   knownSymbolCategoryList,
@@ -403,7 +404,7 @@ function formatUnifiedSearchTerminal(payload: {
   }>;
   searchRef?: string;
   progress?: { targetsReady?: number; targetsTotal?: number };
-  query: { warnings?: string[] };
+  query: { raw?: string; warnings?: string[] };
   sourceStatus?: SourceStatusEntry[];
 }): string {
   const lines: string[] = [];
@@ -458,7 +459,12 @@ function formatUnifiedSearchTerminal(payload: {
 
   for (const entry of display) {
     const location = formatUnifiedSearchLocation(entry.locator);
-    const header = formatUnifiedSearchHeader(entry, useColors, location);
+    const header = formatUnifiedSearchHeader(
+      entry,
+      useColors,
+      location,
+      payload.query.raw,
+    );
     lines.push(header);
     const metadata = formatUnifiedSearchMetadata(entry, useColors);
     if (metadata.length > 0) {
@@ -779,18 +785,124 @@ function formatUnifiedSearchHeader(
   },
   useColors: boolean,
   location: string | undefined,
+  rawQuery: string | undefined,
 ): string {
-  const primary =
-    entry.type === "documentation_page"
-      ? entry.target
-      : location
-        ? `${entry.target} ${location}`
-        : entry.target;
+  const primary = formatUnifiedSearchPrimary(
+    entry.type,
+    entry.target,
+    location,
+    rawQuery,
+    useColors,
+  );
   const badge = `[${formatUnifiedSearchResultLabel(entry.type)}]`;
   const title = entry.title
     ? highlightRanges(entry.title, entry.highlights?.title, useColors)
     : undefined;
-  return `${highlight(primary, useColors)} ${dim(badge, useColors)}${title ? ` - ${title}` : ""}`;
+  return `${primary} ${dim(badge, useColors)}${title ? ` - ${title}` : ""}`;
+}
+
+function formatUnifiedSearchPrimary(
+  type: string,
+  target: string,
+  location: string | undefined,
+  rawQuery: string | undefined,
+  useColors: boolean,
+): string {
+  const formattedTarget = highlight(target, useColors);
+  if (type === "documentation_page" || !location) {
+    return formattedTarget;
+  }
+
+  return `${formattedTarget} ${formatLocationWithQueryHighlights(
+    location,
+    rawQuery,
+    useColors,
+  )}`;
+}
+
+function formatLocationWithQueryHighlights(
+  location: string,
+  rawQuery: string | undefined,
+  useColors: boolean,
+): string {
+  const ranges = buildQueryTermRanges(location, rawQuery);
+  if (ranges.length === 0) return highlight(location, useColors);
+  if (!useColors) return location;
+
+  let result = "";
+  let cursor = 0;
+  for (const [start, end] of ranges) {
+    if (cursor < start)
+      result += highlight(location.slice(cursor, start), true);
+    result += highlightMatch(location.slice(start, end), true);
+    cursor = end;
+  }
+  if (cursor < location.length)
+    result += highlight(location.slice(cursor), true);
+  return result;
+}
+
+function buildQueryTermRanges(
+  text: string,
+  rawQuery: string | undefined,
+): Array<readonly [number, number]> {
+  const terms = extractQueryHighlightTerms(rawQuery);
+  if (terms.length === 0) return [];
+
+  const lowerText = text.toLowerCase();
+  const ranges: Array<readonly [number, number]> = [];
+  for (const term of terms) {
+    const lowerTerm = term.toLowerCase();
+    let cursor = 0;
+    while (cursor < lowerText.length) {
+      const start = lowerText.indexOf(lowerTerm, cursor);
+      if (start === -1) break;
+      const end = start + lowerTerm.length;
+      ranges.push([start, end]);
+      cursor = end;
+    }
+  }
+
+  return mergeRanges(ranges);
+}
+
+function extractQueryHighlightTerms(rawQuery: string | undefined): string[] {
+  if (!rawQuery) return [];
+
+  const booleanOperators = new Set(["AND", "OR", "NOT"]);
+  const terms = new Set<string>();
+  for (const [candidate] of rawQuery.matchAll(/[A-Za-z0-9_./@:-]+/g)) {
+    const normalised = /^[A-Za-z]+:.+/.test(candidate)
+      ? candidate.split(":").slice(1).join(":")
+      : candidate;
+    const term = normalised.replace(/^[-+]+/, "").replace(/[-+]+$/, "");
+    if (term.length < 2) continue;
+    if (booleanOperators.has(term.toUpperCase())) continue;
+    terms.add(term);
+  }
+
+  return Array.from(terms).sort((left, right) => right.length - left.length);
+}
+
+function mergeRanges(
+  ranges: Array<readonly [number, number]>,
+): Array<readonly [number, number]> {
+  const sorted = ranges
+    .filter(([start, end]) => end > start)
+    .sort((left, right) => left[0] - right[0] || left[1] - right[1]);
+  const merged: Array<readonly [number, number]> = [];
+  for (const current of sorted) {
+    const previous = merged[merged.length - 1];
+    if (!previous || current[0] > previous[1]) {
+      merged.push(current);
+      continue;
+    }
+    merged[merged.length - 1] = [
+      previous[0],
+      Math.max(previous[1], current[1]),
+    ];
+  }
+  return merged;
 }
 
 function formatUnifiedSearchMetadata(

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -556,7 +556,10 @@ function formatSearchStatusCompletedTerminal(payload: {
     results: payload.result.results,
     searchRef: payload.searchRef,
     progress: undefined,
-    query: { warnings: payload.result.warnings },
+    query: {
+      raw: payload.result.query?.raw,
+      warnings: payload.result.warnings,
+    },
     sourceStatus: payload.result.sourceStatus,
   });
 }
@@ -573,7 +576,10 @@ function formatSearchStatusPartialTerminal(
     results: payload.result.results,
     searchRef: payload.searchRef,
     progress: payload.progress,
-    query: { warnings: payload.result.warnings },
+    query: {
+      raw: payload.result.query?.raw,
+      warnings: payload.result.warnings,
+    },
     sourceStatus: payload.result.sourceStatus,
   });
 }
@@ -851,14 +857,16 @@ function buildQueryTermRanges(
 
   const lowerText = text.toLowerCase();
   const ranges: Array<readonly [number, number]> = [];
-  for (const term of terms) {
+  for (const term of terms.sort((left, right) => right.length - left.length)) {
     const lowerTerm = term.toLowerCase();
     let cursor = 0;
     while (cursor < lowerText.length) {
       const start = lowerText.indexOf(lowerTerm, cursor);
       if (start === -1) break;
       const end = start + lowerTerm.length;
-      ranges.push([start, end]);
+      if (!ranges.some((range) => rangesOverlap(range, [start, end]))) {
+        ranges.push([start, end]);
+      }
       cursor = end;
     }
   }
@@ -871,17 +879,47 @@ function extractQueryHighlightTerms(rawQuery: string | undefined): string[] {
 
   const booleanOperators = new Set(["AND", "OR", "NOT"]);
   const terms = new Set<string>();
-  for (const [candidate] of rawQuery.matchAll(/[A-Za-z0-9_./@:-]+/g)) {
-    const normalised = /^[A-Za-z]+:.+/.test(candidate)
-      ? candidate.split(":").slice(1).join(":")
-      : candidate;
-    const term = normalised.replace(/^[-+]+/, "").replace(/[-+]+$/, "");
-    if (term.length < 2) continue;
-    if (booleanOperators.has(term.toUpperCase())) continue;
-    terms.add(term);
+  const quotedRanges: Array<readonly [number, number]> = [];
+  // Preserve quoted phrases as a single best-effort location term so a phrase
+  // query does not degrade into scattered word highlights in paths.
+  for (const match of rawQuery.matchAll(/"([^"]+)"/g)) {
+    const phrase = match[1];
+    if (phrase) addQueryHighlightTerm(phrase, terms, booleanOperators);
+    if (typeof match.index === "number") {
+      quotedRanges.push([match.index, match.index + match[0].length]);
+    }
   }
 
-  return Array.from(terms).sort((left, right) => right.length - left.length);
+  for (const match of rawQuery.matchAll(/[A-Za-z0-9_./@:-]+/g)) {
+    const index = match.index ?? 0;
+    if (quotedRanges.some(([start, end]) => index >= start && index < end)) {
+      continue;
+    }
+    addQueryHighlightTerm(match[0], terms, booleanOperators);
+  }
+
+  return Array.from(terms);
+}
+
+function addQueryHighlightTerm(
+  candidate: string,
+  terms: Set<string>,
+  booleanOperators: Set<string>,
+): void {
+  const normalised = /^[A-Za-z]+:.+/.test(candidate)
+    ? candidate.split(":").slice(1).join(":")
+    : candidate;
+  const term = normalised.replace(/^[-+]+/, "").replace(/[-+]+$/, "");
+  if (term.length < 2) return;
+  if (booleanOperators.has(term.toUpperCase())) return;
+  terms.add(term);
+}
+
+function rangesOverlap(
+  left: readonly [number, number],
+  right: readonly [number, number],
+): boolean {
+  return left[0] < right[1] && right[0] < left[1];
 }
 
 function mergeRanges(

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -857,7 +857,10 @@ function buildQueryTermRanges(
 
   const lowerText = text.toLowerCase();
   const ranges: Array<readonly [number, number]> = [];
-  for (const term of terms.sort((left, right) => right.length - left.length)) {
+  const orderedTerms = [...terms].sort(
+    (left, right) => right.length - left.length,
+  );
+  for (const term of orderedTerms) {
     const lowerTerm = term.toLowerCase();
     let cursor = 0;
     while (cursor < lowerText.length) {
@@ -884,7 +887,11 @@ function extractQueryHighlightTerms(rawQuery: string | undefined): string[] {
   // query does not degrade into scattered word highlights in paths.
   for (const match of rawQuery.matchAll(/"([^"]+)"/g)) {
     const phrase = match[1];
-    if (phrase) addQueryHighlightTerm(phrase, terms, booleanOperators);
+    if (phrase) {
+      addQueryHighlightTerm(phrase, terms, booleanOperators, {
+        stripQualifier: false,
+      });
+    }
     if (typeof match.index === "number") {
       quotedRanges.push([match.index, match.index + match[0].length]);
     }
@@ -905,10 +912,12 @@ function addQueryHighlightTerm(
   candidate: string,
   terms: Set<string>,
   booleanOperators: Set<string>,
+  options: { stripQualifier: boolean } = { stripQualifier: true },
 ): void {
-  const normalised = /^[A-Za-z]+:.+/.test(candidate)
-    ? candidate.split(":").slice(1).join(":")
-    : candidate;
+  const normalised =
+    options.stripQualifier && /^[A-Za-z]+:.+/.test(candidate)
+      ? candidate.split(":").slice(1).join(":")
+      : candidate;
   const term = normalised.replace(/^[-+]+/, "").replace(/[-+]+$/, "");
   if (term.length < 2) return;
   if (booleanOperators.has(term.toUpperCase())) return;

--- a/src/services/package-intelligence-service.ts
+++ b/src/services/package-intelligence-service.ts
@@ -2044,7 +2044,7 @@ export class PackageIntelligenceServiceImpl
     // Backend returns source=null for package version entries that have no
     // changelog entry. Treat no-source as NOT_FOUND only when no entries
     // came back at all.
-    const source = data.source && data.source.trim() ? data.source : undefined;
+    const source = data.source?.trim() ? data.source : undefined;
     const rawEntries = data.entries ?? [];
     if (!source && rawEntries.length === 0) {
       const target =

--- a/src/shared/colors.test.ts
+++ b/src/shared/colors.test.ts
@@ -5,6 +5,8 @@ import {
   dim,
   error,
   highlight,
+  highlightMatch,
+  highlightRanges,
   shouldUseColors,
   success,
   warning,
@@ -111,5 +113,25 @@ describe("highlight", () => {
 
   it("returns plain text when disabled", () => {
     expect(highlight("important", false)).toBe("important");
+  });
+});
+
+describe("highlightMatch", () => {
+  it("wraps with bold yellow when enabled", () => {
+    const result = highlightMatch("match", true);
+    expect(result).toBe(`${colors.bold}${colors.yellow}match${colors.reset}`);
+  });
+
+  it("returns plain text when disabled", () => {
+    expect(highlightMatch("match", false)).toBe("match");
+  });
+});
+
+describe("highlightRanges", () => {
+  it("renders matched spans with the search-match color", () => {
+    const result = highlightRanges("router middleware", [[7, 17]], true);
+    expect(result).toBe(
+      `router ${colors.bold}${colors.yellow}middleware${colors.reset}`,
+    );
   });
 });

--- a/src/shared/colors.ts
+++ b/src/shared/colors.ts
@@ -71,6 +71,14 @@ export function highlight(text: string, useColors: boolean): string {
 }
 
 /**
+ * Highlight matched search terms.
+ */
+export function highlightMatch(text: string, useColors: boolean): string {
+  if (!useColors) return text;
+  return `${colors.bold}${colors.yellow}${text}${colors.reset}`;
+}
+
+/**
  * Apply half-open character spans to a string.
  * Invalid or overlapping spans are ignored/merged conservatively.
  */
@@ -117,7 +125,7 @@ export function highlightRanges(
   let cursor = 0;
   for (const [start, end] of merged) {
     if (cursor < start) result += text.slice(cursor, start);
-    result += highlight(text.slice(start, end), useColors);
+    result += highlightMatch(text.slice(start, end), useColors);
     cursor = end;
   }
   if (cursor < text.length) result += text.slice(cursor);

--- a/src/shared/grep-repo-response.test.ts
+++ b/src/shared/grep-repo-response.test.ts
@@ -122,7 +122,7 @@ describe("formatGrepRepoTerminal", () => {
       useColors: true,
     });
     expect(stdout).toContain(
-      `src/index.js:10:const ${"\u001b[1m\u001b[36m"}app = e${"\u001b[0m"}xpress();`,
+      `src/index.js:10:const ${"\u001b[1m\u001b[33m"}app = e${"\u001b[0m"}xpress();`,
     );
   });
 

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -31,6 +31,7 @@ export {
   dim,
   error,
   highlight,
+  highlightMatch,
   highlightRanges,
   shouldUseColors,
   success,

--- a/src/shared/unified-search-response.test.ts
+++ b/src/shared/unified-search-response.test.ts
@@ -527,6 +527,10 @@ describe("buildUnifiedSearchStatusPayload", () => {
     }
 
     expect(payload.result).toEqual({
+      query: {
+        raw: "router middleware",
+        sources: ["code"],
+      },
       sources: ["code"],
       hasMore: false,
       results: [

--- a/src/shared/unified-search-response.ts
+++ b/src/shared/unified-search-response.ts
@@ -340,6 +340,8 @@ function buildUnifiedSearchStatusResultPayload(
 function buildStatusQueryEcho(
   result: UnifiedSearchCompleted["result"],
 ): UnifiedSearchQueryEcho {
+  // Status responses only retain the backend result query. Request-only
+  // compile/filter metadata is not available when following up by searchRef.
   const query: UnifiedSearchQueryEcho = {
     raw: result.query,
   };

--- a/src/shared/unified-search-response.ts
+++ b/src/shared/unified-search-response.ts
@@ -159,6 +159,7 @@ export interface UnifiedSearchErrorPayload {
 }
 
 export interface UnifiedSearchStatusResultPayload {
+  query?: UnifiedSearchQueryEcho;
   warnings?: string[];
   sources?: string[];
   hasMore: boolean;
@@ -317,6 +318,7 @@ function buildUnifiedSearchStatusResultPayload(
   result: UnifiedSearchCompleted["result"],
 ): UnifiedSearchStatusResultPayload {
   const payload: UnifiedSearchStatusResultPayload = {
+    query: buildStatusQueryEcho(result),
     hasMore: result.page.hasMore,
     results: result.results.map(buildHitPayload),
   };
@@ -333,6 +335,21 @@ function buildUnifiedSearchStatusResultPayload(
     payload.warnings = combinedWarnings;
   }
   return payload;
+}
+
+function buildStatusQueryEcho(
+  result: UnifiedSearchCompleted["result"],
+): UnifiedSearchQueryEcho {
+  const query: UnifiedSearchQueryEcho = {
+    raw: result.query,
+  };
+  if (result.queryWarnings.length > 0) {
+    query.warnings = result.queryWarnings;
+  }
+  if (result.sources.length > 0) {
+    query.sources = result.sources.map((entry) => entry.toLowerCase());
+  }
+  return query;
 }
 
 function buildQueryEcho(


### PR DESCRIPTION
## Summary

Improves terminal search readability by separating header/path styling from search-match styling.

- adds a yellow match-highlight style for backend-provided title and summary spans
- keeps result targets and path headers cyan while highlighting matching query terms inside path segments
- carries the backend query through `search_status` result payloads so async/follow-up output gets the same location highlighting
- treats quoted query phrases as phrase terms for location highlighting, and prioritizes longer overlapping terms deliberately
- updates grep/search formatter tests for the shared match-span color
- fixes a minor optional-chain lint finding surfaced during validation

## Why

Search output could match on file paths, but path matches were visually lost because both the header and highlight spans used the same cyan style. Yellow match spans make the actual matched term visible while preserving the existing header hierarchy.

## Review Notes

Claude review cleanup addressed:

- fixed the immediate-search vs `search_status` highlighting asymmetry by threading `result.query.raw` through status payloads
- made length sorting observable by using longer-term priority when overlapping ranges compete
- documented and implemented quoted-phrase behavior so quoted phrases do not degrade into scattered path word highlights
- kept the optional-chain cleanup as the existing lint cleanup; the pushed history was not rewritten after PR creation

## Validation

- `bun test`
- `bun run typecheck`
- `bun run format:check`
- `bun run lint`
- `bun run build`
- `bun run smoke:cli`
- `bun run smoke:mcp`