### PR TITLE
fix: close auth callback server after login

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "GitHits plugins for Claude Code - code examples from global open source",
-    "version": "0.4.1"
+    "version": "0.4.2"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Code examples from global open source for developers and AI assistants",
   "author": {
     "name": "GitHits"

--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Code examples from global open source for developers and AI assistants",
   "author": {
     "name": "GitHits"

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Code examples from global open source for developers and AI assistants.",
   "mcpServers": {
     "githits": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "githits",
   "description": "CLI companion for GitHits - code examples from global open source for developers and AI assistants",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "type": "module",
   "files": [
     "dist",

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Code examples from global open source for developers and AI assistants",
   "author": {
     "name": "GitHits"

--- a/src/commands/login.test.ts
+++ b/src/commands/login.test.ts
@@ -395,11 +395,24 @@ describe("loginFlow", () => {
 
   it("returns success after completing OAuth flow", async () => {
     const consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+    const close = mock(() => Promise.resolve());
+    const authService = createMockAuthService({
+      startCallbackServer: mock(() =>
+        Promise.resolve({
+          result: Promise.resolve({
+            type: "success",
+            code: "test-code",
+            state: "test-state",
+          } as const),
+          close,
+        }),
+      ),
+    });
 
     const result = await loginFlow(
       { port: 8080 },
       {
-        authService: createMockAuthService(),
+        authService,
         authStorage: createMockAuthStorage(),
         browserService: createMockBrowserService(),
         mcpUrl,
@@ -408,6 +421,7 @@ describe("loginFlow", () => {
 
     expect(result.status).toBe("success");
     expect(result.message).toContain("Logged in successfully");
+    expect(close).toHaveBeenCalledTimes(1);
     consoleSpy.mockRestore();
   });
 

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -237,6 +237,7 @@ export async function loginFlow(
   try {
     callback = await Promise.race([callbackServer.result, timeoutPromise]);
     if (timeoutId) clearTimeout(timeoutId);
+    await callbackServer.close().catch(() => {});
   } catch (error) {
     if (timeoutId) clearTimeout(timeoutId);
     await callbackServer.close().catch(() => {});


### PR DESCRIPTION
## Summary
- Close the OAuth callback server immediately after successful login callbacks so auto-login CLI commands can exit promptly.
- Bump package patch version to 0.4.2.
- Add regression coverage for closing the callback server on the successful login path.

## Verification
- bun test src/commands/login.test.ts src/services/auth-service.test.ts
- bun run typecheck
- bun run smoke:cli