### PR TITLE
Agent based init

### DIFF
--- a/docs/implementation/cli-commands.md
+++ b/docs/implementation/cli-commands.md
@@ -8,7 +8,7 @@ The CLI exposes `example`, `languages`, `feedback`, top-level indexed `search` /
 
 | Command | Required Args | Options | Description |
 |---|---|---|---|
-| `init` | — | `-y, --yes`, `--skip-login` | Authenticate and set up MCP server for coding agents |
+| `init` | — | `-y, --yes`, `--skip-login`, `--detect-agents`, `--install-agents <ids>`, `--json` | Authenticate and set up MCP server for coding agents; staged flags support agent-safe non-interactive onboarding |
 | `init uninstall` | — | `-y, --yes` | Remove GitHits MCP server configuration from coding agents |
 | `example <query>` | `<query>` | `-l, --lang <language>`, `--license <mode>`, `--explain`, `--json` | Search for code examples |
 | `search <query>` | `--in <target>` | `--source <source>`, `--kind <kind>`, `--category <category>`, `--path-prefix <prefix>`, `--intent <intent>`, `--public`, `--name <name>`, `--lang <language>`, `--allow-partial`, `--limit <n>`, `--offset <n>`, `--wait <seconds>`, `--json` | Unified indexed search across dependency/repository code, docs, and symbols. Defaults to 10 results. |
@@ -29,14 +29,19 @@ The CLI exposes `example`, `languages`, `feedback`, top-level indexed `search` /
 ### `githits init`
 
 ```
-githits init              # Interactive: authenticate, scan, configure unconfigured agents
-githits init --yes        # Non-interactive: authenticate, configure all unconfigured agents
-githits init --skip-login # Skip authentication, configure tools only
-githits init uninstall    # Interactive: remove GitHits MCP config from configured agents
-githits init uninstall -y # Non-interactive: remove all detected GitHits MCP configs
+githits init                         # Interactive: authenticate, scan, configure unconfigured agents
+githits init --yes                   # Interactive shortcut: configure all detected unconfigured agents
+githits init --skip-login            # Skip authentication, configure tools only
+githits init --detect-agents         # Agent-safe discovery: scan and print detected agent IDs/statuses
+githits init --detect-agents --json  # Machine-readable discovery output for agents
+githits init --install-agents cursor # Agent-safe install: configure only explicit detected IDs
+githits init uninstall               # Interactive: remove GitHits MCP config from configured agents
+githits init uninstall -y            # Non-interactive: remove all detected GitHits MCP configs
 ```
 
 Authenticates with GitHits (via OAuth in the browser), then scans for available coding agents, checks which are already configured, and sets up unconfigured ones with your confirmation. All agents are pre-checked before any setup begins, so the status display is fully resolved. CLI agents are considered available only when their executable is on `PATH`; related dot-directories alone do not count. Config-file agents remain filesystem-detected using their known app/config directories. If already authenticated, the login step is skipped automatically. If login fails, the user is prompted to continue with tool setup anyway. If all detected agents are already configured, exits early with a summary.
+
+When `init` is run without a TTY, it prints agent onboarding guidance and exits without scanning, writing config, prompting, or authenticating. Non-interactive `--yes` is rejected for safety because it can configure tools without explicit per-tool user approval. Agentic onboarding must use the staged flow instead: `--detect-agents` first, then `--install-agents <ids>` after the user approves the exact detected IDs. `--install-agents` rescans, rejects unknown or currently undetected IDs before writing, installs only the requested agents, verifies setup, and does not authenticate. After successful or already-configured outcomes it instructs agents to ask before running the separate `githits login` command; if every install fails, it reports installation errors and suppresses auth guidance. `--json` is supported for the staged detect/install modes so agents do not need to scrape prose.
 
 Supports Claude Code, Cursor, Windsurf, VS Code / Copilot, Cline, Claude Desktop, Codex CLI, Pi, Gemini CLI, Google Antigravity, and OpenCode. Uses plugin install (Claude Code), CLI commands (Codex, Gemini CLI), Pi adapter setup plus Pi-owned MCP config writes (Pi), and atomic config file writes (Cursor, Windsurf, VS Code, Cline, Claude Desktop, Google Antigravity, OpenCode). CLI agents use read-only check commands (e.g., `claude plugin list`) to determine configuration status before prompting.
 

--- a/docs/implementation/cli-commands.md
+++ b/docs/implementation/cli-commands.md
@@ -29,19 +29,19 @@ The CLI exposes `example`, `languages`, `feedback`, top-level indexed `search` /
 ### `githits init`
 
 ```
-githits init                         # Interactive: authenticate, scan, configure unconfigured agents
-githits init --yes                   # Interactive shortcut: configure all detected unconfigured agents
-githits init --skip-login            # Skip authentication, configure tools only
-githits init --detect-agents         # Agent-safe discovery: scan and print detected agent IDs/statuses
-githits init --detect-agents --json  # Machine-readable discovery output for agents
-githits init --install-agents cursor # Agent-safe install: configure only explicit detected IDs
-githits init uninstall               # Interactive: remove GitHits MCP config from configured agents
-githits init uninstall -y            # Non-interactive: remove all detected GitHits MCP configs
+githits init                                      # Interactive: authenticate, scan, configure unconfigured agents
+githits init --yes                                # Interactive shortcut: configure all detected unconfigured agents
+githits init --skip-login                         # Skip authentication, configure tools only
+npx -y githits@latest init --detect-agents        # Agent-safe discovery: scan and print detected agent IDs/statuses
+npx -y githits@latest init --detect-agents --json # Machine-readable discovery output for agents
+npx -y githits@latest init --install-agents cursor # Agent-safe install: configure only explicit detected IDs
+githits init uninstall                            # Interactive: remove GitHits MCP config from configured agents
+githits init uninstall -y                         # Non-interactive: remove all detected GitHits MCP configs
 ```
 
 Authenticates with GitHits (via OAuth in the browser), then scans for available coding agents, checks which are already configured, and sets up unconfigured ones with your confirmation. All agents are pre-checked before any setup begins, so the status display is fully resolved. CLI agents are considered available only when their executable is on `PATH`; related dot-directories alone do not count. Config-file agents remain filesystem-detected using their known app/config directories. If already authenticated, the login step is skipped automatically. If login fails, the user is prompted to continue with tool setup anyway. If all detected agents are already configured, exits early with a summary.
 
-When `init` is run without a TTY, it prints agent onboarding guidance and exits without scanning, writing config, prompting, or authenticating. Non-interactive `--yes` is rejected for safety because it can configure tools without explicit per-tool user approval. Agentic onboarding must use the staged flow instead: `--detect-agents` first, then `--install-agents <ids>` after the user approves the exact detected IDs. `--install-agents` rescans, rejects unknown or currently undetected IDs before writing, installs only the requested agents, verifies setup, and does not authenticate. After successful or already-configured outcomes it instructs agents to ask before running the separate `githits login` command; if every install fails, it reports installation errors and suppresses auth guidance. `--json` is supported for the staged detect/install modes so agents do not need to scrape prose.
+When `init` is run without a TTY, it prints agent onboarding guidance and exits without scanning, writing config, prompting, or authenticating. Non-interactive `--yes` is rejected for safety because it can configure tools without explicit per-tool user approval. Agentic onboarding must use the staged flow instead: `npx -y githits@latest init --detect-agents` first, then `npx -y githits@latest init --install-agents <ids>` after the user approves the exact detected IDs. `--install-agents` rescans, rejects unknown or currently undetected IDs before writing, installs only the requested agents, verifies setup, and does not authenticate. After successful or already-configured outcomes it instructs agents to ask before running the separate `npx -y githits@latest login` command; if every install fails, it reports installation errors and suppresses auth guidance. `--json` is supported for the staged detect/install modes so agents do not need to scrape prose.
 
 Supports Claude Code, Cursor, Windsurf, VS Code / Copilot, Cline, Claude Desktop, Codex CLI, Pi, Gemini CLI, Google Antigravity, and OpenCode. Uses plugin install (Claude Code), CLI commands (Codex, Gemini CLI), Pi adapter setup plus Pi-owned MCP config writes (Pi), and atomic config file writes (Cursor, Windsurf, VS Code, Cline, Claude Desktop, Google Antigravity, OpenCode). CLI agents use read-only check commands (e.g., `claude plugin list`) to determine configuration status before prompting.
 

--- a/src/commands/init/init.test.ts
+++ b/src/commands/init/init.test.ts
@@ -31,13 +31,20 @@ import {
 
 /** Suppress console.log during tests */
 let logSpy: ReturnType<typeof spyOn>;
+let errorSpy: ReturnType<typeof spyOn>;
+let originalExitCode: string | number | null | undefined;
 
 beforeEach(() => {
+  originalExitCode = process.exitCode;
+  process.exitCode = 0;
   logSpy = spyOn(console, "log").mockImplementation(() => {});
+  errorSpy = spyOn(console, "error").mockImplementation(() => {});
 });
 
 afterEach(() => {
   logSpy.mockRestore();
+  errorSpy.mockRestore();
+  process.exitCode = originalExitCode;
 });
 
 /** Create mock login deps that report already authenticated */
@@ -91,6 +98,10 @@ function getLogOutput(): string[] {
   return (logSpy.mock.calls as unknown[][]).map((c) => String(c[0] ?? ""));
 }
 
+function getErrorOutput(): string[] {
+  return (errorSpy.mock.calls as unknown[][]).map((c) => String(c[0] ?? ""));
+}
+
 function expectReadyNextSteps(logCalls: string[]): void {
   expect(logCalls.some((msg) => msg.includes("GitHits is now connected"))).toBe(
     true,
@@ -118,6 +129,230 @@ function lookupCommandFor(platform: string = process.platform): string {
 }
 
 describe("initAction", () => {
+  it("prints agent-safe guidance without side effects in non-interactive mode", async () => {
+    const fs = createFsWithDetection(["/home/test/.cursor"]);
+    const execService = createMockExecService();
+    const promptService = createMockPromptService();
+    const createLoginDeps = mock(() =>
+      Promise.resolve({} as LoginDependencies),
+    );
+
+    await initAction(
+      {},
+      {
+        fileSystemService: fs,
+        promptService,
+        execService,
+        createLoginDeps,
+        isInteractive: false,
+      },
+    );
+
+    const logCalls = getLogOutput();
+    expect(logCalls.some((msg) => msg.includes("non-interactive"))).toBe(true);
+    expect(
+      logCalls.some((msg) => msg.includes("githits init --detect-agents")),
+    ).toBe(true);
+    expect(promptService.select).not.toHaveBeenCalled();
+    expect(promptService.checkbox).not.toHaveBeenCalled();
+    expect(execService.exec).not.toHaveBeenCalled();
+    expect(fs.atomicWriteFile).not.toHaveBeenCalled();
+    expect(createLoginDeps).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-interactive --yes before scan, writes, or auth", async () => {
+    const fs = createFsWithDetection(["/home/test/.cursor"]);
+    const execService = createMockExecService();
+    const promptService = createMockPromptService();
+    const createLoginDeps = mock(() =>
+      Promise.resolve({} as LoginDependencies),
+    );
+
+    await initAction(
+      { yes: true },
+      {
+        fileSystemService: fs,
+        promptService,
+        execService,
+        createLoginDeps,
+        isInteractive: false,
+      },
+    );
+
+    expect(process.exitCode).toBe(1);
+    expect(getErrorOutput().some((msg) => msg.includes("--yes"))).toBe(true);
+    expect(promptService.select).not.toHaveBeenCalled();
+    expect(promptService.checkbox).not.toHaveBeenCalled();
+    expect(execService.exec).not.toHaveBeenCalled();
+    expect(fs.atomicWriteFile).not.toHaveBeenCalled();
+    expect(createLoginDeps).not.toHaveBeenCalled();
+  });
+
+  it("detects agents without writing config or authenticating", async () => {
+    const fs = createFsWithDetection(["/home/test/.cursor"]);
+    const execService = createMockExecService();
+    const createLoginDeps = mock(() =>
+      Promise.resolve({} as LoginDependencies),
+    );
+
+    await initAction(
+      { detectAgents: true },
+      {
+        fileSystemService: fs,
+        promptService: createMockPromptService(),
+        execService,
+        createLoginDeps,
+      },
+    );
+
+    const logCalls = getLogOutput();
+    expect(
+      logCalls.some((msg) => msg.includes("Detected supported tools")),
+    ).toBe(true);
+    expect(logCalls.some((msg) => msg.includes("cursor"))).toBe(true);
+    expect(logCalls.some((msg) => msg.includes("needs setup"))).toBe(true);
+    expect(fs.atomicWriteFile).not.toHaveBeenCalled();
+    expect(createLoginDeps).not.toHaveBeenCalled();
+  });
+
+  it("emits JSON for agent detection", async () => {
+    const fs = createFsWithDetection(["/home/test/.cursor"]);
+
+    await initAction(
+      { detectAgents: true, json: true },
+      {
+        fileSystemService: fs,
+        promptService: createMockPromptService(),
+        execService: createMockExecService(),
+        createLoginDeps: createAlreadyAuthLoginDeps(),
+      },
+    );
+
+    const payload = JSON.parse(getLogOutput()[0] ?? "{}");
+    expect(payload.mode).toBe("detect-agents");
+    expect(payload.installableIds).toContain("cursor");
+    expect(payload.suggestedCommand).toContain("--install-agents cursor");
+  });
+
+  it("installs only explicitly requested agents in staged install mode", async () => {
+    const fs = createFsWithDetection([
+      "/home/test/.cursor",
+      "/home/test/.codeium/windsurf",
+    ]);
+
+    await initAction(
+      { installAgents: "cursor" },
+      {
+        fileSystemService: fs,
+        promptService: createMockPromptService(),
+        execService: createMockExecService(),
+        createLoginDeps: createAlreadyAuthLoginDeps(),
+      },
+    );
+
+    expect(fs.atomicWriteFile).toHaveBeenCalledTimes(1);
+    expect(fs.atomicWriteFile).toHaveBeenCalledWith(
+      "/home/test/.cursor/mcp.json",
+      expect.any(String),
+    );
+    const writtenPaths = (fs.atomicWriteFile as ReturnType<typeof mock>).mock
+      .calls as unknown[][];
+    expect(
+      writtenPaths.some((call) =>
+        String(call[0] ?? "").includes(".codeium/windsurf"),
+      ),
+    ).toBe(false);
+    expect(getLogOutput().some((msg) => msg.includes("githits login"))).toBe(
+      true,
+    );
+  });
+
+  it("treats already configured staged install targets as idempotent", async () => {
+    const fs = createFsWithDetection(["/home/test/.cursor"], {
+      "/home/test/.cursor/mcp.json": JSON.stringify({
+        mcpServers: {
+          GitHits: {
+            command: "npx",
+            args: ["-y", "githits@latest", "mcp", "start"],
+          },
+        },
+      }),
+    });
+
+    await initAction(
+      { installAgents: "cursor" },
+      {
+        fileSystemService: fs,
+        promptService: createMockPromptService(),
+        execService: createMockExecService(),
+        createLoginDeps: createAlreadyAuthLoginDeps(),
+      },
+    );
+
+    expect(fs.atomicWriteFile).not.toHaveBeenCalled();
+    expect(
+      getLogOutput().some((msg) => msg.includes("already configured")),
+    ).toBe(true);
+  });
+
+  it("rejects unknown staged install IDs before writing", async () => {
+    const fs = createFsWithDetection(["/home/test/.cursor"]);
+
+    await initAction(
+      { installAgents: "cursor,unknown-agent" },
+      {
+        fileSystemService: fs,
+        promptService: createMockPromptService(),
+        execService: createMockExecService(),
+        createLoginDeps: createAlreadyAuthLoginDeps(),
+      },
+    );
+
+    expect(process.exitCode).toBe(1);
+    expect(fs.atomicWriteFile).not.toHaveBeenCalled();
+    expect(getErrorOutput().some((msg) => msg.includes("unknown-agent"))).toBe(
+      true,
+    );
+  });
+
+  it("rejects undetected staged install IDs before writing", async () => {
+    const fs = createFsWithDetection(["/home/test/.cursor"]);
+
+    await initAction(
+      { installAgents: "windsurf" },
+      {
+        fileSystemService: fs,
+        promptService: createMockPromptService(),
+        execService: createMockExecService(),
+        createLoginDeps: createAlreadyAuthLoginDeps(),
+      },
+    );
+
+    expect(process.exitCode).toBe(1);
+    expect(fs.atomicWriteFile).not.toHaveBeenCalled();
+    expect(getErrorOutput().some((msg) => msg.includes("not detected"))).toBe(
+      true,
+    );
+  });
+
+  it("rejects --yes with staged init modes", async () => {
+    const fs = createFsWithDetection(["/home/test/.cursor"]);
+
+    await initAction(
+      { yes: true, detectAgents: true },
+      {
+        fileSystemService: fs,
+        promptService: createMockPromptService(),
+        execService: createMockExecService(),
+        createLoginDeps: createAlreadyAuthLoginDeps(),
+      },
+    );
+
+    expect(process.exitCode).toBe(1);
+    expect(fs.atomicWriteFile).not.toHaveBeenCalled();
+    expect(getErrorOutput().some((msg) => msg.includes("--yes"))).toBe(true);
+  });
+
   it("prints Agent Skills instructions without changing MCP config", async () => {
     const fs = createFsWithDetection(["/home/test/.cursor"]);
     const execService = createMockExecService();
@@ -2584,5 +2819,17 @@ describe("registerInitCommand", () => {
     expect(
       initCommand?.commands.some((cmd) => cmd.name() === "uninstall"),
     ).toBe(true);
+  });
+
+  it("registers staged agent-safe init options", () => {
+    const program = new Command();
+    registerInitCommand(program);
+
+    const initCommand = program.commands.find((cmd) => cmd.name() === "init");
+    const optionLongNames = initCommand?.options.map((option) => option.long);
+
+    expect(optionLongNames).toContain("--detect-agents");
+    expect(optionLongNames).toContain("--install-agents");
+    expect(optionLongNames).toContain("--json");
   });
 });

--- a/src/commands/init/init.test.ts
+++ b/src/commands/init/init.test.ts
@@ -235,10 +235,14 @@ describe("initAction", () => {
   });
 
   it("installs only explicitly requested agents in staged install mode", async () => {
-    const fs = createFsWithDetection([
-      "/home/test/.cursor",
-      "/home/test/.codeium/windsurf",
-    ]);
+    const configFiles: Record<string, string> = {};
+    const fs = createFsWithDetection(
+      ["/home/test/.cursor", "/home/test/.codeium/windsurf"],
+      configFiles,
+    );
+    fs.atomicWriteFile = mock(async (path: string, content: string) => {
+      configFiles[path] = content;
+    }) as typeof fs.atomicWriteFile;
 
     await initAction(
       { installAgents: "cursor" },
@@ -293,6 +297,56 @@ describe("initAction", () => {
     expect(
       getLogOutput().some((msg) => msg.includes("already configured")),
     ).toBe(true);
+  });
+
+  it("does not print login instructions when all staged installs fail", async () => {
+    const fs = createFsWithDetection(["/home/test/.cursor"]);
+    fs.atomicWriteFile = mock(async () => {
+      throw Object.assign(new Error("Permission denied"), { code: "EACCES" });
+    }) as typeof fs.atomicWriteFile;
+
+    await initAction(
+      { installAgents: "cursor" },
+      {
+        fileSystemService: fs,
+        promptService: createMockPromptService(),
+        execService: createMockExecService(),
+        createLoginDeps: createAlreadyAuthLoginDeps(),
+      },
+    );
+
+    const logCalls = getLogOutput();
+    expect(process.exitCode).toBe(1);
+    expect(logCalls.some((msg) => msg.includes("completed with errors"))).toBe(
+      true,
+    );
+    expect(
+      logCalls.some((msg) => msg.includes("Fix installation errors")),
+    ).toBe(true);
+    expect(logCalls.some((msg) => msg.includes("githits login"))).toBe(false);
+  });
+
+  it("marks auth not required in JSON when all staged installs fail", async () => {
+    const fs = createFsWithDetection(["/home/test/.cursor"]);
+    fs.atomicWriteFile = mock(async () => {
+      throw Object.assign(new Error("Permission denied"), { code: "EACCES" });
+    }) as typeof fs.atomicWriteFile;
+
+    await initAction(
+      { installAgents: "cursor", json: true },
+      {
+        fileSystemService: fs,
+        promptService: createMockPromptService(),
+        execService: createMockExecService(),
+        createLoginDeps: createAlreadyAuthLoginDeps(),
+      },
+    );
+
+    const payload = JSON.parse(getLogOutput()[0] ?? "{}");
+    expect(process.exitCode).toBe(1);
+    expect(payload.outcomes[0].status).toBe("failed");
+    expect(payload.auth.required).toBe(false);
+    expect(JSON.stringify(payload)).not.toContain("githits login");
   });
 
   it("rejects unknown staged install IDs before writing", async () => {

--- a/src/commands/init/init.test.ts
+++ b/src/commands/init/init.test.ts
@@ -151,7 +151,9 @@ describe("initAction", () => {
     const logCalls = getLogOutput();
     expect(logCalls.some((msg) => msg.includes("non-interactive"))).toBe(true);
     expect(
-      logCalls.some((msg) => msg.includes("githits init --detect-agents")),
+      logCalls.some((msg) =>
+        msg.includes("npx -y githits@latest init --detect-agents"),
+      ),
     ).toBe(true);
     expect(promptService.select).not.toHaveBeenCalled();
     expect(promptService.checkbox).not.toHaveBeenCalled();
@@ -266,9 +268,9 @@ describe("initAction", () => {
         String(call[0] ?? "").includes(".codeium/windsurf"),
       ),
     ).toBe(false);
-    expect(getLogOutput().some((msg) => msg.includes("githits login"))).toBe(
-      true,
-    );
+    expect(
+      getLogOutput().some((msg) => msg.includes("npx -y githits@latest login")),
+    ).toBe(true);
   });
 
   it("treats already configured staged install targets as idempotent", async () => {
@@ -323,7 +325,9 @@ describe("initAction", () => {
     expect(
       logCalls.some((msg) => msg.includes("Fix installation errors")),
     ).toBe(true);
-    expect(logCalls.some((msg) => msg.includes("githits login"))).toBe(false);
+    expect(logCalls.some((msg) => msg.includes("githits@latest login"))).toBe(
+      false,
+    );
   });
 
   it("marks auth not required in JSON when all staged installs fail", async () => {
@@ -346,7 +350,7 @@ describe("initAction", () => {
     expect(process.exitCode).toBe(1);
     expect(payload.outcomes[0].status).toBe("failed");
     expect(payload.auth.required).toBe(false);
-    expect(JSON.stringify(payload)).not.toContain("githits login");
+    expect(JSON.stringify(payload)).not.toContain("githits@latest login");
   });
 
   it("rejects unknown staged install IDs before writing", async () => {

--- a/src/commands/init/init.test.ts
+++ b/src/commands/init/init.test.ts
@@ -67,6 +67,22 @@ function createAlreadyAuthLoginDeps(): () => Promise<LoginDependencies> {
   );
 }
 
+function createUnauthLoginDeps(): () => Promise<
+  LoginDependencies & { hasValidToken: boolean }
+> {
+  return mock(() =>
+    Promise.resolve({
+      authService: createMockAuthService(),
+      authStorage: createMockAuthStorage({
+        loadTokens: mock(() => Promise.resolve(null)),
+      }),
+      browserService: createMockBrowserService(),
+      mcpUrl: "https://mcp.githits.com",
+      hasValidToken: false,
+    }),
+  );
+}
+
 /**
  * Create a FileSystemService mock that detects specific agents
  * and optionally has config files with content.
@@ -226,7 +242,7 @@ describe("initAction", () => {
         fileSystemService: fs,
         promptService: createMockPromptService(),
         execService: createMockExecService(),
-        createLoginDeps: createAlreadyAuthLoginDeps(),
+        createLoginDeps: createUnauthLoginDeps(),
       },
     );
 
@@ -252,7 +268,7 @@ describe("initAction", () => {
         fileSystemService: fs,
         promptService: createMockPromptService(),
         execService: createMockExecService(),
-        createLoginDeps: createAlreadyAuthLoginDeps(),
+        createLoginDeps: createUnauthLoginDeps(),
       },
     );
 
@@ -271,6 +287,34 @@ describe("initAction", () => {
     expect(
       getLogOutput().some((msg) => msg.includes("npx -y githits@latest login")),
     ).toBe(true);
+  });
+
+  it("does not print login instructions when staged install finds existing auth", async () => {
+    const fs = createFsWithDetection(["/home/test/.cursor"], {
+      "/home/test/.cursor/mcp.json": JSON.stringify({
+        mcpServers: {
+          GitHits: {
+            command: "npx",
+            args: ["-y", "githits@latest", "mcp", "start"],
+          },
+        },
+      }),
+    });
+
+    await initAction(
+      { installAgents: "cursor", json: true },
+      {
+        fileSystemService: fs,
+        promptService: createMockPromptService(),
+        execService: createMockExecService(),
+        createLoginDeps: createAlreadyAuthLoginDeps(),
+      },
+    );
+
+    const payload = JSON.parse(getLogOutput()[0] ?? "{}");
+    expect(payload.auth.required).toBe(false);
+    expect(payload.auth.status).toBe("authenticated");
+    expect(JSON.stringify(payload)).not.toContain("githits@latest login");
   });
 
   it("treats already configured staged install targets as idempotent", async () => {

--- a/src/commands/init/init.test.ts
+++ b/src/commands/init/init.test.ts
@@ -233,6 +233,28 @@ describe("initAction", () => {
     expect(createLoginDeps).not.toHaveBeenCalled();
   });
 
+  it("prints no-tools guidance when staged detection finds no agents", async () => {
+    const fs = createFsWithDetection([]);
+
+    await initAction(
+      { detectAgents: true },
+      {
+        fileSystemService: fs,
+        promptService: createMockPromptService(),
+        execService: createMockExecService(),
+        createLoginDeps: createAlreadyAuthLoginDeps(),
+      },
+    );
+
+    const logCalls = getLogOutput();
+    expect(
+      logCalls.some((msg) => msg.includes("No supported AI coding tools")),
+    ).toBe(true);
+    expect(
+      logCalls.some((msg) => msg.includes("already configured for detected")),
+    ).toBe(false);
+  });
+
   it("emits JSON for agent detection", async () => {
     const fs = createFsWithDetection(["/home/test/.cursor"]);
 

--- a/src/commands/init/init.ts
+++ b/src/commands/init/init.ts
@@ -859,22 +859,37 @@ function printInstallValidationFailure(
   process.exitCode = 1;
 }
 
+function hasUsableInstallOutcome(outcomes: AgentOutcome[]): boolean {
+  return outcomes.some(
+    (outcome) =>
+      outcome.status === "success" || outcome.status === "already_configured",
+  );
+}
+
 function printAgenticInstallJson(outcomes: AgentOutcome[]): void {
+  const canAuthenticate = hasUsableInstallOutcome(outcomes);
   console.log(
     JSON.stringify(
       {
         mode: "install-agents",
         outcomes,
-        auth: {
-          required: true,
-          command: "githits login",
-          noBrowserCommand: "githits login --no-browser",
-        },
-        instructions: [
-          "Ask the user before running githits login.",
-          "Browser sign-in happens outside chat and terminal input.",
-          "Do not ask the user to paste passwords, tokens, cookies, or OAuth codes into chat.",
-        ],
+        auth: canAuthenticate
+          ? {
+              required: true,
+              command: "githits login",
+              noBrowserCommand: "githits login --no-browser",
+            }
+          : {
+              required: false,
+              reason: "Fix installation errors before starting sign-in.",
+            },
+        instructions: canAuthenticate
+          ? [
+              "Ask the user before running githits login.",
+              "Browser sign-in happens outside chat and terminal input.",
+              "Do not ask the user to paste passwords, tokens, cookies, or OAuth codes into chat.",
+            ]
+          : ["Fix installation errors before asking the user to sign in."],
       },
       null,
       2,
@@ -935,6 +950,7 @@ async function runInstallAgentsMode(
   );
 
   const failed = outcomes.filter((outcome) => outcome.status === "failed");
+  const canAuthenticate = hasUsableInstallOutcome(outcomes);
   if (failed.length > 0) {
     process.exitCode = 1;
   }
@@ -954,7 +970,11 @@ async function runInstallAgentsMode(
     }
   }
   console.log();
-  printAgenticLoginInstructions(useColors);
+  if (canAuthenticate) {
+    printAgenticLoginInstructions(useColors);
+  } else {
+    console.log("Fix installation errors before starting sign-in.");
+  }
   console.log();
 }
 

--- a/src/commands/init/init.ts
+++ b/src/commands/init/init.ts
@@ -57,6 +57,12 @@ export interface InitOptions {
   yes?: boolean;
   /** Skip the login step */
   skipLogin?: boolean;
+  /** Scan supported agents without installing anything */
+  detectAgents?: boolean;
+  /** Comma-separated agent IDs to install non-interactively */
+  installAgents?: string;
+  /** Emit machine-readable output for staged non-interactive modes */
+  json?: boolean;
 }
 
 /** Options for the init uninstall command */
@@ -76,6 +82,8 @@ export interface InitDependencies {
   execService: ExecService;
   /** Factory to create auth deps for the login step. Omit to skip login. */
   createLoginDeps?: () => Promise<InitLoginDependencies>;
+  /** Whether this invocation can safely prompt on stdin/stdout. */
+  isInteractive?: boolean;
 }
 
 /** Tracks per-agent setup outcome for the summary */
@@ -84,6 +92,14 @@ interface AgentOutcome {
   name: string;
   status: "success" | "already_configured" | "failed" | "skipped";
   message?: string;
+}
+
+type StagedAgentStatus = "needs_setup" | "already_configured" | "not_detected";
+
+interface StagedAgentEntry {
+  id: string;
+  name: string;
+  status: StagedAgentStatus;
 }
 
 /** Tracks per-agent uninstall outcome for the summary */
@@ -231,6 +247,66 @@ function printAuthNotCheckedNextSteps(useColors: boolean): void {
   console.log();
   console.log("  If your agent asks you to sign in, run:");
   console.log(`    ${formatCommand("npx githits@latest login", useColors)}`);
+}
+
+function printAgenticLoginInstructions(useColors: boolean): void {
+  console.log(
+    "  Authentication is still required before agents can use GitHits.",
+  );
+  console.log();
+  console.log("  Agent instruction:");
+  console.log();
+  console.log("  Ask the user:");
+  console.log(
+    '    "GitHits needs to open a browser sign-in page. The sign-in happens in your browser, not in this chat or terminal. I will not see or handle your credentials. Should I run `githits login` now?"',
+  );
+  console.log();
+  console.log("  If the user approves, run:");
+  console.log(`    ${formatCommand("githits login", useColors)}`);
+  console.log();
+  console.log("  If the browser cannot open, run:");
+  console.log(`    ${formatCommand("githits login --no-browser", useColors)}`);
+}
+
+function printNonInteractiveInitGuidance(useColors: boolean): void {
+  console.log(
+    "  This setup is interactive. Because this session is non-interactive, no changes were made.",
+  );
+  console.log();
+  console.log(
+    "  If you are an AI coding agent helping a user install GitHits:",
+  );
+  console.log();
+  console.log("  1. Run:");
+  console.log(
+    `     ${formatCommand("githits init --detect-agents", useColors)}`,
+  );
+  console.log();
+  console.log("  2. Show the detected tools to the user.");
+  console.log();
+  console.log("  3. Ask which tools should receive the GitHits MCP server.");
+  console.log();
+  console.log("  4. Only after approval, run:");
+  console.log(
+    `     ${formatCommand("githits init --install-agents <ids>", useColors)}`,
+  );
+  console.log();
+  console.log("  Do not choose tools for the user.");
+}
+
+function printNonInteractiveYesRejected(useColors: boolean): void {
+  console.error(
+    "Non-interactive `githits init --yes` is not supported because it can configure tools without explicit per-tool approval.",
+  );
+  console.error();
+  console.error("Use the agent-safe staged flow instead:");
+  console.error(
+    `  ${formatCommand("githits init --detect-agents", useColors)}`,
+  );
+  console.error(
+    `  ${formatCommand("githits init --install-agents <ids>", useColors)}`,
+  );
+  process.exitCode = 1;
 }
 
 const GITHITS_ASCII_LOGO = String.raw`
@@ -569,6 +645,319 @@ function printScanSummary(scan: ScanResult, useColors: boolean): void {
   }
 }
 
+function buildStagedAgentEntries(scan: ScanResult): StagedAgentEntry[] {
+  const statuses = new Map<string, StagedAgentStatus>();
+  for (const agent of scan.needsSetup) statuses.set(agent.id, "needs_setup");
+  for (const agent of scan.alreadyConfigured) {
+    statuses.set(agent.id, "already_configured");
+  }
+  for (const agent of scan.notDetected) statuses.set(agent.id, "not_detected");
+
+  return agentDefinitions.map((agent) => ({
+    id: agent.id,
+    name: agent.name,
+    status: statuses.get(agent.id) ?? "not_detected",
+  }));
+}
+
+function printAgenticDetectSummary(scan: ScanResult, useColors: boolean): void {
+  const entries = buildStagedAgentEntries(scan);
+  const detected = entries.filter((entry) => entry.status !== "not_detected");
+  const installable = entries.filter((entry) => entry.status === "needs_setup");
+  const notDetected = entries.filter(
+    (entry) => entry.status === "not_detected",
+  );
+
+  console.log("Detected supported tools:");
+  console.log();
+  if (detected.length === 0) {
+    console.log("  None detected.");
+  } else {
+    console.log("  ID                 Tool                  Status");
+    for (const entry of detected) {
+      console.log(
+        `  ${entry.id.padEnd(18)} ${entry.name.padEnd(21)} ${entry.status.replace("_", " ")}`,
+      );
+    }
+  }
+
+  console.log();
+  console.log("Not detected:");
+  console.log(
+    `  ${notDetected.length > 0 ? notDetected.map((entry) => entry.id).join(", ") : "none"}`,
+  );
+  console.log();
+
+  if (installable.length === 0) {
+    console.log("No detected tools need setup.");
+    console.log();
+    console.log("Next step for agents:");
+    console.log(
+      "  Tell the user that GitHits is already configured for detected tools.",
+    );
+    return;
+  }
+
+  const installableIds = installable.map((entry) => entry.id);
+  console.log("Next step for agents:");
+  console.log();
+  console.log("  Ask the user:");
+  console.log(
+    `    "GitHits can be installed for ${installable.map((entry) => entry.name).join(", ")}. Which should I configure?"`,
+  );
+  console.log();
+  console.log("  If the user approves all detected tools needing setup, run:");
+  console.log(
+    `    ${formatCommand(`githits init --install-agents ${installableIds.join(",")}`, useColors)}`,
+  );
+  console.log();
+  console.log("  Do not choose tools for the user.");
+}
+
+function printAgenticDetectJson(scan: ScanResult): void {
+  const entries = buildStagedAgentEntries(scan);
+  const installableIds = entries
+    .filter((entry) => entry.status === "needs_setup")
+    .map((entry) => entry.id);
+  console.log(
+    JSON.stringify(
+      {
+        mode: "detect-agents",
+        agents: entries,
+        installableIds,
+        suggestedCommand:
+          installableIds.length > 0
+            ? `githits init --install-agents ${installableIds.join(",")}`
+            : null,
+        instructions: [
+          "Show detected tools to the user.",
+          "Ask which tools should receive the GitHits MCP server.",
+          "Run --install-agents only with user-approved IDs.",
+          "Do not choose tools for the user.",
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+function getStagedModeCount(options: InitOptions): number {
+  return [
+    options.detectAgents === true,
+    options.installAgents !== undefined,
+  ].filter(Boolean).length;
+}
+
+function failInitArgument(message: string, json: boolean | undefined): void {
+  if (json) {
+    console.error(JSON.stringify({ error: message, code: "INVALID_ARGUMENT" }));
+  } else {
+    console.error(message);
+  }
+  process.exitCode = 1;
+}
+
+function validateInitModeOptions(options: InitOptions): boolean {
+  const stagedModeCount = getStagedModeCount(options);
+  if (stagedModeCount > 1) {
+    failInitArgument(
+      "Use only one staged init mode: --detect-agents or --install-agents.",
+      options.json,
+    );
+    return false;
+  }
+  if (options.yes && stagedModeCount > 0) {
+    failInitArgument(
+      "--yes cannot be combined with --detect-agents or --install-agents.",
+      options.json,
+    );
+    return false;
+  }
+  if (options.json && stagedModeCount === 0) {
+    failInitArgument(
+      "--json is only supported with --detect-agents or --install-agents.",
+      options.json,
+    );
+    return false;
+  }
+  return true;
+}
+
+function parseAgentIdList(value: string | undefined): string[] {
+  if (!value) return [];
+  const ids = value
+    .split(",")
+    .map((id) => id.trim())
+    .filter((id) => id.length > 0);
+  return [...new Set(ids)];
+}
+
+function findAgentsByIds(scan: ScanResult, ids: string[]): AgentDefinition[] {
+  const detected = [...scan.needsSetup, ...scan.alreadyConfigured];
+  return ids
+    .map((id) => detected.find((agent) => agent.id === id))
+    .filter((agent): agent is AgentDefinition => Boolean(agent));
+}
+
+function validateInstallAgentIds(
+  scan: ScanResult,
+  ids: string[],
+): { ok: true } | { ok: false; message: string; detectedIds: string[] } {
+  const supportedIds = new Set(agentDefinitions.map((agent) => agent.id));
+  const detectedIds = [...scan.needsSetup, ...scan.alreadyConfigured].map(
+    (agent) => agent.id,
+  );
+  const detectedIdSet = new Set(detectedIds);
+  if (ids.length === 0) {
+    return {
+      ok: false,
+      message:
+        detectedIds.length > 0
+          ? `Provide at least one agent ID. Detected IDs: ${detectedIds.join(", ")}.`
+          : "Provide at least one agent ID. No supported agents are currently detected.",
+      detectedIds,
+    };
+  }
+
+  const unknown = ids.filter((id) => !supportedIds.has(id));
+  if (unknown.length > 0) {
+    return {
+      ok: false,
+      message: `Unsupported agent ID${unknown.length !== 1 ? "s" : ""}: ${unknown.join(", ")}.`,
+      detectedIds,
+    };
+  }
+
+  const undetected = ids.filter((id) => !detectedIdSet.has(id));
+  if (undetected.length > 0) {
+    return {
+      ok: false,
+      message: `Agent ID${undetected.length !== 1 ? "s" : ""} not detected: ${undetected.join(", ")}. Detected IDs: ${detectedIds.length > 0 ? detectedIds.join(", ") : "none"}.`,
+      detectedIds,
+    };
+  }
+
+  return { ok: true };
+}
+
+function printInstallValidationFailure(
+  failure: { message: string; detectedIds: string[] },
+  json: boolean | undefined,
+): void {
+  if (json) {
+    console.error(
+      JSON.stringify({
+        error: failure.message,
+        code: "INVALID_ARGUMENT",
+        detectedIds: failure.detectedIds,
+      }),
+    );
+  } else {
+    console.error(failure.message);
+  }
+  process.exitCode = 1;
+}
+
+function printAgenticInstallJson(outcomes: AgentOutcome[]): void {
+  console.log(
+    JSON.stringify(
+      {
+        mode: "install-agents",
+        outcomes,
+        auth: {
+          required: true,
+          command: "githits login",
+          noBrowserCommand: "githits login --no-browser",
+        },
+        instructions: [
+          "Ask the user before running githits login.",
+          "Browser sign-in happens outside chat and terminal input.",
+          "Do not ask the user to paste passwords, tokens, cookies, or OAuth codes into chat.",
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+async function runDetectAgentsMode(
+  options: InitOptions,
+  fileSystemService: FileSystemService,
+  execService: ExecService,
+  useColors: boolean,
+): Promise<void> {
+  const scan = await scanAgents(
+    agentDefinitions,
+    fileSystemService,
+    execService,
+  );
+  if (options.json) {
+    printAgenticDetectJson(scan);
+    return;
+  }
+
+  printAgenticDetectSummary(scan, useColors);
+}
+
+async function runInstallAgentsMode(
+  options: InitOptions,
+  fileSystemService: FileSystemService,
+  execService: ExecService,
+  useColors: boolean,
+): Promise<void> {
+  const requestedIds = parseAgentIdList(options.installAgents);
+  const scan = await scanAgents(
+    agentDefinitions,
+    fileSystemService,
+    execService,
+  );
+  const validation = validateInstallAgentIds(scan, requestedIds);
+  if (!validation.ok) {
+    printInstallValidationFailure(validation, options.json);
+    return;
+  }
+
+  const agents = findAgentsByIds(scan, requestedIds);
+  if (!options.json) {
+    console.log("Installing GitHits MCP:");
+    console.log();
+  }
+
+  const outcomes = await installSelectedAgents(
+    agents,
+    scan,
+    fileSystemService,
+    execService,
+    useColors,
+    !options.json,
+  );
+
+  const failed = outcomes.filter((outcome) => outcome.status === "failed");
+  if (failed.length > 0) {
+    process.exitCode = 1;
+  }
+
+  if (options.json) {
+    printAgenticInstallJson(outcomes);
+    return;
+  }
+
+  console.log();
+  if (failed.length === 0) {
+    console.log("GitHits MCP installation complete.");
+  } else {
+    console.log("GitHits MCP installation completed with errors.");
+    for (const outcome of failed) {
+      console.log(`  ${outcome.name}: ${outcome.message ?? "Unknown error"}`);
+    }
+  }
+  console.log();
+  printAgenticLoginInstructions(useColors);
+  console.log();
+}
+
 function printAuthExplanation(): void {
   console.log(
     "    GitHits authentication is required before your agent can use GitHits tools.",
@@ -743,6 +1132,101 @@ async function verifyAgentConfigured(
   };
 }
 
+async function executeAgentSetupWithVerification(
+  agent: AgentDefinition,
+  fileSystemService: FileSystemService,
+  execService: ExecService,
+): Promise<SetupResult> {
+  const config = getResolvedSetupConfig(agent, fileSystemService);
+  let result =
+    config.method === "cli"
+      ? await executeCliSetup(config, execService)
+      : config.method === "config-file"
+        ? await executeConfigFileSetup(config, fileSystemService)
+        : await executeCompositeSetup(config, fileSystemService, execService);
+
+  if (result.status === "success" || result.status === "already_configured") {
+    const verification = await verifyAgentConfigured(
+      agent,
+      fileSystemService,
+      execService,
+    );
+    if (!verification.ok) {
+      result = {
+        status: "failed",
+        message:
+          agent.id === "gemini-cli"
+            ? "Gemini installation did not complete. Retry, or run: gemini extensions install --consent https://github.com/githits-com/githits-cli"
+            : (verification.message ??
+              `${agent.name} verification failed after setup.`),
+      };
+    }
+  }
+
+  return result;
+}
+
+async function installSelectedAgents(
+  agents: AgentDefinition[],
+  scan: ScanResult,
+  fileSystemService: FileSystemService,
+  execService: ExecService,
+  useColors: boolean,
+  printResults: boolean,
+): Promise<AgentOutcome[]> {
+  const alreadyConfiguredIds = new Set(
+    scan.alreadyConfigured.map((agent) => agent.id),
+  );
+  const outcomes: AgentOutcome[] = [];
+  const installTasks = createInstallTaskReporter(useColors);
+
+  for (const agent of agents) {
+    if (alreadyConfiguredIds.has(agent.id)) {
+      outcomes.push({
+        id: agent.id,
+        name: agent.name,
+        status: "already_configured",
+      });
+      if (printResults) {
+        printTask("warning", agent.name, "already configured", useColors);
+      }
+      continue;
+    }
+
+    const finishTask = printResults ? installTasks.start(agent.name) : () => {};
+    let result: SetupResult;
+    try {
+      result = await executeAgentSetupWithVerification(
+        agent,
+        fileSystemService,
+        execService,
+      );
+    } finally {
+      finishTask();
+    }
+
+    outcomes.push({
+      id: agent.id,
+      name: agent.name,
+      status: result.status,
+      message: result.status === "failed" ? result.message : undefined,
+    });
+
+    if (!printResults) {
+      continue;
+    }
+    if (result.status === "success") {
+      printTask("success", agent.name, "configured and verified", useColors);
+    } else if (result.status === "already_configured") {
+      printTask("warning", agent.name, "already configured", useColors);
+    } else {
+      printTask("failed", agent.name, result.message, useColors);
+    }
+  }
+
+  return outcomes;
+}
+
 async function verifyAgentUnconfigured(
   agent: (typeof agentDefinitions)[number],
   fileSystemService: FileSystemService,
@@ -913,7 +1397,43 @@ export async function initAction(
   const useColors = shouldUseColors();
   const { fileSystemService, promptService, execService, createLoginDeps } =
     deps;
+  const isInteractive = deps.isInteractive ?? true;
+
+  if (!validateInitModeOptions(options)) {
+    return;
+  }
+
+  if (options.detectAgents) {
+    await runDetectAgentsMode(
+      options,
+      fileSystemService,
+      execService,
+      useColors,
+    );
+    return;
+  }
+
+  if (options.installAgents !== undefined) {
+    await runInstallAgentsMode(
+      options,
+      fileSystemService,
+      execService,
+      useColors,
+    );
+    return;
+  }
+
   printInitIntro(useColors);
+
+  if (!isInteractive) {
+    if (options.yes) {
+      printNonInteractiveYesRejected(useColors);
+      return;
+    }
+    printNonInteractiveInitGuidance(useColors);
+    console.log();
+    return;
+  }
 
   if (!options.yes) {
     let intent: InitIntent;
@@ -996,8 +1516,6 @@ export async function initAction(
     printTask("success", "Selected all detected tools", "--yes", useColors);
   }
 
-  const outcomes: AgentOutcome[] = [];
-
   if (toSetup.length === 0 && scan.needsSetup.length > 0) {
     printTask("skipped", "Setup skipped", "no tools selected", useColors);
     console.log();
@@ -1028,63 +1546,14 @@ export async function initAction(
     return;
   }
 
-  const installTasks = createInstallTaskReporter(useColors);
-  for (const agent of toSetup) {
-    const config = getResolvedSetupConfig(agent, fileSystemService);
-    const finishTask = installTasks.start(agent.name);
-
-    let result: SetupResult;
-    try {
-      result =
-        config.method === "cli"
-          ? await executeCliSetup(config, execService)
-          : config.method === "config-file"
-            ? await executeConfigFileSetup(config, fileSystemService)
-            : await executeCompositeSetup(
-                config,
-                fileSystemService,
-                execService,
-              );
-
-      if (
-        result.status === "success" ||
-        result.status === "already_configured"
-      ) {
-        const verification = await verifyAgentConfigured(
-          agent,
-          fileSystemService,
-          execService,
-        );
-        if (!verification.ok) {
-          result = {
-            status: "failed",
-            message:
-              agent.id === "gemini-cli"
-                ? "Gemini installation did not complete. Retry, or run: gemini extensions install --consent https://github.com/githits-com/githits-cli"
-                : (verification.message ??
-                  `${agent.name} verification failed after setup.`),
-          };
-        }
-      }
-    } finally {
-      finishTask();
-    }
-
-    outcomes.push({
-      id: agent.id,
-      name: agent.name,
-      status: result.status,
-      message: result.status === "failed" ? result.message : undefined,
-    });
-
-    if (result.status === "success") {
-      printTask("success", agent.name, "configured and verified", useColors);
-    } else if (result.status === "already_configured") {
-      printTask("warning", agent.name, "already configured", useColors);
-    } else {
-      printTask("failed", agent.name, result.message, useColors);
-    }
-  }
+  const outcomes = await installSelectedAgents(
+    toSetup,
+    scan,
+    fileSystemService,
+    execService,
+    useColors,
+    true,
+  );
 
   console.log();
 
@@ -1362,6 +1831,12 @@ export function registerInitCommand(program: Command) {
     .description(INIT_DESCRIPTION)
     .option("-y, --yes", "Skip prompts, configure all detected tools")
     .option("--skip-login", "Skip authentication step")
+    .option("--detect-agents", "Scan supported agents without installing")
+    .option(
+      "--install-agents <ids>",
+      "Install MCP server for comma-separated agent IDs from --detect-agents",
+    )
+    .option("--json", "Emit JSON for --detect-agents or --install-agents")
     .action(async (options: InitOptions) => {
       const fileSystemService = new FileSystemServiceImpl();
       const promptService = new PromptServiceImpl();
@@ -1371,6 +1846,8 @@ export function registerInitCommand(program: Command) {
         promptService,
         execService,
         createLoginDeps: () => createContainer(),
+        isInteractive:
+          process.stdin.isTTY === true && process.stdout.isTTY === true,
       });
     });
 

--- a/src/commands/init/init.ts
+++ b/src/commands/init/init.ts
@@ -142,6 +142,8 @@ type InitAuthStatus =
   | "failed_continue"
   | "cancelled";
 
+type StagedInstallAuthStatus = "authenticated" | "required" | "not_checked";
+
 type SafeScanResult =
   | { ok: true; scan: ScanResult }
   | { ok: false; error: Error };
@@ -274,6 +276,19 @@ function printAgenticLoginInstructions(useColors: boolean): void {
   console.log(
     `    ${formatCommand(AGENT_LOGIN_NO_BROWSER_COMMAND, useColors)}`,
   );
+}
+
+function printAgenticAlreadyAuthenticated(): void {
+  console.log("  GitHits MCP is installed and you are already signed in.");
+  console.log();
+  console.log("  Open a new coding agent session so it reloads MCP config.");
+}
+
+function printAgenticAuthNotChecked(useColors: boolean): void {
+  console.log("  GitHits MCP is installed. Sign-in status was not checked.");
+  console.log();
+  console.log("  If the user is not already signed in, ask before running:");
+  console.log(`    ${formatCommand(AGENT_LOGIN_COMMAND, useColors)}`);
 }
 
 function printNonInteractiveInitGuidance(useColors: boolean): void {
@@ -870,7 +885,70 @@ function hasUsableInstallOutcome(outcomes: AgentOutcome[]): boolean {
   );
 }
 
-function printAgenticInstallJson(outcomes: AgentOutcome[]): void {
+async function getStagedInstallAuthStatus(
+  createLoginDeps: InitDependencies["createLoginDeps"],
+): Promise<StagedInstallAuthStatus> {
+  if (!createLoginDeps) return "not_checked";
+  try {
+    const loginDeps = await createLoginDeps();
+    if (typeof loginDeps.hasValidToken === "boolean") {
+      return loginDeps.hasValidToken ? "authenticated" : "required";
+    }
+    const tokens = await loginDeps.authStorage.loadTokens(loginDeps.mcpUrl);
+    const expired = tokens?.expiresAt
+      ? new Date(tokens.expiresAt) < new Date()
+      : false;
+    return tokens && !expired ? "authenticated" : "required";
+  } catch {
+    return "not_checked";
+  }
+}
+
+function buildAgenticInstallAuthPayload(
+  authStatus: StagedInstallAuthStatus,
+): Record<string, unknown> {
+  if (authStatus === "authenticated") {
+    return { required: false, status: "authenticated" };
+  }
+  if (authStatus === "required") {
+    return {
+      required: true,
+      status: "required",
+      command: AGENT_LOGIN_COMMAND,
+      noBrowserCommand: AGENT_LOGIN_NO_BROWSER_COMMAND,
+    };
+  }
+  return {
+    required: null,
+    status: "not_checked",
+    command: AGENT_LOGIN_COMMAND,
+    noBrowserCommand: AGENT_LOGIN_NO_BROWSER_COMMAND,
+  };
+}
+
+function buildAgenticInstallInstructions(
+  authStatus: StagedInstallAuthStatus,
+): string[] {
+  if (authStatus === "authenticated") {
+    return ["Open a new coding agent session so it reloads MCP config."];
+  }
+  if (authStatus === "required") {
+    return [
+      `Ask the user before running ${AGENT_LOGIN_COMMAND}.`,
+      "Browser sign-in happens outside chat and terminal input.",
+      "Do not ask the user to paste passwords, tokens, cookies, or OAuth codes into chat.",
+    ];
+  }
+  return [
+    "Sign-in status was not checked.",
+    `If the user is not already signed in, ask before running ${AGENT_LOGIN_COMMAND}.`,
+  ];
+}
+
+function printAgenticInstallJson(
+  outcomes: AgentOutcome[],
+  authStatus: StagedInstallAuthStatus,
+): void {
   const canAuthenticate = hasUsableInstallOutcome(outcomes);
   console.log(
     JSON.stringify(
@@ -878,21 +956,14 @@ function printAgenticInstallJson(outcomes: AgentOutcome[]): void {
         mode: "install-agents",
         outcomes,
         auth: canAuthenticate
-          ? {
-              required: true,
-              command: AGENT_LOGIN_COMMAND,
-              noBrowserCommand: AGENT_LOGIN_NO_BROWSER_COMMAND,
-            }
+          ? buildAgenticInstallAuthPayload(authStatus)
           : {
               required: false,
+              status: "not_applicable",
               reason: "Fix installation errors before starting sign-in.",
             },
         instructions: canAuthenticate
-          ? [
-              `Ask the user before running ${AGENT_LOGIN_COMMAND}.`,
-              "Browser sign-in happens outside chat and terminal input.",
-              "Do not ask the user to paste passwords, tokens, cookies, or OAuth codes into chat.",
-            ]
+          ? buildAgenticInstallInstructions(authStatus)
           : ["Fix installation errors before asking the user to sign in."],
       },
       null,
@@ -924,6 +995,7 @@ async function runInstallAgentsMode(
   options: InitOptions,
   fileSystemService: FileSystemService,
   execService: ExecService,
+  createLoginDeps: InitDependencies["createLoginDeps"],
   useColors: boolean,
 ): Promise<void> {
   const requestedIds = parseAgentIdList(options.installAgents);
@@ -955,12 +1027,15 @@ async function runInstallAgentsMode(
 
   const failed = outcomes.filter((outcome) => outcome.status === "failed");
   const canAuthenticate = hasUsableInstallOutcome(outcomes);
+  const authStatus = canAuthenticate
+    ? await getStagedInstallAuthStatus(createLoginDeps)
+    : "not_checked";
   if (failed.length > 0) {
     process.exitCode = 1;
   }
 
   if (options.json) {
-    printAgenticInstallJson(outcomes);
+    printAgenticInstallJson(outcomes, authStatus);
     return;
   }
 
@@ -975,7 +1050,13 @@ async function runInstallAgentsMode(
   }
   console.log();
   if (canAuthenticate) {
-    printAgenticLoginInstructions(useColors);
+    if (authStatus === "authenticated") {
+      printAgenticAlreadyAuthenticated();
+    } else if (authStatus === "required") {
+      printAgenticLoginInstructions(useColors);
+    } else {
+      printAgenticAuthNotChecked(useColors);
+    }
   } else {
     console.log("Fix installation errors before starting sign-in.");
   }
@@ -1442,6 +1523,7 @@ export async function initAction(
       options,
       fileSystemService,
       execService,
+      createLoginDeps,
       useColors,
     );
     return;

--- a/src/commands/init/init.ts
+++ b/src/commands/init/init.ts
@@ -707,6 +707,16 @@ function printAgenticDetectSummary(scan: ScanResult, useColors: boolean): void {
   );
   console.log();
 
+  if (detected.length === 0) {
+    console.log("No supported AI coding tools detected.");
+    console.log();
+    console.log("Next step for agents:");
+    console.log(
+      "  Tell the user to install a supported coding tool, then run detection again.",
+    );
+    return;
+  }
+
   if (installable.length === 0) {
     console.log("No detected tools need setup.");
     console.log();

--- a/src/commands/init/init.ts
+++ b/src/commands/init/init.ts
@@ -198,6 +198,12 @@ function formatCommand(command: string, useColors: boolean): string {
   return colorizeBrand(command, "secondary", useColors, { bold: true });
 }
 
+const AGENT_SAFE_CLI = "npx -y githits@latest";
+const AGENT_DETECT_COMMAND = `${AGENT_SAFE_CLI} init --detect-agents`;
+const AGENT_INSTALL_COMMAND = `${AGENT_SAFE_CLI} init --install-agents`;
+const AGENT_LOGIN_COMMAND = `${AGENT_SAFE_CLI} login`;
+const AGENT_LOGIN_NO_BROWSER_COMMAND = `${AGENT_SAFE_CLI} login --no-browser`;
+
 function printReadyNextSteps(): void {
   console.log("  GitHits is now connected to your coding agents.");
   console.log();
@@ -258,14 +264,16 @@ function printAgenticLoginInstructions(useColors: boolean): void {
   console.log();
   console.log("  Ask the user:");
   console.log(
-    '    "GitHits needs to open a browser sign-in page. The sign-in happens in your browser, not in this chat or terminal. I will not see or handle your credentials. Should I run `githits login` now?"',
+    `    "GitHits needs to open a browser sign-in page. The sign-in happens in your browser, not in this chat or terminal. I will not see or handle your credentials. Should I run \`${AGENT_LOGIN_COMMAND}\` now?"`,
   );
   console.log();
   console.log("  If the user approves, run:");
-  console.log(`    ${formatCommand("githits login", useColors)}`);
+  console.log(`    ${formatCommand(AGENT_LOGIN_COMMAND, useColors)}`);
   console.log();
   console.log("  If the browser cannot open, run:");
-  console.log(`    ${formatCommand("githits login --no-browser", useColors)}`);
+  console.log(
+    `    ${formatCommand(AGENT_LOGIN_NO_BROWSER_COMMAND, useColors)}`,
+  );
 }
 
 function printNonInteractiveInitGuidance(useColors: boolean): void {
@@ -278,9 +286,7 @@ function printNonInteractiveInitGuidance(useColors: boolean): void {
   );
   console.log();
   console.log("  1. Run:");
-  console.log(
-    `     ${formatCommand("githits init --detect-agents", useColors)}`,
-  );
+  console.log(`     ${formatCommand(AGENT_DETECT_COMMAND, useColors)}`);
   console.log();
   console.log("  2. Show the detected tools to the user.");
   console.log();
@@ -288,7 +294,7 @@ function printNonInteractiveInitGuidance(useColors: boolean): void {
   console.log();
   console.log("  4. Only after approval, run:");
   console.log(
-    `     ${formatCommand("githits init --install-agents <ids>", useColors)}`,
+    `     ${formatCommand(`${AGENT_INSTALL_COMMAND} <ids>`, useColors)}`,
   );
   console.log();
   console.log("  Do not choose tools for the user.");
@@ -300,11 +306,9 @@ function printNonInteractiveYesRejected(useColors: boolean): void {
   );
   console.error();
   console.error("Use the agent-safe staged flow instead:");
+  console.error(`  ${formatCommand(AGENT_DETECT_COMMAND, useColors)}`);
   console.error(
-    `  ${formatCommand("githits init --detect-agents", useColors)}`,
-  );
-  console.error(
-    `  ${formatCommand("githits init --install-agents <ids>", useColors)}`,
+    `  ${formatCommand(`${AGENT_INSTALL_COMMAND} <ids>`, useColors)}`,
   );
   process.exitCode = 1;
 }
@@ -708,7 +712,7 @@ function printAgenticDetectSummary(scan: ScanResult, useColors: boolean): void {
   console.log();
   console.log("  If the user approves all detected tools needing setup, run:");
   console.log(
-    `    ${formatCommand(`githits init --install-agents ${installableIds.join(",")}`, useColors)}`,
+    `    ${formatCommand(`${AGENT_INSTALL_COMMAND} ${installableIds.join(",")}`, useColors)}`,
   );
   console.log();
   console.log("  Do not choose tools for the user.");
@@ -727,7 +731,7 @@ function printAgenticDetectJson(scan: ScanResult): void {
         installableIds,
         suggestedCommand:
           installableIds.length > 0
-            ? `githits init --install-agents ${installableIds.join(",")}`
+            ? `${AGENT_INSTALL_COMMAND} ${installableIds.join(",")}`
             : null,
         instructions: [
           "Show detected tools to the user.",
@@ -876,8 +880,8 @@ function printAgenticInstallJson(outcomes: AgentOutcome[]): void {
         auth: canAuthenticate
           ? {
               required: true,
-              command: "githits login",
-              noBrowserCommand: "githits login --no-browser",
+              command: AGENT_LOGIN_COMMAND,
+              noBrowserCommand: AGENT_LOGIN_NO_BROWSER_COMMAND,
             }
           : {
               required: false,
@@ -885,7 +889,7 @@ function printAgenticInstallJson(outcomes: AgentOutcome[]): void {
             },
         instructions: canAuthenticate
           ? [
-              "Ask the user before running githits login.",
+              `Ask the user before running ${AGENT_LOGIN_COMMAND}.`,
               "Browser sign-in happens outside chat and terminal input.",
               "Do not ask the user to paste passwords, tokens, cookies, or OAuth codes into chat.",
             ]


### PR DESCRIPTION
This pull request expands and tests the new staged, agent-safe onboarding flow for the `githits init` CLI command. It adds new flags, updates documentation, and introduces comprehensive test coverage for non-interactive and agent onboarding scenarios, ensuring the CLI behaves safely and predictably in both interactive and automated environments.

**Documentation updates:**

* Added `--detect-agents`, `--install-agents <ids>`, and `--json` flags to the `init` command documentation, and described the staged, agent-safe onboarding process for non-interactive environments. Clarified behavior when running without a TTY and the rejection of `--yes` for non-interactive safety. [[1]](diffhunk://#diff-6ce42bd222561aafada36f783f1e0e25fdf2f3f71e52b279d1c769d626eab2d2L11-R11) [[2]](diffhunk://#diff-6ce42bd222561aafada36f783f1e0e25fdf2f3f71e52b279d1c769d626eab2d2L33-R45)

**Testing and implementation:**

* Added extensive tests for the new staged onboarding modes, including:
  - Guidance and safety checks for non-interactive mode (prints instructions, no side effects).
  - Rejection of non-interactive `--yes` before any agent scan or config.
  - Detection and JSON output for supported agents.
  - Staged install mode: installs only explicitly requested agents, handles already-configured agents idempotently, suppresses login instructions on failure, and validates agent IDs.
  - Error handling for unknown or undetected agent IDs and for misuse of `--yes` with staged modes.
* Added helper mocks and utilities for agent detection, login state, and error/output capturing to support the new tests. [[1]](diffhunk://#diff-efe3745db077bf907464486add8cd96684abb96505806f75d1aa6d07f0b5f84aR34-R47) [[2]](diffhunk://#diff-efe3745db077bf907464486add8cd96684abb96505806f75d1aa6d07f0b5f84aR70-R85) [[3]](diffhunk://#diff-efe3745db077bf907464486add8cd96684abb96505806f75d1aa6d07f0b5f84aR117-R120)
* Verified that the CLI registers the new staged onboarding options.