### PR TITLE
fix: clarify the agent's local-only scope in the init intro

### DIFF
--- a/src/commands/init/init.test.ts
+++ b/src/commands/init/init.test.ts
@@ -595,7 +595,7 @@ describe("initAction", () => {
     const logCalls = getLogOutput();
     expect(
       logCalls.some((msg) =>
-        msg.includes("Your agent can read your local codebase"),
+        msg.includes("Your agent can only read your local codebase"),
       ),
     ).toBe(true);
     expect(

--- a/src/commands/init/init.ts
+++ b/src/commands/init/init.ts
@@ -487,7 +487,7 @@ function printTask(
 
 function printInitIntro(useColors: boolean): void {
   console.log(colorizeLogo(GITHITS_ASCII_LOGO, useColors));
-  console.log("  Your agent can read your local codebase.");
+  console.log("  Your agent can only read your local codebase.");
   console.log();
   console.log(
     "  GitHits lets it navigate the open-source code your app depends on.",


### PR DESCRIPTION
## Summary

Adds "only" to the init intro opener so it reads *"Your agent can only read your local codebase."* — sharpens the emphasis on the local-scope limitation that GitHits addresses.

One-word copy tweak; the existing test assertion was updated to match.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test src/commands/init/init.test.ts` green (existing assertion updated)
- [x] `bun run dev init` — eyeball the new line in the intro

🤖 Generated with [Claude Code](https://claude.com/claude-code)