### PR TITLE
Improve init next steps

### DIFF
--- a/src/commands/init/init.test.ts
+++ b/src/commands/init/init.test.ts
@@ -88,6 +88,25 @@ function getLogOutput(): string[] {
   return (logSpy.mock.calls as unknown[][]).map((c) => String(c[0] ?? ""));
 }
 
+function expectReadyNextSteps(logCalls: string[]): void {
+  expect(logCalls.some((msg) => msg.includes("Setup complete"))).toBe(true);
+  expect(
+    logCalls.some((msg) => msg.includes("You're ready to use GitHits")),
+  ).toBe(true);
+  expect(
+    logCalls.some((msg) =>
+      msg.includes(
+        'npx githits@latest example "How do I use useEffect cleanup?"',
+      ),
+    ),
+  ).toBe(true);
+  expect(
+    logCalls.some((msg) =>
+      msg.includes("query planner selects join strategies"),
+    ),
+  ).toBe(true);
+}
+
 function lookupCommandFor(platform: string = process.platform): string {
   return platform === "win32" ? "where" : "which";
 }
@@ -147,7 +166,7 @@ describe("initAction", () => {
     expect(logCalls.some((msg) => msg.includes("already configured"))).toBe(
       true,
     );
-    expect(logCalls.some((msg) => msg.includes("Nothing to do"))).toBe(true);
+    expectReadyNextSteps(logCalls);
   });
 
   it("handles mixed status: configured + unconfigured", async () => {
@@ -243,7 +262,7 @@ describe("initAction", () => {
 
     expect(promptService.confirm3).not.toHaveBeenCalled();
     const logCalls = getLogOutput();
-    expect(logCalls.some((msg) => msg.includes("Nothing to do"))).toBe(true);
+    expectReadyNextSteps(logCalls);
   });
 
   it("sets up CLI agents that are not yet configured", async () => {
@@ -402,7 +421,7 @@ describe("initAction", () => {
     );
 
     const logCalls = getLogOutput();
-    expect(logCalls.some((msg) => msg.includes("Nothing to do"))).toBe(true);
+    expectReadyNextSteps(logCalls);
   });
 
   it("treats equivalent local npx @latest configs as already configured", async () => {
@@ -429,7 +448,7 @@ describe("initAction", () => {
 
     expect(fs.atomicWriteFile).not.toHaveBeenCalled();
     const logCalls = getLogOutput();
-    expect(logCalls.some((msg) => msg.includes("Nothing to do"))).toBe(true);
+    expectReadyNextSteps(logCalls);
   });
 
   it("migrates non-@latest local config to @latest", async () => {
@@ -546,9 +565,9 @@ describe("initAction", () => {
     expect(
       logCalls.some((msg) => msg.includes("Setup completed with errors")),
     ).toBe(true);
-    expect(logCalls.some((msg) => msg.includes("Done! GitHits is ready"))).toBe(
-      false,
-    );
+    expect(
+      logCalls.some((msg) => msg.includes("You're ready to use GitHits")),
+    ).toBe(false);
     expect(logCalls.some((msg) => msg.includes("- Claude Code:"))).toBe(true);
   });
 
@@ -895,9 +914,9 @@ describe("initAction", () => {
           msg.includes("authentication is still required"),
         ),
       ).toBe(true);
-      expect(
-        logCalls.some((msg) => msg.includes("Done! GitHits is ready")),
-      ).toBe(false);
+      expect(logCalls.some((msg) => msg.includes("Setup complete"))).toBe(
+        false,
+      );
     });
 
     it("cancels setup when login fails and user declines to continue", async () => {

--- a/src/commands/init/init.ts
+++ b/src/commands/init/init.ts
@@ -87,6 +87,20 @@ interface UninstallScanResult {
   failed: AgentUninstallOutcome[];
 }
 
+function printReadyNextSteps(): void {
+  console.log("  Setup complete. You're ready to use GitHits.");
+  console.log();
+  console.log("  Try a quick code example search:");
+  console.log(
+    '    npx githits@latest example "How do I use useEffect cleanup?"',
+  );
+  console.log();
+  console.log("  Or ask your agent to explore a real codebase:");
+  console.log(
+    "    Use GitHits to inspect postgres/postgres and explain how the query planner selects join strategies.",
+  );
+}
+
 async function verifyAgentConfigured(
   agent: (typeof agentDefinitions)[number],
   fileSystemService: FileSystemService,
@@ -330,9 +344,9 @@ export async function initAction(
       console.log("  Run `githits login` before using GitHits tools.\n");
       return;
     }
-    console.log(
-      "  All detected agents are already configured. Nothing to do.\n",
-    );
+    console.log("  All detected agents are already configured.");
+    printReadyNextSteps();
+    console.log();
     return;
   }
 
@@ -433,7 +447,7 @@ export async function initAction(
     console.log("  MCP is configured, but authentication is still required.");
     console.log("  Run `githits login` before using GitHits tools.");
   } else if (configured > 0 || alreadyDone > 0) {
-    console.log("  Done! GitHits is ready.");
+    printReadyNextSteps();
   } else if (skipped > 0) {
     console.log("  Setup skipped.");
   }


### PR DESCRIPTION
## Summary
- Replace the terse init success message with friendly, actionable next steps.
- Show `npx githits@latest example ...` and an agent prompt for exploring a real codebase.
- Cover the ready-state copy in init command tests while preserving auth/error behavior.

## Tests
- `bun test src/commands/init/init.test.ts`
- `bun run typecheck`