### PR TITLE
fix: refresh auth before init login

### DIFF
--- a/docs/implementation/auth.md
+++ b/docs/implementation/auth.md
@@ -45,6 +45,7 @@ Tokens are JWTs with a configurable expiration (typically 1 hour). The CLI handl
 - **Shared retry helper** — GitHits REST calls and package/source service calls both use the same token-refresh/retry flow, so auth drift is handled consistently across both service families.
 - **Concurrent coalescing** — Multiple concurrent refresh requests share a single in-flight Promise. Storage writes use compare-and-swap helpers so a failed refresh cannot overwrite or clear credentials another process already updated.
 - **At login** (`src/commands/login.ts`) — Checks if existing token is still valid before starting the OAuth flow. Respects `--force` flag to re-authenticate regardless.
+- **At init** (`src/commands/init/init.ts`) — Resolves auth through `createContainer()` at the login step so standard token refresh runs before falling back to browser login.
 - **At auth status** (`src/commands/auth-status.ts`) — Attempts refresh before reporting "Token expired".
 
 For short-lived CLI commands, each invocation gets a fresh `TokenManager`. For the long-running MCP server, the same `TokenManager` + `RefreshingGitHitsService` instance is reused across all tool calls, ensuring tokens stay fresh throughout the session.

--- a/src/commands/init/init.test.ts
+++ b/src/commands/init/init.test.ts
@@ -1007,6 +1007,93 @@ describe("initAction", () => {
       expect(fs.atomicWriteFile).toHaveBeenCalled();
     });
 
+    it("skips browser login when token resolution already refreshed auth", async () => {
+      const fs = createFsWithDetection(["/home/test/.cursor"]);
+      const promptService = createMockPromptService({
+        confirm3: mock(() => Promise.resolve("yes" as ConfirmChoice)),
+      });
+      const discoverEndpoints = mock(() =>
+        Promise.reject(new Error("login flow should not run")),
+      );
+      const open = mock(() =>
+        Promise.reject(new Error("browser not expected")),
+      );
+      const loadTokens = mock(() =>
+        Promise.resolve(
+          createValidTokenData({
+            expiresAt: new Date(Date.now() - 3600_000).toISOString(),
+          }),
+        ),
+      );
+      const createLoginDeps = mock(() =>
+        Promise.resolve({
+          authService: createMockAuthService({ discoverEndpoints }),
+          authStorage: createMockAuthStorage({ loadTokens }),
+          browserService: createMockBrowserService({ open }),
+          mcpUrl: "https://mcp.githits.com",
+          hasValidToken: true,
+        }),
+      );
+
+      await initAction(
+        {},
+        {
+          fileSystemService: fs,
+          promptService,
+          execService: createMockExecService(),
+          createLoginDeps,
+        },
+      );
+
+      const logCalls = getLogOutput();
+      expect(
+        logCalls.some((msg) => msg.includes("Already authenticated")),
+      ).toBe(true);
+      expect(discoverEndpoints).not.toHaveBeenCalled();
+      expect(open).not.toHaveBeenCalled();
+      expect(loadTokens).not.toHaveBeenCalled();
+      expect(fs.atomicWriteFile).toHaveBeenCalled();
+    });
+
+    it("clears stale client before init login when token resolution found no token", async () => {
+      const fs = createFsWithDetection(["/home/test/.cursor"]);
+      const promptService = createMockPromptService({
+        confirm3: mock(() => Promise.resolve("yes" as ConfirmChoice)),
+      });
+      const authStorage = createMockAuthStorage({
+        loadTokens: mock(() => Promise.resolve(null)),
+      });
+      const createLoginDeps = mock(() =>
+        Promise.resolve({
+          authService: createMockAuthService(),
+          authStorage,
+          browserService: createMockBrowserService(),
+          mcpUrl: "https://mcp.githits.com",
+          hasValidToken: false,
+        }),
+      );
+
+      await initAction(
+        {},
+        {
+          fileSystemService: fs,
+          promptService,
+          execService: createMockExecService(),
+          createLoginDeps,
+        },
+      );
+
+      expect(authStorage.clearClient).toHaveBeenCalledWith(
+        "https://mcp.githits.com",
+      );
+      expect(authStorage.saveAuthSession).toHaveBeenCalledWith(
+        "https://mcp.githits.com",
+        expect.any(Object),
+        expect.any(Object),
+      );
+      expect(fs.atomicWriteFile).toHaveBeenCalled();
+    });
+
     it("runs login flow and proceeds on success", async () => {
       const fs = createFsWithDetection(["/home/test/.cursor"]);
       const promptService = createMockPromptService({

--- a/src/commands/init/init.ts
+++ b/src/commands/init/init.ts
@@ -1,6 +1,6 @@
 import { ExitPromptError } from "@inquirer/core";
 import type { Command } from "commander";
-import { createAuthCommandDependencies } from "../../container.js";
+import { createContainer } from "../../container.js";
 import type { ExecService } from "../../services/exec-service.js";
 import { ExecServiceImpl } from "../../services/exec-service.js";
 import type { FileSystemService } from "../../services/filesystem-service.js";
@@ -54,13 +54,17 @@ export interface InitUninstallOptions {
   yes?: boolean;
 }
 
+interface InitLoginDependencies extends LoginDependencies {
+  hasValidToken?: boolean;
+}
+
 /** Dependencies for the init command */
 export interface InitDependencies {
   fileSystemService: FileSystemService;
   promptService: PromptService;
   execService: ExecService;
   /** Factory to create auth deps for the login step. Omit to skip login. */
-  createLoginDeps?: () => Promise<LoginDependencies>;
+  createLoginDeps?: () => Promise<InitLoginDependencies>;
 }
 
 /** Tracks per-agent setup outcome for the summary */
@@ -343,7 +347,9 @@ export async function initAction(
     let loginResult: LoginFlowResult;
     try {
       const loginDeps = await createLoginDeps();
-      loginResult = await loginFlow({}, loginDeps);
+      loginResult = loginDeps.hasValidToken
+        ? { status: "already_authenticated", message: "Already logged in." }
+        : await loginFlow({}, loginDeps);
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);
       loginResult = { status: "failed", message: msg };
@@ -807,7 +813,7 @@ export function registerInitCommand(program: Command) {
         fileSystemService,
         promptService,
         execService,
-        createLoginDeps: () => createAuthCommandDependencies(),
+        createLoginDeps: () => createContainer(),
       });
     });
 


### PR DESCRIPTION
## Summary
- route init authentication through the standard container token resolution path
- skip browser login when token refresh already produced a valid token
- document init's auth refresh behavior and cover refreshed/no-token fallback cases

## Tests
- bun test src/commands/init/init.test.ts src/commands/login.test.ts src/shared/auto-login.test.ts src/services/token-manager.test.ts
- bun run build