### PR TITLE
Add dependency update quarantine

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+# This repo installs with Bun, so Dependabot uses the Bun ecosystem and the local
+# install-time age gate is configured in bunfig.toml.
+version: 2
+updates:
+  - package-ecosystem: "bun"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 3
+      semver-major-days: 7
+      include: ["*"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 3
+      semver-major-days: 7
+      include: ["*"]

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,2 @@
+[install]
+minimumReleaseAge = 259200


### PR DESCRIPTION
## Summary
- Add Dependabot coverage for Bun/package updates and GitHub Actions with 3-day default and 7-day major cooldowns.
- Add Bun install-time release-age gating via bunfig.toml for local and CI installs.
- Document that Bun is the active package manager for this repo's dependency update controls.

## Verification
- Parsed and validated .github/dependabot.yml coverage for bun and github-actions.
- Parsed and validated bunfig.toml minimumReleaseAge = 259200.
- Ran bun install --dry-run successfully with Bun 1.3.11.