### PR TITLE
fix: steer agents toward code_files

### DIFF
--- a/eval/agentic/README.md
+++ b/eval/agentic/README.md
@@ -135,7 +135,7 @@ least one agent for quick iteration.
 | Dependency graph UX, `pkg_deps` | `package-dependencies.md` |
 | Release notes UX, `pkg_changelog` | `package-changelog.md`; use `package-changelog-range.md` for range/body-preview behavior |
 | Documentation browsing, `docs_list`, `docs_read` | `docs-discovery.md`; use `docs-search-followup.md` for search-to-read handoff and `docs-search-noise.md` for noisy docs-result recovery |
-| File listing / file read UX, `code_files`, `code_read` | `code-file-navigation.md`; use `code-read-window.md` for focused source-window behavior |
+| File listing / file read UX, `code_files`, `code_read` | `code-file-navigation.md`; use `code-files-listing.md` for focused listing behavior; use `code-read-window.md` for focused source-window behavior |
 | Deterministic source search UX, `code_grep` | `code-grep-investigation.md` |
 | Multi-tool code navigation strategy and MCP instructions | `express-router.md` |
 
@@ -171,6 +171,12 @@ Notable findings to keep in mind when evaluating future changes:
   names a source file and line area. Claude Haiku does this directly; Codex mini
   has been observed doing package/search preflight before the eventual bounded
   `code_read`, so review raw calls when tuning general tool-selection guidance.
+- `code-files-listing.md` should show direct path enumeration with `code_files`.
+  Claude Haiku does this directly. Codex mini has been observed oscillating
+  between `code_read`, `code_grep`, and `code_files`, and can self-report that
+  `code_files` is unavailable even when earlier runs used it; treat raw calls as
+  the source of truth and fix concrete validation/error issues rather than
+  overfitting instructions to one noisy run.
 - `tool-calls.json` is the source of truth for tool usage. The final JSON is for
   the agent's assessment of clarity, issues, and usefulness.
 - `report.json` and `agent:e2e:report` are derived review aids. They normalize

--- a/eval/agentic/workloads/code-files-listing.md
+++ b/eval/agentic/workloads/code-files-listing.md
@@ -1,0 +1,6 @@
+# Workload: Focused Source File Listing
+
+List the JavaScript source files under `lib/` in `npm:express`, then identify
+which listed files correspond to the application factory, request prototype, and
+response prototype modules. Do not summarize file contents; this is a path
+discovery task.

--- a/src/commands/code/code-nav-cli-helpers.ts
+++ b/src/commands/code/code-nav-cli-helpers.ts
@@ -217,8 +217,9 @@ export function handleCodeNavCommandError(
   json: boolean,
   terminalRenderer: (mapped: MappedError) => string,
   exitCode = 1,
+  mapMappedError: (mapped: MappedError) => MappedError = (mapped) => mapped,
 ): never {
-  const mapped = mapCodeNavigationError(error);
+  const mapped = mapMappedError(mapCodeNavigationError(error));
   if (json) {
     // eslint-disable-next-line no-console
     console.error(

--- a/src/commands/code/read.ts
+++ b/src/commands/code/read.ts
@@ -8,6 +8,7 @@ import {
 import { shouldUseColors } from "../../shared/colors.js";
 import { InvalidPackageSpecError, requireAuth } from "../../shared/index.js";
 import { toPkgseerRegistryLowercase } from "../../shared/pkgseer-registry.js";
+import { withReadFileRecovery } from "../../shared/read-file-error.js";
 import { buildReadFileParams } from "../../shared/read-file-request.js";
 import {
   buildReadFileSuccessPayload,
@@ -60,6 +61,8 @@ export async function pkgReadAction(
 ): Promise<void> {
   requireAuth(deps);
 
+  let requestedFilePath = "";
+
   try {
     if (!deps.codeNavigationUrl || !deps.codeNavigationService) {
       throw new InvalidPackageSpecError(
@@ -83,6 +86,7 @@ export async function pkgReadAction(
 
     const target = resolveCliCodeNavTarget(spec, options);
     const pathWithRange = parsePathWithOptionalRange(path.trim());
+    requestedFilePath = pathWithRange.filePath;
     const range = resolveLineRange(options, pathWithRange);
     const wait = parseIntCliOption(
       options.wait,
@@ -126,6 +130,8 @@ export async function pkgReadAction(
       error,
       options.json ?? false,
       formatFileErrorWithFilesHint,
+      1,
+      (mapped) => withReadFileRecovery(mapped, requestedFilePath),
     );
   }
 }

--- a/src/commands/mcp-instructions.test.ts
+++ b/src/commands/mcp-instructions.test.ts
@@ -81,6 +81,22 @@ describe("buildMcpInstructions", () => {
     expect(instructions).toContain("Delegate multi-call work to a sub-agent");
   });
 
+  it("steers file enumeration to code_files instead of directory probes", () => {
+    const deps = createTestDeps();
+    const instructions = buildMcpInstructions(deps);
+
+    expect(instructions).toContain(
+      "First choice for file-listing/path-enumeration tasks",
+    );
+    expect(instructions).toContain(
+      "do not use `code_read` to probe directories",
+    );
+    expect(instructions).toContain(
+      "never test directory paths with `code_read`",
+    );
+    expect(instructions).toContain('path_prefix: "lib/"');
+  });
+
   it("expands core trigger criteria to cover comparative cross-OSS questions", () => {
     const deps = createTestDeps();
     const instructions = buildMcpInstructions(deps);
@@ -163,14 +179,13 @@ describe("buildMcpInstructions", () => {
       expect(`${name}=${idx}`).not.toContain("=-1");
     }
 
-    // Discovery first, then code reading (grep → read → files), then
-    // docs, then package metadata. `code_files` follows `code_read`
-    // because it is a path-discovery fallback, not the step after a hit.
+    // Discovery first, then file/path enumeration, then code grep/read,
+    // docs, then package metadata.
     expect(positions.search).toBeLessThan(positions.searchStatus);
-    expect(positions.searchStatus).toBeLessThan(positions.codeGrep);
+    expect(positions.searchStatus).toBeLessThan(positions.codeFiles);
+    expect(positions.codeFiles).toBeLessThan(positions.codeGrep);
     expect(positions.codeGrep).toBeLessThan(positions.codeRead);
-    expect(positions.codeRead).toBeLessThan(positions.codeFiles);
-    expect(positions.codeFiles).toBeLessThan(positions.docsList);
+    expect(positions.codeRead).toBeLessThan(positions.docsList);
     expect(positions.docsList).toBeLessThan(positions.docsRead);
     expect(positions.docsRead).toBeLessThan(positions.pkgInfo);
     expect(positions.pkgInfo).toBeLessThan(positions.pkgVulns);

--- a/src/commands/mcp-instructions.ts
+++ b/src/commands/mcp-instructions.ts
@@ -39,10 +39,10 @@ const CODE_GREP_BULLET =
   "- `code_grep` — deterministic text or regex grep over indexed source. Use it when you know the pattern; use `search` for discovery. Narrow with `path`, `path_prefix`, `globs`, or `extensions`. Each match's `filePath`/file heading plus line number chains into `code_read`.";
 
 const CODE_READ_BULLET =
-  "- `code_read` — read a dependency file by `path`. **MCP cap: 150 lines per call**. When you already have an exact path (e.g. from a stack trace), call this directly; otherwise locate it first with `search` or `code_grep` and pick a focused `start_line` / `end_line` window. Binary files set `isBinary: true` and omit `content`. On `FILE_NOT_FOUND` / `NOT_FOUND`, call `code_files` for the actual path.";
+  "- `code_read` — read one exact dependency file by `path`; do not use it to probe/list directories like `lib` or `lib/`. **MCP cap: 150 lines per call**. When you already have an exact path (e.g. from a stack trace), call this directly; otherwise locate it first with `search`, `code_grep`, or `code_files` and pick a focused `start_line` / `end_line` window. Binary files set `isBinary: true` and omit `content`. On `FILE_NOT_FOUND` / `NOT_FOUND`, follow `details.action` or call `code_files` for the actual path.";
 
 const CODE_FILES_BULLET =
-  '- `code_files` — list files in an indexed dependency. `path`, `path_prefix`, and `globs` are OR-ed selectors; extensions, language, file type, and file-intent filters intersect on top. Returned paths feed into `code_read` and help scope `code_grep`; pass `format: "json"` for language/type/size metadata.';
+  '- `code_files` — list or discover file paths in an indexed dependency. First choice for file-listing/path-enumeration tasks such as "files under lib/" (`path_prefix: "lib/"`, optional `extensions: ["js"]`); do not use `code_read` to probe directories and do not use `code_grep` with empty or generic patterns to list files. `path`, `path_prefix`, and `globs` are OR-ed selectors; extensions, language, file type, and file-intent filters intersect on top. Returned paths feed into `code_read` and help scope `code_grep`; pass `format: "json"` for language/type/size metadata.';
 
 const DOCS_LIST_BULLET =
   '- `docs_list` — browse hosted and repository-backed package docs when you need the available pages. It is not topic search; for "find docs about X", call `search` with `sources:["docs"]`, then pass the returned `pageId` to `docs_read`. Entries include stable pageIds, source URLs, and repo-file follow-up metadata when available.';
@@ -71,7 +71,7 @@ const PKG_CHANGELOG_BULLET =
  * habits and the test invariant continue to anchor here.
  */
 const STRATEGY_TIP =
-  'Strategy — reference-first. Locate symbols and lines with `search` or `code_grep` first, then read the needed window with `code_read` using explicit `start_line` / `end_line` (typical 80-150 lines around the match; the MCP `code_read` surface caps each call at 150 lines). Source, symbols, tests, and call sites beat docs prose for behavioral claims; use `sources:["symbol"]` when you want symbol-shaped results, `code_grep` for deterministic text matching, and `get_example` for global canonical examples after package-scoped grounding.';
+  'Strategy — reference-first. For file/path enumeration, call `code_files` directly; never test directory paths with `code_read`. For behavioral claims, locate symbols and lines with `search` or `code_grep` first, then read the needed window with `code_read` using explicit `start_line` / `end_line` (typical 80-150 lines around the match; the MCP `code_read` surface caps each call at 150 lines). Source, symbols, tests, and call sites beat docs prose; use `sources:["symbol"]` when you want symbol-shaped results, `code_grep` for deterministic text matching, and `get_example` for global canonical examples after package-scoped grounding.';
 
 /**
  * Build the server-level instructions string for the current session.
@@ -82,17 +82,15 @@ const STRATEGY_TIP =
  */
 export function buildMcpInstructions(_deps: Dependencies): string {
   // Bullets ordered by agent decision flow: discovery (search) →
-  // code reading (grep, read, files) → docs → package metadata.
-  // `code_files` follows `code_read` because it is the path-
-  // discovery fallback when a known path doesn't resolve, not the
-  // step after a hit. Each bullet name↔registration is enforced by
+  // file/path enumeration (files) → source grep/read → docs →
+  // package metadata. Each bullet name↔registration is enforced by
   // `mcp-instructions.test.ts`.
   const bullets = [
     SEARCH_BULLET,
     SEARCH_STATUS_BULLET,
+    CODE_FILES_BULLET,
     CODE_GREP_BULLET,
     CODE_READ_BULLET,
-    CODE_FILES_BULLET,
     DOCS_LIST_BULLET,
     DOCS_READ_BULLET,
     PKG_INFO_BULLET,

--- a/src/shared/grep-repo-request.test.ts
+++ b/src/shared/grep-repo-request.test.ts
@@ -106,6 +106,15 @@ describe("buildGrepRepoParams", () => {
     });
     expect(params.pattern).toBe(" middleware ");
   });
+
+  it("rejects omitted patterns with a code_files recovery hint", () => {
+    expect(() =>
+      buildGrepRepoParams({
+        target,
+        pathPrefix: "lib/",
+      }),
+    ).toThrow(/pattern.*code_files/);
+  });
 });
 
 describe("GREP_REPO_PATTERN_NOTE", () => {

--- a/src/shared/grep-repo-request.ts
+++ b/src/shared/grep-repo-request.ts
@@ -49,7 +49,7 @@ export interface GrepRepoRequestPathSelectorInput {
 
 export interface GrepRepoRequestInput {
   target: CodeNavigationTarget;
-  pattern: string;
+  pattern?: string;
   path?: string;
   pathPrefix?: string;
   globs?: string[];
@@ -95,7 +95,7 @@ export function buildGrepRepoParams(
   const pattern = input.pattern ?? "";
   if (pattern.length === 0 || pattern.trim().length === 0) {
     throw new InvalidPackageSpecError(
-      "`pattern` is required — pass the text to search for.",
+      "`pattern` is required — pass the text to search for. If you are trying to list files or count files in scope, use `code_files` instead.",
     );
   }
   if (Buffer.byteLength(pattern, "utf8") > PATTERN_MAX) {

--- a/src/shared/read-file-error.ts
+++ b/src/shared/read-file-error.ts
@@ -1,0 +1,38 @@
+import type { MappedError } from "./code-navigation-error-map.js";
+
+export function withReadFileRecovery(
+  mapped: MappedError,
+  requestedPath: string,
+): MappedError {
+  if (mapped.code !== "FILE_NOT_FOUND" && mapped.code !== "NOT_FOUND") {
+    return mapped;
+  }
+
+  return {
+    ...mapped,
+    details: {
+      ...mapped.details,
+      action: buildReadFileNotFoundAction(requestedPath),
+    },
+  };
+}
+
+function buildReadFileNotFoundAction(requestedPath: string): string {
+  const prefix = buildPathPrefixSuggestion(requestedPath);
+  return (
+    "`code_read` reads files only, not directories. " +
+    `Use \`code_files\` with \`path_prefix: ${JSON.stringify(prefix)}\` ` +
+    "to list candidate files, then pass an emitted `path` back to `code_read`."
+  );
+}
+
+function buildPathPrefixSuggestion(requestedPath: string): string {
+  const trimmed = requestedPath.trim();
+  if (trimmed === "") return "";
+  if (trimmed.endsWith("/")) return trimmed;
+
+  const slash = trimmed.lastIndexOf("/");
+  const basename = slash === -1 ? trimmed : trimmed.slice(slash + 1);
+  if (!basename.includes(".")) return `${trimmed}/`;
+  return slash === -1 ? "" : trimmed.slice(0, slash + 1);
+}

--- a/src/shared/read-file-request.test.ts
+++ b/src/shared/read-file-request.test.ts
@@ -33,6 +33,12 @@ describe("buildReadFileParams — defaults and validation", () => {
     );
   });
 
+  it("rejects directory prefixes before they reach the backend", () => {
+    expect(() => buildReadFileParams({ target, filePath: "lib/" })).toThrow(
+      /code_files.*path_prefix: "lib\/"/,
+    );
+  });
+
   it("passes line range through", () => {
     const { params } = buildReadFileParams({
       target,

--- a/src/shared/read-file-request.ts
+++ b/src/shared/read-file-request.ts
@@ -35,6 +35,11 @@ export function buildReadFileParams(
       "`file_path` is required — pass the path to the file within the package or repo.",
     );
   }
+  if (filePath.endsWith("/")) {
+    throw new InvalidPackageSpecError(
+      `\`file_path\` must be an exact file path, not a directory prefix. Use \`code_files\` with \`path_prefix: ${JSON.stringify(filePath)}\` to list files, then pass an emitted \`path\` to \`code_read\`.`,
+    );
+  }
 
   const startLine = normaliseLine(input.startLine, "start_line");
   const endLine = normaliseLine(input.endLine, "end_line");

--- a/src/tools/grep-repo.test.ts
+++ b/src/tools/grep-repo.test.ts
@@ -227,6 +227,22 @@ describe("createGrepRepoTool — validation errors", () => {
     );
   });
 
+  it("returns INVALID_ARGUMENT envelope when pattern is omitted", async () => {
+    const tool = createGrepRepoTool(createMockCodeNavigationService());
+    const result = await tool.handler(
+      {
+        target: { registry: "npm", package_name: "express" },
+        path_prefix: "lib/",
+      },
+      {},
+    );
+    expect(result.isError).toBe(true);
+    const payload = parseText(result) as { code: string; error: string };
+    expect(payload.code).toBe("INVALID_ARGUMENT");
+    expect(payload.error).toContain("`pattern` is required");
+    expect(payload.error).toContain("use `code_files` instead");
+  });
+
   it("returns INVALID_ARGUMENT for out-of-range numeric arguments", async () => {
     const tool = createGrepRepoTool(createMockCodeNavigationService());
     const result = await tool.handler(

--- a/src/tools/grep-repo.ts
+++ b/src/tools/grep-repo.ts
@@ -20,7 +20,7 @@ import { errorResult, type ToolDefinition, textResult } from "./types.js";
 
 export interface GrepRepoArgs {
   target: CodeTargetArg;
-  pattern: string;
+  pattern?: string;
   path?: string;
   path_prefix?: string;
   globs?: string[];
@@ -42,7 +42,7 @@ export interface GrepRepoArgs {
 
 const schema = {
   target: codeTargetSchema,
-  pattern: z.string().describe(GREP_REPO_PATTERN_NOTE),
+  pattern: z.string().optional().describe(GREP_REPO_PATTERN_NOTE),
   path: z
     .string()
     .optional()

--- a/src/tools/list-files.test.ts
+++ b/src/tools/list-files.test.ts
@@ -18,6 +18,10 @@ describe("createListFilesTool — metadata", () => {
     const tool = createListFilesTool(createMockCodeNavigationService());
     expect(tool.name).toBe("code_files");
     expect(tool.description).toContain("List files in an indexed dependency");
+    expect(tool.description).toContain(
+      "First choice for file/path enumeration",
+    );
+    expect(tool.description).toContain("`path_prefix` for directory prefixes");
     expect(Object.keys(tool.schema).sort()).toEqual([
       "exclude_doc_files",
       "exclude_file_intents",

--- a/src/tools/list-files.ts
+++ b/src/tools/list-files.ts
@@ -108,7 +108,10 @@ const schema = {
 };
 
 const DESCRIPTION =
-  "List files in an indexed dependency. Use this to discover paths " +
+  "List files in an indexed dependency. First choice for file/path " +
+  "enumeration tasks such as files under a directory; use " +
+  "`path_prefix` for directory prefixes (e.g. `lib/`) and optional " +
+  "`extensions` for language filtering. Use this to discover paths " +
   "before `code_read` (when `code_read` returns `FILE_NOT_FOUND` or " +
   "you don't yet know the path) and to scope `code_grep`. Address " +
   "via `target.registry` + `target.package_name` (package scope) or " +

--- a/src/tools/read-file.test.ts
+++ b/src/tools/read-file.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, mock } from "bun:test";
 import {
   CodeNavigationFileNotFoundError,
   CodeNavigationIndexingError,
+  CodeNavigationTargetNotFoundError,
 } from "../services/index.js";
 import {
   createMockCodeNavigationService,
@@ -18,8 +19,9 @@ describe("createReadFileTool — metadata", () => {
     const tool = createReadFileTool(createMockCodeNavigationService());
     expect(tool.name).toBe("code_read");
     expect(tool.description).toContain(
-      "Read a file from an indexed dependency",
+      "Read one exact file from an indexed dependency",
     );
+    expect(tool.description).toContain("does not list directories");
     expect(tool.description).toContain("NOT_FOUND");
     expect(Object.keys(tool.schema).sort()).toEqual([
       "end_line",
@@ -221,6 +223,26 @@ describe("createReadFileTool — validation errors", () => {
       "INVALID_ARGUMENT",
     );
   });
+
+  it("returns INVALID_ARGUMENT for directory prefixes without calling readFile", async () => {
+    const readFile = mock(() => Promise.resolve(defaultReadFileResult));
+    const tool = createReadFileTool(
+      createMockCodeNavigationService({ readFile }),
+    );
+    const result = await tool.handler(
+      {
+        target: { registry: "npm", package_name: "express" },
+        path: "lib/",
+      },
+      {},
+    );
+    expect(result.isError).toBe(true);
+    const payload = parseText(result) as { code: string; error: string };
+    expect(payload.code).toBe("INVALID_ARGUMENT");
+    expect(payload.error).toContain("exact file path");
+    expect(payload.error).toContain('path_prefix: "lib/"');
+    expect(readFile).not.toHaveBeenCalled();
+  });
 });
 
 describe("createReadFileTool — service errors", () => {
@@ -246,10 +268,39 @@ describe("createReadFileTool — service errors", () => {
     expect(result.isError).toBe(true);
     const payload = parseText(result) as {
       code: string;
-      details?: { filePath?: string };
+      details?: { action?: string; filePath?: string };
     };
     expect(payload.code).toBe("FILE_NOT_FOUND");
     expect(payload.details?.filePath).toBe("nope.js");
+    expect(payload.details?.action).toContain("`code_files`");
+    expect(payload.details?.action).toContain('path_prefix: ""');
+    expect(payload.details?.action).toContain("emitted `path`");
+  });
+
+  it("points directory-looking NOT_FOUND errors at code_files path_prefix", async () => {
+    const service = createMockCodeNavigationService({
+      readFile: mock(() =>
+        Promise.reject(
+          new CodeNavigationTargetNotFoundError("File not found in repository"),
+        ),
+      ),
+    });
+    const tool = createReadFileTool(service);
+    const result = await tool.handler(
+      {
+        target: { registry: "npm", package_name: "express" },
+        path: "lib",
+      },
+      {},
+    );
+    expect(result.isError).toBe(true);
+    const payload = parseText(result) as {
+      code: string;
+      details?: { action?: string };
+    };
+    expect(payload.code).toBe("NOT_FOUND");
+    expect(payload.details?.action).toContain("reads files only");
+    expect(payload.details?.action).toContain('path_prefix: "lib/"');
   });
 
   it("classifies CodeNavigationIndexingError as INDEXING", async () => {

--- a/src/tools/read-file.ts
+++ b/src/tools/read-file.ts
@@ -1,6 +1,9 @@
 import { z } from "zod";
 import type { CodeNavigationService } from "../services/index.js";
-import { mapCodeNavigationError } from "../shared/code-navigation-error-map.js";
+import {
+  type MappedError,
+  mapCodeNavigationError,
+} from "../shared/code-navigation-error-map.js";
 import { toPkgseerRegistryLowercase } from "../shared/pkgseer-registry.js";
 import { buildReadFileParams } from "../shared/read-file-request.js";
 import {
@@ -41,7 +44,7 @@ const schema = {
   path: z
     .string()
     .describe(
-      "Path to the file. Package addressing: package-relative. Repo addressing: repo-relative. This is the same `path` key that `code_files` emits for each entry, so chaining needs no renaming.",
+      "Exact file path to read, not a directory. Package addressing: package-relative. Repo addressing: repo-relative. Use `code_files` with `path_prefix` to list directories, then pass an emitted `path` here.",
     ),
   start_line: z
     .number()
@@ -70,7 +73,9 @@ const schema = {
 };
 
 const DESCRIPTION =
-  "Read a file from an indexed dependency. **MCP cap: " +
+  "Read one exact file from an indexed dependency; it does not list " +
+  "directories. Use `code_files` with `path_prefix` for file/path " +
+  "enumeration. **MCP cap: " +
   `${MCP_READ_MAX_SPAN} lines per call** — broader requests (or no ` +
   `range) silently truncate to the first ${MCP_READ_MAX_SPAN} lines ` +
   "from your start, with a `hint` describing what was returned vs. " +
@@ -177,7 +182,10 @@ export function createReadFileTool(
         }
         return textResult(JSON.stringify(payload));
       } catch (error) {
-        const mapped = mapCodeNavigationError(error);
+        const mapped = withReadFileRecovery(
+          mapCodeNavigationError(error),
+          args.path,
+        );
         return errorResult(
           JSON.stringify({
             error: mapped.message,
@@ -189,6 +197,43 @@ export function createReadFileTool(
       }
     },
   };
+}
+
+function withReadFileRecovery(
+  mapped: MappedError,
+  requestedPath: string,
+): MappedError {
+  if (mapped.code !== "FILE_NOT_FOUND" && mapped.code !== "NOT_FOUND") {
+    return mapped;
+  }
+
+  return {
+    ...mapped,
+    details: {
+      ...mapped.details,
+      action: buildReadFileNotFoundAction(requestedPath),
+    },
+  };
+}
+
+function buildReadFileNotFoundAction(requestedPath: string): string {
+  const prefix = buildPathPrefixSuggestion(requestedPath);
+  return (
+    "`code_read` reads files only, not directories. " +
+    `Use \`code_files\` with \`path_prefix: ${JSON.stringify(prefix)}\` ` +
+    "to list candidate files, then pass an emitted `path` back to `code_read`."
+  );
+}
+
+function buildPathPrefixSuggestion(requestedPath: string): string {
+  const trimmed = requestedPath.trim();
+  if (trimmed === "") return "";
+  if (trimmed.endsWith("/")) return trimmed;
+
+  const slash = trimmed.lastIndexOf("/");
+  const basename = slash === -1 ? trimmed : trimmed.slice(slash + 1);
+  if (!basename.includes(".")) return `${trimmed}/`;
+  return slash === -1 ? "" : trimmed.slice(0, slash + 1);
 }
 
 function isTextFormat(format: ReadFileArgs["format"]): boolean {

--- a/src/tools/read-file.ts
+++ b/src/tools/read-file.ts
@@ -1,10 +1,8 @@
 import { z } from "zod";
 import type { CodeNavigationService } from "../services/index.js";
-import {
-  type MappedError,
-  mapCodeNavigationError,
-} from "../shared/code-navigation-error-map.js";
+import { mapCodeNavigationError } from "../shared/code-navigation-error-map.js";
 import { toPkgseerRegistryLowercase } from "../shared/pkgseer-registry.js";
+import { withReadFileRecovery } from "../shared/read-file-error.js";
 import { buildReadFileParams } from "../shared/read-file-request.js";
 import {
   buildReadFileSuccessPayload,
@@ -197,43 +195,6 @@ export function createReadFileTool(
       }
     },
   };
-}
-
-function withReadFileRecovery(
-  mapped: MappedError,
-  requestedPath: string,
-): MappedError {
-  if (mapped.code !== "FILE_NOT_FOUND" && mapped.code !== "NOT_FOUND") {
-    return mapped;
-  }
-
-  return {
-    ...mapped,
-    details: {
-      ...mapped.details,
-      action: buildReadFileNotFoundAction(requestedPath),
-    },
-  };
-}
-
-function buildReadFileNotFoundAction(requestedPath: string): string {
-  const prefix = buildPathPrefixSuggestion(requestedPath);
-  return (
-    "`code_read` reads files only, not directories. " +
-    `Use \`code_files\` with \`path_prefix: ${JSON.stringify(prefix)}\` ` +
-    "to list candidate files, then pass an emitted `path` back to `code_read`."
-  );
-}
-
-function buildPathPrefixSuggestion(requestedPath: string): string {
-  const trimmed = requestedPath.trim();
-  if (trimmed === "") return "";
-  if (trimmed.endsWith("/")) return trimmed;
-
-  const slash = trimmed.lastIndexOf("/");
-  const basename = slash === -1 ? trimmed : trimmed.slice(slash + 1);
-  if (!basename.includes(".")) return `${trimmed}/`;
-  return slash === -1 ? "" : trimmed.slice(0, slash + 1);
 }
 
 function isTextFormat(format: ReadFileArgs["format"]): boolean {


### PR DESCRIPTION
## Summary
- Clarifies MCP guidance so path enumeration uses `code_files` before grep/read flows.
- Adds recovery validation for directory-style `code_read` calls and missing `code_grep.pattern` calls.
- Adds a focused agentic workload for `code_files` listing behavior and documents observed Codex mini instability.

## Verification
- `bun test src/shared/grep-repo-request.test.ts src/tools/grep-repo.test.ts src/shared/read-file-request.test.ts src/tools/read-file.test.ts src/tools/list-files.test.ts src/commands/mcp-instructions.test.ts`
- `bun run typecheck`
- `bun run build`
- `bun run smoke:mcp`
- `bun run smoke:cli`
- `bun run agent:e2e --agent codex --server local --workload eval/agentic/workloads/code-files-listing.md --timeout 300 --out .agent-eval/runs/code-files-listing-codex-default-tool-availability`
- `bun run agent:e2e --agent claude --server local --workload eval/agentic/workloads/code-files-listing.md --timeout 300 --out .agent-eval/runs/code-files-listing-claude-default-after-guidance`