### PR TITLE
feat: redesign init onboarding flow and CLI visual feedback

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -32,6 +32,7 @@ import {
   FileSystemServiceImpl,
   NpmRegistryUpdateCheckService,
 } from "./services/index.js";
+import { colorizeBrand, shouldUseColors } from "./shared/colors.js";
 import {
   createRootCliPreAction,
   endTelemetrySpan,
@@ -42,6 +43,7 @@ import {
 } from "./shared/index.js";
 
 const program = new Command();
+const useColors = shouldUseColors();
 const argv = process.argv.slice(2);
 const commandSpans = new WeakMap<
   Command,
@@ -90,9 +92,13 @@ const rootCliPreAction = createRootCliPreAction({
 
 program
   .name("githits")
-  .description("Code examples from global open source for your AI assistant")
+  .description("Grounded open-source context for AI coding agents")
   .version(version)
   .option("--no-color", "Disable colored output")
+  .configureHelp({
+    styleTitle: (title: string) =>
+      colorizeBrand(title, "primary", useColors, { bold: true }),
+  })
   .hook("preAction", async (thisCommand, actionCommand) => {
     const command = actionCommand ?? thisCommand;
     commandSpans.set(
@@ -108,14 +114,14 @@ program
   .addHelpText(
     "after",
     `
-Getting started:
-  githits init                         Set up MCP for your coding agents
-  githits login                        Authenticate with your GitHits account
+${colorizeBrand("Getting started:", "primary", useColors, { bold: true })}
+  githits init                         Connect GitHits to your coding agents
+  githits login                        Sign in to your GitHits account
   githits mcp                          Show MCP setup instructions
-  githits example "query"              Get code examples
+  githits example "query"              Find real-world implementations
 
 Learn more at https://githits.com
-Docs: https://app.githits.com/docs/
+Docs: https://docs.githits.com
 Support: support@githits.com`,
   );
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -43,8 +43,13 @@ import {
 } from "./shared/index.js";
 
 const program = new Command();
-const useColors = shouldUseColors();
 const argv = process.argv.slice(2);
+// Bridge the --no-color flag to the NO_COLOR convention that every
+// shouldUseColors() call across the CLI reads.
+if (argv.includes("--no-color")) {
+  process.env.NO_COLOR = "1";
+}
+const useColors = shouldUseColors();
 const commandSpans = new WeakMap<
   Command,
   ReturnType<typeof startTelemetrySpan>

--- a/src/commands/code/files.ts
+++ b/src/commands/code/files.ts
@@ -6,7 +6,12 @@ import {
   MAX_WAIT_TIMEOUT_MS,
 } from "../../shared/code-navigation-defaults.js";
 import { shouldUseColors } from "../../shared/colors.js";
-import { InvalidPackageSpecError, requireAuth } from "../../shared/index.js";
+import {
+  InvalidPackageSpecError,
+  requireAuth,
+  SPINNER_MESSAGES,
+  startSpinner,
+} from "../../shared/index.js";
 import {
   buildListFilesParams,
   type ListFilesRequestBuildResult,
@@ -110,7 +115,10 @@ export async function pkgFilesAction(
       limit,
       waitTimeoutMs: wait,
     });
-    const result = await deps.codeNavigationService.listFiles(build.params);
+    const spinner = startSpinner(SPINNER_MESSAGES.code, !options.json);
+    const result = await deps.codeNavigationService
+      .listFiles(build.params)
+      .finally(() => spinner.stop());
 
     const payload = buildListFilesSuccessPayload(result, {
       registry: target.registry

--- a/src/commands/code/grep.ts
+++ b/src/commands/code/grep.ts
@@ -15,6 +15,8 @@ import {
   type GrepRepoRequestInput,
   InvalidPackageSpecError,
   requireAuth,
+  SPINNER_MESSAGES,
+  startSpinner,
 } from "../../shared/index.js";
 import { toPkgseerRegistryLowercase } from "../../shared/pkgseer-registry.js";
 import {
@@ -130,7 +132,10 @@ export async function pkgGrepAction(
       symbolFields: options.symbolField,
       waitTimeoutMs: wait,
     });
-    const result = await deps.codeNavigationService.grepRepo(build.params);
+    const spinner = startSpinner(SPINNER_MESSAGES.code, !options.json);
+    const result = await deps.codeNavigationService
+      .grepRepo(build.params)
+      .finally(() => spinner.stop());
 
     const payload = buildGrepRepoSuccessPayload(result, {
       registry: target.registry

--- a/src/commands/code/index.ts
+++ b/src/commands/code/index.ts
@@ -23,7 +23,7 @@ export async function registerCodeCommandGroup(
 
   const codeCommand = program
     .command("code")
-    .summary("Source-level operations on indexed dependencies")
+    .summary("Inspect dependency source code and symbols")
     .description(
       "List files, read files, and grep substrings inside indexed dependency source. Every command accepts either `<spec>` (registry:name[@version]) or `--repo-url <url> [--git-ref <ref>]`. Omitted package versions use the latest release; omitted repo refs use the default-branch intent. For package-level metadata use `githits pkg`.",
     );

--- a/src/commands/code/read.ts
+++ b/src/commands/code/read.ts
@@ -6,7 +6,12 @@ import {
   MAX_WAIT_TIMEOUT_MS,
 } from "../../shared/code-navigation-defaults.js";
 import { shouldUseColors } from "../../shared/colors.js";
-import { InvalidPackageSpecError, requireAuth } from "../../shared/index.js";
+import {
+  InvalidPackageSpecError,
+  requireAuth,
+  SPINNER_MESSAGES,
+  startSpinner,
+} from "../../shared/index.js";
 import { toPkgseerRegistryLowercase } from "../../shared/pkgseer-registry.js";
 import { withReadFileRecovery } from "../../shared/read-file-error.js";
 import { buildReadFileParams } from "../../shared/read-file-request.js";
@@ -102,7 +107,10 @@ export async function pkgReadAction(
       endLine: range.endLine,
       waitTimeoutMs: wait,
     });
-    const result = await deps.codeNavigationService.readFile(build.params);
+    const spinner = startSpinner(SPINNER_MESSAGES.code, !options.json);
+    const result = await deps.codeNavigationService
+      .readFile(build.params)
+      .finally(() => spinner.stop());
 
     const payload = buildReadFileSuccessPayload(result, {
       registry: target.registry

--- a/src/commands/docs/index.ts
+++ b/src/commands/docs/index.ts
@@ -19,7 +19,7 @@ export async function registerDocsCommandGroup(
 
   const docsCommand = program
     .command("docs")
-    .summary("Browse and read mixed package documentation")
+    .summary("Browse and read package documentation")
     .description(
       "Browse and read package documentation across hosted docs and repository-backed docs. Docs are mixed by default; entries are source-badged and repo-backed pages also expose exact file follow-up metadata.",
     );

--- a/src/commands/docs/list.ts
+++ b/src/commands/docs/list.ts
@@ -11,6 +11,8 @@ import {
   mapPackageIntelligenceError,
   parsePackageSpec,
   requireAuth,
+  SPINNER_MESSAGES,
+  startSpinner,
 } from "../../shared/index.js";
 
 export interface DocsListCommandOptions {
@@ -50,9 +52,10 @@ export async function docsListAction(
       limit,
       after: options.after,
     });
-    const result = await deps.packageIntelligenceService.listPackageDocs(
-      build.params,
-    );
+    const spinner = startSpinner(SPINNER_MESSAGES.docs, !options.json);
+    const result = await deps.packageIntelligenceService
+      .listPackageDocs(build.params)
+      .finally(() => spinner.stop());
     const payload = buildListPackageDocsSuccessPayload(result, {
       limitExplicit: build.limitExplicit,
       afterExplicit: build.afterExplicit,

--- a/src/commands/docs/read.ts
+++ b/src/commands/docs/read.ts
@@ -10,7 +10,9 @@ import {
   mapPackageIntelligenceError,
   parseLinesOption,
   requireAuth,
+  SPINNER_MESSAGES,
   shouldUseColors,
+  startSpinner,
 } from "../../shared/index.js";
 
 export interface DocsReadCommandOptions {
@@ -43,9 +45,10 @@ export async function docsReadAction(
     const range = options.lines ? parseLinesOption(options.lines) : undefined;
 
     const build = buildReadPackageDocParams({ pageId });
-    const result = await deps.packageIntelligenceService.readPackageDoc(
-      build.params,
-    );
+    const spinner = startSpinner(SPINNER_MESSAGES.docs, !options.json);
+    const result = await deps.packageIntelligenceService
+      .readPackageDoc(build.params)
+      .finally(() => spinner.stop());
     const payload = buildReadPackageDocSuccessPayload(
       result,
       build.params.pageId,

--- a/src/commands/example.ts
+++ b/src/commands/example.ts
@@ -3,6 +3,8 @@ import type { GitHitsService } from "../services/githits-service.js";
 import { AuthenticationError } from "../services/githits-service.js";
 import { extractSolutionId } from "../shared/extract-solution-id.js";
 import { AuthRequiredError, requireAuth } from "../shared/require-auth.js";
+import { startSpinner } from "../shared/spinner.js";
+import { SPINNER_MESSAGES } from "../shared/spinner-messages.js";
 
 export interface ExampleOptions {
   lang?: string;
@@ -34,12 +36,15 @@ export async function exampleAction(
   requireAuth(deps);
 
   try {
-    const result = await deps.githitsService.search({
-      query,
-      language: options.lang,
-      licenseMode: options.license,
-      includeExplanation: options.explain,
-    });
+    const spinner = startSpinner(SPINNER_MESSAGES.example, !options.json);
+    const result = await deps.githitsService
+      .search({
+        query,
+        language: options.lang,
+        licenseMode: options.license,
+        includeExplanation: options.explain,
+      })
+      .finally(() => spinner.stop());
 
     if (options.json) {
       const solutionId = extractSolutionId(result);
@@ -90,7 +95,7 @@ Examples:
 export function registerExampleCommand(program: Command) {
   program
     .command("example")
-    .summary("Get code examples from global open source")
+    .summary("Find real-world implementations from open-source code")
     .description(EXAMPLE_DESCRIPTION)
     .argument("<query>", "Natural language example-search query")
     .option(

--- a/src/commands/feedback.ts
+++ b/src/commands/feedback.ts
@@ -88,7 +88,7 @@ Examples:
 export function registerFeedbackCommand(program: Command) {
   program
     .command("feedback")
-    .summary("Submit feedback on a tool result or the GitHits experience")
+    .summary("Submit feedback about GitHits results or experience")
     .description(FEEDBACK_DESCRIPTION)
     .argument(
       "[solution_id]",

--- a/src/commands/init/init.test.ts
+++ b/src/commands/init/init.test.ts
@@ -95,16 +95,12 @@ function expectReadyNextSteps(logCalls: string[]): void {
   expect(logCalls.some((msg) => msg.includes("GitHits is connected"))).toBe(
     true,
   );
+  expect(logCalls.some((msg) => msg.includes("Your agent can now:"))).toBe(
+    true,
+  );
   expect(
     logCalls.some((msg) =>
-      msg.includes(
-        'npx githits@latest example "How do I use useEffect cleanup?"',
-      ),
-    ),
-  ).toBe(true);
-  expect(
-    logCalls.some((msg) =>
-      msg.includes("HTTP retries with exponential backoff"),
+      msg.includes("How does Next.js implement route prefetching"),
     ),
   ).toBe(true);
 }
@@ -196,36 +192,25 @@ describe("initAction", () => {
     expect(fs.atomicWriteFile).toHaveBeenCalled();
     const logCalls = getLogOutput();
     expect(
-      logCalls.some((msg) => msg.includes("source-backed open-source context")),
-    ).toBe(true);
-    expect(
-      logCalls.some((msg) => msg.includes("stores tokens in your OS keychain")),
+      logCalls.some((msg) =>
+        msg.includes("GitHits helps coding agents stop guessing"),
+      ),
     ).toBe(true);
     expect(
       logCalls.some((msg) =>
-        msg.includes("https://docs.githits.com/quickstart"),
+        msg.includes("grounded context from real open-source code"),
       ),
     ).toBe(true);
-    expect(logCalls.some((msg) => msg.includes("What will happen"))).toBe(true);
+    expect(logCalls.some((msg) => msg.includes("Your agent can:"))).toBe(true);
     expect(
-      logCalls.some(
-        (msg) =>
-          msg.includes("1. Detect tools") &&
-          msg.includes("Find supported AI coding tools"),
-      ),
+      logCalls.some((msg) => msg.includes("https://docs.githits.com")),
     ).toBe(true);
-    expect(
-      logCalls.some(
-        (msg) =>
-          msg.includes("2. Choose tools") &&
-          msg.includes("Pick which detected tools"),
-      ),
-    ).toBe(true);
+    expect(logCalls.some((msg) => msg.includes("1. Detect tools"))).toBe(true);
+    expect(logCalls.some((msg) => msg.includes("2. Choose tools"))).toBe(true);
     expect(logCalls.some((msg) => msg.includes("3. Sign in"))).toBe(true);
     expect(logCalls.some((msg) => msg.includes("4. Install and verify"))).toBe(
       true,
     );
-    expect(logCalls.some((msg) => msg.includes("5. Ready"))).toBe(true);
     expect(
       logCalls.some(
         (msg) => msg.includes("Cursor") && msg.includes("installing"),

--- a/src/commands/init/init.test.ts
+++ b/src/commands/init/init.test.ts
@@ -103,6 +103,9 @@ function expectReadyNextSteps(logCalls: string[]): void {
       msg.includes("How does Next.js implement route prefetching"),
     ),
   ).toBe(true);
+  expect(
+    logCalls.some((msg) => msg.includes("Agent instruction snippet")),
+  ).toBe(true);
 }
 
 function expectAuthNotCheckedNextSteps(logCalls: string[]): void {

--- a/src/commands/init/init.test.ts
+++ b/src/commands/init/init.test.ts
@@ -92,20 +92,16 @@ function getLogOutput(): string[] {
 }
 
 function expectReadyNextSteps(logCalls: string[]): void {
-  expect(logCalls.some((msg) => msg.includes("GitHits is connected"))).toBe(
+  expect(logCalls.some((msg) => msg.includes("GitHits is now connected"))).toBe(
     true,
   );
-  expect(logCalls.some((msg) => msg.includes("Your agent can now:"))).toBe(
-    true,
-  );
+  expect(logCalls.some((msg) => msg.includes("new abilities"))).toBe(true);
   expect(
     logCalls.some((msg) =>
       msg.includes("How does Next.js implement route prefetching"),
     ),
   ).toBe(true);
-  expect(
-    logCalls.some((msg) => msg.includes("Agent instruction snippet")),
-  ).toBe(true);
+  expect(logCalls.some((msg) => msg.includes("trigger guides"))).toBe(true);
 }
 
 function expectAuthNotCheckedNextSteps(logCalls: string[]): void {
@@ -198,15 +194,15 @@ describe("initAction", () => {
     const logCalls = getLogOutput();
     expect(
       logCalls.some((msg) =>
-        msg.includes("GitHits helps coding agents stop guessing"),
+        msg.includes("Your agent can read your local codebase"),
       ),
     ).toBe(true);
     expect(
       logCalls.some((msg) =>
-        msg.includes("grounded context from real open-source code"),
+        msg.includes("navigate the open-source code your app depends on"),
       ),
     ).toBe(true);
-    expect(logCalls.some((msg) => msg.includes("Your agent can:"))).toBe(true);
+    expect(logCalls.some((msg) => msg.includes("With GitHits"))).toBe(true);
     expect(
       logCalls.some((msg) => msg.includes("https://docs.githits.com")),
     ).toBe(true);

--- a/src/commands/init/init.ts
+++ b/src/commands/init/init.ts
@@ -183,56 +183,42 @@ function formatCommand(command: string, useColors: boolean): string {
 }
 
 function printReadyNextSteps(useColors: boolean): void {
-  console.log("  GitHits is connected to your coding agent.");
-  console.log();
-  console.log("  Your agent can now:");
-  console.log("  • Explore real open-source repositories");
-  console.log("  • Inspect dependency internals");
-  console.log("  • Navigate unfamiliar codebases");
-  console.log("  • Ground responses in production code");
-  console.log("  • Use real implementations instead of guessing");
-  console.log();
-  console.log("  Try asking your agent:");
-  console.log();
-  console.log("    “How does Next.js implement route prefetching internally?”");
-  console.log();
-  console.log("    “Trace how authentication flows through this repo.”");
-  console.log();
-  console.log("    “Find where retries are handled in the Stripe SDK.”");
+  console.log("  GitHits is now connected to your coding agents.");
   console.log();
   console.log(
-    "    “Compare how different OSS projects structure background jobs.”",
+    "  Here are some examples of the new abilities that your agent just got:",
   );
   console.log();
-  const snippetHeading = "Agent instruction snippet";
-  console.log(`  ${snippetHeading}`);
+  console.log("  • Find usage examples");
   console.log(
-    `  ${colorize("-".repeat(snippetHeading.length), "dim", useColors)}`,
+    "      -> ”Use get example to find how to use Azure Speech SDK TranscribeDefinition”",
   );
   console.log();
-  console.log("  Add this to your AGENTS.md or CLAUDE.md:");
-  console.log();
-  const snippetBody = [
-    "When work depends on open-source libraries, use GitHits before guessing.",
-    "",
-    "Use:",
-    "- Code Examples for real-world implementation patterns",
-    "- Code Navigation to inspect dependency source code",
-    "- Documentation Access for hosted and repo-backed docs",
-    "- Package Inspection for metadata, vulnerabilities, and changelogs",
-    "",
-    "Prefer grounded implementations over guessing.",
-  ];
-  for (const line of snippetBody) {
-    console.log(line ? `  ${colorize(line, "italic", useColors)}` : "");
-  }
-  console.log();
-  console.log("  Full version:");
   console.log(
-    "  https://docs.githits.com/guides/trigger-githits#agent-instruction-snippet",
+    "  • Search, grep, list files, and read exact lines in any repo or package to gather information",
+  );
+  console.log(
+    "      -> “How does Next.js implement route prefetching internally?”",
   );
   console.log();
-  console.log("  Docs: https://docs.githits.com");
+  console.log(
+    "  • Inspect dependency versions, changelogs, and upgrade changes",
+  );
+  console.log(
+    "      -> “What kind of changes there were between pydantic-ai version 1.95 and 1.99?”",
+  );
+  console.log();
+  console.log(
+    "  Open a new coding agent session and try out one of the above.",
+  );
+  console.log();
+  console.log(
+    '  In you normal workflow, your agent will call GitHits automatically depending on the task, but you can prompt it to use GitHits explicitly by adding "use GitHits".',
+  );
+  console.log();
+  console.log(
+    "  See docs for more use cases and trigger guides: https://docs.githits.com",
+  );
 }
 
 function printAuthRequiredNextSteps(useColors: boolean): void {
@@ -334,7 +320,8 @@ const INIT_INTENT_CHOICES: SelectChoice<InitIntent>[] = [
   {
     name: "Connect GitHits to my agent (Recommended)",
     value: "mcp",
-    description: "Installs the local GitHits MCP server.",
+    description:
+      "Install the local GitHits MCP server for your coding agents. Allows agents to seamlessly use GitHits.",
   },
   {
     name: "Use Agent Skills instead",
@@ -400,20 +387,32 @@ function printTask(
 
 function printInitIntro(useColors: boolean): void {
   console.log(colorizeLogo(GITHITS_ASCII_LOGO, useColors));
-  console.log("  GitHits helps coding agents stop guessing.");
-  console.log();
-  console.log("  Instead of retry loops and hallucinated solutions,");
-  console.log("  your agent gets grounded context from real open-source code.");
-  console.log();
-  console.log(`  ${colorizeBrand("Your agent can:", "primary", useColors)}`);
-  console.log("  • Explore production codebases");
-  console.log("  • Inspect dependency internals");
-  console.log("  • Navigate large repositories");
-  console.log("  • Find real implementations");
-  console.log("  • Ground responses in actual code instead of guesses");
+  console.log("  Your agent can read your local codebase.");
   console.log();
   console.log(
-    "  Works with Cursor, Claude Code, Codex CLI, VS Code and Windsurf, plus more.",
+    "  GitHits lets it navigate the open-source code your app depends on.",
+  );
+  console.log();
+  console.log(
+    `  ${colorizeBrand("With GitHits, your agent can:", "primary", useColors)}`,
+  );
+  console.log(
+    "  • Find implementation examples from open-source code, issues, discussions, and pull requests",
+  );
+  console.log(
+    "  • Search, grep, list files, and read exact lines in any repo or package",
+  );
+  console.log(
+    "  • Inspect dependency internals, versions, changelogs, and upgrade changes",
+  );
+  console.log("  • Access package documentation");
+  console.log();
+  console.log(
+    "  No cloning or local indexing required. GitHits handles everything automatically.",
+  );
+  console.log();
+  console.log(
+    "  Works with Cursor, Claude Code, Codex, OpenCode, Pi, VS Code, Windsurf, and more.",
   );
   console.log();
   console.log("  More info: https://docs.githits.com");

--- a/src/commands/init/init.ts
+++ b/src/commands/init/init.ts
@@ -182,7 +182,7 @@ function formatCommand(command: string, useColors: boolean): string {
   return colorizeBrand(command, "secondary", useColors, { bold: true });
 }
 
-function printReadyNextSteps(): void {
+function printReadyNextSteps(useColors: boolean): void {
   console.log("  GitHits is connected to your coding agent.");
   console.log();
   console.log("  Your agent can now:");
@@ -202,6 +202,34 @@ function printReadyNextSteps(): void {
   console.log();
   console.log(
     "    “Compare how different OSS projects structure background jobs.”",
+  );
+  console.log();
+  const snippetHeading = "Agent instruction snippet";
+  console.log(`  ${snippetHeading}`);
+  console.log(
+    `  ${colorize("-".repeat(snippetHeading.length), "dim", useColors)}`,
+  );
+  console.log();
+  console.log("  Add this to your AGENTS.md or CLAUDE.md:");
+  console.log();
+  const snippetBody = [
+    "When work depends on open-source libraries, use GitHits before guessing.",
+    "",
+    "Use:",
+    "- Code Examples for real-world implementation patterns",
+    "- Code Navigation to inspect dependency source code",
+    "- Documentation Access for hosted and repo-backed docs",
+    "- Package Inspection for metadata, vulnerabilities, and changelogs",
+    "",
+    "Prefer grounded implementations over guessing.",
+  ];
+  for (const line of snippetBody) {
+    console.log(line ? `  ${colorize(line, "italic", useColors)}` : "");
+  }
+  console.log();
+  console.log("  Full version:");
+  console.log(
+    "  https://docs.githits.com/guides/trigger-githits#agent-instruction-snippet",
   );
   console.log();
   console.log("  Docs: https://docs.githits.com");
@@ -689,7 +717,7 @@ function printPostSetupNextSteps(
     useColors,
   );
   if (shouldPrintReady(authStatus)) {
-    printReadyNextSteps();
+    printReadyNextSteps(useColors);
   } else if (authStatus === "failed_continue") {
     printAuthRequiredNextSteps(useColors);
   } else {

--- a/src/commands/init/init.ts
+++ b/src/commands/init/init.ts
@@ -15,9 +15,11 @@ import { PromptServiceImpl } from "../../services/prompt-service.js";
 import {
   colorize,
   colorizeBrand,
+  colorizeTerminal,
   error as errorFmt,
   shouldUseColors,
   success,
+  type TerminalColor,
   warning,
 } from "../../shared/colors.js";
 import type {
@@ -175,40 +177,48 @@ function getPiConfigFileUninstall(
   return configStep ?? null;
 }
 
+/** Style a CLI command so it stands out from surrounding text. */
+function formatCommand(command: string, useColors: boolean): string {
+  return colorizeBrand(command, "secondary", useColors, { bold: true });
+}
+
 function printReadyNextSteps(): void {
-  console.log("  GitHits is connected to your AI coding tool.");
+  console.log("  GitHits is connected to your coding agent.");
   console.log();
-  console.log("  Start a coding task as usual. When your agent needs real");
-  console.log(
-    "  open-source examples, dependency source code, docs, or package",
-  );
-  console.log("  metadata, it can use GitHits.");
+  console.log("  Your agent can now:");
+  console.log("  • Explore real open-source repositories");
+  console.log("  • Inspect dependency internals");
+  console.log("  • Navigate unfamiliar codebases");
+  console.log("  • Ground responses in production code");
+  console.log("  • Use real implementations instead of guessing");
   console.log();
-  console.log("  Try the CLI directly:");
-  console.log(
-    '    npx githits@latest example "How do I use useEffect cleanup?"',
-  );
+  console.log("  Try asking your agent:");
   console.log();
-  console.log("  Or ask your agent:");
+  console.log("    “How does Next.js implement route prefetching internally?”");
+  console.log();
+  console.log("    “Trace how authentication flows through this repo.”");
+  console.log();
+  console.log("    “Find where retries are handled in the Stripe SDK.”");
+  console.log();
   console.log(
-    "    Use GitHits Code Examples to find a real open-source implementation of HTTP retries with exponential backoff in Python.",
+    "    “Compare how different OSS projects structure background jobs.”",
   );
   console.log();
   console.log("  Docs: https://docs.githits.com");
 }
 
-function printAuthRequiredNextSteps(): void {
+function printAuthRequiredNextSteps(useColors: boolean): void {
   console.log("  GitHits MCP is configured, but sign-in is still needed.");
   console.log();
   console.log("  Sign in when you're ready:");
-  console.log("    npx githits@latest login");
+  console.log(`    ${formatCommand("npx githits@latest login", useColors)}`);
 }
 
-function printAuthNotCheckedNextSteps(): void {
+function printAuthNotCheckedNextSteps(useColors: boolean): void {
   console.log("  GitHits MCP is configured. Sign-in was not checked.");
   console.log();
   console.log("  If your agent asks you to sign in, run:");
-  console.log("    npx githits@latest login");
+  console.log(`    ${formatCommand("npx githits@latest login", useColors)}`);
 }
 
 const GITHITS_ASCII_LOGO = String.raw`
@@ -219,22 +229,94 @@ const GITHITS_ASCII_LOGO = String.raw`
   \____|_|\__|_| |_|_|\__|___/
 `;
 
+/** Per-column color stops for the logo's warm gradient. */
+const LOGO_GRADIENT: ReadonlyArray<{ until: number; color: TerminalColor }> = [
+  {
+    until: 13,
+    color: {
+      hex: "#FF4FAE",
+      rgb: [255, 79, 174],
+      ansi256: 205,
+      ansi16: "magenta",
+    },
+  },
+  {
+    until: 19,
+    color: {
+      hex: "#FF5D8E",
+      rgb: [255, 93, 142],
+      ansi256: 204,
+      ansi16: "magenta",
+    },
+  },
+  {
+    until: 21,
+    color: {
+      hex: "#FF6B6F",
+      rgb: [255, 107, 111],
+      ansi256: 203,
+      ansi16: "red",
+    },
+  },
+  {
+    until: 25,
+    color: { hex: "#FF794F", rgb: [255, 121, 79], ansi256: 209, ansi16: "red" },
+  },
+  {
+    until: 30,
+    color: {
+      hex: "#FF872F",
+      rgb: [255, 135, 47],
+      ansi256: 208,
+      ansi16: "yellow",
+    },
+  },
+];
+
+/** Apply the column-based gradient to each row of the ASCII logo. */
+function colorizeLogo(logo: string, useColors: boolean): string {
+  if (!useColors) {
+    return logo;
+  }
+  return logo
+    .split("\n")
+    .map((line) => {
+      if (line.length === 0) {
+        return line;
+      }
+      let cursor = 0;
+      let colored = "";
+      for (const { until, color } of LOGO_GRADIENT) {
+        if (cursor >= line.length) {
+          break;
+        }
+        colored += colorizeTerminal(
+          line.slice(cursor, until),
+          color,
+          useColors,
+        );
+        cursor = until;
+      }
+      return cursor < line.length ? colored + line.slice(cursor) : colored;
+    })
+    .join("\n");
+}
+
 const INIT_INTENT_CHOICES: SelectChoice<InitIntent>[] = [
   {
-    name: "Install GitHits MCP server",
+    name: "Connect GitHits to my agent (Recommended)",
     value: "mcp",
-    description: "Recommended. Lets your agent call GitHits tools directly.",
+    description: "Installs the local GitHits MCP server.",
   },
   {
-    name: "I'd rather use Agent Skills",
+    name: "Use Agent Skills instead",
     value: "skills",
-    description:
-      "Use instruction-driven Skills instead of the local MCP server.",
+    description: "Use Skills instead of the local MCP server.",
   },
   {
-    name: "Later",
+    name: "Exit",
     value: "later",
-    description: "Exit without changing anything.",
+    description: "Leave setup without making changes.",
   },
 ];
 
@@ -289,71 +371,44 @@ function printTask(
 }
 
 function printInitIntro(useColors: boolean): void {
-  console.log(colorizeBrand(GITHITS_ASCII_LOGO, "primary", useColors));
-  console.log(
-    "  GitHits adds source-backed open-source context to your AI coding tool.",
-  );
-  console.log(
-    "  When local files and model memory are not enough, your agent can use",
-  );
-  console.log(
-    "  GitHits for real open-source examples, dependency source code, docs,",
-  );
-  console.log("  and package metadata.");
+  console.log(colorizeLogo(GITHITS_ASCII_LOGO, useColors));
+  console.log("  GitHits helps coding agents stop guessing.");
+  console.log();
+  console.log("  Instead of retry loops and hallucinated solutions,");
+  console.log("  your agent gets grounded context from real open-source code.");
+  console.log();
+  console.log(`  ${colorizeBrand("Your agent can:", "primary", useColors)}`);
+  console.log("  • Explore production codebases");
+  console.log("  • Inspect dependency internals");
+  console.log("  • Navigate large repositories");
+  console.log("  • Find real implementations");
+  console.log("  • Ground responses in actual code instead of guesses");
   console.log();
   console.log(
-    "  Most users should install the local MCP server. It lets your agent call",
-  );
-  console.log(
-    "  GitHits tools directly, stores tokens in your OS keychain, and does not",
-  );
-  console.log("  write secrets into your coding tool config.");
-  console.log();
-  console.log("  Choose how you want to connect GitHits:");
-  console.log(
-    "    MCP server   Recommended. Configure your AI coding tool automatically.",
-  );
-  console.log(
-    "    Agent Skills Use Skills instead if you prefer that workflow over MCP.",
+    "  Works with Cursor, Claude Code, Codex CLI, VS Code and Windsurf, plus more.",
   );
   console.log();
-  console.log("  More info: https://docs.githits.com/quickstart");
-  console.log();
-  console.log("  What will happen:");
-  console.log(
-    "    1. Detect tools        Find supported AI coding tools on this machine.",
-  );
-  console.log(
-    "    2. Choose tools        Pick which detected tools should get GitHits MCP.",
-  );
-  console.log(
-    "    3. Sign in             Connect this CLI to GitHits, unless already signed in.",
-  );
-  console.log(
-    "    4. Install and verify  Add the local MCP server entry and confirm it works.",
-  );
-  console.log(
-    "    5. Ready               Restart or open your coding tool and start coding.",
-  );
+  console.log("  More info: https://docs.githits.com");
   console.log();
 }
 
-function printSkillsInstructions(): void {
+function printSkillsInstructions(useColors: boolean): void {
   console.log("\n  Install GitHits Agent Skills:");
   console.log();
-  console.log("    npx skills add githits-com/githits-cli");
+  console.log(
+    `    ${formatCommand("npx skills add githits-com/githits-cli", useColors)}`,
+  );
+  console.log();
+  console.log("  During setup, choose where you want to enable GitHits.");
   console.log();
   console.log(
-    "  During installation, choose which coding tools should receive the Skills.",
+    "  IMPORTANT: Use either Agent Skills or the local MCP server in the same",
   );
-  console.log(
-    "  Do not use GitHits Skills and GitHits MCP in the same coding tool at the",
-  );
-  console.log("  same time; they expose overlapping capabilities.");
+  console.log("  coding tool, not both.");
   console.log();
-  console.log("  GitHits still needs sign-in before tools can access results:");
+  console.log("  Then sign in so your agent can use GitHits:");
   console.log();
-  console.log("    npx githits@latest login");
+  console.log(`    ${formatCommand("npx githits@latest login", useColors)}`);
   console.log();
 }
 
@@ -491,21 +546,13 @@ function printScanSummary(scan: ScanResult, useColors: boolean): void {
 
 function printAuthExplanation(): void {
   console.log(
-    "    GitHits tools require sign-in before they can return results.",
+    "    GitHits authentication is required before your agent can use GitHits tools.",
   );
   console.log();
-  console.log(
-    "    We will open your browser to GitHits. After you approve access,",
-  );
-  console.log(
-    "    the browser redirects back to this terminal through localhost.",
-  );
-  console.log("    Tokens are stored in your OS keychain.");
+  console.log("    We'll open your browser to connect your account.");
+  console.log("    Credentials are stored securely in your OS keychain.");
   console.log();
-  console.log("    No secrets are written into your tool's MCP config.");
-  console.log(
-    "    For CI or headless machines, use GITHITS_API_TOKEN instead.",
-  );
+  console.log("    No API keys or secrets are written into your MCP config.");
   console.log();
 }
 
@@ -590,7 +637,7 @@ async function runInitAuthentication(
     console.log(
       `    ${warning(`Login failed: ${loginResult.message}`, useColors)}\n`,
     );
-    printAuthRecoveryHint();
+    printAuthRecoveryHint(useColors);
 
     if (options.yes) {
       console.log("    Continuing without authentication...\n");
@@ -644,9 +691,9 @@ function printPostSetupNextSteps(
   if (shouldPrintReady(authStatus)) {
     printReadyNextSteps();
   } else if (authStatus === "failed_continue") {
-    printAuthRequiredNextSteps();
+    printAuthRequiredNextSteps(useColors);
   } else {
-    printAuthNotCheckedNextSteps();
+    printAuthNotCheckedNextSteps(useColors);
   }
 }
 
@@ -861,7 +908,7 @@ export async function initAction(
     let intent: InitIntent;
     try {
       intent = await promptService.select(
-        "  How would you like to use GitHits?",
+        "  What do you want to do?",
         INIT_INTENT_CHOICES,
         "mcp",
       );
@@ -874,7 +921,7 @@ export async function initAction(
     }
 
     if (intent === "skills") {
-      printSkillsInstructions();
+      printSkillsInstructions(useColors);
       return;
     }
     if (intent === "later") {
@@ -886,7 +933,7 @@ export async function initAction(
   }
 
   printSection(1, "Detect tools", useColors);
-  console.log("    Scanning supported AI coding tools...");
+  console.log("    Scanning for compatible AI coding tools...");
   renderScanProgress = true;
   if (lastScanProgress) {
     progress.onProgress(lastScanProgress);
@@ -915,7 +962,7 @@ export async function initAction(
   if (!options.yes && scan.needsSetup.length > 0) {
     try {
       toSetup = await promptService.checkbox(
-        "  Select AI coding tools to configure with GitHits MCP:",
+        "  Select which tools should use GitHits:",
         buildInitAgentChoices(scan),
       );
     } catch (err) {
@@ -1071,7 +1118,10 @@ export async function initUninstallAction(
   const { fileSystemService, promptService, execService } = deps;
 
   console.log(
-    `\n  ${colorizeBrand("GitHits", "primary", useColors, { bold: true })} — Remove MCP server from your coding agents\n`,
+    `\n  ${colorize("Disconnect GitHits from your coding agents.", "bold", useColors)}`,
+  );
+  console.log(
+    `  ${colorize("Removes the local GitHits MCP configuration.", "dim", useColors)}\n`,
   );
 
   console.log("  Scanning for configured agents...\n");
@@ -1263,31 +1313,24 @@ export async function initUninstallAction(
   console.log();
 }
 
-function printAuthRecoveryHint(): void {
+function printAuthRecoveryHint(useColors: boolean): void {
   console.log(
     "    You can still configure MCP, but GitHits tools will require auth.",
   );
   console.log("    Recovery steps:");
-  console.log("      githits auth status");
-  console.log("      githits login --force");
+  console.log(`      ${formatCommand("githits auth status", useColors)}`);
+  console.log(`      ${formatCommand("githits login --force", useColors)}`);
   console.log("    For CI or locked-down machines, set GITHITS_API_TOKEN.");
   console.log(
     "    If your system keychain is unavailable, set GITHITS_AUTH_STORAGE=file after accepting plaintext storage.\n",
   );
 }
 
-const INIT_DESCRIPTION = `Set up GitHits for your AI coding tools.
+const INIT_DESCRIPTION = `Connect GitHits to your coding agents.
 
-Walks through GitHits setup options, lets you install the local GitHits MCP
-server or use Agent Skills, scans for available tools (Claude Code, Cursor, Windsurf,
-VS Code, Cline, Claude Desktop, Codex CLI, Pi, Gemini CLI, Google Antigravity),
-checks which are already configured, signs you in, and configures selected
-tools with GitHits MCP.
-
-Supports CLI-based setup (Claude Code, Codex, Gemini CLI), Pi package setup,
-and config
-file editing (Cursor, Windsurf, VS Code, Cline, Claude Desktop,
-Google Antigravity) with atomic writes.`;
+Installs the local GitHits MCP server — the recommended way to connect — or
+sets up Agent Skills instead. Detects supported coding tools on this machine,
+signs you in, and configures the tools you select.`;
 
 const INIT_UNINSTALL_DESCRIPTION = `Remove GitHits MCP server configuration from your coding agents.
 
@@ -1302,7 +1345,7 @@ tokens are not removed; use \`githits logout\` to remove stored credentials.`;
 export function registerInitCommand(program: Command) {
   const initCommand = program
     .command("init")
-    .summary("Set up MCP server for your AI coding tools")
+    .summary("Connect GitHits to your coding agents")
     .description(INIT_DESCRIPTION)
     .option("-y, --yes", "Skip prompts, configure all detected tools")
     .option("--skip-login", "Skip authentication step")

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -408,7 +408,7 @@ to get a URL you can open on another device.`;
 export function registerLoginCommand(program: Command) {
   program
     .command("login")
-    .summary("Authenticate with your GitHits account")
+    .summary("Sign in to your GitHits account")
     .description(LOGIN_DESCRIPTION)
     .option("--no-browser", "Print URL instead of opening browser")
     .option("--port <port>", "Port for local callback server", parseInt)

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -198,7 +198,7 @@ function showMcpSetupInstructions(): void {
 export function registerMcpCommand(program: Command) {
   const mcpCommand = program
     .command("mcp")
-    .summary("Show setup instructions or start MCP server")
+    .summary("Show MCP setup instructions or start the local MCP server")
     .description(
       `Start the Model Context Protocol (MCP) server using STDIO transport.
 

--- a/src/commands/pkg/index.ts
+++ b/src/commands/pkg/index.ts
@@ -25,9 +25,7 @@ export async function registerPkgCommandGroup(
 
   const pkgCommand = program
     .command("pkg")
-    .summary(
-      "Package metadata: info, vulnerabilities, dependencies, changelog, upgrade reviews",
-    )
+    .summary("Package metadata, dependencies, vulnerabilities and changelogs")
     .description(
       "Inspect package metadata from npm, PyPI, Hex, Crates, NuGet, Maven, Packagist, RubyGems, Go, vcpkg, and Zig: overviews, advisories, dependency graphs, and changelogs. Advisory data is unavailable for vcpkg and Zig. For source-level operations inside a dependency, use `githits code`.",
     );

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -18,7 +18,9 @@ import {
   knownSymbolKindList,
   parseUnifiedSearchTargetSpec,
   requireAuth,
+  SPINNER_MESSAGES,
   shouldUseColors,
+  startSpinner,
   toFileIntent,
   toSymbolCategory,
   toSymbolKind,
@@ -87,7 +89,10 @@ export async function searchAction(
       waitTimeoutMs: parseWaitMs(options.wait),
     });
 
-    const outcome = await service.search(built.params);
+    const spinner = startSpinner(SPINNER_MESSAGES.search, !options.json);
+    const outcome = await service
+      .search(built.params)
+      .finally(() => spinner.stop());
     const payload = buildUnifiedSearchSuccessPayload(
       built.params,
       built.rawQuery,
@@ -172,7 +177,7 @@ the original request used --allow-partial, or final results.`;
 export function registerSearchCommand(program: Command) {
   program
     .command("search")
-    .summary("Search indexed dependency and repository code, docs, and symbols")
+    .summary("Explore repository code, dependencies, docs and symbols")
     .description(SEARCH_DESCRIPTION)
     .argument("<query>", "Search query")
     .requiredOption(
@@ -240,7 +245,7 @@ export function registerSearchCommand(program: Command) {
 
   program
     .command("search-status")
-    .summary("Check status of a prior search")
+    .summary("Check the status of a previous search")
     .description(SEARCH_STATUS_DESCRIPTION)
     .argument("<search-ref>", "Search reference returned by githits search")
     .option("--json", "Output as JSON")

--- a/src/shared/colors.test.ts
+++ b/src/shared/colors.test.ts
@@ -62,7 +62,7 @@ describe("colorizeTerminal", () => {
     const result = colorizeTerminal("GitHits", brandColors.primary, true, {
       colorDepth: 24,
     });
-    expect(result).toBe("\x1b[38;2;255;79;174mGitHits\x1b[0m");
+    expect(result).toBe("\x1b[38;2;255;114;190mGitHits\x1b[0m");
   });
 
   it("falls back to 256-color when truecolor is unavailable", () => {

--- a/src/shared/colors.ts
+++ b/src/shared/colors.ts
@@ -31,8 +31,8 @@ export type BrandColorName = keyof typeof brandColors;
  */
 export const brandColors = {
   primary: {
-    hex: "#FF4FAE",
-    rgb: [255, 79, 174],
+    hex: "#FF72BE",
+    rgb: [255, 114, 190],
     ansi256: 205,
     ansi16: "magenta",
   },

--- a/src/shared/colors.ts
+++ b/src/shared/colors.ts
@@ -7,6 +7,7 @@ export const colors = {
   reset: "\x1b[0m",
   bold: "\x1b[1m",
   dim: "\x1b[2m",
+  italic: "\x1b[3m",
   green: "\x1b[32m",
   yellow: "\x1b[33m",
   blue: "\x1b[34m",

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -203,6 +203,8 @@ export {
   createRootCliPreAction,
   type RootCliPreActionDependencies,
 } from "./root-cli-pre-action.js";
+export { type Spinner, startSpinner } from "./spinner.js";
+export { SPINNER_MESSAGES } from "./spinner-messages.js";
 export {
   buildRetryCandidateLine,
   buildTargetResolutionNotes,

--- a/src/shared/spinner-messages.ts
+++ b/src/shared/spinner-messages.ts
@@ -1,0 +1,28 @@
+/**
+ * Rotating spinner labels per command. Each list cycles every ~2s while
+ * a command waits on the GitHits backend, so long requests feel alive.
+ */
+export const SPINNER_MESSAGES = {
+  example: [
+    "Searching real implementations...",
+    "Exploring open-source code...",
+    "Finding production patterns...",
+    "Grounding results...",
+  ],
+  search: [
+    "Exploring repositories...",
+    "Tracing symbols...",
+    "Inspecting dependencies...",
+    "Scanning source code...",
+  ],
+  code: [
+    "Inspecting source code...",
+    "Resolving symbols...",
+    "Reading dependency internals...",
+  ],
+  docs: [
+    "Reading documentation...",
+    "Resolving references...",
+    "Collecting package docs...",
+  ],
+} as const;

--- a/src/shared/spinner.test.ts
+++ b/src/shared/spinner.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, mock } from "bun:test";
+import { startSpinner } from "./spinner.js";
+
+describe("startSpinner", () => {
+  const origIsTTY = process.stderr.isTTY;
+  const origWrite = process.stderr.write;
+
+  afterEach(() => {
+    process.stderr.isTTY = origIsTTY;
+    process.stderr.write = origWrite;
+  });
+
+  function captureStderr(): string[] {
+    const writes: string[] = [];
+    process.stderr.write = mock((chunk: string) => {
+      writes.push(String(chunk));
+      return true;
+    }) as typeof process.stderr.write;
+    return writes;
+  }
+
+  it("is a no-op when disabled", () => {
+    process.stderr.isTTY = true;
+    const writes = captureStderr();
+
+    startSpinner("Loading...", false).stop();
+
+    expect(writes).toHaveLength(0);
+  });
+
+  it("is a no-op when stderr is not a TTY", () => {
+    process.stderr.isTTY = false;
+    const writes = captureStderr();
+
+    startSpinner("Loading...").stop();
+
+    expect(writes).toHaveLength(0);
+  });
+
+  it("renders a frame on stderr and clears the line on stop", () => {
+    process.stderr.isTTY = true;
+    const writes = captureStderr();
+
+    const spinner = startSpinner("Loading...");
+    expect(writes.some((w) => w.includes("Loading..."))).toBe(true);
+
+    spinner.stop();
+    expect(writes[writes.length - 1]).toBe("\r\x1b[2K");
+  });
+
+  it("accepts a rotating message list and shows the first label", () => {
+    process.stderr.isTTY = true;
+    const writes = captureStderr();
+
+    startSpinner(["First label...", "Second label..."]).stop();
+
+    expect(writes.some((w) => w.includes("First label..."))).toBe(true);
+  });
+});

--- a/src/shared/spinner.ts
+++ b/src/shared/spinner.ts
@@ -1,0 +1,54 @@
+import { colorizeBrand } from "./colors.js";
+
+const SPINNER_FRAMES = ["|", "/", "-", "\\"] as const;
+const FRAME_INTERVAL_MS = 80;
+const MESSAGE_INTERVAL_MS = 2000;
+
+/** Handle for an active spinner. */
+export interface Spinner {
+  /** Stop the animation and clear the spinner line. */
+  stop(): void;
+}
+
+/**
+ * Start an animated progress spinner on stderr.
+ *
+ * Renders only when stderr is an interactive TTY, so piped output,
+ * `--json` consumers, and agent/MCP callers never see spinner frames.
+ * Writing to stderr keeps stdout (the command result) clean.
+ *
+ * Pass an array of labels to rotate them every ~2s while the glyph
+ * keeps spinning; a single string stays fixed.
+ */
+export function startSpinner(
+  message: string | readonly string[],
+  enabled = true,
+): Spinner {
+  if (!enabled || !process.stderr.isTTY) {
+    return { stop: () => {} };
+  }
+
+  const messages = typeof message === "string" ? [message] : message;
+  const framesPerMessage = Math.round(MESSAGE_INTERVAL_MS / FRAME_INTERVAL_MS);
+  const useColors = process.env.NO_COLOR === undefined;
+  let frame = 0;
+  const render = (): void => {
+    const glyph = SPINNER_FRAMES[frame % SPINNER_FRAMES.length] ?? "|";
+    const label =
+      messages[Math.floor(frame / framesPerMessage) % messages.length] ?? "";
+    frame += 1;
+    process.stderr.write(
+      `\r\x1b[2K${colorizeBrand(glyph, "primary", useColors)} ${label}`,
+    );
+  };
+
+  render();
+  const interval = setInterval(render, FRAME_INTERVAL_MS);
+
+  return {
+    stop: () => {
+      clearInterval(interval);
+      process.stderr.write("\r\x1b[2K");
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Reworks `githits init` and the surrounding CLI surface, on top of #112:

- Rewrites copy across every init screen — intro, detect/choose/sign-in/install/ready, Agent Skills, and uninstall — in a clearer, agent-focused voice
- Updates the brand primary color and paints the ASCII logo with a per-letter warm gradient
- Styles CLI commands in the secondary brand color via a shared helper
- Highlights `--help` section titles and aligns command descriptions
- Adds an animated spinner with rotating labels to `example`, `search`, `code`, and `docs` while they wait on the backend
- Fixes `--no-color`, which was registered but never wired up

## Audit notes

- **`--no-color`** was a real pre-existing bug — the flag did nothing. Fixed here and independently verified (`--no-color --help` emits zero ANSI).
- Full `bun test` shows failures that are **pre-existing and environment-sensitive** (Windows path separators, auth-storage paths, file-lock timing, sandbox spawn permissions, Pi global-bin fallback, OpenCode setup). The count varies by environment — 9 locally, 15 in a stricter sandbox. Verified via baseline (stashing the changes) that this work introduces **zero new test failures**; CI on Linux should give the clean signal.
- `bun run build` and `bun run typecheck` pass.

## Test plan

- [ ] `bun test` in CI (Linux) — confirm only the known pre-existing failures remain
- [ ] `bun run dev init` — walk the redesigned onboarding flow
- [ ] `bun run dev init uninstall` — check the uninstall screen
- [ ] `bun run dev --help` and `bun run dev --no-color --help` — verify help styling and that `--no-color` suppresses it
- [ ] `bun run dev example "..."` — confirm the rotating spinner appears while waiting

🤖 Generated with [Claude Code](https://claude.com/claude-code)