### PR TITLE
feat: improve init onboarding flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ GitHits gives your AI coding assistant access to verified, canonical code exampl
 npx githits init
 ```
 
-`init` explains the setup options, lets you install the local GitHits MCP server or use GitHits Skills, detects supported coding tools, signs you in, and connects the selected agents to GitHits.
+`init` walks you through setup: choose the local MCP server or Agent Skills, detect your coding tools, sign in, and connect everything to GitHits.
 
-Supported tools: Claude Code, Cursor, Windsurf, VS Code / Copilot, Cline, Claude Desktop, Codex CLI, Gemini CLI, Google Antigravity, and OpenCode.
+Supported tools: Claude Code, Cursor, Windsurf, VS Code / Copilot, Cline, Claude Desktop, Codex CLI, Pi, Gemini CLI, Google Antigravity, and OpenCode.
 
 If you are using a tool that is not listed above, use the manual MCP setup instructions near the end of this README.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ GitHits gives your AI coding assistant access to verified, canonical code exampl
 npx githits init
 ```
 
-`init` authenticates with your [GitHits](https://githits.com) account, then auto-detects your installed coding tools and configures each one with GitHits MCP.
+`init` explains the setup options, lets you install the local GitHits MCP server or use GitHits Skills, detects supported coding tools, signs you in, and connects the selected agents to GitHits.
 
 Supported tools: Claude Code, Cursor, Windsurf, VS Code / Copilot, Cline, Claude Desktop, Codex CLI, Gemini CLI, Google Antigravity, and OpenCode.
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -32,6 +32,7 @@ import {
   FileSystemServiceImpl,
   NpmRegistryUpdateCheckService,
 } from "./services/index.js";
+import { colorizeBrand, shouldUseColors } from "./shared/colors.js";
 import {
   createRootCliPreAction,
   endTelemetrySpan,
@@ -42,6 +43,7 @@ import {
 } from "./shared/index.js";
 
 const program = new Command();
+const useColors = shouldUseColors();
 const argv = process.argv.slice(2);
 const commandSpans = new WeakMap<
   Command,
@@ -90,9 +92,13 @@ const rootCliPreAction = createRootCliPreAction({
 
 program
   .name("githits")
-  .description("Code examples from global open source for your AI assistant")
+  .description("Grounded open-source context for AI coding agents")
   .version(version)
   .option("--no-color", "Disable colored output")
+  .configureHelp({
+    styleTitle: (title: string) =>
+      colorizeBrand(title, "primary", useColors, { bold: true }),
+  })
   .hook("preAction", async (thisCommand, actionCommand) => {
     const command = actionCommand ?? thisCommand;
     commandSpans.set(
@@ -108,14 +114,14 @@ program
   .addHelpText(
     "after",
     `
-Getting started:
-  githits init                         Set up MCP for your coding agents
-  githits login                        Authenticate with your GitHits account
+${colorizeBrand("Getting started:", "primary", useColors, { bold: true })}
+  githits init                         Connect GitHits to your coding agents
+  githits login                        Sign in to your GitHits account
   githits mcp                          Show MCP setup instructions
-  githits example "query"              Get code examples
+  githits example "query"              Find real-world implementations
 
 Learn more at https://githits.com
-Docs: https://app.githits.com/docs/
+Docs: https://docs.githits.com
 Support: support@githits.com`,
   );
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -43,8 +43,13 @@ import {
 } from "./shared/index.js";
 
 const program = new Command();
-const useColors = shouldUseColors();
 const argv = process.argv.slice(2);
+// Bridge the --no-color flag to the NO_COLOR convention that every
+// shouldUseColors() call across the CLI reads.
+if (argv.includes("--no-color")) {
+  process.env.NO_COLOR = "1";
+}
+const useColors = shouldUseColors();
 const commandSpans = new WeakMap<
   Command,
   ReturnType<typeof startTelemetrySpan>

--- a/src/commands/code/files.ts
+++ b/src/commands/code/files.ts
@@ -6,7 +6,12 @@ import {
   MAX_WAIT_TIMEOUT_MS,
 } from "../../shared/code-navigation-defaults.js";
 import { shouldUseColors } from "../../shared/colors.js";
-import { InvalidPackageSpecError, requireAuth } from "../../shared/index.js";
+import {
+  InvalidPackageSpecError,
+  requireAuth,
+  SPINNER_MESSAGES,
+  startSpinner,
+} from "../../shared/index.js";
 import {
   buildListFilesParams,
   type ListFilesRequestBuildResult,
@@ -110,7 +115,10 @@ export async function pkgFilesAction(
       limit,
       waitTimeoutMs: wait,
     });
-    const result = await deps.codeNavigationService.listFiles(build.params);
+    const spinner = startSpinner(SPINNER_MESSAGES.code, !options.json);
+    const result = await deps.codeNavigationService
+      .listFiles(build.params)
+      .finally(() => spinner.stop());
 
     const payload = buildListFilesSuccessPayload(result, {
       registry: target.registry

--- a/src/commands/code/grep.ts
+++ b/src/commands/code/grep.ts
@@ -15,6 +15,8 @@ import {
   type GrepRepoRequestInput,
   InvalidPackageSpecError,
   requireAuth,
+  SPINNER_MESSAGES,
+  startSpinner,
 } from "../../shared/index.js";
 import { toPkgseerRegistryLowercase } from "../../shared/pkgseer-registry.js";
 import {
@@ -130,7 +132,10 @@ export async function pkgGrepAction(
       symbolFields: options.symbolField,
       waitTimeoutMs: wait,
     });
-    const result = await deps.codeNavigationService.grepRepo(build.params);
+    const spinner = startSpinner(SPINNER_MESSAGES.code, !options.json);
+    const result = await deps.codeNavigationService
+      .grepRepo(build.params)
+      .finally(() => spinner.stop());
 
     const payload = buildGrepRepoSuccessPayload(result, {
       registry: target.registry

--- a/src/commands/code/index.ts
+++ b/src/commands/code/index.ts
@@ -23,7 +23,7 @@ export async function registerCodeCommandGroup(
 
   const codeCommand = program
     .command("code")
-    .summary("Source-level operations on indexed dependencies")
+    .summary("Inspect dependency source code and symbols")
     .description(
       "List files, read files, and grep substrings inside indexed dependency source. Every command accepts either `<spec>` (registry:name[@version]) or `--repo-url <url> [--git-ref <ref>]`. Omitted package versions use the latest release; omitted repo refs use the default-branch intent. For package-level metadata use `githits pkg`.",
     );

--- a/src/commands/code/read.ts
+++ b/src/commands/code/read.ts
@@ -6,7 +6,12 @@ import {
   MAX_WAIT_TIMEOUT_MS,
 } from "../../shared/code-navigation-defaults.js";
 import { shouldUseColors } from "../../shared/colors.js";
-import { InvalidPackageSpecError, requireAuth } from "../../shared/index.js";
+import {
+  InvalidPackageSpecError,
+  requireAuth,
+  SPINNER_MESSAGES,
+  startSpinner,
+} from "../../shared/index.js";
 import { toPkgseerRegistryLowercase } from "../../shared/pkgseer-registry.js";
 import { withReadFileRecovery } from "../../shared/read-file-error.js";
 import { buildReadFileParams } from "../../shared/read-file-request.js";
@@ -102,7 +107,10 @@ export async function pkgReadAction(
       endLine: range.endLine,
       waitTimeoutMs: wait,
     });
-    const result = await deps.codeNavigationService.readFile(build.params);
+    const spinner = startSpinner(SPINNER_MESSAGES.code, !options.json);
+    const result = await deps.codeNavigationService
+      .readFile(build.params)
+      .finally(() => spinner.stop());
 
     const payload = buildReadFileSuccessPayload(result, {
       registry: target.registry

--- a/src/commands/docs/index.ts
+++ b/src/commands/docs/index.ts
@@ -19,7 +19,7 @@ export async function registerDocsCommandGroup(
 
   const docsCommand = program
     .command("docs")
-    .summary("Browse and read mixed package documentation")
+    .summary("Browse and read package documentation")
     .description(
       "Browse and read package documentation across hosted docs and repository-backed docs. Docs are mixed by default; entries are source-badged and repo-backed pages also expose exact file follow-up metadata.",
     );

--- a/src/commands/docs/list.ts
+++ b/src/commands/docs/list.ts
@@ -11,6 +11,8 @@ import {
   mapPackageIntelligenceError,
   parsePackageSpec,
   requireAuth,
+  SPINNER_MESSAGES,
+  startSpinner,
 } from "../../shared/index.js";
 
 export interface DocsListCommandOptions {
@@ -50,9 +52,10 @@ export async function docsListAction(
       limit,
       after: options.after,
     });
-    const result = await deps.packageIntelligenceService.listPackageDocs(
-      build.params,
-    );
+    const spinner = startSpinner(SPINNER_MESSAGES.docs, !options.json);
+    const result = await deps.packageIntelligenceService
+      .listPackageDocs(build.params)
+      .finally(() => spinner.stop());
     const payload = buildListPackageDocsSuccessPayload(result, {
       limitExplicit: build.limitExplicit,
       afterExplicit: build.afterExplicit,

--- a/src/commands/docs/read.ts
+++ b/src/commands/docs/read.ts
@@ -10,7 +10,9 @@ import {
   mapPackageIntelligenceError,
   parseLinesOption,
   requireAuth,
+  SPINNER_MESSAGES,
   shouldUseColors,
+  startSpinner,
 } from "../../shared/index.js";
 
 export interface DocsReadCommandOptions {
@@ -43,9 +45,10 @@ export async function docsReadAction(
     const range = options.lines ? parseLinesOption(options.lines) : undefined;
 
     const build = buildReadPackageDocParams({ pageId });
-    const result = await deps.packageIntelligenceService.readPackageDoc(
-      build.params,
-    );
+    const spinner = startSpinner(SPINNER_MESSAGES.docs, !options.json);
+    const result = await deps.packageIntelligenceService
+      .readPackageDoc(build.params)
+      .finally(() => spinner.stop());
     const payload = buildReadPackageDocSuccessPayload(
       result,
       build.params.pageId,

--- a/src/commands/example.ts
+++ b/src/commands/example.ts
@@ -3,6 +3,8 @@ import type { GitHitsService } from "../services/githits-service.js";
 import { AuthenticationError } from "../services/githits-service.js";
 import { extractSolutionId } from "../shared/extract-solution-id.js";
 import { AuthRequiredError, requireAuth } from "../shared/require-auth.js";
+import { startSpinner } from "../shared/spinner.js";
+import { SPINNER_MESSAGES } from "../shared/spinner-messages.js";
 
 export interface ExampleOptions {
   lang?: string;
@@ -34,12 +36,15 @@ export async function exampleAction(
   requireAuth(deps);
 
   try {
-    const result = await deps.githitsService.search({
-      query,
-      language: options.lang,
-      licenseMode: options.license,
-      includeExplanation: options.explain,
-    });
+    const spinner = startSpinner(SPINNER_MESSAGES.example, !options.json);
+    const result = await deps.githitsService
+      .search({
+        query,
+        language: options.lang,
+        licenseMode: options.license,
+        includeExplanation: options.explain,
+      })
+      .finally(() => spinner.stop());
 
     if (options.json) {
       const solutionId = extractSolutionId(result);
@@ -90,7 +95,7 @@ Examples:
 export function registerExampleCommand(program: Command) {
   program
     .command("example")
-    .summary("Get code examples from global open source")
+    .summary("Find real-world implementations from open-source code")
     .description(EXAMPLE_DESCRIPTION)
     .argument("<query>", "Natural language example-search query")
     .option(

--- a/src/commands/feedback.ts
+++ b/src/commands/feedback.ts
@@ -88,7 +88,7 @@ Examples:
 export function registerFeedbackCommand(program: Command) {
   program
     .command("feedback")
-    .summary("Submit feedback on a tool result or the GitHits experience")
+    .summary("Submit feedback about GitHits results or experience")
     .description(FEEDBACK_DESCRIPTION)
     .argument(
       "[solution_id]",

--- a/src/commands/init/agent-definitions.test.ts
+++ b/src/commands/init/agent-definitions.test.ts
@@ -5,6 +5,7 @@ import {
   createMockFileSystemService,
 } from "../../services/test-helpers.js";
 import {
+  type AgentDefinition,
   agentDefinitions,
   buildCheckboxChoices,
   detectAgents,
@@ -1045,6 +1046,23 @@ describe("scanAgents", () => {
     return platform === "win32" ? "where" : "which";
   }
 
+  function createPathOnlyAgent(id: string): AgentDefinition {
+    return {
+      id,
+      name: id,
+      detectionMethod: "path",
+      setupMethod: "config-file",
+      detectPaths: () => [`/agents/${id}`],
+      getSetupConfig: () => ({
+        method: "config-file",
+        configPath: `/agents/${id}/mcp.json`,
+        serversKey: "mcpServers",
+        serverName: "GitHits",
+        serverConfig: {},
+      }),
+    };
+  }
+
   /** Helper to create fs + exec mocks for scan tests */
   function createScanMocks(opts: {
     detectedDirs?: string[];
@@ -1081,6 +1099,35 @@ describe("scanAgents", () => {
     });
     return { fs, execService };
   }
+
+  it("scans agents in parallel and reports progress", async () => {
+    let activeChecks = 0;
+    let maxActiveChecks = 0;
+    const fs = createMockFileSystemService({
+      isDirectory: mock(async () => {
+        activeChecks += 1;
+        maxActiveChecks = Math.max(maxActiveChecks, activeChecks);
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        activeChecks -= 1;
+        return false;
+      }),
+    });
+    const execService = createMockExecService();
+    const progress: number[] = [];
+
+    const result = await scanAgents(
+      [createPathOnlyAgent("one"), createPathOnlyAgent("two")],
+      fs,
+      execService,
+      {
+        onProgress: ({ completed }) => progress.push(completed),
+      },
+    );
+
+    expect(result.notDetected.map((agent) => agent.id)).toEqual(["one", "two"]);
+    expect(maxActiveChecks).toBe(2);
+    expect(progress).toEqual([1, 2]);
+  });
 
   it("categorizes config-file agent as alreadyConfigured when config has GitHits", async () => {
     const { fs, execService } = createScanMocks({

--- a/src/commands/init/agent-definitions.ts
+++ b/src/commands/init/agent-definitions.ts
@@ -752,113 +752,157 @@ export interface ScanResult {
   notDetected: AgentDefinition[];
 }
 
+export interface ScanProgress {
+  completed: number;
+  total: number;
+  agent: AgentDefinition;
+}
+
+export interface ScanAgentsOptions {
+  onProgress?: (progress: ScanProgress) => void;
+}
+
+type AgentScanOutcome =
+  | { status: "needs_setup"; agent: AgentDefinition }
+  | { status: "already_configured"; agent: AgentDefinition }
+  | { status: "not_detected"; agent: AgentDefinition };
+
+async function scanSingleAgent(
+  agent: AgentDefinition,
+  fs: FileSystemService,
+  execService: ExecService,
+): Promise<AgentScanOutcome> {
+  // Check if available using the agent's declared detection contract.
+  let detected = false;
+  let setupContext: AgentSetupContext | undefined;
+
+  if (agent.detectCommand) {
+    try {
+      const resolvedCommand = await agent.detectCommand(execService, fs);
+      if (resolvedCommand) {
+        detected = true;
+        setupContext = { command: resolvedCommand.command };
+      }
+    } catch {
+      detected = false;
+    }
+  } else if (agent.detectionMethod === "binary" && agent.detectBinary) {
+    try {
+      detected = await agent.detectBinary(execService);
+    } catch {
+      detected = false;
+    }
+  } else if (agent.detectionMethod === "path" && agent.detectPaths) {
+    const paths = agent.detectPaths(fs);
+    for (const path of paths) {
+      if (await fs.isDirectory(path)) {
+        detected = true;
+        break;
+      }
+    }
+  } else if (agent.detectionMethod === "hybrid") {
+    let binaryDetected = false;
+    let pathDetected = false;
+
+    if (agent.detectBinary) {
+      try {
+        binaryDetected = await agent.detectBinary(execService);
+      } catch {
+        binaryDetected = false;
+      }
+    }
+
+    if (!binaryDetected && agent.detectPaths) {
+      const paths = agent.detectPaths(fs);
+      for (const path of paths) {
+        if (await fs.isDirectory(path)) {
+          pathDetected = true;
+          break;
+        }
+      }
+    }
+
+    detected = binaryDetected || pathDetected;
+  }
+
+  if (!detected) {
+    return { status: "not_detected", agent };
+  }
+
+  const config = agent.getSetupConfig(fs, setupContext);
+  const scannedAgent: AgentDefinition = {
+    ...agent,
+    resolvedSetupConfig: config,
+    resolvedSetupContext: setupContext,
+  };
+  if (agent.id === "gemini-cli" && config.method === "cli") {
+    if (!config.checkCommand) {
+      return { status: "needs_setup", agent: scannedAgent };
+    }
+
+    const checkStatus = await getCliCheckStatus(
+      config.checkCommand,
+      execService,
+    );
+    let configured = checkStatus === "configured";
+    // Only use filesystem fallback when the CLI probe itself failed.
+    // If Gemini explicitly reports "not installed", do not override it.
+    if (!configured && checkStatus === "probe_failed") {
+      configured = await isGeminiExtensionInstalledFromFilesystem(fs);
+    }
+    return {
+      status: configured ? "already_configured" : "needs_setup",
+      agent: scannedAgent,
+    };
+  }
+
+  if (await isSetupAlreadyConfigured(config, fs, execService)) {
+    return { status: "already_configured", agent: scannedAgent };
+  }
+  return { status: "needs_setup", agent: scannedAgent };
+}
+
 /**
  * Scan all agents: detect availability and check configuration status.
  * Config-file agents get a pre-check via isAlreadyConfigured().
  * CLI agents with a checkCommand get a pre-check via isCliAlreadyConfigured().
  * CLI agents without a checkCommand are treated as needsSetup.
+ * Agent probes run in parallel while output order remains definition order.
  */
 export async function scanAgents(
   definitions: AgentDefinition[],
   fs: FileSystemService,
   execService: ExecService,
+  options: ScanAgentsOptions = {},
 ): Promise<ScanResult> {
   const result: ScanResult = {
     needsSetup: [],
     alreadyConfigured: [],
     notDetected: [],
   };
+  let completed = 0;
 
-  for (const agent of definitions) {
-    // Check if available using the agent's declared detection contract
-    let detected = false;
-    let setupContext: AgentSetupContext | undefined;
+  const outcomes = await Promise.all(
+    definitions.map((agent) =>
+      scanSingleAgent(agent, fs, execService).then((outcome) => {
+        completed += 1;
+        options.onProgress?.({
+          completed,
+          total: definitions.length,
+          agent: outcome.agent,
+        });
+        return outcome;
+      }),
+    ),
+  );
 
-    if (agent.detectCommand) {
-      try {
-        const resolvedCommand = await agent.detectCommand(execService, fs);
-        if (resolvedCommand) {
-          detected = true;
-          setupContext = { command: resolvedCommand.command };
-        }
-      } catch {
-        detected = false;
-      }
-    } else if (agent.detectionMethod === "binary" && agent.detectBinary) {
-      try {
-        detected = await agent.detectBinary(execService);
-      } catch {
-        detected = false;
-      }
-    } else if (agent.detectionMethod === "path" && agent.detectPaths) {
-      const paths = agent.detectPaths(fs);
-      for (const path of paths) {
-        if (await fs.isDirectory(path)) {
-          detected = true;
-          break;
-        }
-      }
-    } else if (agent.detectionMethod === "hybrid") {
-      let binaryDetected = false;
-      let pathDetected = false;
-
-      if (agent.detectBinary) {
-        try {
-          binaryDetected = await agent.detectBinary(execService);
-        } catch {
-          binaryDetected = false;
-        }
-      }
-
-      if (!binaryDetected && agent.detectPaths) {
-        const paths = agent.detectPaths(fs);
-        for (const path of paths) {
-          if (await fs.isDirectory(path)) {
-            pathDetected = true;
-            break;
-          }
-        }
-      }
-
-      detected = binaryDetected || pathDetected;
-    }
-
-    if (!detected) {
-      result.notDetected.push(agent);
-      continue;
-    }
-
-    // Detected — check configuration status
-    const config = agent.getSetupConfig(fs, setupContext);
-    const scannedAgent: AgentDefinition = {
-      ...agent,
-      resolvedSetupConfig: config,
-      resolvedSetupContext: setupContext,
-    };
-    if (agent.id === "gemini-cli" && config.method === "cli") {
-      if (config.checkCommand) {
-        const checkStatus = await getCliCheckStatus(
-          config.checkCommand,
-          execService,
-        );
-        let configured = checkStatus === "configured";
-        // Only use filesystem fallback when the CLI probe itself failed.
-        // If Gemini explicitly reports "not installed", do not override it.
-        if (!configured && checkStatus === "probe_failed") {
-          configured = await isGeminiExtensionInstalledFromFilesystem(fs);
-        }
-        if (configured) {
-          result.alreadyConfigured.push(scannedAgent);
-        } else {
-          result.needsSetup.push(scannedAgent);
-        }
-      } else {
-        result.needsSetup.push(scannedAgent);
-      }
-    } else if (await isSetupAlreadyConfigured(config, fs, execService)) {
-      result.alreadyConfigured.push(scannedAgent);
+  for (const outcome of outcomes) {
+    if (outcome.status === "already_configured") {
+      result.alreadyConfigured.push(outcome.agent);
+    } else if (outcome.status === "needs_setup") {
+      result.needsSetup.push(outcome.agent);
     } else {
-      result.needsSetup.push(scannedAgent);
+      result.notDetected.push(outcome.agent);
     }
   }
 

--- a/src/commands/init/init.test.ts
+++ b/src/commands/init/init.test.ts
@@ -95,16 +95,12 @@ function expectReadyNextSteps(logCalls: string[]): void {
   expect(logCalls.some((msg) => msg.includes("GitHits is connected"))).toBe(
     true,
   );
+  expect(logCalls.some((msg) => msg.includes("Your agent can now:"))).toBe(
+    true,
+  );
   expect(
     logCalls.some((msg) =>
-      msg.includes(
-        'npx githits@latest example "How do I use useEffect cleanup?"',
-      ),
-    ),
-  ).toBe(true);
-  expect(
-    logCalls.some((msg) =>
-      msg.includes("HTTP retries with exponential backoff"),
+      msg.includes("How does Next.js implement route prefetching"),
     ),
   ).toBe(true);
 }
@@ -196,36 +192,25 @@ describe("initAction", () => {
     expect(fs.atomicWriteFile).toHaveBeenCalled();
     const logCalls = getLogOutput();
     expect(
-      logCalls.some((msg) => msg.includes("source-backed open-source context")),
-    ).toBe(true);
-    expect(
-      logCalls.some((msg) => msg.includes("stores tokens in your OS keychain")),
+      logCalls.some((msg) =>
+        msg.includes("GitHits helps coding agents stop guessing"),
+      ),
     ).toBe(true);
     expect(
       logCalls.some((msg) =>
-        msg.includes("https://docs.githits.com/quickstart"),
+        msg.includes("grounded context from real open-source code"),
       ),
     ).toBe(true);
-    expect(logCalls.some((msg) => msg.includes("What will happen"))).toBe(true);
+    expect(logCalls.some((msg) => msg.includes("Your agent can:"))).toBe(true);
     expect(
-      logCalls.some(
-        (msg) =>
-          msg.includes("1. Detect tools") &&
-          msg.includes("Find supported AI coding tools"),
-      ),
+      logCalls.some((msg) => msg.includes("https://docs.githits.com")),
     ).toBe(true);
-    expect(
-      logCalls.some(
-        (msg) =>
-          msg.includes("2. Choose tools") &&
-          msg.includes("Pick which detected tools"),
-      ),
-    ).toBe(true);
+    expect(logCalls.some((msg) => msg.includes("1. Detect tools"))).toBe(true);
+    expect(logCalls.some((msg) => msg.includes("2. Choose tools"))).toBe(true);
     expect(logCalls.some((msg) => msg.includes("3. Sign in"))).toBe(true);
     expect(logCalls.some((msg) => msg.includes("4. Install and verify"))).toBe(
       true,
     );
-    expect(logCalls.some((msg) => msg.includes("5. Ready"))).toBe(true);
     expect(
       logCalls.some(
         (msg) => msg.includes("Cursor") && msg.includes("installing"),

--- a/src/commands/init/init.test.ts
+++ b/src/commands/init/init.test.ts
@@ -150,6 +150,7 @@ describe("initAction", () => {
       ),
     ).toBe(true);
     expect(fs.atomicWriteFile).not.toHaveBeenCalled();
+    expect(execService.exec).not.toHaveBeenCalled();
     expect(createLoginDeps).not.toHaveBeenCalled();
   });
 
@@ -172,6 +173,7 @@ describe("initAction", () => {
 
     const logCalls = getLogOutput();
     expect(logCalls.some((msg) => msg.includes("No changes made"))).toBe(true);
+    expect(execService.exec).not.toHaveBeenCalled();
     expect(fs.atomicWriteFile).not.toHaveBeenCalled();
   });
 

--- a/src/commands/init/init.test.ts
+++ b/src/commands/init/init.test.ts
@@ -103,6 +103,9 @@ function expectReadyNextSteps(logCalls: string[]): void {
       msg.includes("How does Next.js implement route prefetching"),
     ),
   ).toBe(true);
+  expect(
+    logCalls.some((msg) => msg.includes("Agent instruction snippet")),
+  ).toBe(true);
 }
 
 function expectAuthNotCheckedNextSteps(logCalls: string[]): void {

--- a/src/commands/init/init.test.ts
+++ b/src/commands/init/init.test.ts
@@ -9,7 +9,10 @@ import {
 } from "bun:test";
 import { ExitPromptError } from "@inquirer/core";
 import { Command } from "commander";
-import type { ConfirmChoice } from "../../services/prompt-service.js";
+import type {
+  ConfirmChoice,
+  PromptService,
+} from "../../services/prompt-service.js";
 import {
   createMockAuthService,
   createMockAuthStorage,
@@ -89,10 +92,9 @@ function getLogOutput(): string[] {
 }
 
 function expectReadyNextSteps(logCalls: string[]): void {
-  expect(logCalls.some((msg) => msg.includes("Setup complete"))).toBe(true);
-  expect(
-    logCalls.some((msg) => msg.includes("You're ready to use GitHits")),
-  ).toBe(true);
+  expect(logCalls.some((msg) => msg.includes("GitHits is connected"))).toBe(
+    true,
+  );
   expect(
     logCalls.some((msg) =>
       msg.includes(
@@ -102,9 +104,18 @@ function expectReadyNextSteps(logCalls: string[]): void {
   ).toBe(true);
   expect(
     logCalls.some((msg) =>
-      msg.includes("query planner selects join strategies"),
+      msg.includes("HTTP retries with exponential backoff"),
     ),
   ).toBe(true);
+}
+
+function expectAuthNotCheckedNextSteps(logCalls: string[]): void {
+  expect(logCalls.some((msg) => msg.includes("Sign-in was not checked"))).toBe(
+    true,
+  );
+  expect(logCalls.some((msg) => msg.includes("npx githits@latest login"))).toBe(
+    true,
+  );
 }
 
 function lookupCommandFor(platform: string = process.platform): string {
@@ -112,12 +123,62 @@ function lookupCommandFor(platform: string = process.platform): string {
 }
 
 describe("initAction", () => {
+  it("prints Agent Skills instructions without changing MCP config", async () => {
+    const fs = createFsWithDetection(["/home/test/.cursor"]);
+    const execService = createMockExecService();
+    const createLoginDeps = mock(() =>
+      Promise.resolve({} as LoginDependencies),
+    );
+    const promptService = createMockPromptService({
+      select: mock(() => Promise.resolve("skills")) as PromptService["select"],
+    });
+
+    await initAction(
+      {},
+      {
+        fileSystemService: fs,
+        promptService,
+        execService,
+        createLoginDeps,
+      },
+    );
+
+    const logCalls = getLogOutput();
+    expect(
+      logCalls.some((msg) =>
+        msg.includes("npx skills add githits-com/githits-cli"),
+      ),
+    ).toBe(true);
+    expect(fs.atomicWriteFile).not.toHaveBeenCalled();
+    expect(createLoginDeps).not.toHaveBeenCalled();
+  });
+
+  it("exits cleanly when user chooses Later", async () => {
+    const fs = createFsWithDetection(["/home/test/.cursor"]);
+    const execService = createMockExecService();
+    const promptService = createMockPromptService({
+      select: mock(() => Promise.resolve("later")) as PromptService["select"],
+    });
+
+    await initAction(
+      {},
+      {
+        fileSystemService: fs,
+        promptService,
+        execService,
+        createLoginDeps: createAlreadyAuthLoginDeps(),
+      },
+    );
+
+    const logCalls = getLogOutput();
+    expect(logCalls.some((msg) => msg.includes("No changes made"))).toBe(true);
+    expect(fs.atomicWriteFile).not.toHaveBeenCalled();
+  });
+
   it("scans agents and sets up unconfigured ones", async () => {
     // Cursor detected but not configured
     const fs = createFsWithDetection(["/home/test/.cursor"]);
-    const promptService = createMockPromptService({
-      confirm3: mock(() => Promise.resolve("yes" as ConfirmChoice)),
-    });
+    const promptService = createMockPromptService();
 
     await initAction(
       {},
@@ -129,10 +190,24 @@ describe("initAction", () => {
       },
     );
 
-    // Should attempt to write cursor config (no checkbox prompt)
-    expect(promptService.checkbox).not.toHaveBeenCalled();
-    expect(promptService.confirm3).toHaveBeenCalled();
+    // Checkbox selection is the approval boundary.
+    expect(promptService.checkbox).toHaveBeenCalled();
+    expect(promptService.confirm3).not.toHaveBeenCalled();
     expect(fs.atomicWriteFile).toHaveBeenCalled();
+    const logCalls = getLogOutput();
+    expect(logCalls.some((msg) => msg.includes("What will happen"))).toBe(true);
+    expect(logCalls.some((msg) => msg.includes("1. Detect Agents"))).toBe(true);
+    expect(logCalls.some((msg) => msg.includes("2. Choose Agents"))).toBe(true);
+    expect(logCalls.some((msg) => msg.includes("3. Sign In"))).toBe(true);
+    expect(logCalls.some((msg) => msg.includes("4. Install And Verify"))).toBe(
+      true,
+    );
+    expect(logCalls.some((msg) => msg.includes("5. Ready"))).toBe(true);
+    expect(
+      logCalls.some(
+        (msg) => msg.includes("Cursor") && msg.includes("installing"),
+      ),
+    ).toBe(true);
   });
 
   it("skips already-configured agents without prompting", async () => {
@@ -184,9 +259,7 @@ describe("initAction", () => {
         }),
       },
     );
-    const promptService = createMockPromptService({
-      confirm3: mock(() => Promise.resolve("yes" as ConfirmChoice)),
-    });
+    const promptService = createMockPromptService();
 
     await initAction(
       {},
@@ -199,7 +272,8 @@ describe("initAction", () => {
     );
 
     // Should only set up windsurf
-    expect(promptService.confirm3).toHaveBeenCalledTimes(1);
+    expect(promptService.checkbox).toHaveBeenCalledTimes(1);
+    expect(promptService.confirm3).not.toHaveBeenCalled();
     expect(fs.atomicWriteFile).toHaveBeenCalled();
     const logCalls = getLogOutput();
     expect(
@@ -212,6 +286,34 @@ describe("initAction", () => {
         (msg) => msg.includes("Windsurf") && msg.includes("needs setup"),
       ),
     ).toBe(true);
+  });
+
+  it("configures only the agents selected in the checkbox", async () => {
+    const fs = createFsWithDetection([
+      "/home/test/.cursor",
+      "/home/test/.codeium/windsurf",
+    ]);
+    const promptService = createMockPromptService({
+      checkbox: mock((_message, choices) =>
+        Promise.resolve([choices[0]!.value]),
+      ),
+    });
+
+    await initAction(
+      {},
+      {
+        fileSystemService: fs,
+        promptService,
+        execService: createMockExecService(),
+        createLoginDeps: createAlreadyAuthLoginDeps(),
+      },
+    );
+
+    expect(fs.atomicWriteFile).toHaveBeenCalledTimes(1);
+    expect(fs.atomicWriteFile).toHaveBeenCalledWith(
+      "/home/test/.cursor/mcp.json",
+      expect.any(String),
+    );
   });
 
   it("sets up Pi by installing adapter and writing Pi-owned MCP config", async () => {
@@ -516,14 +618,13 @@ describe("initAction", () => {
     expect(execService.exec).toHaveBeenCalledWith("claude", expect.any(Array));
   });
 
-  it("stops prompting after 'always' response", async () => {
+  it("uses one checkbox prompt for multiple unconfigured agents", async () => {
     // Two unconfigured config-file agents
     const fs = createFsWithDetection([
       "/home/test/.cursor",
       "/home/test/.codeium/windsurf",
     ]);
-    const confirm3 = mock(() => Promise.resolve("always" as ConfirmChoice));
-    const promptService = createMockPromptService({ confirm3 });
+    const promptService = createMockPromptService();
 
     await initAction(
       {},
@@ -535,14 +636,14 @@ describe("initAction", () => {
       },
     );
 
-    // confirm3 called once (first agent), then "always" kicks in
-    expect(confirm3).toHaveBeenCalledTimes(1);
+    expect(promptService.checkbox).toHaveBeenCalledTimes(1);
+    expect(promptService.confirm3).not.toHaveBeenCalled();
   });
 
-  it("skips agent when user responds 'no'", async () => {
+  it("skips setup when user selects no agents", async () => {
     const fs = createFsWithDetection(["/home/test/.cursor"]);
     const promptService = createMockPromptService({
-      confirm3: mock(() => Promise.resolve("no" as ConfirmChoice)),
+      checkbox: mock(() => Promise.resolve([])),
     });
 
     await initAction(
@@ -597,7 +698,9 @@ describe("initAction", () => {
     expect(execService.exec).toHaveBeenCalledTimes(8);
     const logCalls = getLogOutput();
     expect(
-      logCalls.some((msg) => msg.includes("No coding agents detected")),
+      logCalls.some((msg) =>
+        msg.includes("No supported coding agents detected"),
+      ),
     ).toBe(true);
   });
 
@@ -768,18 +871,16 @@ describe("initAction", () => {
     expect(
       logCalls.some((msg) => msg.includes("Setup completed with errors")),
     ).toBe(true);
-    expect(
-      logCalls.some((msg) => msg.includes("You're ready to use GitHits")),
-    ).toBe(false);
+    expect(logCalls.some((msg) => msg.includes("GitHits is connected"))).toBe(
+      false,
+    );
     expect(logCalls.some((msg) => msg.includes("- Claude Code:"))).toBe(true);
   });
 
   it("treats Gemini already-installed setup output as already configured", async () => {
     const lookupCmd = lookupCommandFor();
     const fs = createFsWithDetection([]);
-    const promptService = createMockPromptService({
-      confirm3: mock(() => Promise.resolve("yes" as ConfirmChoice)),
-    });
+    const promptService = createMockPromptService();
     const execService = createMockExecService({
       exec: mock((cmd: string, args: string[]) => {
         const key = `${cmd} ${args.join(" ")}`;
@@ -910,9 +1011,7 @@ describe("initAction", () => {
 
     const logCalls = getLogOutput();
     expect(
-      logCalls.some(
-        (msg) => msg.includes("Gemini CLI") && msg.includes("not detected"),
-      ),
+      logCalls.some((msg) => msg.includes("supported agents not found")),
     ).toBe(true);
     expect(
       logCalls.some(
@@ -922,10 +1021,10 @@ describe("initAction", () => {
     expect(promptService.confirm3).not.toHaveBeenCalled();
   });
 
-  it("handles Ctrl+C on confirm3 prompt gracefully", async () => {
+  it("handles Ctrl+C on checkbox prompt gracefully", async () => {
     const fs = createFsWithDetection(["/home/test/.cursor"]);
     const promptService = createMockPromptService({
-      confirm3: mock(() =>
+      checkbox: mock(() =>
         Promise.reject(new ExitPromptError("User force closed")),
       ),
     });
@@ -944,10 +1043,10 @@ describe("initAction", () => {
     expect(logCalls.some((msg) => msg.includes("cancelled"))).toBe(true);
   });
 
-  it("rethrows non-ExitPromptError from confirm3", async () => {
+  it("rethrows non-ExitPromptError from checkbox", async () => {
     const fs = createFsWithDetection(["/home/test/.cursor"]);
     const promptService = createMockPromptService({
-      confirm3: mock(() => Promise.reject(new Error("Unexpected error"))),
+      checkbox: mock(() => Promise.reject(new Error("Unexpected error"))),
     });
 
     await expect(
@@ -966,7 +1065,7 @@ describe("initAction", () => {
   it("shows 'Setup skipped' when all unconfigured agents are skipped", async () => {
     const fs = createFsWithDetection(["/home/test/.cursor"]);
     const promptService = createMockPromptService({
-      confirm3: mock(() => Promise.resolve("no" as ConfirmChoice)),
+      checkbox: mock(() => Promise.resolve([])),
     });
 
     await initAction(
@@ -1001,9 +1100,9 @@ describe("initAction", () => {
       );
 
       const logCalls = getLogOutput();
-      expect(
-        logCalls.some((msg) => msg.includes("Already authenticated")),
-      ).toBe(true);
+      expect(logCalls.some((msg) => msg.includes("Already signed in"))).toBe(
+        true,
+      );
       expect(fs.atomicWriteFile).toHaveBeenCalled();
     });
 
@@ -1046,9 +1145,9 @@ describe("initAction", () => {
       );
 
       const logCalls = getLogOutput();
-      expect(
-        logCalls.some((msg) => msg.includes("Already authenticated")),
-      ).toBe(true);
+      expect(logCalls.some((msg) => msg.includes("Already signed in"))).toBe(
+        true,
+      );
       expect(discoverEndpoints).not.toHaveBeenCalled();
       expect(open).not.toHaveBeenCalled();
       expect(loadTokens).not.toHaveBeenCalled();
@@ -1120,7 +1219,7 @@ describe("initAction", () => {
 
       const logCalls = getLogOutput();
       expect(
-        logCalls.some((msg) => msg.includes("Logged in successfully")),
+        logCalls.some((msg) => msg.includes("Signed in successfully")),
       ).toBe(true);
       expect(fs.atomicWriteFile).toHaveBeenCalled();
     });
@@ -1128,7 +1227,12 @@ describe("initAction", () => {
     it("prompts to continue when login fails", async () => {
       const fs = createFsWithDetection(["/home/test/.cursor"]);
       const promptService = createMockPromptService({
-        confirm3: mock(() => Promise.resolve("yes" as ConfirmChoice)),
+        select: mock((message, choices, defaultValue) => {
+          if (String(message).includes("Authentication failed")) {
+            return Promise.resolve("continue_without_auth");
+          }
+          return Promise.resolve(defaultValue ?? choices[0]?.value);
+        }),
       });
       const createLoginDeps = mock(() =>
         Promise.resolve({
@@ -1156,24 +1260,27 @@ describe("initAction", () => {
       const logCalls = getLogOutput();
       expect(logCalls.some((msg) => msg.includes("Login failed"))).toBe(true);
       expect(
-        logCalls.some((msg) => msg.includes("GitHits tools will require auth")),
+        logCalls.some((msg) =>
+          msg.includes("Continuing without authentication"),
+        ),
       ).toBe(true);
       expect(fs.atomicWriteFile).toHaveBeenCalled();
     });
 
     it("does not claim GitHits is ready after continuing without auth", async () => {
-      const fs = createFsWithDetection(["/home/test/.cursor"], {
-        "/home/test/.cursor/mcp.json": JSON.stringify({
-          mcpServers: {
-            GitHits: {
-              command: "npx",
-              args: ["-y", "githits@latest", "mcp", "start"],
-            },
-          },
-        }),
+      const configFiles: Record<string, string> = {};
+      const fs = createFsWithDetection(["/home/test/.cursor"], configFiles);
+      fs.atomicWriteFile = mock((path: string, content: string) => {
+        configFiles[path] = content;
+        return Promise.resolve();
       });
       const promptService = createMockPromptService({
-        confirm3: mock(() => Promise.resolve("yes" as ConfirmChoice)),
+        select: mock((message, choices, defaultValue) => {
+          if (String(message).includes("Authentication failed")) {
+            return Promise.resolve("continue_without_auth");
+          }
+          return Promise.resolve(defaultValue ?? choices[0]?.value);
+        }),
       });
       const createLoginDeps = mock(() =>
         Promise.resolve({
@@ -1200,11 +1307,9 @@ describe("initAction", () => {
 
       const logCalls = getLogOutput();
       expect(
-        logCalls.some((msg) =>
-          msg.includes("authentication is still required"),
-        ),
+        logCalls.some((msg) => msg.includes("sign-in is still needed")),
       ).toBe(true);
-      expect(logCalls.some((msg) => msg.includes("Setup complete"))).toBe(
+      expect(logCalls.some((msg) => msg.includes("GitHits is connected"))).toBe(
         false,
       );
     });
@@ -1212,7 +1317,12 @@ describe("initAction", () => {
     it("cancels setup when login fails and user declines to continue", async () => {
       const fs = createFsWithDetection(["/home/test/.cursor"]);
       const promptService = createMockPromptService({
-        confirm3: mock(() => Promise.resolve("no" as ConfirmChoice)),
+        select: mock((message, choices, defaultValue) => {
+          if (String(message).includes("Authentication failed")) {
+            return Promise.resolve("cancel");
+          }
+          return Promise.resolve(defaultValue ?? choices[0]?.value);
+        }),
       });
       const createLoginDeps = mock(() =>
         Promise.resolve({
@@ -1298,7 +1408,12 @@ describe("initAction", () => {
     });
 
     it("skips login when createLoginDeps is not provided", async () => {
-      const fs = createFsWithDetection(["/home/test/.cursor"]);
+      const configFiles: Record<string, string> = {};
+      const fs = createFsWithDetection(["/home/test/.cursor"], configFiles);
+      fs.atomicWriteFile = mock((path: string, content: string) => {
+        configFiles[path] = content;
+        return Promise.resolve();
+      });
       const promptService = createMockPromptService({
         confirm3: mock(() => Promise.resolve("yes" as ConfirmChoice)),
       });
@@ -1316,6 +1431,10 @@ describe("initAction", () => {
       expect(
         logCalls.some((msg) => msg.includes("Checking authentication")),
       ).toBe(false);
+      expect(logCalls.some((msg) => msg.includes("GitHits is connected"))).toBe(
+        false,
+      );
+      expectAuthNotCheckedNextSteps(logCalls);
       expect(fs.atomicWriteFile).toHaveBeenCalled();
     });
   });

--- a/src/commands/init/init.test.ts
+++ b/src/commands/init/init.test.ts
@@ -195,9 +195,32 @@ describe("initAction", () => {
     expect(promptService.confirm3).not.toHaveBeenCalled();
     expect(fs.atomicWriteFile).toHaveBeenCalled();
     const logCalls = getLogOutput();
+    expect(
+      logCalls.some((msg) => msg.includes("source-backed open-source context")),
+    ).toBe(true);
+    expect(
+      logCalls.some((msg) => msg.includes("stores tokens in your OS keychain")),
+    ).toBe(true);
+    expect(
+      logCalls.some((msg) =>
+        msg.includes("https://docs.githits.com/quickstart"),
+      ),
+    ).toBe(true);
     expect(logCalls.some((msg) => msg.includes("What will happen"))).toBe(true);
-    expect(logCalls.some((msg) => msg.includes("1. Detect tools"))).toBe(true);
-    expect(logCalls.some((msg) => msg.includes("2. Choose tools"))).toBe(true);
+    expect(
+      logCalls.some(
+        (msg) =>
+          msg.includes("1. Detect tools") &&
+          msg.includes("Find supported AI coding tools"),
+      ),
+    ).toBe(true);
+    expect(
+      logCalls.some(
+        (msg) =>
+          msg.includes("2. Choose tools") &&
+          msg.includes("Pick which detected tools"),
+      ),
+    ).toBe(true);
     expect(logCalls.some((msg) => msg.includes("3. Sign in"))).toBe(true);
     expect(logCalls.some((msg) => msg.includes("4. Install and verify"))).toBe(
       true,

--- a/src/commands/init/init.test.ts
+++ b/src/commands/init/init.test.ts
@@ -92,20 +92,16 @@ function getLogOutput(): string[] {
 }
 
 function expectReadyNextSteps(logCalls: string[]): void {
-  expect(logCalls.some((msg) => msg.includes("GitHits is connected"))).toBe(
+  expect(logCalls.some((msg) => msg.includes("GitHits is now connected"))).toBe(
     true,
   );
-  expect(logCalls.some((msg) => msg.includes("Your agent can now:"))).toBe(
-    true,
-  );
+  expect(logCalls.some((msg) => msg.includes("new abilities"))).toBe(true);
   expect(
     logCalls.some((msg) =>
       msg.includes("How does Next.js implement route prefetching"),
     ),
   ).toBe(true);
-  expect(
-    logCalls.some((msg) => msg.includes("Agent instruction snippet")),
-  ).toBe(true);
+  expect(logCalls.some((msg) => msg.includes("trigger guides"))).toBe(true);
 }
 
 function expectAuthNotCheckedNextSteps(logCalls: string[]): void {
@@ -198,15 +194,15 @@ describe("initAction", () => {
     const logCalls = getLogOutput();
     expect(
       logCalls.some((msg) =>
-        msg.includes("GitHits helps coding agents stop guessing"),
+        msg.includes("Your agent can read your local codebase"),
       ),
     ).toBe(true);
     expect(
       logCalls.some((msg) =>
-        msg.includes("grounded context from real open-source code"),
+        msg.includes("navigate the open-source code your app depends on"),
       ),
     ).toBe(true);
-    expect(logCalls.some((msg) => msg.includes("Your agent can:"))).toBe(true);
+    expect(logCalls.some((msg) => msg.includes("With GitHits"))).toBe(true);
     expect(
       logCalls.some((msg) => msg.includes("https://docs.githits.com")),
     ).toBe(true);

--- a/src/commands/init/init.test.ts
+++ b/src/commands/init/init.test.ts
@@ -196,10 +196,10 @@ describe("initAction", () => {
     expect(fs.atomicWriteFile).toHaveBeenCalled();
     const logCalls = getLogOutput();
     expect(logCalls.some((msg) => msg.includes("What will happen"))).toBe(true);
-    expect(logCalls.some((msg) => msg.includes("1. Detect Agents"))).toBe(true);
-    expect(logCalls.some((msg) => msg.includes("2. Choose Agents"))).toBe(true);
-    expect(logCalls.some((msg) => msg.includes("3. Sign In"))).toBe(true);
-    expect(logCalls.some((msg) => msg.includes("4. Install And Verify"))).toBe(
+    expect(logCalls.some((msg) => msg.includes("1. Detect tools"))).toBe(true);
+    expect(logCalls.some((msg) => msg.includes("2. Choose tools"))).toBe(true);
+    expect(logCalls.some((msg) => msg.includes("3. Sign in"))).toBe(true);
+    expect(logCalls.some((msg) => msg.includes("4. Install and verify"))).toBe(
       true,
     );
     expect(logCalls.some((msg) => msg.includes("5. Ready"))).toBe(true);
@@ -699,7 +699,7 @@ describe("initAction", () => {
     const logCalls = getLogOutput();
     expect(
       logCalls.some((msg) =>
-        msg.includes("No supported coding agents detected"),
+        msg.includes("No supported AI coding tools detected"),
       ),
     ).toBe(true);
   });
@@ -1011,7 +1011,7 @@ describe("initAction", () => {
 
     const logCalls = getLogOutput();
     expect(
-      logCalls.some((msg) => msg.includes("supported agents not found")),
+      logCalls.some((msg) => msg.includes("supported tools not found")),
     ).toBe(true);
     expect(
       logCalls.some(

--- a/src/commands/init/init.ts
+++ b/src/commands/init/init.ts
@@ -183,56 +183,42 @@ function formatCommand(command: string, useColors: boolean): string {
 }
 
 function printReadyNextSteps(useColors: boolean): void {
-  console.log("  GitHits is connected to your coding agent.");
-  console.log();
-  console.log("  Your agent can now:");
-  console.log("  • Explore real open-source repositories");
-  console.log("  • Inspect dependency internals");
-  console.log("  • Navigate unfamiliar codebases");
-  console.log("  • Ground responses in production code");
-  console.log("  • Use real implementations instead of guessing");
-  console.log();
-  console.log("  Try asking your agent:");
-  console.log();
-  console.log("    “How does Next.js implement route prefetching internally?”");
-  console.log();
-  console.log("    “Trace how authentication flows through this repo.”");
-  console.log();
-  console.log("    “Find where retries are handled in the Stripe SDK.”");
+  console.log("  GitHits is now connected to your coding agents.");
   console.log();
   console.log(
-    "    “Compare how different OSS projects structure background jobs.”",
+    "  Here are some examples of the new abilities that your agent just got:",
   );
   console.log();
-  const snippetHeading = "Agent instruction snippet";
-  console.log(`  ${snippetHeading}`);
+  console.log("  • Find usage examples");
   console.log(
-    `  ${colorize("-".repeat(snippetHeading.length), "dim", useColors)}`,
+    "      -> ”Use get example to find how to use Azure Speech SDK TranscribeDefinition”",
   );
   console.log();
-  console.log("  Add this to your AGENTS.md or CLAUDE.md:");
-  console.log();
-  const snippetBody = [
-    "When work depends on open-source libraries, use GitHits before guessing.",
-    "",
-    "Use:",
-    "- Code Examples for real-world implementation patterns",
-    "- Code Navigation to inspect dependency source code",
-    "- Documentation Access for hosted and repo-backed docs",
-    "- Package Inspection for metadata, vulnerabilities, and changelogs",
-    "",
-    "Prefer grounded implementations over guessing.",
-  ];
-  for (const line of snippetBody) {
-    console.log(line ? `  ${colorize(line, "italic", useColors)}` : "");
-  }
-  console.log();
-  console.log("  Full version:");
   console.log(
-    "  https://docs.githits.com/guides/trigger-githits#agent-instruction-snippet",
+    "  • Search, grep, list files, and read exact lines in any repo or package to gather information",
+  );
+  console.log(
+    "      -> “How does Next.js implement route prefetching internally?”",
   );
   console.log();
-  console.log("  Docs: https://docs.githits.com");
+  console.log(
+    "  • Inspect dependency versions, changelogs, and upgrade changes",
+  );
+  console.log(
+    "      -> “What kind of changes there were between pydantic-ai version 1.95 and 1.99?”",
+  );
+  console.log();
+  console.log(
+    "  Open a new coding agent session and try out one of the above.",
+  );
+  console.log();
+  console.log(
+    '  In you normal workflow, your agent will call GitHits automatically depending on the task, but you can prompt it to use GitHits explicitly by adding "use GitHits".',
+  );
+  console.log();
+  console.log(
+    "  See docs for more use cases and trigger guides: https://docs.githits.com",
+  );
 }
 
 function printAuthRequiredNextSteps(useColors: boolean): void {
@@ -334,7 +320,8 @@ const INIT_INTENT_CHOICES: SelectChoice<InitIntent>[] = [
   {
     name: "Connect GitHits to my agent (Recommended)",
     value: "mcp",
-    description: "Installs the local GitHits MCP server.",
+    description:
+      "Install the local GitHits MCP server for your coding agents. Allows agents to seamlessly use GitHits.",
   },
   {
     name: "Use Agent Skills instead",
@@ -400,20 +387,32 @@ function printTask(
 
 function printInitIntro(useColors: boolean): void {
   console.log(colorizeLogo(GITHITS_ASCII_LOGO, useColors));
-  console.log("  GitHits helps coding agents stop guessing.");
-  console.log();
-  console.log("  Instead of retry loops and hallucinated solutions,");
-  console.log("  your agent gets grounded context from real open-source code.");
-  console.log();
-  console.log(`  ${colorizeBrand("Your agent can:", "primary", useColors)}`);
-  console.log("  • Explore production codebases");
-  console.log("  • Inspect dependency internals");
-  console.log("  • Navigate large repositories");
-  console.log("  • Find real implementations");
-  console.log("  • Ground responses in actual code instead of guesses");
+  console.log("  Your agent can read your local codebase.");
   console.log();
   console.log(
-    "  Works with Cursor, Claude Code, Codex CLI, VS Code and Windsurf, plus more.",
+    "  GitHits lets it navigate the open-source code your app depends on.",
+  );
+  console.log();
+  console.log(
+    `  ${colorizeBrand("With GitHits, your agent can:", "primary", useColors)}`,
+  );
+  console.log(
+    "  • Find implementation examples from open-source code, issues, discussions, and pull requests",
+  );
+  console.log(
+    "  • Search, grep, list files, and read exact lines in any repo or package",
+  );
+  console.log(
+    "  • Inspect dependency internals, versions, changelogs, and upgrade changes",
+  );
+  console.log("  • Access package documentation");
+  console.log();
+  console.log(
+    "  No cloning or local indexing required. GitHits handles everything automatically.",
+  );
+  console.log();
+  console.log(
+    "  Works with Cursor, Claude Code, Codex, OpenCode, Pi, VS Code, Windsurf, and more.",
   );
   console.log();
   console.log("  More info: https://docs.githits.com");

--- a/src/commands/init/init.ts
+++ b/src/commands/init/init.ts
@@ -182,7 +182,7 @@ function formatCommand(command: string, useColors: boolean): string {
   return colorizeBrand(command, "secondary", useColors, { bold: true });
 }
 
-function printReadyNextSteps(useColors: boolean): void {
+function printReadyNextSteps(): void {
   console.log("  GitHits is now connected to your coding agents.");
   console.log();
   console.log(
@@ -191,7 +191,7 @@ function printReadyNextSteps(useColors: boolean): void {
   console.log();
   console.log("  • Find usage examples");
   console.log(
-    "      -> ”Use get example to find how to use Azure Speech SDK TranscribeDefinition”",
+    "      -> “Find a real example of using Azure Speech SDK TranscribeDefinition”",
   );
   console.log();
   console.log(
@@ -204,16 +204,14 @@ function printReadyNextSteps(useColors: boolean): void {
   console.log(
     "  • Inspect dependency versions, changelogs, and upgrade changes",
   );
-  console.log(
-    "      -> “What kind of changes there were between pydantic-ai version 1.95 and 1.99?”",
-  );
+  console.log("      -> “What changed between pydantic-ai 1.95 and 1.99?”");
   console.log();
   console.log(
     "  Open a new coding agent session and try out one of the above.",
   );
   console.log();
   console.log(
-    '  In you normal workflow, your agent will call GitHits automatically depending on the task, but you can prompt it to use GitHits explicitly by adding "use GitHits".',
+    '  In your normal workflow, your agent will call GitHits automatically depending on the task, but you can prompt it to use GitHits explicitly by adding "use GitHits".',
   );
   console.log();
   console.log(
@@ -716,7 +714,7 @@ function printPostSetupNextSteps(
     useColors,
   );
   if (shouldPrintReady(authStatus)) {
-    printReadyNextSteps(useColors);
+    printReadyNextSteps();
   } else if (authStatus === "failed_continue") {
     printAuthRequiredNextSteps(useColors);
   } else {

--- a/src/commands/init/init.ts
+++ b/src/commands/init/init.ts
@@ -14,6 +14,7 @@ import type {
 import { PromptServiceImpl } from "../../services/prompt-service.js";
 import {
   colorize,
+  colorizeBrand,
   error as errorFmt,
   shouldUseColors,
   success,
@@ -263,7 +264,9 @@ const AUTH_START_CHOICES: SelectChoice<InitAuthStartChoice>[] = [
 
 function printSection(index: number, title: string, useColors: boolean): void {
   console.log();
-  console.log(`  ${colorize(`${index}. ${title}`, "bold", useColors)}`);
+  console.log(
+    `  ${colorizeBrand(`${index}. ${title}`, "primary", useColors, { bold: true })}`,
+  );
   console.log(`  ${colorize("-".repeat(title.length + 3), "dim", useColors)}`);
 }
 
@@ -286,7 +289,7 @@ function printTask(
 }
 
 function printInitIntro(useColors: boolean): void {
-  console.log(colorize(GITHITS_ASCII_LOGO, "magenta", useColors));
+  console.log(colorizeBrand(GITHITS_ASCII_LOGO, "primary", useColors));
   console.log(
     "  GitHits adds source-backed open-source context to your AI coding tool.",
   );
@@ -379,7 +382,7 @@ function createScanProgressReporter(useColors: boolean): ScanProgressReporter {
     onProgress: (progress) => {
       const width = 20;
       const filled = Math.round((progress.completed / progress.total) * width);
-      const bar = `${colorize("#".repeat(filled), "magenta", useColors)}${"-".repeat(width - filled)}`;
+      const bar = `${colorizeBrand("#".repeat(filled), "primary", useColors)}${"-".repeat(width - filled)}`;
       const line = `  Scanning tools [${bar}] ${progress.completed}/${progress.total} ${progress.agent.name}`;
       process.stdout.write(`\r\x1b[2K${line}`);
       wrote = true;
@@ -407,9 +410,9 @@ function createInstallTaskReporter(useColors: boolean): InstallTaskReporter {
     start: (label) => {
       let frame = 0;
       const render = () => {
-        const spinner = colorize(
+        const spinner = colorizeBrand(
           frames[frame % frames.length] ?? "-",
-          "magenta",
+          "primary",
           useColors,
         );
         frame += 1;
@@ -1068,7 +1071,7 @@ export async function initUninstallAction(
   const { fileSystemService, promptService, execService } = deps;
 
   console.log(
-    `\n  ${colorize("GitHits", "bold", useColors)} — Remove MCP server from your coding agents\n`,
+    `\n  ${colorizeBrand("GitHits", "primary", useColors, { bold: true })} — Remove MCP server from your coding agents\n`,
   );
 
   console.log("  Scanning for configured agents...\n");

--- a/src/commands/init/init.ts
+++ b/src/commands/init/init.ts
@@ -6,8 +6,10 @@ import { ExecServiceImpl } from "../../services/exec-service.js";
 import type { FileSystemService } from "../../services/filesystem-service.js";
 import { FileSystemServiceImpl } from "../../services/filesystem-service.js";
 import type {
+  CheckboxChoice,
   ConfirmChoice,
   PromptService,
+  SelectChoice,
 } from "../../services/prompt-service.js";
 import { PromptServiceImpl } from "../../services/prompt-service.js";
 import {
@@ -17,13 +19,19 @@ import {
   success,
   warning,
 } from "../../shared/colors.js";
-import type { LoginDependencies, LoginFlowResult } from "../login.js";
+import type {
+  LoginDependencies,
+  LoginFlowResult,
+  LoginOutput,
+} from "../login.js";
 import { loginFlow } from "../login.js";
 import {
   type AgentDefinition,
   agentDefinitions,
   type ConfigFileSetup,
   isGeminiExtensionInstalledFromFilesystem,
+  type ScanProgress,
+  type ScanResult,
   type SetupConfig,
   scanAgents,
 } from "./agent-definitions.js";
@@ -34,10 +42,10 @@ import {
   executeCompositeUninstall,
   executeConfigFileSetup,
   executeConfigFileUninstall,
-  formatSetupPreview,
   formatUninstallPreview,
   getCliCheckStatus,
   getConfigUninstallCheckStatus,
+  type SetupResult,
 } from "./setup-handlers.js";
 
 /** Options for the init command */
@@ -102,6 +110,43 @@ interface UninstallScanResult {
   failed: AgentUninstallOutcome[];
 }
 
+type InitIntent = "mcp" | "skills" | "later";
+
+type InitAuthStartChoice = "sign_in" | "skip" | "cancel";
+
+type InitAuthRecoveryChoice = "retry" | "continue_without_auth" | "cancel";
+
+type InitAuthStatus =
+  | "authenticated"
+  | "skipped"
+  | "unavailable"
+  | "failed_continue"
+  | "cancelled";
+
+type SafeScanResult =
+  | { ok: true; scan: ScanResult }
+  | { ok: false; error: Error };
+
+interface ScanProgressReporter {
+  onProgress(progress: ScanProgress): void;
+  finish(): void;
+}
+
+interface InstallTaskReporter {
+  start(label: string): () => void;
+}
+
+function createInitLoginOutput(): LoginOutput {
+  return {
+    write: (message) => {
+      const lines = message.replace(/\n$/, "").split("\n");
+      for (const line of lines) {
+        console.log(line.length > 0 ? `    ${line}` : "");
+      }
+    },
+  };
+}
+
 function getResolvedSetupConfig(
   agent: AgentDefinition,
   fileSystemService: FileSystemService,
@@ -130,17 +175,454 @@ function getPiConfigFileUninstall(
 }
 
 function printReadyNextSteps(): void {
-  console.log("  Setup complete. You're ready to use GitHits.");
+  console.log("  GitHits is connected to your coding agent.");
   console.log();
-  console.log("  Try a quick code example search:");
+  console.log("  Start a coding task as usual. When your agent needs real");
+  console.log("  open-source examples or package context, it can use GitHits.");
+  console.log();
+  console.log("  Try the CLI directly:");
   console.log(
     '    npx githits@latest example "How do I use useEffect cleanup?"',
   );
   console.log();
-  console.log("  Or ask your agent to explore a real codebase:");
+  console.log("  Or ask your agent:");
   console.log(
-    "    Use GitHits to inspect postgres/postgres and explain how the query planner selects join strategies.",
+    "    Use GitHits Code Examples to find a real open-source implementation of HTTP retries with exponential backoff in Python.",
   );
+  console.log();
+  console.log("  Docs: https://docs.githits.com");
+}
+
+function printAuthRequiredNextSteps(): void {
+  console.log("  GitHits MCP is configured, but sign-in is still needed.");
+  console.log();
+  console.log("  Sign in when you're ready:");
+  console.log("    npx githits@latest login");
+}
+
+function printAuthNotCheckedNextSteps(): void {
+  console.log("  GitHits MCP is configured. Sign-in was not checked.");
+  console.log();
+  console.log("  If your agent asks you to sign in, run:");
+  console.log("    npx githits@latest login");
+}
+
+const GITHITS_ASCII_LOGO = String.raw`
+   ____ _ _   _   _ _ _       
+  / ___(_) |_| | | (_) |_ ___ 
+ | |  _| | __| |_| | | __/ __|
+ | |_| | | |_|  _  | | |_\__ \
+  \____|_|\__|_| |_|_|\__|___/
+`;
+
+const INIT_INTENT_CHOICES: SelectChoice<InitIntent>[] = [
+  {
+    name: "Install GitHits MCP server",
+    value: "mcp",
+    description: "Recommended. Lets your agent call GitHits tools directly.",
+  },
+  {
+    name: "I'd rather use Agent Skills",
+    value: "skills",
+    description:
+      "Use instruction-driven Skills instead of the local MCP server.",
+  },
+  {
+    name: "Later",
+    value: "later",
+    description: "Exit without changing anything.",
+  },
+];
+
+const AUTH_RECOVERY_CHOICES: SelectChoice<InitAuthRecoveryChoice>[] = [
+  { name: "Retry sign in", value: "retry" },
+  {
+    name: "Configure MCP without signing in",
+    value: "continue_without_auth",
+    description: "Your agent will ask you to sign in before using GitHits.",
+  },
+  { name: "Cancel setup", value: "cancel" },
+];
+
+const AUTH_START_CHOICES: SelectChoice<InitAuthStartChoice>[] = [
+  {
+    name: "Sign in now",
+    value: "sign_in",
+    description: "Open your browser and connect this CLI to GitHits.",
+  },
+  {
+    name: "Skip for now",
+    value: "skip",
+    description: "Finish MCP setup and sign in later with `githits login`.",
+  },
+  { name: "Cancel setup", value: "cancel" },
+];
+
+function printSection(index: number, title: string, useColors: boolean): void {
+  console.log();
+  console.log(`  ${colorize(`${index}. ${title}`, "bold", useColors)}`);
+  console.log(`  ${colorize("-".repeat(title.length + 3), "dim", useColors)}`);
+}
+
+function printTask(
+  status: "success" | "warning" | "skipped" | "failed",
+  label: string,
+  detail: string | undefined,
+  useColors: boolean,
+): void {
+  const suffix = detail ? `  ${colorize(detail, "dim", useColors)}` : "";
+  if (status === "success") {
+    console.log(`    ${success(label, useColors)}${suffix}`);
+  } else if (status === "failed") {
+    console.log(`    ${errorFmt(label, useColors)}${suffix}`);
+  } else if (status === "warning") {
+    console.log(`    ${warning(label, useColors)}${suffix}`);
+  } else {
+    console.log(`    ${colorize("○", "dim", useColors)} ${label}${suffix}`);
+  }
+}
+
+function printInitIntro(useColors: boolean): void {
+  console.log(colorize(GITHITS_ASCII_LOGO, "magenta", useColors));
+  console.log(
+    "  GitHits gives AI coding agents real open-source examples, dependency",
+  );
+  console.log(
+    "  source code, docs, and package metadata when local context is not enough.",
+  );
+  console.log();
+  console.log("  Choose how you want your agent to use GitHits:");
+  console.log(
+    "    MCP server   Default path. Your agent can call GitHits tools directly.",
+  );
+  console.log(
+    "    Agent Skills Use Skills instead of MCP when your harness supports them.",
+  );
+  console.log();
+  console.log(
+    "  MCP setup adds a local server entry. It does not write secrets into",
+  );
+  console.log("  your agent config.");
+  console.log();
+  console.log("  What will happen:");
+  console.log("    1. Detect agents");
+  console.log("    2. Choose agents");
+  console.log("    3. Sign in");
+  console.log("    4. Install and verify");
+  console.log("    5. Ready");
+  console.log();
+}
+
+function printSkillsInstructions(): void {
+  console.log("\n  Install GitHits Agent Skills:");
+  console.log();
+  console.log("    npx skills add githits-com/githits-cli");
+  console.log();
+  console.log(
+    "  During installation, choose which harnesses should receive the Skills.",
+  );
+  console.log(
+    "  Do not use GitHits Skills and GitHits MCP in the same harness at the",
+  );
+  console.log("  same time; they provide overlapping guidance.");
+  console.log();
+  console.log("  GitHits still needs sign-in before tools can access results:");
+  console.log();
+  console.log("    npx githits@latest login");
+  console.log();
+}
+
+function startSafeInitScan(
+  fileSystemService: FileSystemService,
+  execService: ExecService,
+  onProgress?: (progress: ScanProgress) => void,
+): Promise<SafeScanResult> {
+  return scanAgents(agentDefinitions, fileSystemService, execService, {
+    onProgress,
+  })
+    .then((scan) => ({ ok: true as const, scan }))
+    .catch((error: unknown) => ({
+      ok: false as const,
+      error: error instanceof Error ? error : new Error(String(error)),
+    }));
+}
+
+function createScanProgressReporter(useColors: boolean): ScanProgressReporter {
+  if (!process.stdout.isTTY) {
+    return { onProgress: () => {}, finish: () => {} };
+  }
+
+  let wrote = false;
+  return {
+    onProgress: (progress) => {
+      const width = 20;
+      const filled = Math.round((progress.completed / progress.total) * width);
+      const bar = `${colorize("#".repeat(filled), "magenta", useColors)}${"-".repeat(width - filled)}`;
+      const line = `  Scanning agents [${bar}] ${progress.completed}/${progress.total} ${progress.agent.name}`;
+      process.stdout.write(`\r\x1b[2K${line}`);
+      wrote = true;
+    },
+    finish: () => {
+      if (wrote) {
+        process.stdout.write("\r\x1b[2K");
+      }
+    },
+  };
+}
+
+function createInstallTaskReporter(useColors: boolean): InstallTaskReporter {
+  if (!process.stdout.isTTY) {
+    return {
+      start: (label) => {
+        printTask("skipped", label, "installing...", useColors);
+        return () => {};
+      },
+    };
+  }
+
+  const frames = ["-", "\\", "|", "/"];
+  return {
+    start: (label) => {
+      let frame = 0;
+      const render = () => {
+        const spinner = colorize(
+          frames[frame % frames.length] ?? "-",
+          "magenta",
+          useColors,
+        );
+        frame += 1;
+        process.stdout.write(`\r\x1b[2K    ${spinner} ${label}  installing...`);
+      };
+      render();
+      const interval = setInterval(render, 80);
+      return () => {
+        clearInterval(interval);
+        process.stdout.write("\r\x1b[2K");
+      };
+    },
+  };
+}
+
+async function unwrapSafeScan(
+  scanPromise: Promise<SafeScanResult>,
+): Promise<ScanResult> {
+  const result = await scanPromise;
+  if (!result.ok) {
+    throw result.error;
+  }
+  return result.scan;
+}
+
+function formatAgentNames(agents: AgentDefinition[]): string {
+  if (agents.length === 0) return "none";
+  if (agents.length === 1) return agents[0]?.name ?? "unknown";
+  if (agents.length === 2) {
+    return `${agents[0]?.name ?? "unknown"} and ${agents[1]?.name ?? "unknown"}`;
+  }
+  const names = agents.map((agent) => agent.name);
+  return `${names.slice(0, -1).join(", ")}, and ${names[names.length - 1]}`;
+}
+
+function buildInitAgentChoices(
+  scan: ScanResult,
+): CheckboxChoice<AgentDefinition>[] {
+  return [
+    ...scan.needsSetup.map((agent) => ({
+      name: `${agent.name} (detected)`,
+      value: agent,
+      checked: true,
+    })),
+    ...scan.alreadyConfigured.map((agent) => ({
+      name: `${agent.name} (already configured)`,
+      value: agent,
+      disabled: "already configured",
+    })),
+  ];
+}
+
+function printScanSummary(scan: ScanResult, useColors: boolean): void {
+  const detected = scan.needsSetup.length + scan.alreadyConfigured.length;
+  for (const agent of scan.alreadyConfigured) {
+    printTask("success", agent.name, "already configured", useColors);
+  }
+  for (const agent of scan.needsSetup) {
+    printTask("warning", agent.name, "needs setup", useColors);
+  }
+  if (scan.notDetected.length > 0) {
+    printTask(
+      "skipped",
+      `${scan.notDetected.length} supported agent${scan.notDetected.length !== 1 ? "s" : ""} not found`,
+      formatAgentNames(scan.notDetected),
+      useColors,
+    );
+  }
+  if (detected > 0) {
+    console.log();
+    console.log(
+      `    Found ${detected} supported agent${detected !== 1 ? "s" : ""}.`,
+    );
+  }
+}
+
+function printAuthExplanation(): void {
+  console.log(
+    "    GitHits tools require sign-in before they can return results.",
+  );
+  console.log();
+  console.log(
+    "    We will open your browser to GitHits. After you approve access,",
+  );
+  console.log(
+    "    the browser redirects back to this terminal through localhost.",
+  );
+  console.log("    Tokens are stored in your OS keychain.");
+  console.log();
+  console.log("    No secrets are written into your agent MCP config.");
+  console.log(
+    "    For CI or headless machines, use GITHITS_API_TOKEN instead.",
+  );
+  console.log();
+}
+
+async function runInitAuthentication(
+  options: InitOptions,
+  promptService: PromptService,
+  createLoginDeps: InitDependencies["createLoginDeps"],
+  useColors: boolean,
+): Promise<InitAuthStatus> {
+  if (options.skipLogin) {
+    console.log("  Skipping authentication (--skip-login).\n");
+    return "skipped";
+  }
+  if (!createLoginDeps) {
+    printTask(
+      "warning",
+      "Sign-in unavailable",
+      "sign in later with `githits login`",
+      useColors,
+    );
+    return "unavailable";
+  }
+
+  while (true) {
+    let loginResult: LoginFlowResult;
+    try {
+      const loginDeps = await createLoginDeps();
+      if (loginDeps.hasValidToken) {
+        printTask("success", "Already signed in", undefined, useColors);
+        return "authenticated";
+      }
+
+      printAuthExplanation();
+      if (!options.yes) {
+        let authChoice: InitAuthStartChoice;
+        try {
+          authChoice = await promptService.select(
+            "  Continue with browser sign-in?",
+            AUTH_START_CHOICES,
+            "sign_in",
+          );
+        } catch (err) {
+          if (err instanceof ExitPromptError) {
+            console.log("\n  Setup cancelled.\n");
+            return "cancelled";
+          }
+          throw err;
+        }
+
+        if (authChoice === "skip") {
+          printTask(
+            "warning",
+            "Sign-in skipped",
+            "your agent will ask you to sign in later",
+            useColors,
+          );
+          return "skipped";
+        }
+        if (authChoice === "cancel") {
+          console.log(
+            "\n  Setup cancelled. Run `githits login` to authenticate.\n",
+          );
+          return "cancelled";
+        }
+      }
+
+      loginResult = await loginFlow({}, loginDeps, createInitLoginOutput());
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      loginResult = { status: "failed", message: msg };
+    }
+
+    if (loginResult.status === "already_authenticated") {
+      printTask("success", "Already signed in", undefined, useColors);
+      return "authenticated";
+    }
+    if (loginResult.status === "success") {
+      printTask("success", "Signed in successfully", undefined, useColors);
+      return "authenticated";
+    }
+
+    console.log(
+      `    ${warning(`Login failed: ${loginResult.message}`, useColors)}\n`,
+    );
+    printAuthRecoveryHint();
+
+    if (options.yes) {
+      console.log("    Continuing without authentication...\n");
+      return "failed_continue";
+    }
+
+    let choice: InitAuthRecoveryChoice;
+    try {
+      choice = await promptService.select(
+        "  Authentication failed. What would you like to do?",
+        AUTH_RECOVERY_CHOICES,
+        "retry",
+      );
+    } catch (err) {
+      if (err instanceof ExitPromptError) {
+        console.log("\n  Setup cancelled.\n");
+        return "cancelled";
+      }
+      throw err;
+    }
+
+    if (choice === "retry") {
+      console.log();
+      continue;
+    }
+    if (choice === "cancel") {
+      console.log(
+        "\n  Setup cancelled. Run `githits login` to authenticate.\n",
+      );
+      return "cancelled";
+    }
+
+    console.log("    Continuing without authentication...\n");
+    return "failed_continue";
+  }
+}
+
+function shouldPrintReady(authStatus: InitAuthStatus): boolean {
+  return authStatus === "authenticated";
+}
+
+function printPostSetupNextSteps(
+  authStatus: InitAuthStatus,
+  useColors: boolean,
+): void {
+  printSection(
+    5,
+    shouldPrintReady(authStatus) ? "Ready" : "Next Steps",
+    useColors,
+  );
+  if (shouldPrintReady(authStatus)) {
+    printReadyNextSteps();
+  } else if (authStatus === "failed_continue") {
+    printAuthRequiredNextSteps();
+  } else {
+    printAuthNotCheckedNextSteps();
+  }
 }
 
 async function verifyAgentConfigured(
@@ -334,177 +816,175 @@ export async function initAction(
   const useColors = shouldUseColors();
   const { fileSystemService, promptService, execService, createLoginDeps } =
     deps;
-  let continuedWithoutAuth = false;
+  printInitIntro(useColors);
 
-  // Header
-  console.log(
-    `\n  ${colorize("GitHits", "bold", useColors)} — Set up MCP server for your coding agents\n`,
-  );
-
-  // Login step (before tool configuration)
-  if (!options.skipLogin && createLoginDeps) {
-    console.log("  Checking authentication...\n");
-    let loginResult: LoginFlowResult;
-    try {
-      const loginDeps = await createLoginDeps();
-      loginResult = loginDeps.hasValidToken
-        ? { status: "already_authenticated", message: "Already logged in." }
-        : await loginFlow({}, loginDeps);
-    } catch (error) {
-      const msg = error instanceof Error ? error.message : String(error);
-      loginResult = { status: "failed", message: msg };
-    }
-
-    if (loginResult.status === "already_authenticated") {
-      console.log(`    ${success("Already authenticated", useColors)}\n`);
-    } else if (loginResult.status === "success") {
-      console.log(`    ${success("Logged in successfully", useColors)}\n`);
-    } else {
-      console.log(
-        `    ${warning(`Login failed: ${loginResult.message}`, useColors)}\n`,
-      );
-      printAuthRecoveryHint();
-      if (!options.yes) {
-        try {
-          const choice = await promptService.confirm3(
-            "Continue without authentication?",
-          );
-          if (choice === "no") {
-            console.log(
-              "\n  Setup cancelled. Run `githits login` to authenticate.\n",
-            );
-            return;
-          }
-        } catch (err) {
-          if (err instanceof ExitPromptError) {
-            console.log("\n  Setup cancelled.\n");
-            return;
-          }
-          throw err;
-        }
-      }
-      continuedWithoutAuth = true;
-      console.log("    Continuing without authentication...\n");
-    }
-  }
-
-  // Scan for available agents and check configuration status
-  console.log("  Scanning for available agents...\n");
-  const scan = await scanAgents(
-    agentDefinitions,
+  const progress = createScanProgressReporter(useColors);
+  let renderScanProgress = false;
+  let lastScanProgress: ScanProgress | undefined;
+  const scanPromise = startSafeInitScan(
     fileSystemService,
     execService,
+    (scanProgress) => {
+      lastScanProgress = scanProgress;
+      if (renderScanProgress) {
+        progress.onProgress(scanProgress);
+      }
+    },
   );
 
-  // Display status list
-  for (const agent of scan.alreadyConfigured) {
-    console.log(
-      `    ${success(`${agent.name} — already configured`, useColors)}`,
-    );
-  }
-  for (const agent of scan.needsSetup) {
-    console.log(
-      `    ${colorize(`● ${agent.name} — needs setup`, "cyan", useColors)}`,
-    );
-  }
-  for (const agent of scan.notDetected) {
-    console.log(
-      `    ${colorize(`${agent.name} — not detected`, "dim", useColors)}`,
-    );
-  }
-  console.log();
-
-  // All agents not detected
-  if (scan.needsSetup.length === 0 && scan.alreadyConfigured.length === 0) {
-    console.log(
-      "  No coding agents detected. Install an agent and try again.\n",
-    );
-    return;
-  }
-
-  // All detected agents already configured
-  if (scan.needsSetup.length === 0) {
-    if (continuedWithoutAuth) {
-      console.log(
-        "  MCP is already configured, but authentication is still required.",
+  if (!options.yes) {
+    let intent: InitIntent;
+    try {
+      intent = await promptService.select(
+        "  How would you like to use GitHits?",
+        INIT_INTENT_CHOICES,
+        "mcp",
       );
-      console.log("  Run `githits login` before using GitHits tools.\n");
+    } catch (err) {
+      if (err instanceof ExitPromptError) {
+        console.log("\n  Setup cancelled. No changes made.\n");
+        return;
+      }
+      throw err;
+    }
+
+    if (intent === "skills") {
+      printSkillsInstructions();
       return;
     }
-    console.log("  All detected agents are already configured.");
-    printReadyNextSteps();
+    if (intent === "later") {
+      console.log(
+        "\n  No changes made. Run `githits init` whenever you're ready.\n",
+      );
+      return;
+    }
+  }
+
+  printSection(1, "Detect Agents", useColors);
+  console.log("    Scanning supported coding agents...");
+  renderScanProgress = true;
+  if (lastScanProgress) {
+    progress.onProgress(lastScanProgress);
+  }
+  let scan: ScanResult;
+  try {
+    scan = await unwrapSafeScan(scanPromise);
+  } finally {
+    progress.finish();
+  }
+  printScanSummary(scan, useColors);
+
+  if (scan.needsSetup.length === 0 && scan.alreadyConfigured.length === 0) {
+    printTask(
+      "warning",
+      "No supported coding agents detected",
+      "install an agent and run `githits init` again",
+      useColors,
+    );
     console.log();
     return;
   }
 
-  // Sequential setup for unconfigured agents
-  const toSetup = scan.needsSetup;
-  const outcomes: AgentOutcome[] = [];
-  let alwaysMode = options.yes ?? false;
-
-  for (const agent of toSetup) {
-    console.log(`  Setting up ${colorize(agent.name, "bold", useColors)}...\n`);
-
-    const config =
-      agent.resolvedSetupConfig ?? agent.getSetupConfig(fileSystemService);
-
-    // Show preview
-    const preview = formatSetupPreview(config);
-    for (const line of preview.split("\n")) {
-      console.log(`    ${line}`);
-    }
-    console.log();
-
-    // Confirm (unless --yes or "always" mode)
-    if (!alwaysMode) {
-      let choice: ConfirmChoice;
-      try {
-        choice = await promptService.confirm3("Proceed?");
-      } catch (err) {
-        if (err instanceof ExitPromptError) {
-          console.log("\n  Setup cancelled.\n");
-          return;
-        }
-        throw err;
-      }
-
-      if (choice === "no") {
-        outcomes.push({ id: agent.id, name: agent.name, status: "skipped" });
-        console.log();
-        continue;
-      }
-      if (choice === "always") {
-        alwaysMode = true;
-      }
-    }
-
-    // Execute setup
-    let result =
-      config.method === "cli"
-        ? await executeCliSetup(config, execService)
-        : config.method === "config-file"
-          ? await executeConfigFileSetup(config, fileSystemService)
-          : await executeCompositeSetup(config, fileSystemService, execService);
-
-    if (result.status === "success" || result.status === "already_configured") {
-      const verification = await verifyAgentConfigured(
-        agent,
-        fileSystemService,
-        execService,
+  let toSetup = scan.needsSetup;
+  printSection(2, "Choose Agents", useColors);
+  if (!options.yes && scan.needsSetup.length > 0) {
+    try {
+      toSetup = await promptService.checkbox(
+        "  Select agents to configure with GitHits MCP:",
+        buildInitAgentChoices(scan),
       );
-      if (!verification.ok) {
-        result = {
-          status: "failed",
-          message:
-            agent.id === "gemini-cli"
-              ? "Gemini installation did not complete. Retry, or run: gemini extensions install --consent https://github.com/githits-com/githits-cli"
-              : (verification.message ??
-                `${agent.name} verification failed after setup.`),
-        };
+    } catch (err) {
+      if (err instanceof ExitPromptError) {
+        console.log("\n  Setup cancelled. No changes made.\n");
+        return;
       }
+      throw err;
+    }
+  } else if (scan.needsSetup.length === 0) {
+    printTask(
+      "success",
+      "No agent changes needed",
+      "all detected agents already have GitHits MCP",
+      useColors,
+    );
+  } else {
+    printTask("success", "Selected all detected agents", "--yes", useColors);
+  }
+
+  const outcomes: AgentOutcome[] = [];
+
+  if (toSetup.length === 0 && scan.needsSetup.length > 0) {
+    printTask("skipped", "Setup skipped", "no agents selected", useColors);
+    console.log();
+    return;
+  }
+
+  printSection(3, "Sign In", useColors);
+  const authStatus = await runInitAuthentication(
+    options,
+    promptService,
+    createLoginDeps,
+    useColors,
+  );
+  if (authStatus === "cancelled") {
+    return;
+  }
+
+  printSection(4, "Install And Verify", useColors);
+  if (toSetup.length === 0) {
+    printTask(
+      "success",
+      "Nothing to install",
+      "all detected agents are already configured",
+      useColors,
+    );
+    printPostSetupNextSteps(authStatus, useColors);
+    console.log();
+    return;
+  }
+
+  const installTasks = createInstallTaskReporter(useColors);
+  for (const agent of toSetup) {
+    const config = getResolvedSetupConfig(agent, fileSystemService);
+    const finishTask = installTasks.start(agent.name);
+
+    let result: SetupResult;
+    try {
+      result =
+        config.method === "cli"
+          ? await executeCliSetup(config, execService)
+          : config.method === "config-file"
+            ? await executeConfigFileSetup(config, fileSystemService)
+            : await executeCompositeSetup(
+                config,
+                fileSystemService,
+                execService,
+              );
+
+      if (
+        result.status === "success" ||
+        result.status === "already_configured"
+      ) {
+        const verification = await verifyAgentConfigured(
+          agent,
+          fileSystemService,
+          execService,
+        );
+        if (!verification.ok) {
+          result = {
+            status: "failed",
+            message:
+              agent.id === "gemini-cli"
+                ? "Gemini installation did not complete. Retry, or run: gemini extensions install --consent https://github.com/githits-com/githits-cli"
+                : (verification.message ??
+                  `${agent.name} verification failed after setup.`),
+          };
+        }
+      }
+    } finally {
+      finishTask();
     }
 
-    // Record and display outcome
     outcomes.push({
       id: agent.id,
       name: agent.name,
@@ -513,33 +993,26 @@ export async function initAction(
     });
 
     if (result.status === "success") {
-      console.log(`    ${success(`${agent.name} configured`, useColors)}\n`);
+      printTask("success", agent.name, "configured and verified", useColors);
     } else if (result.status === "already_configured") {
-      console.log(
-        `    ${warning(`${agent.name} already configured`, useColors)}\n`,
-      );
+      printTask("warning", agent.name, "already configured", useColors);
     } else {
-      console.log(`    ${errorFmt(result.message, useColors)}\n`);
+      printTask("failed", agent.name, result.message, useColors);
     }
   }
 
-  // Summary
+  console.log();
+
   const configured = outcomes.filter((o) => o.status === "success").length;
   const alreadyDone =
     outcomes.filter((o) => o.status === "already_configured").length +
     scan.alreadyConfigured.length;
   const failed = outcomes.filter((o) => o.status === "failed").length;
-  const skipped = outcomes.filter((o) => o.status === "skipped").length;
 
   if (failed > 0) {
     console.log("  Setup completed with errors.");
-  } else if (continuedWithoutAuth && (configured > 0 || alreadyDone > 0)) {
-    console.log("  MCP is configured, but authentication is still required.");
-    console.log("  Run `githits login` before using GitHits tools.");
   } else if (configured > 0 || alreadyDone > 0) {
-    printReadyNextSteps();
-  } else if (skipped > 0) {
-    console.log("  Setup skipped.");
+    printPostSetupNextSteps(authStatus, useColors);
   }
 
   if (failed > 0) {
@@ -552,8 +1025,10 @@ export async function initAction(
       );
     }
   }
-  if (skipped > 0) {
-    console.log(`  ${skipped} agent${skipped !== 1 ? "s" : ""} skipped.`);
+  if (scan.alreadyConfigured.length > 0) {
+    console.log(
+      `  ${scan.alreadyConfigured.length} agent${scan.alreadyConfigured.length !== 1 ? "s" : ""} already configured.`,
+    );
   }
 
   console.log();
@@ -776,12 +1251,13 @@ function printAuthRecoveryHint(): void {
   );
 }
 
-const INIT_DESCRIPTION = `Set up GitHits MCP server for your coding agents.
+const INIT_DESCRIPTION = `Set up GitHits for your coding agents.
 
-Authenticates with your GitHits account, then scans for available agents
-(Claude Code, Cursor, Windsurf, VS Code, Cline, Claude Desktop, Codex CLI,
-Pi, Gemini CLI, Google Antigravity), checks which are already configured,
-and sets up unconfigured ones with your confirmation.
+Explains GitHits setup options, lets you install the GitHits MCP server or use
+Agent Skills, scans for available agents (Claude Code, Cursor, Windsurf,
+VS Code, Cline, Claude Desktop, Codex CLI, Pi, Gemini CLI, Google Antigravity),
+checks which are already configured, signs you in, and configures selected
+agents with GitHits MCP.
 
 Supports CLI-based setup (Claude Code, Codex, Gemini CLI), Pi package setup,
 and config

--- a/src/commands/init/init.ts
+++ b/src/commands/init/init.ts
@@ -288,31 +288,50 @@ function printTask(
 function printInitIntro(useColors: boolean): void {
   console.log(colorize(GITHITS_ASCII_LOGO, "magenta", useColors));
   console.log(
-    "  GitHits gives AI coding agents real open-source examples, dependency",
+    "  GitHits adds source-backed open-source context to your AI coding tool.",
   );
   console.log(
-    "  source code, docs, and package metadata when local context is not enough.",
-  );
-  console.log();
-  console.log("  Choose how you want your agent to use GitHits:");
-  console.log(
-    "    MCP server   Default path. Your agent can call GitHits tools directly.",
+    "  When local files and model memory are not enough, your agent can use",
   );
   console.log(
-    "    Agent Skills Use Skills instead of MCP when your coding tool supports them.",
+    "  GitHits for real open-source examples, dependency source code, docs,",
   );
+  console.log("  and package metadata.");
   console.log();
   console.log(
-    "  MCP setup adds a local MCP server entry. It does not write secrets into",
+    "  Most users should install the local MCP server. It lets your agent call",
   );
-  console.log("  your coding tool config.");
+  console.log(
+    "  GitHits tools directly, stores tokens in your OS keychain, and does not",
+  );
+  console.log("  write secrets into your coding tool config.");
+  console.log();
+  console.log("  Choose how you want to connect GitHits:");
+  console.log(
+    "    MCP server   Recommended. Configure your AI coding tool automatically.",
+  );
+  console.log(
+    "    Agent Skills Use Skills instead if you prefer that workflow over MCP.",
+  );
+  console.log();
+  console.log("  More info: https://docs.githits.com/quickstart");
   console.log();
   console.log("  What will happen:");
-  console.log("    1. Detect tools");
-  console.log("    2. Choose tools");
-  console.log("    3. Sign in");
-  console.log("    4. Install and verify");
-  console.log("    5. Ready");
+  console.log(
+    "    1. Detect tools        Find supported AI coding tools on this machine.",
+  );
+  console.log(
+    "    2. Choose tools        Pick which detected tools should get GitHits MCP.",
+  );
+  console.log(
+    "    3. Sign in             Connect this CLI to GitHits, unless already signed in.",
+  );
+  console.log(
+    "    4. Install and verify  Add the local MCP server entry and confirm it works.",
+  );
+  console.log(
+    "    5. Ready               Restart or open your coding tool and start coding.",
+  );
   console.log();
 }
 

--- a/src/commands/init/init.ts
+++ b/src/commands/init/init.ts
@@ -175,10 +175,13 @@ function getPiConfigFileUninstall(
 }
 
 function printReadyNextSteps(): void {
-  console.log("  GitHits is connected to your coding agent.");
+  console.log("  GitHits is connected to your AI coding tool.");
   console.log();
   console.log("  Start a coding task as usual. When your agent needs real");
-  console.log("  open-source examples or package context, it can use GitHits.");
+  console.log(
+    "  open-source examples, dependency source code, docs, or package",
+  );
+  console.log("  metadata, it can use GitHits.");
   console.log();
   console.log("  Try the CLI directly:");
   console.log(
@@ -296,17 +299,17 @@ function printInitIntro(useColors: boolean): void {
     "    MCP server   Default path. Your agent can call GitHits tools directly.",
   );
   console.log(
-    "    Agent Skills Use Skills instead of MCP when your harness supports them.",
+    "    Agent Skills Use Skills instead of MCP when your coding tool supports them.",
   );
   console.log();
   console.log(
-    "  MCP setup adds a local server entry. It does not write secrets into",
+    "  MCP setup adds a local MCP server entry. It does not write secrets into",
   );
-  console.log("  your agent config.");
+  console.log("  your coding tool config.");
   console.log();
   console.log("  What will happen:");
-  console.log("    1. Detect agents");
-  console.log("    2. Choose agents");
+  console.log("    1. Detect tools");
+  console.log("    2. Choose tools");
   console.log("    3. Sign in");
   console.log("    4. Install and verify");
   console.log("    5. Ready");
@@ -319,12 +322,12 @@ function printSkillsInstructions(): void {
   console.log("    npx skills add githits-com/githits-cli");
   console.log();
   console.log(
-    "  During installation, choose which harnesses should receive the Skills.",
+    "  During installation, choose which coding tools should receive the Skills.",
   );
   console.log(
-    "  Do not use GitHits Skills and GitHits MCP in the same harness at the",
+    "  Do not use GitHits Skills and GitHits MCP in the same coding tool at the",
   );
-  console.log("  same time; they provide overlapping guidance.");
+  console.log("  same time; they expose overlapping capabilities.");
   console.log();
   console.log("  GitHits still needs sign-in before tools can access results:");
   console.log();
@@ -358,7 +361,7 @@ function createScanProgressReporter(useColors: boolean): ScanProgressReporter {
       const width = 20;
       const filled = Math.round((progress.completed / progress.total) * width);
       const bar = `${colorize("#".repeat(filled), "magenta", useColors)}${"-".repeat(width - filled)}`;
-      const line = `  Scanning agents [${bar}] ${progress.completed}/${progress.total} ${progress.agent.name}`;
+      const line = `  Scanning tools [${bar}] ${progress.completed}/${progress.total} ${progress.agent.name}`;
       process.stdout.write(`\r\x1b[2K${line}`);
       wrote = true;
     },
@@ -451,7 +454,7 @@ function printScanSummary(scan: ScanResult, useColors: boolean): void {
   if (scan.notDetected.length > 0) {
     printTask(
       "skipped",
-      `${scan.notDetected.length} supported agent${scan.notDetected.length !== 1 ? "s" : ""} not found`,
+      `${scan.notDetected.length} supported tool${scan.notDetected.length !== 1 ? "s" : ""} not found`,
       formatAgentNames(scan.notDetected),
       useColors,
     );
@@ -459,7 +462,7 @@ function printScanSummary(scan: ScanResult, useColors: boolean): void {
   if (detected > 0) {
     console.log();
     console.log(
-      `    Found ${detected} supported agent${detected !== 1 ? "s" : ""}.`,
+      `    Found ${detected} supported tool${detected !== 1 ? "s" : ""}.`,
     );
   }
 }
@@ -477,7 +480,7 @@ function printAuthExplanation(): void {
   );
   console.log("    Tokens are stored in your OS keychain.");
   console.log();
-  console.log("    No secrets are written into your agent MCP config.");
+  console.log("    No secrets are written into your tool's MCP config.");
   console.log(
     "    For CI or headless machines, use GITHITS_API_TOKEN instead.",
   );
@@ -860,8 +863,8 @@ export async function initAction(
     }
   }
 
-  printSection(1, "Detect Agents", useColors);
-  console.log("    Scanning supported coding agents...");
+  printSection(1, "Detect tools", useColors);
+  console.log("    Scanning supported AI coding tools...");
   renderScanProgress = true;
   if (lastScanProgress) {
     progress.onProgress(lastScanProgress);
@@ -877,8 +880,8 @@ export async function initAction(
   if (scan.needsSetup.length === 0 && scan.alreadyConfigured.length === 0) {
     printTask(
       "warning",
-      "No supported coding agents detected",
-      "install an agent and run `githits init` again",
+      "No supported AI coding tools detected",
+      "install a supported tool and run `githits init` again",
       useColors,
     );
     console.log();
@@ -886,11 +889,11 @@ export async function initAction(
   }
 
   let toSetup = scan.needsSetup;
-  printSection(2, "Choose Agents", useColors);
+  printSection(2, "Choose tools", useColors);
   if (!options.yes && scan.needsSetup.length > 0) {
     try {
       toSetup = await promptService.checkbox(
-        "  Select agents to configure with GitHits MCP:",
+        "  Select AI coding tools to configure with GitHits MCP:",
         buildInitAgentChoices(scan),
       );
     } catch (err) {
@@ -903,23 +906,23 @@ export async function initAction(
   } else if (scan.needsSetup.length === 0) {
     printTask(
       "success",
-      "No agent changes needed",
-      "all detected agents already have GitHits MCP",
+      "No tool changes needed",
+      "all detected tools already have GitHits MCP",
       useColors,
     );
   } else {
-    printTask("success", "Selected all detected agents", "--yes", useColors);
+    printTask("success", "Selected all detected tools", "--yes", useColors);
   }
 
   const outcomes: AgentOutcome[] = [];
 
   if (toSetup.length === 0 && scan.needsSetup.length > 0) {
-    printTask("skipped", "Setup skipped", "no agents selected", useColors);
+    printTask("skipped", "Setup skipped", "no tools selected", useColors);
     console.log();
     return;
   }
 
-  printSection(3, "Sign In", useColors);
+  printSection(3, "Sign in", useColors);
   const authStatus = await runInitAuthentication(
     options,
     promptService,
@@ -930,12 +933,12 @@ export async function initAction(
     return;
   }
 
-  printSection(4, "Install And Verify", useColors);
+  printSection(4, "Install and verify", useColors);
   if (toSetup.length === 0) {
     printTask(
       "success",
       "Nothing to install",
-      "all detected agents are already configured",
+      "all detected tools are already configured",
       useColors,
     );
     printPostSetupNextSteps(authStatus, useColors);
@@ -1017,7 +1020,7 @@ export async function initAction(
 
   if (failed > 0) {
     console.log(
-      `  ${failed} agent${failed !== 1 ? "s" : ""} failed to configure.`,
+      `  ${failed} tool${failed !== 1 ? "s" : ""} failed to configure.`,
     );
     for (const outcome of outcomes.filter((o) => o.status === "failed")) {
       console.log(
@@ -1027,7 +1030,7 @@ export async function initAction(
   }
   if (scan.alreadyConfigured.length > 0) {
     console.log(
-      `  ${scan.alreadyConfigured.length} agent${scan.alreadyConfigured.length !== 1 ? "s" : ""} already configured.`,
+      `  ${scan.alreadyConfigured.length} tool${scan.alreadyConfigured.length !== 1 ? "s" : ""} already configured.`,
     );
   }
 
@@ -1251,13 +1254,13 @@ function printAuthRecoveryHint(): void {
   );
 }
 
-const INIT_DESCRIPTION = `Set up GitHits for your coding agents.
+const INIT_DESCRIPTION = `Set up GitHits for your AI coding tools.
 
-Explains GitHits setup options, lets you install the GitHits MCP server or use
-Agent Skills, scans for available agents (Claude Code, Cursor, Windsurf,
+Walks through GitHits setup options, lets you install the local GitHits MCP
+server or use Agent Skills, scans for available tools (Claude Code, Cursor, Windsurf,
 VS Code, Cline, Claude Desktop, Codex CLI, Pi, Gemini CLI, Google Antigravity),
 checks which are already configured, signs you in, and configures selected
-agents with GitHits MCP.
+tools with GitHits MCP.
 
 Supports CLI-based setup (Claude Code, Codex, Gemini CLI), Pi package setup,
 and config
@@ -1277,9 +1280,9 @@ tokens are not removed; use \`githits logout\` to remove stored credentials.`;
 export function registerInitCommand(program: Command) {
   const initCommand = program
     .command("init")
-    .summary("Set up MCP server for your coding agents")
+    .summary("Set up MCP server for your AI coding tools")
     .description(INIT_DESCRIPTION)
-    .option("-y, --yes", "Skip prompts, configure all detected agents")
+    .option("-y, --yes", "Skip prompts, configure all detected tools")
     .option("--skip-login", "Skip authentication step")
     .action(async (options: InitOptions) => {
       const fileSystemService = new FileSystemServiceImpl();

--- a/src/commands/init/init.ts
+++ b/src/commands/init/init.ts
@@ -843,20 +843,6 @@ export async function initAction(
     deps;
   printInitIntro(useColors);
 
-  const progress = createScanProgressReporter(useColors);
-  let renderScanProgress = false;
-  let lastScanProgress: ScanProgress | undefined;
-  const scanPromise = startSafeInitScan(
-    fileSystemService,
-    execService,
-    (scanProgress) => {
-      lastScanProgress = scanProgress;
-      if (renderScanProgress) {
-        progress.onProgress(scanProgress);
-      }
-    },
-  );
-
   if (!options.yes) {
     let intent: InitIntent;
     try {
@@ -887,10 +873,12 @@ export async function initAction(
 
   printSection(1, "Detect tools", useColors);
   console.log("    Scanning supported AI coding tools...");
-  renderScanProgress = true;
-  if (lastScanProgress) {
-    progress.onProgress(lastScanProgress);
-  }
+  const progress = createScanProgressReporter(useColors);
+  const scanPromise = startSafeInitScan(
+    fileSystemService,
+    execService,
+    (scanProgress) => progress.onProgress(scanProgress),
+  );
   let scan: ScanResult;
   try {
     scan = await unwrapSafeScan(scanPromise);

--- a/src/commands/init/init.ts
+++ b/src/commands/init/init.ts
@@ -182,7 +182,7 @@ function formatCommand(command: string, useColors: boolean): string {
   return colorizeBrand(command, "secondary", useColors, { bold: true });
 }
 
-function printReadyNextSteps(): void {
+function printReadyNextSteps(useColors: boolean): void {
   console.log("  GitHits is connected to your coding agent.");
   console.log();
   console.log("  Your agent can now:");
@@ -202,6 +202,34 @@ function printReadyNextSteps(): void {
   console.log();
   console.log(
     "    “Compare how different OSS projects structure background jobs.”",
+  );
+  console.log();
+  const snippetHeading = "Agent instruction snippet";
+  console.log(`  ${snippetHeading}`);
+  console.log(
+    `  ${colorize("-".repeat(snippetHeading.length), "dim", useColors)}`,
+  );
+  console.log();
+  console.log("  Add this to your AGENTS.md or CLAUDE.md:");
+  console.log();
+  const snippetBody = [
+    "When work depends on open-source libraries, use GitHits before guessing.",
+    "",
+    "Use:",
+    "- Code Examples for real-world implementation patterns",
+    "- Code Navigation to inspect dependency source code",
+    "- Documentation Access for hosted and repo-backed docs",
+    "- Package Inspection for metadata, vulnerabilities, and changelogs",
+    "",
+    "Prefer grounded implementations over guessing.",
+  ];
+  for (const line of snippetBody) {
+    console.log(line ? `  ${colorize(line, "italic", useColors)}` : "");
+  }
+  console.log();
+  console.log("  Full version:");
+  console.log(
+    "  https://docs.githits.com/guides/trigger-githits#agent-instruction-snippet",
   );
   console.log();
   console.log("  Docs: https://docs.githits.com");
@@ -689,7 +717,7 @@ function printPostSetupNextSteps(
     useColors,
   );
   if (shouldPrintReady(authStatus)) {
-    printReadyNextSteps();
+    printReadyNextSteps(useColors);
   } else if (authStatus === "failed_continue") {
     printAuthRequiredNextSteps(useColors);
   } else {

--- a/src/commands/init/init.ts
+++ b/src/commands/init/init.ts
@@ -15,9 +15,11 @@ import { PromptServiceImpl } from "../../services/prompt-service.js";
 import {
   colorize,
   colorizeBrand,
+  colorizeTerminal,
   error as errorFmt,
   shouldUseColors,
   success,
+  type TerminalColor,
   warning,
 } from "../../shared/colors.js";
 import type {
@@ -175,40 +177,48 @@ function getPiConfigFileUninstall(
   return configStep ?? null;
 }
 
+/** Style a CLI command so it stands out from surrounding text. */
+function formatCommand(command: string, useColors: boolean): string {
+  return colorizeBrand(command, "secondary", useColors, { bold: true });
+}
+
 function printReadyNextSteps(): void {
-  console.log("  GitHits is connected to your AI coding tool.");
+  console.log("  GitHits is connected to your coding agent.");
   console.log();
-  console.log("  Start a coding task as usual. When your agent needs real");
-  console.log(
-    "  open-source examples, dependency source code, docs, or package",
-  );
-  console.log("  metadata, it can use GitHits.");
+  console.log("  Your agent can now:");
+  console.log("  • Explore real open-source repositories");
+  console.log("  • Inspect dependency internals");
+  console.log("  • Navigate unfamiliar codebases");
+  console.log("  • Ground responses in production code");
+  console.log("  • Use real implementations instead of guessing");
   console.log();
-  console.log("  Try the CLI directly:");
-  console.log(
-    '    npx githits@latest example "How do I use useEffect cleanup?"',
-  );
+  console.log("  Try asking your agent:");
   console.log();
-  console.log("  Or ask your agent:");
+  console.log("    “How does Next.js implement route prefetching internally?”");
+  console.log();
+  console.log("    “Trace how authentication flows through this repo.”");
+  console.log();
+  console.log("    “Find where retries are handled in the Stripe SDK.”");
+  console.log();
   console.log(
-    "    Use GitHits Code Examples to find a real open-source implementation of HTTP retries with exponential backoff in Python.",
+    "    “Compare how different OSS projects structure background jobs.”",
   );
   console.log();
   console.log("  Docs: https://docs.githits.com");
 }
 
-function printAuthRequiredNextSteps(): void {
+function printAuthRequiredNextSteps(useColors: boolean): void {
   console.log("  GitHits MCP is configured, but sign-in is still needed.");
   console.log();
   console.log("  Sign in when you're ready:");
-  console.log("    npx githits@latest login");
+  console.log(`    ${formatCommand("npx githits@latest login", useColors)}`);
 }
 
-function printAuthNotCheckedNextSteps(): void {
+function printAuthNotCheckedNextSteps(useColors: boolean): void {
   console.log("  GitHits MCP is configured. Sign-in was not checked.");
   console.log();
   console.log("  If your agent asks you to sign in, run:");
-  console.log("    npx githits@latest login");
+  console.log(`    ${formatCommand("npx githits@latest login", useColors)}`);
 }
 
 const GITHITS_ASCII_LOGO = String.raw`
@@ -219,22 +229,94 @@ const GITHITS_ASCII_LOGO = String.raw`
   \____|_|\__|_| |_|_|\__|___/
 `;
 
+/** Per-column color stops for the logo's warm gradient. */
+const LOGO_GRADIENT: ReadonlyArray<{ until: number; color: TerminalColor }> = [
+  {
+    until: 13,
+    color: {
+      hex: "#FF4FAE",
+      rgb: [255, 79, 174],
+      ansi256: 205,
+      ansi16: "magenta",
+    },
+  },
+  {
+    until: 19,
+    color: {
+      hex: "#FF5D8E",
+      rgb: [255, 93, 142],
+      ansi256: 204,
+      ansi16: "magenta",
+    },
+  },
+  {
+    until: 21,
+    color: {
+      hex: "#FF6B6F",
+      rgb: [255, 107, 111],
+      ansi256: 203,
+      ansi16: "red",
+    },
+  },
+  {
+    until: 25,
+    color: { hex: "#FF794F", rgb: [255, 121, 79], ansi256: 209, ansi16: "red" },
+  },
+  {
+    until: 30,
+    color: {
+      hex: "#FF872F",
+      rgb: [255, 135, 47],
+      ansi256: 208,
+      ansi16: "yellow",
+    },
+  },
+];
+
+/** Apply the column-based gradient to each row of the ASCII logo. */
+function colorizeLogo(logo: string, useColors: boolean): string {
+  if (!useColors) {
+    return logo;
+  }
+  return logo
+    .split("\n")
+    .map((line) => {
+      if (line.length === 0) {
+        return line;
+      }
+      let cursor = 0;
+      let colored = "";
+      for (const { until, color } of LOGO_GRADIENT) {
+        if (cursor >= line.length) {
+          break;
+        }
+        colored += colorizeTerminal(
+          line.slice(cursor, until),
+          color,
+          useColors,
+        );
+        cursor = until;
+      }
+      return cursor < line.length ? colored + line.slice(cursor) : colored;
+    })
+    .join("\n");
+}
+
 const INIT_INTENT_CHOICES: SelectChoice<InitIntent>[] = [
   {
-    name: "Install GitHits MCP server",
+    name: "Connect GitHits to my agent (Recommended)",
     value: "mcp",
-    description: "Recommended. Lets your agent call GitHits tools directly.",
+    description: "Installs the local GitHits MCP server.",
   },
   {
-    name: "I'd rather use Agent Skills",
+    name: "Use Agent Skills instead",
     value: "skills",
-    description:
-      "Use instruction-driven Skills instead of the local MCP server.",
+    description: "Use Skills instead of the local MCP server.",
   },
   {
-    name: "Later",
+    name: "Exit",
     value: "later",
-    description: "Exit without changing anything.",
+    description: "Leave setup without making changes.",
   },
 ];
 
@@ -289,71 +371,44 @@ function printTask(
 }
 
 function printInitIntro(useColors: boolean): void {
-  console.log(colorizeBrand(GITHITS_ASCII_LOGO, "primary", useColors));
-  console.log(
-    "  GitHits adds source-backed open-source context to your AI coding tool.",
-  );
-  console.log(
-    "  When local files and model memory are not enough, your agent can use",
-  );
-  console.log(
-    "  GitHits for real open-source examples, dependency source code, docs,",
-  );
-  console.log("  and package metadata.");
+  console.log(colorizeLogo(GITHITS_ASCII_LOGO, useColors));
+  console.log("  GitHits helps coding agents stop guessing.");
+  console.log();
+  console.log("  Instead of retry loops and hallucinated solutions,");
+  console.log("  your agent gets grounded context from real open-source code.");
+  console.log();
+  console.log(`  ${colorizeBrand("Your agent can:", "primary", useColors)}`);
+  console.log("  • Explore production codebases");
+  console.log("  • Inspect dependency internals");
+  console.log("  • Navigate large repositories");
+  console.log("  • Find real implementations");
+  console.log("  • Ground responses in actual code instead of guesses");
   console.log();
   console.log(
-    "  Most users should install the local MCP server. It lets your agent call",
-  );
-  console.log(
-    "  GitHits tools directly, stores tokens in your OS keychain, and does not",
-  );
-  console.log("  write secrets into your coding tool config.");
-  console.log();
-  console.log("  Choose how you want to connect GitHits:");
-  console.log(
-    "    MCP server   Recommended. Configure your AI coding tool automatically.",
-  );
-  console.log(
-    "    Agent Skills Use Skills instead if you prefer that workflow over MCP.",
+    "  Works with Cursor, Claude Code, Codex CLI, VS Code and Windsurf, plus more.",
   );
   console.log();
-  console.log("  More info: https://docs.githits.com/quickstart");
-  console.log();
-  console.log("  What will happen:");
-  console.log(
-    "    1. Detect tools        Find supported AI coding tools on this machine.",
-  );
-  console.log(
-    "    2. Choose tools        Pick which detected tools should get GitHits MCP.",
-  );
-  console.log(
-    "    3. Sign in             Connect this CLI to GitHits, unless already signed in.",
-  );
-  console.log(
-    "    4. Install and verify  Add the local MCP server entry and confirm it works.",
-  );
-  console.log(
-    "    5. Ready               Restart or open your coding tool and start coding.",
-  );
+  console.log("  More info: https://docs.githits.com");
   console.log();
 }
 
-function printSkillsInstructions(): void {
+function printSkillsInstructions(useColors: boolean): void {
   console.log("\n  Install GitHits Agent Skills:");
   console.log();
-  console.log("    npx skills add githits-com/githits-cli");
+  console.log(
+    `    ${formatCommand("npx skills add githits-com/githits-cli", useColors)}`,
+  );
+  console.log();
+  console.log("  During setup, choose where you want to enable GitHits.");
   console.log();
   console.log(
-    "  During installation, choose which coding tools should receive the Skills.",
+    "  IMPORTANT: Use either Agent Skills or the local MCP server in the same",
   );
-  console.log(
-    "  Do not use GitHits Skills and GitHits MCP in the same coding tool at the",
-  );
-  console.log("  same time; they expose overlapping capabilities.");
+  console.log("  coding tool, not both.");
   console.log();
-  console.log("  GitHits still needs sign-in before tools can access results:");
+  console.log("  Then sign in so your agent can use GitHits:");
   console.log();
-  console.log("    npx githits@latest login");
+  console.log(`    ${formatCommand("npx githits@latest login", useColors)}`);
   console.log();
 }
 
@@ -491,21 +546,13 @@ function printScanSummary(scan: ScanResult, useColors: boolean): void {
 
 function printAuthExplanation(): void {
   console.log(
-    "    GitHits tools require sign-in before they can return results.",
+    "    GitHits authentication is required before your agent can use GitHits tools.",
   );
   console.log();
-  console.log(
-    "    We will open your browser to GitHits. After you approve access,",
-  );
-  console.log(
-    "    the browser redirects back to this terminal through localhost.",
-  );
-  console.log("    Tokens are stored in your OS keychain.");
+  console.log("    We'll open your browser to connect your account.");
+  console.log("    Credentials are stored securely in your OS keychain.");
   console.log();
-  console.log("    No secrets are written into your tool's MCP config.");
-  console.log(
-    "    For CI or headless machines, use GITHITS_API_TOKEN instead.",
-  );
+  console.log("    No API keys or secrets are written into your MCP config.");
   console.log();
 }
 
@@ -590,7 +637,7 @@ async function runInitAuthentication(
     console.log(
       `    ${warning(`Login failed: ${loginResult.message}`, useColors)}\n`,
     );
-    printAuthRecoveryHint();
+    printAuthRecoveryHint(useColors);
 
     if (options.yes) {
       console.log("    Continuing without authentication...\n");
@@ -644,9 +691,9 @@ function printPostSetupNextSteps(
   if (shouldPrintReady(authStatus)) {
     printReadyNextSteps();
   } else if (authStatus === "failed_continue") {
-    printAuthRequiredNextSteps();
+    printAuthRequiredNextSteps(useColors);
   } else {
-    printAuthNotCheckedNextSteps();
+    printAuthNotCheckedNextSteps(useColors);
   }
 }
 
@@ -861,7 +908,7 @@ export async function initAction(
     let intent: InitIntent;
     try {
       intent = await promptService.select(
-        "  How would you like to use GitHits?",
+        "  What do you want to do?",
         INIT_INTENT_CHOICES,
         "mcp",
       );
@@ -874,7 +921,7 @@ export async function initAction(
     }
 
     if (intent === "skills") {
-      printSkillsInstructions();
+      printSkillsInstructions(useColors);
       return;
     }
     if (intent === "later") {
@@ -886,7 +933,7 @@ export async function initAction(
   }
 
   printSection(1, "Detect tools", useColors);
-  console.log("    Scanning supported AI coding tools...");
+  console.log("    Scanning for compatible AI coding tools...");
   renderScanProgress = true;
   if (lastScanProgress) {
     progress.onProgress(lastScanProgress);
@@ -915,7 +962,7 @@ export async function initAction(
   if (!options.yes && scan.needsSetup.length > 0) {
     try {
       toSetup = await promptService.checkbox(
-        "  Select AI coding tools to configure with GitHits MCP:",
+        "  Select which tools should use GitHits:",
         buildInitAgentChoices(scan),
       );
     } catch (err) {
@@ -1071,7 +1118,10 @@ export async function initUninstallAction(
   const { fileSystemService, promptService, execService } = deps;
 
   console.log(
-    `\n  ${colorizeBrand("GitHits", "primary", useColors, { bold: true })} — Remove MCP server from your coding agents\n`,
+    `\n  ${colorize("Disconnect GitHits from your coding agents.", "bold", useColors)}`,
+  );
+  console.log(
+    `  ${colorize("Removes the local GitHits MCP configuration.", "dim", useColors)}\n`,
   );
 
   console.log("  Scanning for configured agents...\n");
@@ -1263,31 +1313,24 @@ export async function initUninstallAction(
   console.log();
 }
 
-function printAuthRecoveryHint(): void {
+function printAuthRecoveryHint(useColors: boolean): void {
   console.log(
     "    You can still configure MCP, but GitHits tools will require auth.",
   );
   console.log("    Recovery steps:");
-  console.log("      githits auth status");
-  console.log("      githits login --force");
+  console.log(`      ${formatCommand("githits auth status", useColors)}`);
+  console.log(`      ${formatCommand("githits login --force", useColors)}`);
   console.log("    For CI or locked-down machines, set GITHITS_API_TOKEN.");
   console.log(
     "    If your system keychain is unavailable, set GITHITS_AUTH_STORAGE=file after accepting plaintext storage.\n",
   );
 }
 
-const INIT_DESCRIPTION = `Set up GitHits for your AI coding tools.
+const INIT_DESCRIPTION = `Connect GitHits to your coding agents.
 
-Walks through GitHits setup options, lets you install the local GitHits MCP
-server or use Agent Skills, scans for available tools (Claude Code, Cursor, Windsurf,
-VS Code, Cline, Claude Desktop, Codex CLI, Pi, Gemini CLI, Google Antigravity),
-checks which are already configured, signs you in, and configures selected
-tools with GitHits MCP.
-
-Supports CLI-based setup (Claude Code, Codex, Gemini CLI), Pi package setup,
-and config
-file editing (Cursor, Windsurf, VS Code, Cline, Claude Desktop,
-Google Antigravity) with atomic writes.`;
+Installs the local GitHits MCP server — the recommended way to connect — or
+sets up Agent Skills instead. Detects supported coding tools on this machine,
+signs you in, and configures the tools you select.`;
 
 const INIT_UNINSTALL_DESCRIPTION = `Remove GitHits MCP server configuration from your coding agents.
 
@@ -1302,7 +1345,7 @@ tokens are not removed; use \`githits logout\` to remove stored credentials.`;
 export function registerInitCommand(program: Command) {
   const initCommand = program
     .command("init")
-    .summary("Set up MCP server for your AI coding tools")
+    .summary("Connect GitHits to your coding agents")
     .description(INIT_DESCRIPTION)
     .option("-y, --yes", "Skip prompts, configure all detected tools")
     .option("--skip-login", "Skip authentication step")

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -408,7 +408,7 @@ to get a URL you can open on another device.`;
 export function registerLoginCommand(program: Command) {
   program
     .command("login")
-    .summary("Authenticate with your GitHits account")
+    .summary("Sign in to your GitHits account")
     .description(LOGIN_DESCRIPTION)
     .option("--no-browser", "Print URL instead of opening browser")
     .option("--port <port>", "Port for local callback server", parseInt)

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -198,7 +198,7 @@ function showMcpSetupInstructions(): void {
 export function registerMcpCommand(program: Command) {
   const mcpCommand = program
     .command("mcp")
-    .summary("Show setup instructions or start MCP server")
+    .summary("Show MCP setup instructions or start the local MCP server")
     .description(
       `Start the Model Context Protocol (MCP) server using STDIO transport.
 

--- a/src/commands/pkg/index.ts
+++ b/src/commands/pkg/index.ts
@@ -25,9 +25,7 @@ export async function registerPkgCommandGroup(
 
   const pkgCommand = program
     .command("pkg")
-    .summary(
-      "Package metadata: info, vulnerabilities, dependencies, changelog, upgrade reviews",
-    )
+    .summary("Package metadata, dependencies, vulnerabilities and changelogs")
     .description(
       "Inspect package metadata from npm, PyPI, Hex, Crates, NuGet, Maven, Packagist, RubyGems, Go, vcpkg, and Zig: overviews, advisories, dependency graphs, and changelogs. Advisory data is unavailable for vcpkg and Zig. For source-level operations inside a dependency, use `githits code`.",
     );

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -18,7 +18,9 @@ import {
   knownSymbolKindList,
   parseUnifiedSearchTargetSpec,
   requireAuth,
+  SPINNER_MESSAGES,
   shouldUseColors,
+  startSpinner,
   toFileIntent,
   toSymbolCategory,
   toSymbolKind,
@@ -87,7 +89,10 @@ export async function searchAction(
       waitTimeoutMs: parseWaitMs(options.wait),
     });
 
-    const outcome = await service.search(built.params);
+    const spinner = startSpinner(SPINNER_MESSAGES.search, !options.json);
+    const outcome = await service
+      .search(built.params)
+      .finally(() => spinner.stop());
     const payload = buildUnifiedSearchSuccessPayload(
       built.params,
       built.rawQuery,
@@ -172,7 +177,7 @@ the original request used --allow-partial, or final results.`;
 export function registerSearchCommand(program: Command) {
   program
     .command("search")
-    .summary("Search indexed dependency and repository code, docs, and symbols")
+    .summary("Explore repository code, dependencies, docs and symbols")
     .description(SEARCH_DESCRIPTION)
     .argument("<query>", "Search query")
     .requiredOption(
@@ -240,7 +245,7 @@ export function registerSearchCommand(program: Command) {
 
   program
     .command("search-status")
-    .summary("Check status of a prior search")
+    .summary("Check the status of a previous search")
     .description(SEARCH_STATUS_DESCRIPTION)
     .argument("<search-ref>", "Search reference returned by githits search")
     .option("--json", "Output as JSON")

--- a/src/services/prompt-service.ts
+++ b/src/services/prompt-service.ts
@@ -10,6 +10,18 @@ export interface CheckboxChoice<T> {
   checked?: boolean;
   /** Optional description shown below the choice */
   description?: string;
+  /** Whether the choice is disabled */
+  disabled?: boolean | string;
+}
+
+/** Choice for select prompt */
+export interface SelectChoice<T> {
+  /** Display name */
+  name: string;
+  /** Value returned when selected */
+  value: T;
+  /** Optional description shown below the choice */
+  description?: string;
 }
 
 /** User's confirmation choice for sequential setup */
@@ -20,6 +32,13 @@ export type ConfirmChoice = "yes" | "no" | "always";
  * Wraps @inquirer/prompts for dependency injection and testability.
  */
 export interface PromptService {
+  /** Single-select prompt */
+  select<T>(
+    message: string,
+    choices: SelectChoice<T>[],
+    defaultValue?: T,
+  ): Promise<T>;
+
   /** Multi-select with pre-checked items */
   checkbox<T>(message: string, choices: CheckboxChoice<T>[]): Promise<T[]>;
 
@@ -31,6 +50,14 @@ export interface PromptService {
  * Production implementation using @inquirer/prompts.
  */
 export class PromptServiceImpl implements PromptService {
+  async select<T>(
+    message: string,
+    choices: SelectChoice<T>[],
+    defaultValue?: T,
+  ): Promise<T> {
+    return select({ message, choices, default: defaultValue });
+  }
+
   async checkbox<T>(
     message: string,
     choices: CheckboxChoice<T>[],

--- a/src/services/test-helpers.ts
+++ b/src/services/test-helpers.ts
@@ -851,7 +851,25 @@ export function createMockPromptService(
   impl: Partial<PromptService> = {},
 ): PromptService {
   return {
-    checkbox: mock(() => Promise.resolve([])) as PromptService["checkbox"],
+    select: mock(
+      <T>(_message: string, choices: { value: T }[], defaultValue?: T) =>
+        Promise.resolve((defaultValue ?? choices[0]?.value) as T),
+    ) as PromptService["select"],
+    checkbox: mock(
+      <T>(
+        _message: string,
+        choices: {
+          value: T;
+          checked?: boolean;
+          disabled?: boolean | string;
+        }[],
+      ) =>
+        Promise.resolve(
+          choices
+            .filter((choice) => choice.checked && !choice.disabled)
+            .map((choice) => choice.value),
+        ),
+    ) as PromptService["checkbox"],
     confirm3: mock(() => Promise.resolve("yes" as ConfirmChoice)),
     ...impl,
   };

--- a/src/shared/colors.test.ts
+++ b/src/shared/colors.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import {
+  brandColors,
   colorize,
+  colorizeBrand,
+  colorizeTerminal,
   colors,
   dim,
   error,
@@ -51,6 +54,41 @@ describe("colorize", () => {
 
   it("returns plain text when disabled", () => {
     expect(colorize("hello", "cyan", false)).toBe("hello");
+  });
+});
+
+describe("colorizeTerminal", () => {
+  it("uses truecolor when terminal color depth supports it", () => {
+    const result = colorizeTerminal("GitHits", brandColors.primary, true, {
+      colorDepth: 24,
+    });
+    expect(result).toBe("\x1b[38;2;255;79;174mGitHits\x1b[0m");
+  });
+
+  it("falls back to 256-color when truecolor is unavailable", () => {
+    const result = colorizeTerminal("GitHits", brandColors.primary, true, {
+      colorDepth: 8,
+    });
+    expect(result).toBe("\x1b[38;5;205mGitHits\x1b[0m");
+  });
+
+  it("falls back to 16-color when only basic color is available", () => {
+    const result = colorizeTerminal("GitHits", brandColors.primary, true, {
+      colorDepth: 4,
+    });
+    expect(result).toBe(`${colors.magenta}GitHits${colors.reset}`);
+  });
+
+  it("combines style and terminal color", () => {
+    const result = colorizeBrand("GitHits", "secondary", true, {
+      bold: true,
+      colorDepth: 8,
+    });
+    expect(result).toBe(`${colors.bold}\x1b[38;5;208mGitHits${colors.reset}`);
+  });
+
+  it("returns plain text when disabled", () => {
+    expect(colorizeBrand("GitHits", "primary", false)).toBe("GitHits");
   });
 });
 

--- a/src/shared/colors.test.ts
+++ b/src/shared/colors.test.ts
@@ -62,7 +62,7 @@ describe("colorizeTerminal", () => {
     const result = colorizeTerminal("GitHits", brandColors.primary, true, {
       colorDepth: 24,
     });
-    expect(result).toBe("\x1b[38;2;255;79;174mGitHits\x1b[0m");
+    expect(result).toBe("\x1b[38;2;255;114;190mGitHits\x1b[0m");
   });
 
   it("falls back to 256-color when truecolor is unavailable", () => {

--- a/src/shared/colors.test.ts
+++ b/src/shared/colors.test.ts
@@ -79,6 +79,13 @@ describe("colorizeTerminal", () => {
     expect(result).toBe(`${colors.magenta}GitHits${colors.reset}`);
   });
 
+  it("returns plain text when the terminal reports no color support", () => {
+    const result = colorizeTerminal("GitHits", brandColors.primary, true, {
+      colorDepth: 1,
+    });
+    expect(result).toBe("GitHits");
+  });
+
   it("combines style and terminal color", () => {
     const result = colorizeBrand("GitHits", "secondary", true, {
       bold: true,

--- a/src/shared/colors.ts
+++ b/src/shared/colors.ts
@@ -102,6 +102,7 @@ export function colorizeTerminal(
 ): string {
   if (!useColors) return text;
   const colorDepth = options.colorDepth ?? getColorDepth();
+  if (colorDepth <= 1) return text;
   const prefix = `${options.bold ? colors.bold : ""}${options.dim ? colors.dim : ""}${foregroundColorCode(color, colorDepth)}`;
   return `${prefix}${text}${colors.reset}`;
 }

--- a/src/shared/colors.ts
+++ b/src/shared/colors.ts
@@ -31,8 +31,8 @@ export type BrandColorName = keyof typeof brandColors;
  */
 export const brandColors = {
   primary: {
-    hex: "#FF4FAE",
-    rgb: [255, 79, 174],
+    hex: "#FF72BE",
+    rgb: [255, 114, 190],
     ansi256: 205,
     ansi16: "magenta",
   },

--- a/src/shared/colors.ts
+++ b/src/shared/colors.ts
@@ -7,6 +7,7 @@ export const colors = {
   reset: "\x1b[0m",
   bold: "\x1b[1m",
   dim: "\x1b[2m",
+  italic: "\x1b[3m",
   green: "\x1b[32m",
   yellow: "\x1b[33m",
   blue: "\x1b[34m",

--- a/src/shared/colors.ts
+++ b/src/shared/colors.ts
@@ -15,6 +15,41 @@ export const colors = {
   red: "\x1b[31m",
 };
 
+export interface TerminalColor {
+  /** Source token hex value, kept here so CLI brand colors are easy to audit. */
+  hex: `#${string}`;
+  rgb: readonly [number, number, number];
+  ansi256: number;
+  ansi16: keyof typeof colors;
+}
+
+export type BrandColorName = keyof typeof brandColors;
+
+/**
+ * CLI projection of the GitHits brand palette.
+ * Source: githits-frontend design tokens and brand guidelines PDF.
+ */
+export const brandColors = {
+  primary: {
+    hex: "#FF4FAE",
+    rgb: [255, 79, 174],
+    ansi256: 205,
+    ansi16: "magenta",
+  },
+  secondary: {
+    hex: "#FF872F",
+    rgb: [255, 135, 47],
+    ansi256: 208,
+    ansi16: "yellow",
+  },
+} as const satisfies Record<string, TerminalColor>;
+
+export interface ColorizeTerminalOptions {
+  bold?: boolean;
+  dim?: boolean;
+  colorDepth?: number;
+}
+
 /**
  * Check if we should use colors (TTY and not disabled)
  */
@@ -36,6 +71,48 @@ export function colorize(
 ): string {
   if (!useColors) return text;
   return `${colors[color]}${text}${colors.reset}`;
+}
+
+function getColorDepth(): number {
+  const stream = process.stdout as typeof process.stdout & {
+    getColorDepth?: () => number;
+  };
+  return stream.getColorDepth?.() ?? 1;
+}
+
+function foregroundColorCode(color: TerminalColor, colorDepth: number): string {
+  if (colorDepth >= 24) {
+    const [red, green, blue] = color.rgb;
+    return `\x1b[38;2;${red};${green};${blue}m`;
+  }
+  if (colorDepth >= 8) {
+    return `\x1b[38;5;${color.ansi256}m`;
+  }
+  return colors[color.ansi16];
+}
+
+/**
+ * Colorize text with RGB -> 256-color -> 16-color fallback.
+ */
+export function colorizeTerminal(
+  text: string,
+  color: TerminalColor,
+  useColors: boolean,
+  options: ColorizeTerminalOptions = {},
+): string {
+  if (!useColors) return text;
+  const colorDepth = options.colorDepth ?? getColorDepth();
+  const prefix = `${options.bold ? colors.bold : ""}${options.dim ? colors.dim : ""}${foregroundColorCode(color, colorDepth)}`;
+  return `${prefix}${text}${colors.reset}`;
+}
+
+export function colorizeBrand(
+  text: string,
+  colorName: BrandColorName,
+  useColors: boolean,
+  options?: ColorizeTerminalOptions,
+): string {
+  return colorizeTerminal(text, brandColors[colorName], useColors, options);
 }
 
 /**

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -203,6 +203,8 @@ export {
   createRootCliPreAction,
   type RootCliPreActionDependencies,
 } from "./root-cli-pre-action.js";
+export { type Spinner, startSpinner } from "./spinner.js";
+export { SPINNER_MESSAGES } from "./spinner-messages.js";
 export {
   buildRetryCandidateLine,
   buildTargetResolutionNotes,

--- a/src/shared/spinner-messages.ts
+++ b/src/shared/spinner-messages.ts
@@ -1,0 +1,28 @@
+/**
+ * Rotating spinner labels per command. Each list cycles every ~2s while
+ * a command waits on the GitHits backend, so long requests feel alive.
+ */
+export const SPINNER_MESSAGES = {
+  example: [
+    "Searching real implementations...",
+    "Exploring open-source code...",
+    "Finding production patterns...",
+    "Grounding results...",
+  ],
+  search: [
+    "Exploring repositories...",
+    "Tracing symbols...",
+    "Inspecting dependencies...",
+    "Scanning source code...",
+  ],
+  code: [
+    "Inspecting source code...",
+    "Resolving symbols...",
+    "Reading dependency internals...",
+  ],
+  docs: [
+    "Reading documentation...",
+    "Resolving references...",
+    "Collecting package docs...",
+  ],
+} as const;

--- a/src/shared/spinner.test.ts
+++ b/src/shared/spinner.test.ts
@@ -1,62 +1,43 @@
-import { afterEach, describe, expect, it, mock } from "bun:test";
+import { describe, expect, it, mock } from "bun:test";
 import { startSpinner } from "./spinner.js";
 
 describe("startSpinner", () => {
-  const origStdoutIsTTY = process.stdout.isTTY;
-  const origIsTTY = process.stderr.isTTY;
-  const origWrite = process.stderr.write;
-
-  afterEach(() => {
-    process.stdout.isTTY = origStdoutIsTTY;
-    process.stderr.isTTY = origIsTTY;
-    process.stderr.write = origWrite;
-  });
-
-  function captureStderr(): string[] {
+  function createRuntime(stdoutIsTTY = true, stderrIsTTY = true) {
     const writes: string[] = [];
-    process.stderr.write = mock((chunk: string) => {
+    const writeStderr = mock((chunk: string) => {
       writes.push(String(chunk));
-      return true;
-    }) as typeof process.stderr.write;
-    return writes;
+    });
+    return { runtime: { stdoutIsTTY, stderrIsTTY, writeStderr }, writes };
   }
 
   it("is a no-op when disabled", () => {
-    process.stdout.isTTY = true;
-    process.stderr.isTTY = true;
-    const writes = captureStderr();
+    const { runtime, writes } = createRuntime();
 
-    startSpinner("Loading...", false).stop();
+    startSpinner("Loading...", false, runtime).stop();
 
     expect(writes).toHaveLength(0);
   });
 
   it("is a no-op when stderr is not a TTY", () => {
-    process.stdout.isTTY = true;
-    process.stderr.isTTY = false;
-    const writes = captureStderr();
+    const { runtime, writes } = createRuntime(true, false);
 
-    startSpinner("Loading...").stop();
+    startSpinner("Loading...", true, runtime).stop();
 
     expect(writes).toHaveLength(0);
   });
 
   it("is a no-op when stdout is not a TTY", () => {
-    process.stdout.isTTY = false;
-    process.stderr.isTTY = true;
-    const writes = captureStderr();
+    const { runtime, writes } = createRuntime(false, true);
 
-    startSpinner("Loading...").stop();
+    startSpinner("Loading...", true, runtime).stop();
 
     expect(writes).toHaveLength(0);
   });
 
   it("renders a frame on stderr and clears the line on stop", () => {
-    process.stdout.isTTY = true;
-    process.stderr.isTTY = true;
-    const writes = captureStderr();
+    const { runtime, writes } = createRuntime();
 
-    const spinner = startSpinner("Loading...");
+    const spinner = startSpinner("Loading...", true, runtime);
     expect(writes.some((w) => w.includes("Loading..."))).toBe(true);
 
     spinner.stop();
@@ -64,11 +45,9 @@ describe("startSpinner", () => {
   });
 
   it("accepts a rotating message list and shows the first label", () => {
-    process.stdout.isTTY = true;
-    process.stderr.isTTY = true;
-    const writes = captureStderr();
+    const { runtime, writes } = createRuntime();
 
-    startSpinner(["First label...", "Second label..."]).stop();
+    startSpinner(["First label...", "Second label..."], true, runtime).stop();
 
     expect(writes.some((w) => w.includes("First label..."))).toBe(true);
   });

--- a/src/shared/spinner.test.ts
+++ b/src/shared/spinner.test.ts
@@ -2,10 +2,12 @@ import { afterEach, describe, expect, it, mock } from "bun:test";
 import { startSpinner } from "./spinner.js";
 
 describe("startSpinner", () => {
+  const origStdoutIsTTY = process.stdout.isTTY;
   const origIsTTY = process.stderr.isTTY;
   const origWrite = process.stderr.write;
 
   afterEach(() => {
+    process.stdout.isTTY = origStdoutIsTTY;
     process.stderr.isTTY = origIsTTY;
     process.stderr.write = origWrite;
   });
@@ -20,6 +22,7 @@ describe("startSpinner", () => {
   }
 
   it("is a no-op when disabled", () => {
+    process.stdout.isTTY = true;
     process.stderr.isTTY = true;
     const writes = captureStderr();
 
@@ -29,6 +32,7 @@ describe("startSpinner", () => {
   });
 
   it("is a no-op when stderr is not a TTY", () => {
+    process.stdout.isTTY = true;
     process.stderr.isTTY = false;
     const writes = captureStderr();
 
@@ -37,7 +41,18 @@ describe("startSpinner", () => {
     expect(writes).toHaveLength(0);
   });
 
+  it("is a no-op when stdout is not a TTY", () => {
+    process.stdout.isTTY = false;
+    process.stderr.isTTY = true;
+    const writes = captureStderr();
+
+    startSpinner("Loading...").stop();
+
+    expect(writes).toHaveLength(0);
+  });
+
   it("renders a frame on stderr and clears the line on stop", () => {
+    process.stdout.isTTY = true;
     process.stderr.isTTY = true;
     const writes = captureStderr();
 
@@ -49,6 +64,7 @@ describe("startSpinner", () => {
   });
 
   it("accepts a rotating message list and shows the first label", () => {
+    process.stdout.isTTY = true;
     process.stderr.isTTY = true;
     const writes = captureStderr();
 

--- a/src/shared/spinner.test.ts
+++ b/src/shared/spinner.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, mock } from "bun:test";
+import { startSpinner } from "./spinner.js";
+
+describe("startSpinner", () => {
+  const origIsTTY = process.stderr.isTTY;
+  const origWrite = process.stderr.write;
+
+  afterEach(() => {
+    process.stderr.isTTY = origIsTTY;
+    process.stderr.write = origWrite;
+  });
+
+  function captureStderr(): string[] {
+    const writes: string[] = [];
+    process.stderr.write = mock((chunk: string) => {
+      writes.push(String(chunk));
+      return true;
+    }) as typeof process.stderr.write;
+    return writes;
+  }
+
+  it("is a no-op when disabled", () => {
+    process.stderr.isTTY = true;
+    const writes = captureStderr();
+
+    startSpinner("Loading...", false).stop();
+
+    expect(writes).toHaveLength(0);
+  });
+
+  it("is a no-op when stderr is not a TTY", () => {
+    process.stderr.isTTY = false;
+    const writes = captureStderr();
+
+    startSpinner("Loading...").stop();
+
+    expect(writes).toHaveLength(0);
+  });
+
+  it("renders a frame on stderr and clears the line on stop", () => {
+    process.stderr.isTTY = true;
+    const writes = captureStderr();
+
+    const spinner = startSpinner("Loading...");
+    expect(writes.some((w) => w.includes("Loading..."))).toBe(true);
+
+    spinner.stop();
+    expect(writes[writes.length - 1]).toBe("\r\x1b[2K");
+  });
+
+  it("accepts a rotating message list and shows the first label", () => {
+    process.stderr.isTTY = true;
+    const writes = captureStderr();
+
+    startSpinner(["First label...", "Second label..."]).stop();
+
+    expect(writes.some((w) => w.includes("First label..."))).toBe(true);
+  });
+});

--- a/src/shared/spinner.ts
+++ b/src/shared/spinner.ts
@@ -13,9 +13,9 @@ export interface Spinner {
 /**
  * Start an animated progress spinner on stderr.
  *
- * Renders only when stderr is an interactive TTY, so piped output,
+ * Renders only when stdout and stderr are interactive TTYs, so piped output,
  * `--json` consumers, and agent/MCP callers never see spinner frames.
- * Writing to stderr keeps stdout (the command result) clean.
+ * Writing to stderr keeps stdout (the command result) clean when interactive.
  *
  * Pass an array of labels to rotate them every ~2s while the glyph
  * keeps spinning; a single string stays fixed.
@@ -24,7 +24,7 @@ export function startSpinner(
   message: string | readonly string[],
   enabled = true,
 ): Spinner {
-  if (!enabled || !process.stderr.isTTY) {
+  if (!enabled || !process.stdout.isTTY || !process.stderr.isTTY) {
     return { stop: () => {} };
   }
 

--- a/src/shared/spinner.ts
+++ b/src/shared/spinner.ts
@@ -1,0 +1,54 @@
+import { colorizeBrand } from "./colors.js";
+
+const SPINNER_FRAMES = ["|", "/", "-", "\\"] as const;
+const FRAME_INTERVAL_MS = 80;
+const MESSAGE_INTERVAL_MS = 2000;
+
+/** Handle for an active spinner. */
+export interface Spinner {
+  /** Stop the animation and clear the spinner line. */
+  stop(): void;
+}
+
+/**
+ * Start an animated progress spinner on stderr.
+ *
+ * Renders only when stderr is an interactive TTY, so piped output,
+ * `--json` consumers, and agent/MCP callers never see spinner frames.
+ * Writing to stderr keeps stdout (the command result) clean.
+ *
+ * Pass an array of labels to rotate them every ~2s while the glyph
+ * keeps spinning; a single string stays fixed.
+ */
+export function startSpinner(
+  message: string | readonly string[],
+  enabled = true,
+): Spinner {
+  if (!enabled || !process.stderr.isTTY) {
+    return { stop: () => {} };
+  }
+
+  const messages = typeof message === "string" ? [message] : message;
+  const framesPerMessage = Math.round(MESSAGE_INTERVAL_MS / FRAME_INTERVAL_MS);
+  const useColors = process.env.NO_COLOR === undefined;
+  let frame = 0;
+  const render = (): void => {
+    const glyph = SPINNER_FRAMES[frame % SPINNER_FRAMES.length] ?? "|";
+    const label =
+      messages[Math.floor(frame / framesPerMessage) % messages.length] ?? "";
+    frame += 1;
+    process.stderr.write(
+      `\r\x1b[2K${colorizeBrand(glyph, "primary", useColors)} ${label}`,
+    );
+  };
+
+  render();
+  const interval = setInterval(render, FRAME_INTERVAL_MS);
+
+  return {
+    stop: () => {
+      clearInterval(interval);
+      process.stderr.write("\r\x1b[2K");
+    },
+  };
+}

--- a/src/shared/spinner.ts
+++ b/src/shared/spinner.ts
@@ -10,6 +10,13 @@ export interface Spinner {
   stop(): void;
 }
 
+interface SpinnerRuntime {
+  stdoutIsTTY?: boolean;
+  stderrIsTTY?: boolean;
+  writeStderr?: (chunk: string) => void;
+  useColors?: boolean;
+}
+
 /**
  * Start an animated progress spinner on stderr.
  *
@@ -23,21 +30,27 @@ export interface Spinner {
 export function startSpinner(
   message: string | readonly string[],
   enabled = true,
+  runtime: SpinnerRuntime = {},
 ): Spinner {
-  if (!enabled || !process.stdout.isTTY || !process.stderr.isTTY) {
+  const stdoutIsTTY = runtime.stdoutIsTTY ?? process.stdout.isTTY;
+  const stderrIsTTY = runtime.stderrIsTTY ?? process.stderr.isTTY;
+  const writeStderr =
+    runtime.writeStderr ?? ((chunk) => process.stderr.write(chunk));
+
+  if (!enabled || !stdoutIsTTY || !stderrIsTTY) {
     return { stop: () => {} };
   }
 
   const messages = typeof message === "string" ? [message] : message;
   const framesPerMessage = Math.round(MESSAGE_INTERVAL_MS / FRAME_INTERVAL_MS);
-  const useColors = process.env.NO_COLOR === undefined;
+  const useColors = runtime.useColors ?? process.env.NO_COLOR === undefined;
   let frame = 0;
   const render = (): void => {
     const glyph = SPINNER_FRAMES[frame % SPINNER_FRAMES.length] ?? "|";
     const label =
       messages[Math.floor(frame / framesPerMessage) % messages.length] ?? "";
     frame += 1;
-    process.stderr.write(
+    writeStderr(
       `\r\x1b[2K${colorizeBrand(glyph, "primary", useColors)} ${label}`,
     );
   };
@@ -48,7 +61,7 @@ export function startSpinner(
   return {
     stop: () => {
       clearInterval(interval);
-      process.stderr.write("\r\x1b[2K");
+      writeStderr("\r\x1b[2K");
     },
   };
 }


### PR DESCRIPTION
## Summary
- Redesigns `githits init` into a phase-based onboarding flow with setup mode selection, clearer auth, and progress feedback
- Adds parallel agent scanning progress and install task reporting
- Aligns init and README copy with docs.githits.com terminology for AI coding tools, local MCP server, Agent Skills, and source-backed context

## Verification
- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `bun test`
- `bun run build`
- `bun run smoke:cli`
- `bun test src/commands/init/init.test.ts`