### PR TITLE
docs: hide internal skills from public listing

### DIFF
--- a/.agents/skills/githits-release/SKILL.md
+++ b/.agents/skills/githits-release/SKILL.md
@@ -5,6 +5,8 @@ description: >-
   release-version consistency, plugin manifests, user-visible changelog notes,
   MCP instruction quality, and the special lifecycle for published Agent Skills.
 compatibility: Project-local skill for GitHits maintainers; not packaged for end users.
+metadata:
+  internal: true
 ---
 
 Use this skill for GitHits release work, version-bump PRs, release-readiness reviews, and release notes.

--- a/plugins/claude/skills/search/SKILL.md
+++ b/plugins/claude/skills/search/SKILL.md
@@ -3,6 +3,8 @@ name: search
 description:
   Use GitHits MCP tools to find real-world code examples when model knowledge
   is insufficient.
+metadata:
+  internal: true
 ---
 
 Use GitHits when:


### PR DESCRIPTION
## Summary

- mark the project-local githits-release skill as internal
- mark the Claude plugin search skill as internal
- keep both available via the Skills CLI internal-skill opt-in path

## Verification

- npx -y skills add . --list