### PR TITLE
fix: preserve code read blank lines

### DIFF
--- a/eval/agentic/README.md
+++ b/eval/agentic/README.md
@@ -135,7 +135,7 @@ least one agent for quick iteration.
 | Dependency graph UX, `pkg_deps` | `package-dependencies.md` |
 | Release notes UX, `pkg_changelog` | `package-changelog.md`; use `package-changelog-range.md` for range/body-preview behavior |
 | Documentation browsing, `docs_list`, `docs_read` | `docs-discovery.md`; use `docs-search-followup.md` for search-to-read handoff and `docs-search-noise.md` for noisy docs-result recovery |
-| File listing / file read UX, `code_files`, `code_read` | `code-file-navigation.md` |
+| File listing / file read UX, `code_files`, `code_read` | `code-file-navigation.md`; use `code-read-window.md` for focused source-window behavior |
 | Deterministic source search UX, `code_grep` | `code-grep-investigation.md` |
 | Multi-tool code navigation strategy and MCP instructions | `express-router.md` |
 
@@ -167,6 +167,10 @@ Notable findings to keep in mind when evaluating future changes:
 - Codex sometimes reports a tool as unavailable until it performs additional
   tool discovery. Use `tool-calls.json` to distinguish actual unavailable tools
   from delayed discovery.
+- `code-read-window.md` should show focused bounded reads when the prompt already
+  names a source file and line area. Claude Haiku does this directly; Codex mini
+  has been observed doing package/search preflight before the eventual bounded
+  `code_read`, so review raw calls when tuning general tool-selection guidance.
 - `tool-calls.json` is the source of truth for tool usage. The final JSON is for
   the agent's assessment of clarity, issues, and usefulness.
 - `report.json` and `agent:e2e:report` are derived review aids. They normalize

--- a/eval/agentic/workloads/code-read-window.md
+++ b/eval/agentic/workloads/code-read-window.md
@@ -1,0 +1,6 @@
+# Workload: Focused Source Window Reading
+
+You are investigating how `npm:express` initializes the internal router for an
+application instance. Inspect `lib/application.js` around lines 55-90, then
+explain the getter or initialization logic and the exact options passed to the
+router constructor.

--- a/src/shared/read-file-response.test.ts
+++ b/src/shared/read-file-response.test.ts
@@ -4,6 +4,7 @@ import {
   buildReadFileSuccessPayload,
   formatReadFileTerminal,
 } from "./read-file-response.js";
+import { renderReadFileText } from "./read-file-text.js";
 
 const baseResult: ReadFileResult = {
   filePath: "src/index.js",
@@ -139,6 +140,56 @@ describe("formatReadFileTerminal", () => {
     expect(output).toContain("src/index.js · javascript · lines 1-5 of 5");
     expect(output).toContain("1  // Express entry point");
     expect(output).toContain("2  'use strict';");
+  });
+
+  it("verbose mode: preserves a trailing blank line when it is inside the returned range", () => {
+    const envelope = buildReadFileSuccessPayload(
+      {
+        filePath: "lib/application.js",
+        language: "javascript",
+        totalLines: 632,
+        startLine: 33,
+        endLine: 35,
+        content:
+          "var slice = Array.prototype.slice;\nvar flatten = Array.prototype.flat;\n",
+        isBinary: false,
+      },
+      { ...baseOptions, requestedFilePath: "lib/application.js" },
+    );
+    const output = formatReadFileTerminal(envelope, {
+      useColors: false,
+      verbose: true,
+    });
+    expect(output).toContain("33  var slice = Array.prototype.slice;");
+    expect(output).toContain("34  var flatten = Array.prototype.flat;");
+    expect(output).toContain("35  \n");
+
+    const text = renderReadFileText(envelope);
+    expect(text.endsWith("35  ")).toBe(true);
+  });
+
+  it("verbose mode: drops only one trailing transport newline when range metadata is absent", () => {
+    const envelope = buildReadFileSuccessPayload(
+      {
+        filePath: "src/no-range.js",
+        language: "javascript",
+        content: "line 1\n\n",
+        isBinary: false,
+      },
+      { ...baseOptions, requestedFilePath: "src/no-range.js" },
+    );
+    const output = formatReadFileTerminal(envelope, {
+      useColors: false,
+      verbose: true,
+    });
+    expect(output).toContain("1  line 1");
+    expect(output).toContain("2  \n");
+    expect(output).not.toContain("3  ");
+
+    const text = renderReadFileText(envelope);
+    expect(text).toContain("1  line 1");
+    expect(text.endsWith("2  ")).toBe(true);
+    expect(text).not.toContain("3  ");
   });
 
   it("plain mode: binary sentinel only — no header", () => {

--- a/src/shared/read-file-response.ts
+++ b/src/shared/read-file-response.ts
@@ -153,13 +153,7 @@ function formatVerboseBody(
   lines.push(buildHeader(envelope, options));
   lines.push("");
 
-  const content = envelope.content ?? "";
-  const bodyLines = content.split("\n");
-  // If the backend trailing-newline-terminates, drop the trailing
-  // empty line so the gutter doesn't render a ghost line.
-  if (bodyLines.length > 0 && bodyLines[bodyLines.length - 1] === "") {
-    bodyLines.pop();
-  }
+  const bodyLines = splitReadFileContentLines(envelope);
   const startLine = envelope.startLine ?? 1;
   const endLine = startLine + bodyLines.length - 1;
   const gutterWidth = String(endLine).length;
@@ -177,6 +171,38 @@ function formatVerboseBody(
   }
   lines.push("");
   return lines.join("\n");
+}
+
+export function splitReadFileContentLines(
+  envelope: Pick<LeanReadFileEnvelope, "content" | "startLine" | "endLine">,
+): string[] {
+  if (!envelope.content) return [];
+
+  const bodyLines = envelope.content.split("\n");
+  const expectedCount = expectedLineCount(envelope);
+  if (expectedCount === undefined) {
+    if (bodyLines[bodyLines.length - 1] === "") bodyLines.pop();
+    return bodyLines;
+  }
+
+  while (
+    bodyLines.length > 0 &&
+    bodyLines[bodyLines.length - 1] === "" &&
+    bodyLines.length > expectedCount
+  ) {
+    bodyLines.pop();
+  }
+  return bodyLines;
+}
+
+function expectedLineCount(
+  envelope: Pick<LeanReadFileEnvelope, "startLine" | "endLine">,
+): number | undefined {
+  if (envelope.startLine === undefined || envelope.endLine === undefined) {
+    return undefined;
+  }
+  if (envelope.endLine < envelope.startLine) return undefined;
+  return envelope.endLine - envelope.startLine + 1;
 }
 
 function buildHeader(

--- a/src/shared/read-file-text.ts
+++ b/src/shared/read-file-text.ts
@@ -1,4 +1,5 @@
 import type { LeanReadFileEnvelope } from "./read-file-response.js";
+import { splitReadFileContentLines } from "./read-file-response.js";
 
 const SEP = " | ";
 
@@ -10,7 +11,12 @@ export function renderReadFileText(envelope: LeanReadFileEnvelope): string {
   if (envelope.isBinary) {
     lines.push("Binary file - cannot display as text.");
   } else if (envelope.content) {
-    appendNumberedContent(lines, envelope.content, envelope.startLine ?? 1);
+    appendNumberedContent(
+      lines,
+      envelope.content,
+      envelope.startLine ?? 1,
+      envelope.endLine,
+    );
   } else {
     lines.push("(no content returned)");
   }
@@ -44,13 +50,11 @@ function appendNumberedContent(
   lines: string[],
   content: string,
   startLine: number,
+  endLine?: number,
 ): void {
-  const bodyLines = content.split("\n");
-  if (bodyLines.length > 0 && bodyLines[bodyLines.length - 1] === "") {
-    bodyLines.pop();
-  }
-  const endLine = startLine + bodyLines.length - 1;
-  const width = String(endLine).length;
+  const bodyLines = splitReadFileContentLines({ content, startLine, endLine });
+  const renderedEndLine = startLine + bodyLines.length - 1;
+  const width = String(renderedEndLine).length;
   for (let i = 0; i < bodyLines.length; i += 1) {
     lines.push(
       `${String(startLine + i).padStart(width, " ")}  ${bodyLines[i]}`,


### PR DESCRIPTION
## Summary
- Preserve significant trailing blank lines in numbered `code_read` output when backend line ranges include them.
- Share line splitting between CLI verbose output and MCP `text-v1` rendering.
- Add a focused `code-read-window` agent workload and document observed small-model behavior.

## Testing
- `bun test src/shared/read-file-response.test.ts src/tools/read-file.test.ts src/tools/read-file-parity.test.ts src/commands/code/read.test.ts`
- `bun run typecheck`
- `bun run build`
- `bun run smoke:cli`
- `bun run smoke:mcp`
- `bun run agent:e2e --agent claude --model haiku --server local --workload eval/agentic/workloads/code-read-window.md --timeout 300 --out .agent-eval/runs/code-read-window-haiku-focused`
- `bun run agent:e2e --agent codex --model gpt-5.4-mini --server local --workload eval/agentic/workloads/code-read-window.md --timeout 300 --out .agent-eval/runs/code-read-window-codex-mini-focused`