### PR TITLE
fix: sharpen code grep output

### DIFF
--- a/docs/implementation/tools.md
+++ b/docs/implementation/tools.md
@@ -218,7 +218,7 @@ More files available. Pass limit=N or refine the filter.
 **Grep anatomy** (`code_grep` text-v1):
 
 ```
-code_grep | <N> matches in <M> files | pattern="..." [regex,case-sensitive] [filter echo]
+code_grep | <N> matches in <M> files | pattern="..." [regex,case-sensitive]
 [blank]
 <filePath> (<count>)
   142: matching line content
@@ -234,7 +234,7 @@ code_grep | <N> matches in <M> files | pattern="..." [regex,case-sensitive] [fil
 [More matches available. Pass cursor=<token> for the next page.]
 ```
 
-Standard grep -A/-B notation: `:` separator on match lines, `-` on context lines. Non-adjacent blocks within the same file are separated by `--`. The `(<count>)` after the file path is the per-file match count; the header sums across files. Header flags (`regex`, `case-sensitive`) appear only when the request used them. Filter echoes (`path_prefix=`, `exts=`, `max_matches=`, etc.) appear only when the caller supplied them. Match-line offsets, file content hashes, file intent, and symbol metadata are dropped in text mode — agents that need them can request `format: "json"`.
+Standard grep -A/-B notation: `:` separator on match lines, `-` on context lines. Non-adjacent blocks within the same file are separated by `--`. The `(<count>)` after the file path is the per-file match count; the header sums across files. Header flags (`regex`, `case-sensitive`) appear only when the request used them. Scope filters are not echoed in text mode; agents already have the tool call arguments in context, and `format: "json"` preserves exact request/filter metadata for programmatic use. Match-line offsets, file content hashes, file intent, and symbol metadata are dropped in text mode — agents that need them can request `format: "json"`.
 
 **Errors in text mode.** `search` errors render as text in `text-v1` mode: `search | ERROR | code=<CODE> [| retryable]\n<message>` followed by an indented `details:` block when present. `code_files` and `code_grep` keep errors JSON-formatted in either mode for now — revisit if agent feedback warrants.
 

--- a/eval/agentic/workloads/REPORTING.md
+++ b/eval/agentic/workloads/REPORTING.md
@@ -2,7 +2,7 @@ Return only valid JSON matching the provided schema. Do not include markdown,
 prose, code fences, or any text outside the JSON object. Include:
 
 - `status`: `success`, `failure`, or `inconclusive`.
-- `answer`: your final answer with evidence.
+- `answer`: your final answer with evidence as a string.
 - `toolIssues`: string descriptions of GitHits tool calls that failed or
   returned unclear output, if any.
 - `expectedToolUse`: string list of GitHits tools you expected to use for this

--- a/src/commands/mcp-instructions.ts
+++ b/src/commands/mcp-instructions.ts
@@ -36,7 +36,7 @@ const SEARCH_STATUS_BULLET =
   "- `search_status` — follow up a prior `search` by `searchRef` to check progress, fetch partial hits, or fetch final results.";
 
 const CODE_GREP_BULLET =
-  "- `code_grep` — deterministic text or regex grep over indexed source. Use it when you know the pattern; use `search` for discovery. Narrow with `path`, `path_prefix`, `globs`, or `extensions`. Each match's `path:line` chains into `code_read`.";
+  "- `code_grep` — deterministic text or regex grep over indexed source. Use it when you know the pattern; use `search` for discovery. Narrow with `path`, `path_prefix`, `globs`, or `extensions`. Each match's `filePath`/file heading plus line number chains into `code_read`.";
 
 const CODE_READ_BULLET =
   "- `code_read` — read a dependency file by `path`. **MCP cap: 150 lines per call**. When you already have an exact path (e.g. from a stack trace), call this directly; otherwise locate it first with `search` or `code_grep` and pick a focused `start_line` / `end_line` window. Binary files set `isBinary: true` and omit `content`. On `FILE_NOT_FOUND` / `NOT_FOUND`, call `code_files` for the actual path.";

--- a/src/shared/grep-repo-response.test.ts
+++ b/src/shared/grep-repo-response.test.ts
@@ -126,6 +126,29 @@ describe("formatGrepRepoTerminal", () => {
     );
   });
 
+  it("maps UTF-8 byte offsets to string indexes for highlighting", () => {
+    const envelope = buildGrepRepoSuccessPayload(
+      {
+        ...baseResult,
+        matches: [
+          {
+            ...baseResult.matches[0]!,
+            lineContent: "const café = express();",
+            matchStartByte: 14,
+            matchEndByte: 21,
+          },
+        ],
+      },
+      baseOptions,
+    );
+    const { stdout } = formatGrepRepoTerminal(envelope, {
+      useColors: true,
+    });
+    expect(stdout).toContain(
+      `const café = ${"\u001b[1m\u001b[33m"}express${"\u001b[0m"}();`,
+    );
+  });
+
   it("heading mode emits a file heading with compact line rows", () => {
     const envelope = buildGrepRepoSuccessPayload(baseResult, baseOptions);
     const { stdout } = formatGrepRepoTerminal(envelope, {
@@ -145,6 +168,38 @@ describe("formatGrepRepoTerminal", () => {
     expect(stdout).toContain("1 match in 1 file");
     expect(stdout).toContain("src/index.js\n");
     expect(stdout).toContain("> 10  const app = express();");
+  });
+
+  it("verbose mode renders minimal symbol hints", () => {
+    const envelope = buildGrepRepoSuccessPayload(
+      {
+        ...baseResult,
+        matches: [
+          {
+            ...baseResult.matches[0]!,
+            symbol: {
+              ...baseResult.matches[0]!.symbol,
+              category: "callable",
+              isPublic: true,
+              startLine: 1,
+              endLine: 20,
+              parentPath: "express",
+            },
+          },
+        ],
+      },
+      baseOptions,
+    );
+
+    const { stdout } = formatGrepRepoTerminal(envelope, {
+      useColors: false,
+      verbose: true,
+    });
+    expect(stdout).toContain(
+      "in: express.createRouter (function) public L1-20",
+    );
+    expect(stdout).not.toContain("category=callable");
+    expect(stdout).not.toContain("parent=express");
   });
 
   it("renders context in chronological order", () => {

--- a/src/shared/grep-repo-response.ts
+++ b/src/shared/grep-repo-response.ts
@@ -2,6 +2,8 @@ import type { GrepRepoMatch, GrepRepoResult } from "../services/index.js";
 import { colorize, dim, highlightRanges } from "./colors.js";
 import { shellQuote } from "./shell-quote.js";
 
+const UTF8_ENCODER = new TextEncoder();
+
 export interface LeanGrepRepoMatch {
   filePath: string;
   line: number;
@@ -525,7 +527,7 @@ function renderVerboseLine(
     const matchRow = `${colorize(">", "bold", useColors)} ${gutter}  ${highlightRanges(line.content, line.highlightRanges, useColors)}`;
     if (line.symbolHint) {
       const hintIndent = " ".repeat(2 + gutterWidth + 2);
-      return `${matchRow}\n${hintIndent}${dim(`↳ in: ${line.symbolHint}`, useColors)}`;
+      return `${matchRow}\n${hintIndent}${dim(`in: ${line.symbolHint}`, useColors)}`;
     }
     return matchRow;
   }
@@ -543,8 +545,9 @@ function formatSymbolHint(
   if (symbol.kind) parts.push(`(${symbol.kind})`);
   if (symbol.isPublic === true) parts.push("public");
   if (symbol.arity !== undefined) parts.push(`arity=${symbol.arity}`);
-  if (symbol.callerCount !== undefined)
+  if (symbol.callerCount !== undefined) {
     parts.push(`callers=${symbol.callerCount}`);
+  }
   if (symbol.startLine !== undefined && symbol.endLine !== undefined) {
     parts.push(`L${symbol.startLine}-${symbol.endLine}`);
   }
@@ -647,5 +650,18 @@ function mergeRanges(
 }
 
 function clampCharacterOffset(text: string, offset: number): number {
-  return Math.max(0, Math.min(text.length, offset));
+  if (offset <= 0) return 0;
+
+  let byteOffset = 0;
+  for (let index = 0; index < text.length; ) {
+    const codePoint = text.codePointAt(index);
+    if (codePoint === undefined) break;
+    const char = String.fromCodePoint(codePoint);
+    const nextByteOffset = byteOffset + UTF8_ENCODER.encode(char).length;
+    if (nextByteOffset > offset) return index;
+    byteOffset = nextByteOffset;
+    index += char.length;
+  }
+
+  return text.length;
 }

--- a/src/shared/grep-repo-text.test.ts
+++ b/src/shared/grep-repo-text.test.ts
@@ -168,7 +168,7 @@ describe("renderGrepRepoText", () => {
     expect(text).toContain("regex,case-sensitive");
   });
 
-  it("echoes filter inputs in header when set", () => {
+  it("keeps filter inputs out of the header", () => {
     const text = renderGrepRepoText(
       envelope({
         totalMatches: 1,
@@ -181,9 +181,33 @@ describe("renderGrepRepoText", () => {
         },
       }),
     );
-    expect(text).toContain('path_prefix="src/integrations"');
-    expect(text).toContain("exts=ts,tsx");
-    expect(text).toContain("max_matches=30");
+    const header = text.split("\n")[0] ?? "";
+    expect(header).toBe('code_grep | 1 match in 1 file | pattern="applyEdit"');
+  });
+
+  it("keeps symbol metadata out of text output", () => {
+    const text = renderGrepRepoText(
+      envelope({
+        totalMatches: 1,
+        uniqueFilesMatched: 1,
+        matches: [
+          match({
+            symbol: {
+              name: "applyEdit",
+              qualifiedPath: "diff.applyEdit",
+              kind: "function",
+              startLine: 140,
+              endLine: 160,
+            },
+          }),
+        ],
+      }),
+    );
+    expect(text).toContain(
+      "  142: export function applyEdit(input: string): string {",
+    );
+    expect(text).not.toContain("Symbols:");
+    expect(text).not.toContain("diff.applyEdit");
   });
 
   it("uses ASCII separators only", () => {

--- a/src/shared/grep-repo-text.ts
+++ b/src/shared/grep-repo-text.ts
@@ -88,29 +88,7 @@ function buildHeader(envelope: LeanGrepRepoEnvelope): string {
   if (envelope.caseSensitive) flags.push("case-sensitive");
   if (flags.length > 0) parts.push(flags.join(","));
 
-  const filterEcho = buildFilterEcho(envelope);
-  if (filterEcho) parts.push(filterEcho);
-
   return parts.join(SEP);
-}
-
-function buildFilterEcho(envelope: LeanGrepRepoEnvelope): string {
-  const filter = envelope.filter;
-  if (!filter) return "";
-  const parts: string[] = [];
-  if (filter.path) parts.push(`path=${quote(filter.path)}`);
-  if (filter.pathPrefix) parts.push(`path_prefix=${quote(filter.pathPrefix)}`);
-  if (filter.globs?.length) parts.push(`globs=${filter.globs.join(",")}`);
-  if (filter.extensions?.length) {
-    parts.push(`exts=${filter.extensions.join(",")}`);
-  }
-  if (typeof filter.maxMatches === "number") {
-    parts.push(`max_matches=${filter.maxMatches}`);
-  }
-  if (typeof filter.maxMatchesPerFile === "number") {
-    parts.push(`max_matches_per_file=${filter.maxMatchesPerFile}`);
-  }
-  return parts.join(" ");
 }
 
 function buildTrailer(envelope: LeanGrepRepoEnvelope): string[] {

--- a/src/tools/grep-repo.test.ts
+++ b/src/tools/grep-repo.test.ts
@@ -226,6 +226,22 @@ describe("createGrepRepoTool — validation errors", () => {
       "INVALID_ARGUMENT",
     );
   });
+
+  it("returns INVALID_ARGUMENT for out-of-range numeric arguments", async () => {
+    const tool = createGrepRepoTool(createMockCodeNavigationService());
+    const result = await tool.handler(
+      {
+        target: { registry: "npm", package_name: "express" },
+        pattern: "middleware",
+        max_matches: 1001,
+      },
+      {},
+    );
+    expect(result.isError).toBe(true);
+    expect((parseText(result) as { code: string }).code).toBe(
+      "INVALID_ARGUMENT",
+    );
+  });
 });
 
 describe("createGrepRepoTool — service errors", () => {

--- a/src/tools/grep-repo.ts
+++ b/src/tools/grep-repo.ts
@@ -93,7 +93,7 @@ const DESCRIPTION =
   'Use this when you know the pattern (literal by default; pass `pattern_type: "regex"` for RE2). ' +
   "Use `search` for discovery instead. " +
   "Whole-target grep is the default — narrow with `path`, `path_prefix`, `globs`, or `extensions` to keep responses small. " +
-  "Each match's `path` chains into `code_read.path`; pick a window around `match.line` for `code_read.start_line` / `end_line`.";
+  "Each match's `filePath` (or text file heading) chains into `code_read.path`; pick a window around `match.line` for `code_read.start_line` / `end_line`.";
 
 export function createGrepRepoTool(
   service: CodeNavigationService,


### PR DESCRIPTION
## Summary
- Keep `code_grep` MCP text compact by removing filter echo and leaving symbol metadata in JSON-only output.
- Correct `code_grep` follow-up wording to use `filePath`/file headings and preserve structured invalid-argument handling.
- Fix CLI grep highlighting for UTF-8 byte offsets and document the updated text contract.

## Testing
- `bun run typecheck`
- `bun test src/shared/grep-repo-text.test.ts src/shared/grep-repo-response.test.ts src/tools/grep-repo.test.ts src/commands/code/grep.test.ts src/tools/grep-repo-parity.test.ts src/shared/grep-repo-request.test.ts src/commands/mcp-instructions.test.ts`
- `bun run build`
- `bun run smoke:cli`
- `bun run smoke:mcp`
- `bun run agent:e2e --agent claude --model haiku --server local --workload eval/agentic/workloads/code-grep-investigation.md --timeout 300 --out .agent-eval/runs/code-grep-haiku-final`

Note: one combined smoke run hit transient `pkg_info` CLI/MCP parity drift from live GitHub counters; rerunning `smoke:cli` and `smoke:mcp` separately passed.