### PR TITLE
feat: support agent eval model selection

### DIFF
--- a/eval/agentic/README.md
+++ b/eval/agentic/README.md
@@ -48,6 +48,8 @@ login should work by default. Automation can use `GITHITS_API_TOKEN`.
 bun run agent:e2e --server local --workload eval/agentic/workloads/express-router.md
 bun run agent:e2e --server published --workload eval/agentic/workloads/express-router.md
 bun run agent:e2e --agent codex --server local --workload eval/agentic/workloads/express-router.md
+bun run agent:e2e --agent claude --model haiku --workload eval/agentic/workloads/package-overview-vulnerabilities.md
+bun run agent:e2e --agent codex --model gpt-5.1-codex-mini --workload eval/agentic/workloads/package-overview-vulnerabilities.md
 bun run agent:e2e:report .agent-eval/runs/<run>
 bun run agent:e2e:report --compare .agent-eval/runs/<before> .agent-eval/runs/<after>
 ```
@@ -56,6 +58,7 @@ Useful options:
 
 ```bash
 --agent <claude|codex>          Agent to run, default `claude`
+--model <name>                  Agent model name or alias, passed through to the agent CLI
 --dry-run                       Generate artifacts without invoking the agent
 --out <dir>                     Output directory, default `.agent-eval/runs/<timestamp>`
 --timeout <seconds>             Per-workload timeout, default 300
@@ -73,6 +76,12 @@ Normal GitHits backend overrides are passed through when set:
 - `GITHITS_AUTH_STORAGE`
 
 Secret-like values are redacted in run metadata.
+
+Use `--model` to evaluate smaller or cheaper models against the same workload.
+Claude accepts aliases such as `sonnet` and `haiku`; Codex accepts model IDs such
+as `gpt-5.1-codex-mini` or `gpt-5.1-codex-nano` when available. The harness
+stores the selected model in `run.json` and `report.json`, and includes it in the
+console summary.
 
 After each run, the harness prints a concise summary with the run directory,
 per-workload status, unique GitHits tool count, raw tool event count,

--- a/eval/agentic/README.md
+++ b/eval/agentic/README.md
@@ -49,7 +49,7 @@ bun run agent:e2e --server local --workload eval/agentic/workloads/express-route
 bun run agent:e2e --server published --workload eval/agentic/workloads/express-router.md
 bun run agent:e2e --agent codex --server local --workload eval/agentic/workloads/express-router.md
 bun run agent:e2e --agent claude --model haiku --workload eval/agentic/workloads/package-overview-vulnerabilities.md
-bun run agent:e2e --agent codex --model gpt-5.1-codex-mini --workload eval/agentic/workloads/package-overview-vulnerabilities.md
+bun run agent:e2e --agent codex --model gpt-5.4-mini --workload eval/agentic/workloads/package-overview-vulnerabilities.md
 bun run agent:e2e:report .agent-eval/runs/<run>
 bun run agent:e2e:report --compare .agent-eval/runs/<before> .agent-eval/runs/<after>
 ```
@@ -79,7 +79,7 @@ Secret-like values are redacted in run metadata.
 
 Use `--model` to evaluate smaller or cheaper models against the same workload.
 Claude accepts aliases such as `sonnet` and `haiku`; Codex accepts model IDs such
-as `gpt-5.1-codex-mini` or `gpt-5.1-codex-nano` when available. The harness
+as `gpt-5.4-mini` or `gpt-5.4-nano` when available. The harness
 stores the selected model in `run.json` and `report.json`, and includes it in the
 console summary.
 

--- a/scripts/agent-eval-report.ts
+++ b/scripts/agent-eval-report.ts
@@ -17,6 +17,7 @@ export interface AgentEvalReportOptions {
 
 export interface AgentEvalRunMetadata {
   agent?: string;
+  model?: string;
   server?: string;
   dryRun?: boolean;
   git?: Record<string, string | undefined>;
@@ -73,6 +74,7 @@ export interface AgentEvalReport {
   schemaVersion: 1;
   status: string;
   agent?: string;
+  model?: string;
   server?: string;
   dryRun?: boolean;
   git?: Record<string, string | undefined>;
@@ -416,6 +418,7 @@ export function buildRunReportFromMetadata(
     schemaVersion: 1,
     status,
     agent: metadata.agent,
+    model: metadata.model,
     server: metadata.server,
     dryRun: metadata.dryRun,
     git: metadata.git,
@@ -439,7 +442,7 @@ function formatDuration(ms: number | undefined): string {
 
 export function formatRunReport(report: AgentEvalReport): string {
   const lines = [
-    `Agent eval: ${report.status} (${report.agent ?? "unknown"}/${report.server ?? "unknown"}) ${report.runDir}`,
+    `Agent eval: ${report.status} (${report.agent ?? "unknown"}${report.model ? `:${report.model}` : ""}/${report.server ?? "unknown"}) ${report.runDir}`,
   ];
   for (const workload of report.workloads) {
     const final = workload.finalReport;

--- a/scripts/agent-eval-report.ts
+++ b/scripts/agent-eval-report.ts
@@ -507,6 +507,12 @@ function formatStatusCounts(summary: ToolCallSummary): string {
     .join(" ");
 }
 
+function formatRunLabel(
+  report: Pick<AgentEvalReport, "agent" | "model" | "server">,
+): string {
+  return `${report.agent ?? "unknown"}${report.model ? `:${report.model}` : ""}/${report.server ?? "unknown"}`;
+}
+
 export function compareReports(
   before: AgentEvalReport,
   after: AgentEvalReport,
@@ -525,7 +531,7 @@ export function compareReports(
         "cross-agent comparison: status/event counts are not comparable; showing tool-name presence only",
       ];
   const lines = [
-    `Agent eval compare: before=${before.runDir} after=${after.runDir}`,
+    `Agent eval compare: before=${before.runDir} (${formatRunLabel(before)}) after=${after.runDir} (${formatRunLabel(after)})`,
     ...warnings.map((warning) => `Warning: ${warning}`),
   ];
   for (const id of ids) {

--- a/scripts/agent-eval.test.ts
+++ b/scripts/agent-eval.test.ts
@@ -546,6 +546,8 @@ describe("agent eval harness", () => {
   it("compares same-agent reports with aggregate status counts", () => {
     const before = buildRunReportFromMetadata("/before", {
       agent: "codex",
+      model: "gpt-5.4-mini",
+      server: "local",
       workloads: [{ id: "pkg-vulns", status: "success" }],
     });
     const afterRunDir = createRunFixture();
@@ -555,6 +557,9 @@ describe("agent eval harness", () => {
     );
     const formatted = formatCompareReport(compareReports(before, after));
 
+    expect(formatted).toContain("before=/before (codex:gpt-5.4-mini/local)");
+    expect(formatted).toContain("after=");
+    expect(formatted).toContain("(codex/local)");
     expect(formatted).toContain("pkg-vulns status unchanged success");
     expect(formatted).toContain("raw events 0 -> 2");
     expect(formatted).toContain("+pkg_vulns");

--- a/scripts/agent-eval.test.ts
+++ b/scripts/agent-eval.test.ts
@@ -10,6 +10,8 @@ import {
 import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
 import {
+  buildClaudeCommand,
+  buildCodexCommand,
   buildCodexConfig,
   buildCodexConfigArgs,
   buildEvalEnv,
@@ -129,6 +131,26 @@ describe("agent eval harness", () => {
     ]);
   });
 
+  it("passes selected models to agent commands", () => {
+    expect(buildClaudeCommand("prompt", "/tmp/mcp.json", "haiku")).toContain(
+      "haiku",
+    );
+    expect(
+      buildCodexCommand(
+        "prompt",
+        "/tmp/work",
+        "/tmp/final.txt",
+        "/tmp/schema.json",
+        {
+          server: "local",
+          repoRoot: "/repo/githits-cli",
+          publishedPackage: "githits@latest",
+          model: "gpt-5.1-codex-mini",
+        },
+      ),
+    ).toContain("gpt-5.1-codex-mini");
+  });
+
   it("preserves normal Claude and GitHits auth environment while filtering unrelated vars", () => {
     const env = buildEvalEnv({
       PATH: "/bin",
@@ -170,6 +192,8 @@ describe("agent eval harness", () => {
         "codex",
         "--server",
         "published",
+        "--model",
+        "gpt-5.1-codex-mini",
         "--published-package",
         "githits@0.4.2",
         "--workload",
@@ -182,6 +206,7 @@ describe("agent eval harness", () => {
     );
 
     expect(options.agent).toBe("codex");
+    expect(options.model).toBe("gpt-5.1-codex-mini");
     expect(options.server).toBe("published");
     expect(options.publishedPackage).toBe("githits@0.4.2");
     expect(options.timeoutSeconds).toBe(12);

--- a/scripts/agent-eval.test.ts
+++ b/scripts/agent-eval.test.ts
@@ -145,10 +145,10 @@ describe("agent eval harness", () => {
           server: "local",
           repoRoot: "/repo/githits-cli",
           publishedPackage: "githits@latest",
-          model: "gpt-5.1-codex-mini",
+          model: "gpt-5.4-mini",
         },
       ),
-    ).toContain("gpt-5.1-codex-mini");
+    ).toContain("gpt-5.4-mini");
   });
 
   it("preserves normal Claude and GitHits auth environment while filtering unrelated vars", () => {
@@ -193,7 +193,7 @@ describe("agent eval harness", () => {
         "--server",
         "published",
         "--model",
-        "gpt-5.1-codex-mini",
+        "gpt-5.4-mini",
         "--published-package",
         "githits@0.4.2",
         "--workload",
@@ -206,7 +206,7 @@ describe("agent eval harness", () => {
     );
 
     expect(options.agent).toBe("codex");
-    expect(options.model).toBe("gpt-5.1-codex-mini");
+    expect(options.model).toBe("gpt-5.4-mini");
     expect(options.server).toBe("published");
     expect(options.publishedPackage).toBe("githits@0.4.2");
     expect(options.timeoutSeconds).toBe(12);

--- a/scripts/agent-eval.ts
+++ b/scripts/agent-eval.ts
@@ -22,6 +22,7 @@ type RunStatus = "dry-run" | "success" | "failed" | "timeout";
 
 export interface AgentEvalOptions {
   agent: AgentName;
+  model?: string;
   server: ServerMode;
   workloads: string[];
   outDir: string;
@@ -175,6 +176,12 @@ export function parseArgs(
         options.server = value;
         break;
       }
+      case "--model": {
+        const value = argv[++i];
+        assert(value, "--model requires a model name");
+        options.model = value;
+        break;
+      }
       case "--workload": {
         const value = argv[++i];
         assert(value, "--workload requires a path");
@@ -238,6 +245,7 @@ function printHelp(): void {
 
 Options:
   --agent claude|codex            Agent to run (default: claude)
+  --model <name>                  Agent model name or alias, e.g. sonnet, haiku, gpt-5.1-codex-mini
   --server local|published        MCP server mode (default: local)
   --workload <path>               Workload markdown path, repeatable
   --out <dir>                     Output directory
@@ -677,8 +685,12 @@ async function runWithTimeout(
   return { stdout, stderr, exitCode, timedOut };
 }
 
-function buildClaudeCommand(prompt: string, mcpConfigPath: string): string[] {
-  return [
+export function buildClaudeCommand(
+  prompt: string,
+  mcpConfigPath: string,
+  model?: string,
+): string[] {
+  const command = [
     "claude",
     "-p",
     prompt,
@@ -693,16 +705,21 @@ function buildClaudeCommand(prompt: string, mcpConfigPath: string): string[] {
     "bypassPermissions",
     "--no-session-persistence",
   ];
+  if (model) command.push("--model", model);
+  return command;
 }
 
-function buildCodexCommand(
+export function buildCodexCommand(
   prompt: string,
   workspaceDir: string,
   finalMessagePath: string,
   schemaPath: string,
-  options: Pick<AgentEvalOptions, "server" | "repoRoot" | "publishedPackage">,
+  options: Pick<
+    AgentEvalOptions,
+    "server" | "repoRoot" | "publishedPackage" | "model"
+  >,
 ): string[] {
-  return [
+  const command = [
     "codex",
     "exec",
     ...buildCodexConfigArgs(options),
@@ -718,8 +735,10 @@ function buildCodexCommand(
     "--sandbox",
     "read-only",
     "--ignore-rules",
-    prompt,
   ];
+  if (options.model) command.push("-m", options.model);
+  command.push(prompt);
+  return command;
 }
 
 async function runWorkload(
@@ -754,7 +773,7 @@ async function runWorkload(
 
   const command =
     options.agent === "claude"
-      ? buildClaudeCommand(prompt, mcpConfigPath)
+      ? buildClaudeCommand(prompt, mcpConfigPath, options.model)
       : buildCodexCommand(
           prompt,
           workspaceDir,
@@ -888,6 +907,7 @@ export async function runAgentEval(options: AgentEvalOptions): Promise<void> {
 
   const runMetadata = {
     agent: options.agent,
+    model: options.model,
     server: options.server,
     publishedPackage: options.publishedPackage,
     dryRun: options.dryRun,

--- a/scripts/agent-eval.ts
+++ b/scripts/agent-eval.ts
@@ -245,7 +245,7 @@ function printHelp(): void {
 
 Options:
   --agent claude|codex            Agent to run (default: claude)
-  --model <name>                  Agent model name or alias, e.g. sonnet, haiku, gpt-5.1-codex-mini
+  --model <name>                  Agent model name or alias, e.g. sonnet, haiku, gpt-5.4-mini
   --server local|published        MCP server mode (default: local)
   --workload <path>               Workload markdown path, repeatable
   --out <dir>                     Output directory


### PR DESCRIPTION
## Summary
- Add `--model <name>` to agent eval runs and pass it through to Claude/Codex CLIs.
- Persist the selected model in run/report metadata and show it in summaries.
- Document smaller-model examples for Claude Haiku/Sonnet and Codex mini/nano-style model IDs.

## Validation
- bun test scripts/agent-eval.test.ts
- bun run typecheck
- bun run format:check
- bun run agent:e2e --dry-run --agent claude --model haiku --out .agent-eval/runs/model-dry-run-haiku --workload eval/agentic/workloads/package-overview-vulnerabilities.md
- bun run agent:e2e:report .agent-eval/runs/model-dry-run-haiku