### PR TITLE
chore: release 0.4.7

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "GitHits plugins for Claude Code - code examples from global open source",
-    "version": "0.4.6"
+    "version": "0.4.7"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "Code examples from global open source for developers and AI assistants",
   "author": {
     "name": "GitHits"

--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "Code examples from global open source for developers and AI assistants",
   "author": {
     "name": "GitHits"

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "Code examples from global open source for developers and AI assistants.",
   "mcpServers": {
     "githits": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "githits",
   "description": "CLI companion for GitHits - code examples from global open source for developers and AI assistants",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "type": "module",
   "files": [
     "dist",

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "Code examples from global open source for developers and AI assistants",
   "author": {
     "name": "GitHits"


### PR DESCRIPTION
## Summary
- Bump package and plugin manifest versions to 0.4.7
- Keep package, OpenCode, Claude, Claude marketplace, Claude payload, and Gemini extension versions aligned

## User-facing changelog
- Redesigned `githits init` onboarding with clearer setup flow, auth guidance, install progress, and Ready screen copy.
- Improved CLI visual feedback with branded colors and animated spinners for backend-backed commands.
- Fixed `--no-color` so CLI output correctly suppresses ANSI styling.
- Suppressed false stale-search warnings when package targets only differ by a `v`-prefixed version label.
- Restored Node 20 compatibility via package engine metadata.

## Verification
- `bun test src/plugin-version-consistency.test.ts`
- `bun run build`
- `bun run smoke:cli`
- `bun test`
- `bun run typecheck`
- `git diff --check`