### PR TITLE
fix: filter transitive upgrade advisories by severity

### DIFF
--- a/docs/implementation/pkg-upgrade-review.md
+++ b/docs/implementation/pkg-upgrade-review.md
@@ -75,8 +75,7 @@ Validation rules:
 - Keep `include_transitive_security` default `true` because direct-only security hides important dependency-tree evidence. Allow callers to pass `false` when latency is more important than transitive vulnerability context.
 - Keep `include_dependency_issues` default `false` initially for the same reason. Turn it on automatically only when the caller explicitly asks for lockfile/dependency-tree evidence, or document that agents should pass it for lockfile reviews.
 - Changelog keyword detection scans the full backend range response and keyword-hit entries are surfaced separately so relevant signals are not hidden by the ordinary sample limit. The ordinary non-keyword sample cap is internal; agents should not need to tune it.
-- `min_severity` maps to the same CVSS thresholds as `pkg_vulns` (`low=0`, `medium=4`, `high=7`, `critical=9`). In v1 it filters direct current/target vulnerability queries only. Transitive aggregate counts from `vulnerabilitySummary` are unfiltered by backend design and must be labeled as unfiltered when shown beside filtered direct counts.
-- Backend follow-up: add severity-filtered transitive vulnerability aggregates so `min_severity` can apply consistently to direct and transitive evidence. Until then, only show the transitive unfiltered caveat when `min_severity` was actually requested.
+- `min_severity` maps to the same CVSS thresholds as `pkg_vulns` (`low=0`, `medium=4`, `high=7`, `critical=9`). It filters direct current/target vulnerability queries and transitive `vulnerabilitySummary(minSeverity:)` aggregates.
 
 CLI shape:
 
@@ -501,7 +500,7 @@ Add the tool in the same style as current package tools:
 - `pkg_deps` existing JSON/text/parity tests continue to pass unchanged, proving the upgrade-review dependency probe did not regress the existing dependency command.
 - Batch execution limits package-level concurrency to 3 by default.
 - `include_transitive_security` defaults on and can be disabled; `include_dependency_issues` selects lazy backend fields only when requested.
-- Text output explicitly labels transitive vulnerability aggregate counts as unfiltered when `min_severity` is supplied.
+- Text output keeps direct and transitive vulnerability counts aligned when `min_severity` is supplied.
 
 ## Resolved Decisions
 

--- a/src/services/package-intelligence-service.ts
+++ b/src/services/package-intelligence-service.ts
@@ -172,6 +172,7 @@ export interface PackageUpgradeDependencyProbeParams {
   registry: PkgseerRegistry;
   packageName: string;
   version: string;
+  minSeverity?: number;
   includeTransitiveSecurity?: boolean;
   includeDependencyIssues?: boolean;
   includeDependencyChanges?: boolean;
@@ -1287,6 +1288,7 @@ query PackageUpgradeDependencyProbe(
   $includeDependencyChanges: Boolean!
   $includeGroups: Boolean!
   $lifecycle: [String!]
+  $minSeverity: Float
 ) {
   packageDependencies(
     registry: $registry
@@ -1324,7 +1326,7 @@ query PackageUpgradeDependencyProbe(
             dependencyType
           }
         }
-        vulnerabilitySummary @include(if: $includeTransitiveSecurity) {
+        vulnerabilitySummary(minSeverity: $minSeverity) @include(if: $includeTransitiveSecurity) {
           affected {
             totalVulnerabilities
             critical
@@ -1377,7 +1379,7 @@ query PackageUpgradeDependencyProbe(
               aliases
               isMalicious
             }
-            advisoryOccurrences(scope: AFFECTED, limit: 5) {
+            advisoryOccurrences(scope: AFFECTED, minSeverity: $minSeverity, limit: 5) {
               version
               affectsResolvedVersion
               matchedAffectedVersionRanges
@@ -2245,6 +2247,7 @@ export class PackageIntelligenceServiceImpl
           includeDependencyChanges: params.includeDependencyChanges === true,
           includeGroups: params.includeGroups === true,
           lifecycle: params.includeGroups === true ? ["peer"] : undefined,
+          minSeverity: params.minSeverity,
         },
         fetchFn: this.fetchFn,
       });

--- a/src/shared/package-upgrade-review-request.ts
+++ b/src/shared/package-upgrade-review-request.ts
@@ -117,6 +117,7 @@ export function buildUpgradeDependencyProbeParams(
     registry: pkg.registry,
     packageName: pkg.packageName,
     version,
+    minSeverity: options.minSeverity,
     includeGroups: true,
     includeTransitiveSecurity: options.includeTransitiveSecurity,
     includeDependencyIssues: options.includeDependencyIssues,

--- a/src/shared/package-upgrade-review-response.test.ts
+++ b/src/shared/package-upgrade-review-response.test.ts
@@ -272,8 +272,8 @@ describe("package upgrade review response", () => {
     expect(response.reviews[0]?.unknowns).toContain(
       "direct vulnerability checks were filtered by min_severity",
     );
-    expect(formatPackageUpgradeReviewTerminal(response)).toContain(
-      "note: transitive counts are not filtered by min_severity",
+    expect(formatPackageUpgradeReviewTerminal(response)).not.toContain(
+      "transitive counts are not filtered by min_severity",
     );
   });
 
@@ -306,43 +306,6 @@ describe("package upgrade review response", () => {
     expect(request.options.minSeverity).toBeUndefined();
     expect(response.reviews[0]?.unknowns).not.toContain(
       "direct vulnerability checks were filtered by min_severity",
-    );
-  });
-
-  it("does not show the transitive min_severity caveat when no filter was requested", async () => {
-    const request = buildPackageUpgradeReviewRequest({
-      registry: "npm",
-      packageName: "zod",
-      currentVersion: "4.3.6",
-      targetVersion: "4.4.3",
-    });
-    const service = serviceWith({
-      packageVulnerabilities: mock((params) =>
-        Promise.resolve(cleanVulnReport(params.version ?? "4.4.3", false)),
-      ) as never,
-      packageChangelog: mock(() =>
-        Promise.resolve({
-          source: "releases",
-          entries: [{ version: "4.4.3", body: "Patch fixes." }],
-        } satisfies ChangelogReport),
-      ),
-      packageUpgradeDependencyProbe: mock((params) =>
-        Promise.resolve(
-          cleanDependencyReport(params.version, {
-            transitive: { vulnerabilitySummary: transitiveSummary([]) },
-          }),
-        ),
-      ) as never,
-    });
-
-    const response = await buildPackageUpgradeReview(
-      service,
-      request.packages,
-      request.options,
-    );
-
-    expect(formatPackageUpgradeReviewTerminal(response)).not.toContain(
-      "transitive counts are not filtered by min_severity",
     );
   });
 

--- a/src/shared/package-upgrade-review-response.ts
+++ b/src/shared/package-upgrade-review-response.ts
@@ -64,7 +64,6 @@ export interface UpgradeSecurity {
 }
 
 export interface UpgradeTransitiveSecurity {
-  unfiltered: true;
   currentAffected: number;
   targetAffected: number;
   introducedPackages: string[];
@@ -184,7 +183,6 @@ export interface BuildPackageUpgradeReviewOptions {
 export interface FormatPackageUpgradeReviewTerminalOptions {
   verbose?: boolean;
   useColors?: boolean;
-  directVulnerabilityFiltered?: boolean;
 }
 
 const DEFAULT_CONCURRENCY = 3;
@@ -705,7 +703,6 @@ function buildTransitiveSecurity(
     )
     .sort();
   return {
-    unfiltered: true,
     currentAffected: current?.affectedPackageCount ?? 0,
     targetAffected: target?.affectedPackageCount ?? 0,
     introducedPackages,
@@ -1197,13 +1194,7 @@ export function formatPackageUpgradeReviewTerminal(
         useColors,
       ),
     );
-    lines.push(
-      ...formatVulnerabilitySection(review.security, {
-        ...options,
-        directVulnerabilityFiltered:
-          hasDirectVulnerabilityFilterUnknown(review),
-      }),
-    );
+    lines.push(...formatVulnerabilitySection(review.security, options));
     const deprecation = formatDeprecationLine(review);
     if (deprecation) lines.push(deprecation);
     lines.push(...formatChangesSection(review.changelog, options));
@@ -1268,12 +1259,6 @@ function formatVulnerabilitySection(
   return lines;
 }
 
-function hasDirectVulnerabilityFilterUnknown(review: UpgradeReview): boolean {
-  return review.unknowns.includes(
-    "direct vulnerability checks were filtered by min_severity",
-  );
-}
-
 function appendAdvisoryLines(
   lines: string[],
   label: string,
@@ -1311,9 +1296,6 @@ function formatTransitiveVulnerabilitySubsection(
   const lines = [
     `  transitive package advisories: current affected packages=${transitive.currentAffected}, target affected packages=${transitive.targetAffected}, fixed packages=${transitive.fixedPackageDetails.length}, added packages=${transitive.introducedPackageDetails.length}`,
   ];
-  if (options.directVulnerabilityFiltered === true) {
-    lines.push("  note: transitive counts are not filtered by min_severity");
-  }
   const limit = options.verbose ? Number.POSITIVE_INFINITY : 5;
   appendTransitivePackageLines(
     lines,

--- a/src/tools/package-upgrade-review.test.ts
+++ b/src/tools/package-upgrade-review.test.ts
@@ -93,6 +93,7 @@ describe("createPackageUpgradeReviewTool", () => {
       registry: "NPM",
       packageName: "express",
       version: "4.18.0",
+      minSeverity: 7,
       includeTransitiveSecurity: true,
       includeDependencyIssues: true,
       includeDependencyChanges: true,


### PR DESCRIPTION
## Summary
- Pass min_severity through the upgrade dependency probe so backend transitive vulnerability aggregates use the same severity threshold as direct advisory checks.
- Remove the stale text-output caveat that transitive counts are unfiltered.
- Update upgrade-review tests and implementation notes for severity-filtered transitive evidence.

## Verification
- bun run typecheck
- bun test src/shared/package-upgrade-review-response.test.ts src/tools/package-upgrade-review.test.ts
- live production check: npm:express@5.0.0..5.2.1 high severity filters transitive counts from 2 -> 0 down to 0 -> 0