### PR TITLE
fix: clarify code navigation target guidance

### DIFF
--- a/skills/githits-code/SKILL.md
+++ b/skills/githits-code/SKILL.md
@@ -40,7 +40,7 @@ githits search '"body parser" OR multer' --in npm:express --source docs --json
 githits search-status <searchRef>
 
 githits code files npm:express lib/ --ext js --limit 100
-githits code read npm:express lib/router/index.js --lines 80-180
+githits code read npm:express lib/express.js --lines 1-90
 githits code grep npm:express "process_params" lib/ -C 3
 githits code grep --repo-url https://github.com/expressjs/express --git-ref HEAD "Router" lib/
 

--- a/skills/githits-code/references/code-and-docs.md
+++ b/skills/githits-code/references/code-and-docs.md
@@ -1,6 +1,6 @@
 # GitHits Code And Docs CLI Reference
 
-Package target syntax is `registry:name[@version]`, for example `npm:express@5.2.1`. Repository target syntax uses `--repo-url <url> --git-ref <ref>` for `code` commands, or `--in https://github.com/org/repo#ref` for `search`.
+Package target syntax is `registry:name[@version]`, for example `npm:express@5.2.1`; omit `@version` for the latest release. Repository target syntax uses `--repo-url <url> --git-ref <ref>` for `code` commands. For `search`, use `--in https://github.com/org/repo` for the backend default-branch snapshot or append `#ref` such as `#HEAD` for a specific/latest ref.
 
 ## Search
 

--- a/src/commands/code/code-nav-cli-helpers.ts
+++ b/src/commands/code/code-nav-cli-helpers.ts
@@ -68,7 +68,7 @@ export function resolveCliCodeNavTarget(
   }
   if (hasRepoUrl && !hasGitRef) {
     throw new InvalidPackageSpecError(
-      "`--repo-url` requires `--git-ref` (a tag, branch, commit, or `HEAD`).",
+      "`--repo-url` requires `--git-ref` for code files/read/grep (a tag, branch, commit, or `HEAD`).",
     );
   }
 

--- a/src/commands/code/files.ts
+++ b/src/commands/code/files.ts
@@ -230,7 +230,7 @@ and \`githits code grep\`.
 filters intersect on top.
 
 Addressing: <spec> (registry:name[@version]) OR --repo-url <url>
---git-ref <ref>. Supported registries: ${PKGSEER_REGISTRY_LIST}.
+--git-ref <ref>. Omitted version means latest release. Supported registries: ${PKGSEER_REGISTRY_LIST}.
 
 By default each result is a bare path for easy piping; pass
 --verbose to include language / file-type / size annotations.

--- a/src/commands/code/grep.ts
+++ b/src/commands/code/grep.ts
@@ -251,6 +251,7 @@ ${CLI_GREP_PATTERN_NOTE}
 Use \`githits search\` for discovery; use \`githits code grep\` when you know the text or regex to match.
 
 Addressing: <spec> (registry:name[@version]) OR --repo-url <url> --git-ref <ref>.
+Omitted version means latest release.
 In spec mode pass <spec> <pattern> [path-prefix]; in repo-URL mode pass only <pattern> [path-prefix].
 
 [path-prefix] matches the same literal prefix semantics as \`githits code files\`.

--- a/src/commands/code/index.ts
+++ b/src/commands/code/index.ts
@@ -25,7 +25,7 @@ export async function registerCodeCommandGroup(
     .command("code")
     .summary("Source-level operations on indexed dependencies")
     .description(
-      "List files, read files, and grep substrings inside indexed dependency source. Every command accepts either `<spec>` (registry:name[@version]) or `--repo-url <url> --git-ref <ref>`. For symbol or unified discovery search use `githits search`; for package-level metadata use `githits pkg`.",
+      "List files, read files, and grep substrings inside indexed dependency source. Every command accepts either `<spec>` (registry:name[@version]) or `--repo-url <url> --git-ref <ref>`. Omitted versions use the latest release. For repo default-branch discovery without refs use `githits search`; for package-level metadata use `githits pkg`.",
     );
 
   registerCodeFilesCommand(codeCommand);

--- a/src/commands/mcp-instructions.ts
+++ b/src/commands/mcp-instructions.ts
@@ -25,7 +25,7 @@ const CORE_BLOCK = `GitHits provides verified, canonical code examples from glob
 
 const PACKAGE_TOOLS_PREAMBLE = `Indexed package/source tools inspect third-party dependency source, docs, and registry metadata. Use them when a stack trace points into a dependency, you need to verify how a library works, or you're evaluating whether to add or upgrade a package.
 
-Package spec: \`registry:name[@version]\`. Default outputs are compact \`text-v1\` for agent context efficiency; pass \`format: "json"\` only when you need structured fields for programmatic parsing.`;
+Targets: \`registry:name[@version]\` (\`registry:name\` = latest release). For \`search\`, repo URL without \`#\` uses the backend default-branch snapshot; exact \`code_*\` tools need \`#ref\` such as \`#HEAD\`. Default outputs are compact \`text-v1\`; pass \`format: "json"\` only for structured parsing.`;
 
 const MULTI_TURN_TIP =
   '**Delegate multi-call work to a sub-agent.** Code-navigation work (`search`, `code_grep`, `code_read`, `code_files`) often takes 3-10 calls. For cross-project comparisons, codebase mapping, pattern surveys, or "how does X actually work" investigations, spawn a sub-task/sub-agent and ask for a compact synthesis. Do it inline only when the raw snippet belongs in the main conversation.';

--- a/src/shared/code-navigation-target.ts
+++ b/src/shared/code-navigation-target.ts
@@ -6,10 +6,9 @@ import { InvalidArgumentError, parsePackageSpec } from "./package-spec.js";
  * Parse a compact code-navigation target string.
  *
  * Package targets use the shared package spec grammar, e.g.
- * `npm:react@18.2.0`. Repository targets are full URLs with an optional
- * `#gitRef` suffix, e.g. `https://github.com/facebook/react#HEAD`.
- * Exact code-navigation tools require repository refs because their
- * backend endpoints operate on a concrete repository identity.
+ * `npm:react@18.2.0` or `npm:react` for the latest release. Repository
+ * targets are full URLs with a `#gitRef` suffix, e.g.
+ * `https://github.com/facebook/react#HEAD`.
  */
 export function parseCodeNavigationTargetSpec(
   spec: string,
@@ -35,7 +34,7 @@ function parseRepoTarget(spec: string): CodeNavigationTarget {
   const hashIndex = spec.lastIndexOf("#");
   if (hashIndex === -1) {
     throw new InvalidArgumentError(
-      "Repository target must include #gitRef for exact code navigation.",
+      "Repository target must include #gitRef for code_files/code_read/code_grep.",
     );
   }
 

--- a/src/shared/grep-repo-request.ts
+++ b/src/shared/grep-repo-request.ts
@@ -198,16 +198,11 @@ function buildPathSelectors(input: {
 
 function normalizeOptionalNonEmpty(
   value: string | undefined,
-  field: string,
+  _field: string,
 ): string | undefined {
   if (value === undefined) return undefined;
   const trimmed = value.trim();
-  if (trimmed.length === 0) {
-    throw new InvalidPackageSpecError(
-      `\`${field}\` cannot be empty when provided.`,
-    );
-  }
-  return trimmed;
+  return trimmed.length > 0 ? trimmed : undefined;
 }
 
 function normalizeStringList(

--- a/src/shared/list-files-request.test.ts
+++ b/src/shared/list-files-request.test.ts
@@ -153,10 +153,15 @@ describe("buildListFilesParams — waitTimeoutMs bounds", () => {
 });
 
 describe("buildListFilesParams — filter validation", () => {
-  it("rejects an empty exact path", () => {
-    expect(() =>
-      buildListFilesParams({ target: packageTarget, path: "   " }),
-    ).toThrow(/`path` cannot be empty/);
+  it("treats an empty exact path as absent", () => {
+    const { params, explicit, filterEcho } = buildListFilesParams({
+      target: packageTarget,
+      path: "   ",
+    });
+
+    expect(params.pathSelectors).toBeUndefined();
+    expect(explicit.path).toBe(false);
+    expect(filterEcho.path).toBeUndefined();
   });
 
   it("rejects empty list entries", () => {

--- a/src/shared/list-files-request.ts
+++ b/src/shared/list-files-request.ts
@@ -201,16 +201,11 @@ function buildPathSelectors(input: {
 
 function normalizeOptionalNonEmpty(
   raw: string | undefined,
-  field: string,
+  _field: string,
 ): string | undefined {
   if (raw === undefined) return undefined;
   const trimmed = raw.trim();
-  if (trimmed.length === 0) {
-    throw new InvalidPackageSpecError(
-      `\`${field}\` cannot be empty when provided.`,
-    );
-  }
-  return trimmed;
+  return trimmed.length > 0 ? trimmed : undefined;
 }
 
 function normalizeStringList(

--- a/src/tools/code-navigation-shared.ts
+++ b/src/tools/code-navigation-shared.ts
@@ -47,7 +47,7 @@ export const structuredCodeTargetSchema = z
       .string()
       .optional()
       .describe(
-        "Git ref - tag, branch, or commit. Required with repo_url. Use HEAD for latest.",
+        "Git ref - tag, branch, or commit. Required with repo_url for code_files/code_read/code_grep. Use HEAD for latest.",
       ),
   })
   .describe(
@@ -60,7 +60,7 @@ export const codeTargetSchema = z.union([
     .string()
     .min(1)
     .describe(
-      "Compact target string. Package: `npm:react@18.2.0`. Repository: `https://github.com/facebook/react#HEAD` (git ref suffix required for exact code navigation).",
+      "Compact target string. Package: `npm:react@18.2.0` or `npm:react` for latest release. Repository: `https://github.com/facebook/react#HEAD` (git ref required for code_files/code_read/code_grep).",
     ),
 ]);
 
@@ -129,7 +129,7 @@ export function resolveCodeTarget(
     }
 
     return invalidTargetResult(
-      "Incomplete repository target: git_ref is required for exact code navigation.",
+      "Incomplete repository target: git_ref is required for code_files/code_read/code_grep.",
     );
   }
 

--- a/src/tools/grep-repo.test.ts
+++ b/src/tools/grep-repo.test.ts
@@ -135,6 +135,30 @@ describe("createGrepRepoTool — happy path", () => {
     );
   });
 
+  it("treats empty optional selectors as omitted", async () => {
+    const grepRepo = mock(() => Promise.resolve(defaultGrepRepoResult));
+    const tool = createGrepRepoTool(
+      createMockCodeNavigationService({ grepRepo }),
+    );
+
+    await tool.handler(
+      {
+        target: { registry: "npm", package_name: "express" },
+        pattern: "middleware",
+        path: "",
+        path_prefix: "",
+        cursor: "",
+      },
+      {},
+    );
+
+    const calls = grepRepo.mock.calls as unknown as Array<
+      [{ pathSelectors?: unknown; cursor?: string }]
+    >;
+    expect(calls[0]?.[0]?.pathSelectors).toBeUndefined();
+    expect(calls[0]?.[0]?.cursor).toBeUndefined();
+  });
+
   it("emits the JSON envelope shape when format=json", async () => {
     const tool = createGrepRepoTool(createMockCodeNavigationService());
     const result = await tool.handler(

--- a/src/tools/list-files.test.ts
+++ b/src/tools/list-files.test.ts
@@ -301,6 +301,22 @@ describe("createListFilesTool — validation errors", () => {
     expect(payload.code).toBe("INVALID_ARGUMENT");
     expect(payload.error).toContain("#gitRef");
   });
+
+  it("treats empty optional selectors as omitted", async () => {
+    const tool = createListFilesTool(createMockCodeNavigationService());
+    const result = await tool.handler(
+      {
+        target: { registry: "npm", package_name: "express" },
+        path: "",
+        path_prefix: "",
+        format: "json",
+      },
+      {},
+    );
+    expect(result.isError).toBeUndefined();
+    const payload = parseText(result) as { filter?: unknown };
+    expect(payload.filter).toBeUndefined();
+  });
 });
 
 describe("createListFilesTool — service errors", () => {

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -94,7 +94,7 @@ const searchTargetSchema = z.union([
     .string()
     .min(1)
     .describe(
-      "Compact discovery target string. Package: `npm:react@18.2.0`. Repository: `https://github.com/facebook/react` for backend default branch or `https://github.com/facebook/react#HEAD` for an explicit ref.",
+      "Compact discovery target string. Package: `npm:react@18.2.0` or `npm:react` for latest release. Repository: `https://github.com/facebook/react` for default-branch snapshot or `https://github.com/facebook/react#HEAD` for latest.",
     ),
 ]);
 
@@ -297,7 +297,7 @@ function resolveSearchTarget(
   const hasRepoTarget = Boolean(target.repo_url || target.git_ref);
   if (hasPackageTarget && hasRepoTarget) {
     return invalidSearchTargetResult(
-      "Invalid target: provide either registry + package_name or repo_url + git_ref, not both.",
+      "Invalid target: provide either registry + package_name or repo_url with optional git_ref, not both.",
     );
   }
   if (!hasPackageTarget && !hasRepoTarget) {


### PR DESCRIPTION
## Summary
- Clarify package/latest and repo-ref target guidance across MCP instructions, tool descriptions, CLI help, and GitHits skills.
- Keep exact code navigation repo targets requiring refs while documenting that `search` can use repo URLs without `#`.
- Treat empty optional `code_files` / `code_grep` selector strings as omitted to reduce agent friction.

## Verification
- `bun run smoke:mcp`
- `bun run smoke:cli`
- `bun test src/tools/list-files.test.ts src/tools/grep-repo.test.ts src/tools/search.test.ts src/commands/code/files.test.ts src/commands/code/read.test.ts src/commands/code/grep.test.ts src/commands/mcp-instructions.test.ts`
- `bun run typecheck`
- Live CLI checks for repo-url missing `--git-ref` and repo-url with `--git-ref HEAD`
- Agent evals: Claude/Codex MCP `express-router`, Claude MCP focused code-navigation workloads, Claude skills `code-file-navigation`