### PR TITLE
fix: correct Dependabot GitHub Actions cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,5 +17,4 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 3
-      semver-major-days: 7
       include: ["*"]


### PR DESCRIPTION
## Summary
- Removes the unsupported semver-specific cooldown option from the `github-actions` Dependabot update block.
- Keeps the generic cooldown and the Bun semver-major cooldown unchanged.

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml"); puts "valid yaml"'`