### PR TITLE
fix: clarify docs search output

### DIFF
--- a/eval/agentic/README.md
+++ b/eval/agentic/README.md
@@ -134,7 +134,7 @@ least one agent for quick iteration.
 | Package overview or vulnerability UX, `pkg_info`, `pkg_vulns` | `package-overview-vulnerabilities.md`; use `package-vulnerability-filter.md` for severity/version filtering behavior; use `package-vulnerability-history.md` for historical/non-affecting advisory scope behavior |
 | Dependency graph UX, `pkg_deps` | `package-dependencies.md` |
 | Release notes UX, `pkg_changelog` | `package-changelog.md`; use `package-changelog-range.md` for range/body-preview behavior |
-| Documentation browsing, `docs_list`, `docs_read` | `docs-discovery.md` |
+| Documentation browsing, `docs_list`, `docs_read` | `docs-discovery.md`; use `docs-search-followup.md` for search-to-read handoff and `docs-search-noise.md` for noisy docs-result recovery |
 | File listing / file read UX, `code_files`, `code_read` | `code-file-navigation.md` |
 | Deterministic source search UX, `code_grep` | `code-grep-investigation.md` |
 | Multi-tool code navigation strategy and MCP instructions | `express-router.md` |

--- a/eval/agentic/workloads/docs-discovery.md
+++ b/eval/agentic/workloads/docs-discovery.md
@@ -2,4 +2,6 @@
 
 You need to learn how Express documents routing behavior. Find relevant package
 documentation for `npm:express`, read enough to summarize how routes are defined,
-and include source references for the documentation you relied on.
+and include source references for the documentation you relied on inside the
+`answer` field. Do not add extra top-level JSON fields beyond the reporting
+schema.

--- a/eval/agentic/workloads/docs-search-followup.md
+++ b/eval/agentic/workloads/docs-search-followup.md
@@ -1,0 +1,6 @@
+# Workload: Docs Search Follow-Up
+
+Find authoritative package documentation for `npm:express` about how route
+handlers are defined. Summarize the route-handler pattern and include the source
+URL or page ID inside the `answer` field. Do not add extra top-level JSON fields
+beyond the reporting schema.

--- a/eval/agentic/workloads/docs-search-noise.md
+++ b/eval/agentic/workloads/docs-search-noise.md
@@ -1,0 +1,6 @@
+# Workload: Docs Search Noise
+
+Find authoritative package documentation for `pypi:flask` about how routing or
+route matching works. Summarize what Flask says about routing and include the
+source URL or page ID inside the `answer` field. Do not add extra top-level JSON
+fields beyond the reporting schema.

--- a/src/commands/docs/list.test.ts
+++ b/src/commands/docs/list.test.ts
@@ -37,6 +37,7 @@ describe("docsListAction", () => {
     expect(output).toContain("123-getting-started");
     expect(output).toContain("[crawled]");
     expect(output).toContain("[repo]");
+    expect(output).toContain("Read a page: githits docs read '<pageId>'");
     writeSpy.mockRestore();
   });
 

--- a/src/commands/mcp-instructions.ts
+++ b/src/commands/mcp-instructions.ts
@@ -45,10 +45,10 @@ const CODE_FILES_BULLET =
   '- `code_files` — list files in an indexed dependency. `path`, `path_prefix`, and `globs` are OR-ed selectors; extensions, language, file type, and file-intent filters intersect on top. Returned paths feed into `code_read` and help scope `code_grep`; pass `format: "json"` for language/type/size metadata.';
 
 const DOCS_LIST_BULLET =
-  "- `docs_list` — browse hosted and repository-backed package docs. Entries include stable pageIds, source URLs, and repo-file follow-up metadata when available.";
+  '- `docs_list` — browse hosted and repository-backed package docs when you need the available pages. It is not topic search; for "find docs about X", call `search` with `sources:["docs"]`, then pass the returned `pageId` to `docs_read`. Entries include stable pageIds, source URLs, and repo-file follow-up metadata when available.';
 
 const DOCS_READ_BULLET =
-  "- `docs_read` — read a documentation page by pageId. Works for both hosted docs and repo-backed docs.";
+  "- `docs_read` — read a documentation page by pageId. Works for both hosted docs and repo-backed docs. Prefer focused `start_line` / `end_line` windows from `search` hits or prior `docs_read` `totalLines` metadata instead of rereading large pages.";
 
 const PKG_INFO_BULLET =
   '- `pkg_info` — latest-version package triage by `registry` + `package_name` (e.g. `npm` + `express`): license, repository popularity, downloads, publish age, and vulnerability status. Set `verbose: true` for GitHub language/topics/last-pushed, recent advisories, and recent changes; pass `format: "json"` for structured fields.';

--- a/src/commands/search.test.ts
+++ b/src/commands/search.test.ts
@@ -621,11 +621,57 @@ describe("searchAction", () => {
 
     const output = String(consoleSpy.mock.calls[0]?.[0]);
     expect(output).toContain(
-      "npm:express@4.18.2 [docs page] - Using Express middleware",
+      "docs-123 [docs page] npm:express - Using Express middleware - hexdocs.pm/express/getting-started.html",
     );
-    expect(output).toContain("pageId:");
     expect(output).toContain("docs-123");
-    expect(output).toContain("[crawled]");
+    expect(output).not.toContain("source:");
+    expect(output).not.toContain("npm:express@4.18.2 [docs page]");
+    expect(output).not.toContain("read:");
+    consoleSpy.mockRestore();
+  });
+
+  it("falls back to target attribution for docs pages without package locator fields", async () => {
+    const consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+
+    if (defaultUnifiedSearchOutcome.state !== "completed") {
+      throw new Error("expected completed outcome fixture");
+    }
+
+    const docsOutcome: UnifiedSearchOutcome = {
+      ...defaultUnifiedSearchOutcome,
+      result: {
+        ...defaultUnifiedSearchOutcome.result,
+        results: [
+          {
+            ...defaultUnifiedSearchOutcome.result.results[0]!,
+            resultType: "DOCUMENTATION_PAGE",
+            targetLabel: "docs.example@stable",
+            title: "Routing",
+            highlights: undefined,
+            locator: {
+              pageId: "docs-routing",
+              sourceKind: "CRAWLED",
+              sourceUrl: "https://docs.example/routing",
+            },
+          },
+        ],
+      },
+    };
+
+    await searchAction(
+      "router middleware",
+      { in: ["npm:express"] },
+      createDeps({
+        codeNavigationService: createMockCodeNavigationService({
+          search: mock(() => Promise.resolve(docsOutcome)),
+        }),
+      }),
+    );
+
+    const output = String(consoleSpy.mock.calls[0]?.[0]);
+    expect(output).toContain(
+      "docs-routing [docs page] docs.example - Routing - docs.example/routing",
+    );
     consoleSpy.mockRestore();
   });
 });

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -448,15 +448,15 @@ function formatUnifiedSearchTerminal(payload: {
     payload.results,
   );
 
-  const baseCount = `${display.length} result(s)`;
+  const baseCount = `${display.length} result${display.length === 1 ? "" : "s"}`;
   const countSuffix = [
     payload.hasMore ? " (more available)" : "",
     duplicatesFolded > 0 ? ` (+${duplicatesFolded} near-duplicate folded)` : "",
   ].join("");
+  const typeSummary = formatUnifiedSearchTypeSummary(display);
   lines.push(
-    `${highlight(baseCount, useColors)}${dim(countSuffix, useColors)}`,
+    `${highlight(baseCount, useColors)}${dim(countSuffix, useColors)}${typeSummary ? dim(` | ${typeSummary}`, useColors) : ""}`,
   );
-  lines.push(dim(formatUnifiedSearchTypeSummary(display), useColors));
   lines.push("");
 
   for (const entry of display) {
@@ -701,7 +701,7 @@ function formatUnifiedSearchTypeSummary(
 
   return Array.from(counts.entries())
     .map(([type, count]) => formatUnifiedSearchCountLabel(type, count))
-    .join(" · ");
+    .join(", ");
 }
 
 function formatUnifiedSearchResultLabel(type: string): string {
@@ -787,9 +787,12 @@ function formatUnifiedSearchHeader(
       startLine?: number;
       endLine?: number;
       pageId?: string;
+      registry?: string;
+      packageName?: string;
       sourceKind?: string;
       sourceUrl?: string;
       requestedRef?: string;
+      version?: string;
     };
     title?: string;
   },
@@ -797,6 +800,10 @@ function formatUnifiedSearchHeader(
   location: string | undefined,
   rawQuery: string | undefined,
 ): string {
+  if (entry.type === "documentation_page") {
+    return formatDocumentationPageHeader(entry, useColors);
+  }
+
   const primary = formatUnifiedSearchPrimary(
     entry.type,
     entry.target,
@@ -809,6 +816,54 @@ function formatUnifiedSearchHeader(
     ? highlightRanges(entry.title, entry.highlights?.title, useColors)
     : undefined;
   return `${primary} ${dim(badge, useColors)}${title ? ` - ${title}` : ""}`;
+}
+
+function formatDocumentationPageHeader(
+  entry: {
+    target: string;
+    highlights?: { title?: Array<readonly [number, number]> };
+    locator: {
+      pageId?: string;
+      registry?: string;
+      packageName?: string;
+      sourceUrl?: string;
+    };
+    title?: string;
+  },
+  useColors: boolean,
+): string {
+  const pageId = entry.locator.pageId ?? "unknown";
+  const title = entry.title
+    ? highlightRanges(entry.title, entry.highlights?.title, useColors)
+    : "Untitled documentation page";
+  const source = entry.locator.sourceUrl
+    ? ` - ${formatDisplayUrl(entry.locator.sourceUrl)}`
+    : "";
+  const target = formatDocsPageTarget(entry.locator, entry.target);
+  return `${highlight(pageId, useColors)} ${dim("[docs page]", useColors)}${target ? ` ${dim(target, useColors)}` : ""} - ${title}${dim(source, useColors)}`;
+}
+
+function formatDisplayUrl(value: string): string {
+  return value.replace(/^https?:\/\//, "");
+}
+
+function formatDocsPageTarget(
+  locator: {
+    registry?: string;
+    packageName?: string;
+    version?: string;
+  },
+  fallbackTarget?: string,
+): string {
+  return locator.registry && locator.packageName
+    ? `${locator.registry}:${locator.packageName}`
+    : stripVersionFromTarget(fallbackTarget);
+}
+
+function stripVersionFromTarget(value: string | undefined): string {
+  if (!value) return "";
+  const atIndex = value.lastIndexOf("@");
+  return atIndex > 0 ? value.slice(0, atIndex) : value;
 }
 
 function formatUnifiedSearchPrimary(
@@ -963,9 +1018,6 @@ function formatUnifiedSearchMetadata(
       pageId?: string;
       sourceKind?: string;
       sourceUrl?: string;
-      filePath?: string;
-      gitRef?: string;
-      requestedRef?: string;
     };
   },
   useColors: boolean,
@@ -975,22 +1027,8 @@ function formatUnifiedSearchMetadata(
   }
 
   const lines: string[] = [];
-  if (entry.locator.pageId) {
-    if (entry.type === "documentation_page") {
-      lines.push(`  ${dim("pageId:", useColors)} ${entry.locator.pageId}`);
-    }
-  }
-
-  const sourceBadge =
-    entry.locator.sourceKind?.toLowerCase() === "repository"
-      ? "[repo]"
-      : entry.locator.sourceKind?.toLowerCase() === "crawled"
-        ? "[crawled]"
-        : undefined;
-  if (entry.locator.sourceUrl && entry.type === "documentation_page") {
-    lines.push(
-      `  ${dim("source:", useColors)} ${sourceBadge ? `${sourceBadge} ` : ""}${entry.locator.sourceUrl}`,
-    );
+  if (entry.type === "documentation_page") {
+    return lines;
   }
 
   return lines;

--- a/src/shared/grep-repo-response.ts
+++ b/src/shared/grep-repo-response.ts
@@ -1,5 +1,6 @@
 import type { GrepRepoMatch, GrepRepoResult } from "../services/index.js";
 import { colorize, dim, highlightRanges } from "./colors.js";
+import { shellQuote } from "./shell-quote.js";
 
 export interface LeanGrepRepoMatch {
   filePath: string;
@@ -613,10 +614,6 @@ function formatCount(
   plural = `${singular}s`,
 ): string {
   return `${count} ${count === 1 ? singular : plural}`;
-}
-
-function shellQuote(value: string): string {
-  return `'${value.replaceAll("'", `'"'"'`)}'`;
 }
 
 function padLeft(text: string, width: number): string {

--- a/src/shared/list-package-docs-response.ts
+++ b/src/shared/list-package-docs-response.ts
@@ -129,6 +129,11 @@ export function formatListPackageDocsTerminal(
     lines.push("");
   }
 
+  lines.push(
+    dim("Read a page: githits docs read '<pageId>'", options.useColors),
+  );
+  lines.push("");
+
   if (envelope.nextCursor) {
     lines.push(dim(`Next cursor: ${envelope.nextCursor}`, options.useColors));
   }
@@ -148,7 +153,7 @@ function buildSummaryHeader(
     envelope.registry && envelope.name
       ? `${envelope.registry}:${envelope.name}${envelope.version ? `@${envelope.version}` : ""}`
       : "package docs";
-  const summary = `${target} · ${envelope.pages.length} page${envelope.pages.length === 1 ? "" : "s"}`;
+  const summary = `${target} | ${envelope.pages.length} page${envelope.pages.length === 1 ? "" : "s"}`;
   const suffix = envelope.total !== undefined ? ` of ${envelope.total}` : "";
   return `${colorize(summary, "bold", useColors)}${dim(suffix, useColors)}`;
 }

--- a/src/shared/shell-quote.ts
+++ b/src/shared/shell-quote.ts
@@ -1,0 +1,3 @@
+export function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'"'"'`)}'`;
+}

--- a/src/shared/unified-search-text.test.ts
+++ b/src/shared/unified-search-text.test.ts
@@ -100,7 +100,7 @@ describe("renderUnifiedSearchSuccess", () => {
 
   it("uses pageId for documentation hits", () => {
     const text = renderUnifiedSearchSuccess(completed([docsHit()]));
-    expect(text).toContain("[1] aider-AI/aider@v0.55.0  docs");
+    expect(text).toContain("[1] aider/edit-formats aider-AI/aider  docs");
     expect(text).toContain('    docs_read page_id="aider/edit-formats"');
     expect(text).toContain("    Edit Formats");
   });
@@ -248,7 +248,7 @@ describe("renderUnifiedSearchSuccess", () => {
     const hitHeaders = text.split("\n").filter((line) => /^\[\d\]/.test(line));
     expect(hitHeaders).toHaveLength(3);
     expect(text).toContain("[1] cline/cline@v3.4.2");
-    expect(text).toContain("[2] aider-AI/aider@v0.55.0");
+    expect(text).toContain("[2] aider/edit-formats aider-AI/aider");
     expect(text).toContain("[3] continuedev/continue@v0.9.42");
   });
 });

--- a/src/shared/unified-search-text.ts
+++ b/src/shared/unified-search-text.ts
@@ -102,7 +102,7 @@ function appendHit(
   index: number,
   hit: UnifiedSearchHitPayload,
 ): void {
-  const headerParts: string[] = [hit.target, shortType(hit.type)];
+  const headerParts: string[] = [formatHitPrimary(hit), shortType(hit.type)];
   lines.push(`[${index}] ${headerParts.join("  ")}`);
 
   const locator = buildLocatorLine(hit);
@@ -120,6 +120,36 @@ function appendHit(
       lines.push(`    ${wrapped}`);
     }
   }
+}
+
+function formatHitPrimary(hit: UnifiedSearchHitPayload): string {
+  const loc = hit.locator;
+  if (hit.type === "documentation_page" && loc.pageId) {
+    const target = formatDocsPageTarget(loc, hit.target);
+    return target ? `${loc.pageId} ${target}` : loc.pageId;
+  }
+  if (hit.type === "repository_doc" && loc.filePath) {
+    return `${hit.target} ${loc.filePath}${formatLineRange(loc.startLine, loc.endLine)}`;
+  }
+  return hit.target;
+}
+
+function formatDocsPageTarget(
+  locator: {
+    registry?: string;
+    packageName?: string;
+  },
+  fallbackTarget?: string,
+): string {
+  return locator.registry && locator.packageName
+    ? `${locator.registry}:${locator.packageName}`
+    : stripVersionFromTarget(fallbackTarget);
+}
+
+function stripVersionFromTarget(value: string | undefined): string {
+  if (!value) return "";
+  const atIndex = value.lastIndexOf("@");
+  return atIndex > 0 ? value.slice(0, atIndex) : value;
 }
 
 /**

--- a/src/tools/list-package-docs.ts
+++ b/src/tools/list-package-docs.ts
@@ -42,6 +42,7 @@ const schema = {
 
 const DESCRIPTION =
   "List mixed package documentation pages from hosted docs and repository-backed docs. " +
+  'This browses available pages; for topic search, use `search` with `sources: ["docs"]` and pass the returned `pageId` to `docs_read`. ' +
   "Every entry includes a stable `pageId`, `sourceKind` (`crawled` or `repo`), and source URL; repo-backed entries also expose `repoUrl` / `gitRef` / `filePath` for exact file reads. " +
   "Pass a returned `pageId` to `docs_read`. Use this to browse before reading a full page.";
 


### PR DESCRIPTION
## Summary
- Make CLI search docs hits use source-appropriate locators: repo docs keep package/file/range, crawled docs start with page ID plus package context and source URL.
- Align MCP search text-v1 locator semantics while preserving exact follow-up lines for agents.
- Clarify docs tool guidance and add docs-search eval workloads for follow-up and noisy-result cases.

## Verification
- `bun run typecheck`
- `bun test src/commands/docs/list.test.ts src/commands/search.test.ts src/tools/list-package-docs.test.ts src/tools/read-package-doc.test.ts src/tools/list-package-docs-parity.test.ts src/commands/mcp-instructions.test.ts src/shared/unified-search-text.test.ts`
- `bun run build`
- `bun run smoke:cli`
- `bun run smoke:mcp`
- `bun run agent:e2e --agent claude --model haiku --server local --workload eval/agentic/workloads/docs-discovery.md --timeout 300 --out .agent-eval/runs/docs-discovery-haiku-final-pr`
- `bun run agent:e2e --agent claude --model haiku --server local --workload eval/agentic/workloads/docs-search-followup.md --timeout 300 --out .agent-eval/runs/docs-search-followup-haiku-final-pr`
- `bun run agent:e2e --agent claude --model haiku --server local --workload eval/agentic/workloads/docs-search-noise.md --timeout 300 --out .agent-eval/runs/docs-search-noise-haiku-final-pr`