### PR TITLE
fix: suppress same-target stale search warnings

### DIFF
--- a/src/shared/unified-search-response.test.ts
+++ b/src/shared/unified-search-response.test.ts
@@ -215,6 +215,37 @@ describe("buildUnifiedSearchSuccessPayload", () => {
     );
   });
 
+  it("suppresses version-prefix-only package stale hit warnings", () => {
+    if (defaultUnifiedSearchOutcome.state !== "completed") {
+      throw new Error("expected completed outcome fixture");
+    }
+    const outcome: UnifiedSearchOutcome = {
+      ...defaultUnifiedSearchOutcome,
+      result: {
+        ...defaultUnifiedSearchOutcome.result,
+        results: [
+          {
+            ...defaultUnifiedSearchOutcome.result.results[0]!,
+            requestedTargetLabel: "npm:express@5.2.1",
+            freshTargetLabel: "npm:express@5.2.1",
+            servedTargetLabel: "npm:express@v5.2.1",
+            freshness: "STALE",
+          },
+        ],
+      },
+    };
+
+    const payload = buildUnifiedSearchSuccessPayload(
+      params,
+      "router middleware",
+      "router middleware",
+      outcome,
+    );
+
+    expect(payload.results[0]).not.toHaveProperty("freshness");
+    expect(payload.warnings).toBeUndefined();
+  });
+
   it("keeps follow-up commands pinned to served locator identity", () => {
     if (defaultUnifiedSearchOutcome.state !== "completed") {
       throw new Error("expected completed outcome fixture");
@@ -578,6 +609,21 @@ describe("buildSourceStatusWarnings — sourceStatus → warnings promotion", ()
           requestedTarget: "githits-com/githits-cli",
           freshTarget: "githits-com/githits-cli@HEAD",
           servedTarget: "githits-com/githits-cli@HEAD",
+          codeIndexState: "STALE",
+        },
+      ]),
+    ).toEqual([]);
+  });
+
+  it("does not warn when only a package version v-prefix differs", () => {
+    expect(
+      buildSourceStatusWarnings([
+        {
+          source: "code",
+          targetLabel: "npm:express@5.2.1",
+          requestedTarget: "npm:express@5.2.1",
+          freshTarget: "npm:express@5.2.1",
+          servedTarget: "npm:express@v5.2.1",
           codeIndexState: "STALE",
         },
       ]),

--- a/src/shared/unified-search-response.ts
+++ b/src/shared/unified-search-response.ts
@@ -682,7 +682,33 @@ function labelsDiverge(input: {
 }): boolean {
   const served = input.servedTarget;
   if (!served) return false;
-  return Boolean(input.freshTarget && input.freshTarget !== served);
+  return Boolean(
+    input.freshTarget &&
+      canonicalTargetLabel(input.freshTarget) !== canonicalTargetLabel(served),
+  );
+}
+
+function canonicalTargetLabel(label: string): string {
+  const parsed = parsePackageVersionLabel(label);
+  if (!parsed) return label;
+  const version = parsed.version.replace(/^v(?=\d)/i, "");
+  return `${parsed.registry.toLowerCase()}:${parsed.packageName}@${version}`;
+}
+
+function parsePackageVersionLabel(
+  label: string,
+): { registry: string; packageName: string; version: string } | undefined {
+  const registryEnd = label.indexOf(":");
+  if (registryEnd <= 0) return undefined;
+  const versionStart = label.lastIndexOf("@");
+  if (versionStart <= registryEnd + 1) return undefined;
+  const version = label.slice(versionStart + 1);
+  if (!version) return undefined;
+  return {
+    registry: label.slice(0, registryEnd),
+    packageName: label.slice(registryEnd + 1, versionStart),
+    version,
+  };
 }
 
 function warningForEntry(


### PR DESCRIPTION
## Summary
- Normalize package target labels before checking stale search warning divergence
- Suppress warnings when stale served labels only differ by a package version v-prefix
- Keep warnings for actual package target drift

## Tests
- bun test src/shared/unified-search-response.test.ts
- bun test src/commands/search.test.ts