### PR TITLE
chore: prepare 0.4.5 release

### DIFF
--- a/.agents/skills/githits-release/SKILL.md
+++ b/.agents/skills/githits-release/SKILL.md
@@ -16,6 +16,7 @@ Use this skill for GitHits release work, version-bump PRs, release-readiness rev
 - Bump every release version together: `package.json`, `.plugin/plugin.json`, `.claude-plugin/plugin.json`, `plugins/claude/.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, and `gemini-extension.json`.
 - Run or rely on `src/plugin-version-consistency.test.ts` to verify package and plugin versions stay aligned.
 - Collect a changelog of user-visible changes before release. Include CLI behavior, MCP tool behavior, Agent Skills, auth/error UX, output format changes, and agent-facing instruction changes.
+- Review public skills before signoff whenever user-facing CLI/MCP behavior changed. After the behavior is released or included in the same release branch, update `skills/githits-code/SKILL.md`, `skills/githits-package/SKILL.md`, and their references so `skills.sh` users get instructions that match the released surface.
 - Keep PR titles and labels release-note friendly; GitHub release notes are generated from merged PRs and `.github/release.yml` categories.
 - Run `bun run build` before release-readiness signoff. Run targeted smoke/eval commands when MCP tools, CLI commands, shared formatters, auth/error envelopes, Agent Skills, or agent-facing instructions changed.
 
@@ -23,7 +24,7 @@ Use this skill for GitHits release work, version-bump PRs, release-readiness rev
 
 - User-facing skills under `skills/` are picked up by `skills.sh` from `main`, not from npm release artifacts.
 - Do not update `skills/` to describe unreleased CLI/MCP behavior. A merge to `main` can expose those skill instructions immediately.
-- After the backing CLI/MCP behavior is released or otherwise available to users, update `skills/` so skill descriptions and examples match the released surface.
+- After the backing CLI/MCP behavior is released or part of the release being prepared, update `skills/` so skill descriptions, decision flows, examples, detailed references, and command-to-MCP mappings match the released surface.
 - When MCP instructions, tool descriptions, or guardrails change, review `skills/githits-code/SKILL.md`, `skills/githits-package/SKILL.md`, and their references for parity. Keep MCP instructions as the quality baseline; they are currently strong and should not be weakened casually.
 - If a skill update is intentionally delayed until after release, note that in the release/change plan so it is not forgotten.
 

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "GitHits plugins for Claude Code - code examples from global open source",
-    "version": "0.4.4"
+    "version": "0.4.5"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Code examples from global open source for developers and AI assistants",
   "author": {
     "name": "GitHits"

--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Code examples from global open source for developers and AI assistants",
   "author": {
     "name": "GitHits"

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Code examples from global open source for developers and AI assistants.",
   "mcpServers": {
     "githits": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "githits",
   "description": "CLI companion for GitHits - code examples from global open source for developers and AI assistants",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "type": "module",
   "files": [
     "dist",

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Code examples from global open source for developers and AI assistants",
   "author": {
     "name": "GitHits"

--- a/skills/githits-package/SKILL.md
+++ b/skills/githits-package/SKILL.md
@@ -3,9 +3,9 @@ name: githits-package
 description: >-
   Use GitHits CLI package-intelligence commands for package/dependency triage:
   overview, latest version, license, repository health, vulnerabilities,
-  advisory history, dependency graphs, transitive provenance, changelogs, and
-  release notes. Activate for packages, dependencies, versions, upgrades, CVEs,
-  dependency footprints, or release changes.
+  advisory history, dependency graphs, transitive provenance, changelogs,
+  release notes, and upgrade reviews. Activate for packages, dependencies,
+  versions, upgrades, CVEs, dependency footprints, or release changes.
 compatibility: Requires shell access, internet access, and either a githits binary on PATH or npx.
 ---
 
@@ -41,6 +41,9 @@ githits pkg deps npm:express --transitive --depth 3 --json
 githits pkg changelog npm:express --limit 3
 githits pkg changelog npm:express --from 4.18.0 --to 4.19.0
 githits pkg changelog --repo-url https://github.com/expressjs/express --limit 2 --no-body
+
+githits pkg upgrade-review npm:zod@4.3.6 --to 4.4.3
+githits pkg upgrade-review --package npm:zod@4.3.6..4.4.3 --package npm:lint-staged@16.2.7..16.4.0 --json
 ```
 
 ## Decision Flow
@@ -49,13 +52,15 @@ githits pkg changelog --repo-url https://github.com/expressjs/express --limit 2 
 - Need security status for a specific installed version: use `githits pkg vulns <registry:name@version>`.
 - Need historical advisories that do not affect the inspected version: use `pkg vulns --scope non_affecting`; use `--scope all` for affected plus historical rows.
 - Need dependency footprint: start with `pkg deps`; add `--lifecycle all` for non-runtime groups and `--transitive` for aggregate transitive graph data.
-- Need upgrade/release context: use `pkg changelog`; use `--from`/`--to` for ranges and `--no-body` for compact timelines.
+- Need upgrade evidence for dependency updates, outdated package bumps, or lockfile changes: prefer `pkg upgrade-review` because it compares current vs target vulnerabilities, changelog range evidence, deprecation metadata, peer changes, dependency changes, and optional transitive evidence. It reports facts only; you still own the final assessment.
+- Need release notes without a current-to-target comparison: use `pkg changelog`; use `--from`/`--to` for ranges and `--no-body` for compact timelines.
 
 ## Gotchas
 
 - Vulnerability data is not available for `vcpkg` or `zig`.
 - Dependency graphs support npm, PyPI, Hex, Crates, Zig, vcpkg, RubyGems, and Go; NuGet/Maven/Packagist are not dependency-graph targets.
 - Changelog range inputs are canonical versions without a leading `v`.
+- For repeatable `pkg upgrade-review --package` entries, prefer `<registry>:<name>@<current>..<target>`; quoted `<current>-><target>` is accepted, but unquoted `>` is shell redirection in zsh/bash.
 - Prefer structured JSON for final comparisons; terminal text is optimized for human scanning.
 
 ## External Content Posture

--- a/skills/githits-package/references/package.md
+++ b/skills/githits-package/references/package.md
@@ -30,9 +30,22 @@ Flags: `--repo-url <url>`, `--from <version>`, `--to <version>`, `--limit 1-50`,
 
 Do not use `registry:name@version` for changelog. Use `--to <version>`.
 
+## Upgrade Review
+
+`githits pkg upgrade-review <registry:name@current> --to <target>` compares current and target package versions and reports upgrade evidence without assigning risk.
+
+Batch form: `githits pkg upgrade-review --package <registry:name@current>..<target> --package <registry:name@current>..<target>`.
+
+Evidence includes current and target direct vulnerabilities, changelog range evidence, target deprecation metadata, peer dependency changes, dependency changes, and optional transitive security or dependency-issue diffs.
+
+Flags: `--package <spec>`, `--to <version>`, `--no-transitive-security`, `--dependency-issues`, `--min-severity low|medium|high|critical`, `--verbose`, `--json`.
+
+Use `pkg upgrade-review` for dependency update assessment instead of inferring safety from semver alone. Use `pkg changelog` directly only when you need release notes without a current-to-target comparison.
+
 ## Command Name Mapping
 
 - `githits pkg info` maps to MCP `pkg_info`.
 - `githits pkg vulns` maps to MCP `pkg_vulns`.
 - `githits pkg deps` maps to MCP `pkg_deps`.
 - `githits pkg changelog` maps to MCP `pkg_changelog`.
+- `githits pkg upgrade-review` maps to MCP `pkg_upgrade_review`.


### PR DESCRIPTION
## Summary
- Bump GitHits package and plugin manifests from 0.4.4 to 0.4.5.
- Align the public package skill with the released `pkg upgrade-review` CLI/MCP surface.
- Tighten internal release instructions so public skill alignment is checked before release signoff.

## Curated user-facing changes since v0.4.4
- Added `githits pkg upgrade-review` and MCP `pkg_upgrade_review` for dependency upgrade evidence across changelogs, vulnerabilities, dependencies, peer changes, deprecations, and compatibility signals.
- Filtered transitive upgrade-review advisories by requested severity.
- Added MCP prompt-injection guardrails for third-party tool output such as package metadata, release notes, advisories, code, comments, and README content.
- Added GitHits Agent Skills for code and package workflows.
- Updated package Agent Skill guidance to use `githits pkg upgrade-review`, including batch examples and MCP mapping to `pkg_upgrade_review`.
- Improved feedback support so CLI/MCP feedback can be generic and no longer requires a `solution_id`.
- Improved `githits init` next steps with friendlier commands after setup.
- Clarified code navigation target guidance for package targets, repo refs, and empty optional selectors.
- Hid internal release/search skills from normal public skill discovery.
- Tightened package vulnerability messaging around transitive `min_severity` caveats.

## Verification
- `bun test src/plugin-version-consistency.test.ts`
- `bun test`
- `bun run build`
- `bun run smoke:mcp`
- `bun run smoke:cli`
- `bun run agent:e2e --agent claude --model haiku --surface skills --server local --workload eval/agentic/workloads/package-upgrade-safety.md --timeout 180`
- `git diff --check`

Note: Codex skills eval for `package-upgrade-safety.md` timed out after 6 minutes and produced no artifacts; Claude Haiku skills eval passed.