### PR TITLE
chore: release v0.4.4

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "GitHits plugins for Claude Code - code examples from global open source",
-    "version": "0.4.3"
+    "version": "0.4.4"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Code examples from global open source for developers and AI assistants",
   "author": {
     "name": "GitHits"

--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Code examples from global open source for developers and AI assistants",
   "author": {
     "name": "GitHits"

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Code examples from global open source for developers and AI assistants.",
   "mcpServers": {
     "githits": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "githits",
   "description": "CLI companion for GitHits - code examples from global open source for developers and AI assistants",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "type": "module",
   "files": [
     "dist",

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Code examples from global open source for developers and AI assistants",
   "author": {
     "name": "GitHits"


### PR DESCRIPTION
## Summary
- Bump npm package and plugin/extension manifests to v0.4.4.
- Trigger the patch release workflow for changes merged since v0.4.3.

## User-Visible Changelog
- Added `githits init uninstall` to remove installed agent integrations cleanly.
- Reduced unwanted auth/keychain prompts during CLI startup.
- Improved code file navigation guidance and read-file error messages.
- Preserved blank lines in `code_read` output.
- Sharpened `code_grep`, docs search/list, and package dependency output for clearer agent and CLI use.

## Verification
- `bun test`
- `bun run build`
- `bun run typecheck`