### PR TITLE
chore: update Zod to v4.4.3

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
         "open": "^11.0.0",
         "semver": "^7.8.0",
         "smol-toml": "^1.6.1",
-        "zod": "^4.1.13",
+        "zod": "^4.4.3",
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.15",
@@ -567,7 +567,7 @@
 
     "zlye": ["zlye@0.4.4", "", { "dependencies": { "picocolors": "^1.1.1" }, "peerDependencies": { "typescript": ">=4.5.0" }, "optionalPeers": ["typescript"] }, "sha512-fwpeC841X3ElOLYRMKXbwX29pitNrsm6nRNvEhDMrRXDl3BhR2i03Bkr0GNrpyYgZJuEzUsBylXAYzgGPXXOCQ=="],
 
-    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
 

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "open": "^11.0.0",
     "semver": "^7.8.0",
     "smol-toml": "^1.6.1",
-    "zod": "^4.1.13"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.15",


### PR DESCRIPTION
## Summary
- update Zod to 4.4.3
- keep the change to package metadata and lockfile only
- verify MCP SDK schema types resolve without casts or package overrides

## Verification
- bun run typecheck
- bun test
- bun run lint
- bun run build
- bun run smoke:cli
- bun run smoke:mcp

Note: CLI and MCP smoke were rerun sequentially after a parallel run exceeded the 120s tool timeout.