### PR TITLE
Add Hermes Agent init support

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "GitHits plugins for Claude Code - code examples from global open source",
-    "version": "0.4.7"
+    "version": "0.4.8"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "description": "Code examples from global open source for developers and AI assistants",
   "author": {
     "name": "GitHits"

--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "description": "Code examples from global open source for developers and AI assistants",
   "author": {
     "name": "GitHits"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ npx githits init
 
 `init` walks you through setup: choose the local MCP server or Agent Skills, detect your coding tools, sign in, and connect everything to GitHits.
 
-Supported tools: Claude Code, Cursor, Windsurf, VS Code / Copilot, Cline, Claude Desktop, Codex CLI, Pi, Gemini CLI, Google Antigravity, and OpenCode.
+Supported tools: Claude Code, Cursor, Windsurf, VS Code / Copilot, Cline, Claude Desktop, Codex CLI, Pi, Gemini CLI, Google Antigravity, OpenCode, and Hermes Agent.
 
 If you are using a tool that is not listed above, use the manual MCP setup instructions near the end of this README.
 

--- a/bun.lock
+++ b/bun.lock
@@ -13,6 +13,7 @@
         "open": "^11.0.0",
         "semver": "^7.8.0",
         "smol-toml": "^1.6.1",
+        "yaml": "^2.9.0",
         "zod": "^4.4.3",
       },
       "devDependencies": {

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "description": "Code examples from global open source for developers and AI assistants.",
   "mcpServers": {
     "githits": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "githits",
   "description": "CLI companion for GitHits - code examples from global open source for developers and AI assistants",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "type": "module",
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "open": "^11.0.0",
     "semver": "^7.8.0",
     "smol-toml": "^1.6.1",
+    "yaml": "^2.9.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "description": "Code examples from global open source for developers and AI assistants",
   "author": {
     "name": "GitHits"

--- a/src/commands/init/agent-definitions.test.ts
+++ b/src/commands/init/agent-definitions.test.ts
@@ -13,8 +13,8 @@ import {
 } from "./agent-definitions.js";
 
 describe("agentDefinitions", () => {
-  it("defines 11 agents", () => {
-    expect(agentDefinitions).toHaveLength(11);
+  it("defines 12 agents", () => {
+    expect(agentDefinitions).toHaveLength(12);
   });
 
   it("has unique ids", () => {
@@ -97,6 +97,50 @@ describe("detection configuration", () => {
     const agent = agentDefinitions.find((a) => a.id === "opencode")!;
     expect(agent.detectBinary).toBeDefined();
     expect(agent.detectPaths).toBeDefined();
+  });
+
+  it("hermes-agent uses hybrid detection", () => {
+    const agent = agentDefinitions.find((a) => a.id === "hermes-agent")!;
+    expect(agent.detectBinary).toBeDefined();
+    expect(agent.detectPaths).toBeDefined();
+  });
+
+  it("hermes-agent detects default ~/.hermes directory", () => {
+    const originalHermesHome = process.env.HERMES_HOME;
+    delete process.env.HERMES_HOME;
+    try {
+      const fs = createMockFileSystemService({
+        getHomeDir: mock(() => "/home/test"),
+        joinPath: mock((...segments: string[]) => segments.join("/")),
+      });
+      const agent = agentDefinitions.find((a) => a.id === "hermes-agent")!;
+      const paths = agent.detectPaths?.(fs);
+      expect(paths).toEqual(["/home/test/.hermes"]);
+    } finally {
+      if (originalHermesHome !== undefined) {
+        process.env.HERMES_HOME = originalHermesHome;
+      }
+    }
+  });
+
+  it("hermes-agent respects HERMES_HOME for detection", () => {
+    const originalHermesHome = process.env.HERMES_HOME;
+    process.env.HERMES_HOME = "~/custom-hermes";
+    try {
+      const fs = createMockFileSystemService({
+        getHomeDir: mock(() => "/home/test"),
+        joinPath: mock((...segments: string[]) => segments.join("/")),
+      });
+      const agent = agentDefinitions.find((a) => a.id === "hermes-agent")!;
+      const paths = agent.detectPaths?.(fs);
+      expect(paths).toEqual(["/home/test/custom-hermes"]);
+    } finally {
+      if (originalHermesHome !== undefined) {
+        process.env.HERMES_HOME = originalHermesHome;
+      } else {
+        delete process.env.HERMES_HOME;
+      }
+    }
   });
 
   it("opencode includes desktop and config detection paths on linux", () => {
@@ -970,6 +1014,57 @@ describe("getSetupConfig", () => {
     }
   });
 
+  it("hermes-agent returns YAML config-file setup with mcp_servers key", () => {
+    const originalHermesHome = process.env.HERMES_HOME;
+    delete process.env.HERMES_HOME;
+    try {
+      const fs = createMockFileSystemService({
+        getHomeDir: mock(() => "/home/test"),
+        joinPath: mock((...segments: string[]) => segments.join("/")),
+      });
+      const agent = agentDefinitions.find((a) => a.id === "hermes-agent")!;
+      const config = agent.getSetupConfig(fs);
+      expect(config.method).toBe("config-file");
+      if (config.method === "config-file") {
+        expect(config.format).toBe("yaml");
+        expect(config.configPath).toBe("/home/test/.hermes/config.yaml");
+        expect(config.serversKey).toBe("mcp_servers");
+        expect(config.serverName).toBe("GitHits");
+        expect(config.serverConfig).toEqual({
+          command: "npx",
+          args: ["-y", "githits@latest", "mcp", "start"],
+        });
+      }
+    } finally {
+      if (originalHermesHome !== undefined) {
+        process.env.HERMES_HOME = originalHermesHome;
+      }
+    }
+  });
+
+  it("hermes-agent respects HERMES_HOME for config path", () => {
+    const originalHermesHome = process.env.HERMES_HOME;
+    process.env.HERMES_HOME = "~/custom-hermes";
+    try {
+      const fs = createMockFileSystemService({
+        getHomeDir: mock(() => "/home/test"),
+        joinPath: mock((...segments: string[]) => segments.join("/")),
+      });
+      const agent = agentDefinitions.find((a) => a.id === "hermes-agent")!;
+      const config = agent.getSetupConfig(fs);
+      expect(config.method).toBe("config-file");
+      if (config.method === "config-file") {
+        expect(config.configPath).toBe("/home/test/custom-hermes/config.yaml");
+      }
+    } finally {
+      if (originalHermesHome !== undefined) {
+        process.env.HERMES_HOME = originalHermesHome;
+      } else {
+        delete process.env.HERMES_HOME;
+      }
+    }
+  });
+
   it("all config-file agents use npm githits@latest mcp start command", () => {
     const fs = createMockFileSystemService({
       getHomeDir: mock(() => "/home/test"),
@@ -986,6 +1081,13 @@ describe("getSetupConfig", () => {
             type: "local",
             command: ["npx", "-y", "githits@latest", "mcp", "start"],
             enabled: true,
+          });
+        } else if (agent.id === "hermes-agent") {
+          expect(config.format).toBe("yaml");
+          expect(config.serversKey).toBe("mcp_servers");
+          expect(config.serverConfig).toEqual({
+            command: "npx",
+            args: ["-y", "githits@latest", "mcp", "start"],
           });
         } else {
           expect(config.serverConfig).toEqual({
@@ -1032,12 +1134,13 @@ describe("detectAgents", () => {
     });
     const detected = await detectAgents(agentDefinitions, fs);
     // detectAgents (deprecated) checks path and hybrid agents
-    expect(detected).toHaveLength(7);
+    expect(detected).toHaveLength(8);
     expect(detected).not.toContain("claude-code");
     expect(detected).not.toContain("codex-cli");
     expect(detected).not.toContain("pi");
     expect(detected).not.toContain("gemini-cli");
     expect(detected).toContain("opencode");
+    expect(detected).toContain("hermes-agent");
   });
 });
 
@@ -1316,6 +1419,40 @@ describe("scanAgents", () => {
     const result = await scanAgents(agentDefinitions, fs, execService);
     expect(result.needsSetup.some((a) => a.id === "opencode")).toBe(true);
     expect(result.notDetected.some((a) => a.id === "opencode")).toBe(false);
+  });
+
+  it("detects Hermes Agent via hermes-agent binary when directory does not exist", async () => {
+    const lookupCmd = lookupCommandFor();
+    const { fs, execService } = createScanMocks({
+      detectedDirs: [],
+      execResults: {
+        [`${lookupCmd} hermes-agent`]: {
+          exitCode: 0,
+          stdout: "/usr/bin/hermes-agent\n",
+          stderr: "",
+        },
+      },
+    });
+    const result = await scanAgents(agentDefinitions, fs, execService);
+    expect(result.needsSetup.some((a) => a.id === "hermes-agent")).toBe(true);
+    expect(result.notDetected.some((a) => a.id === "hermes-agent")).toBe(false);
+  });
+
+  it("does not detect Hermes Agent from generic hermes binary alone", async () => {
+    const lookupCmd = lookupCommandFor();
+    const { fs, execService } = createScanMocks({
+      detectedDirs: [],
+      execResults: {
+        [`${lookupCmd} hermes`]: {
+          exitCode: 0,
+          stdout: "/usr/bin/hermes\n",
+          stderr: "",
+        },
+      },
+    });
+    const result = await scanAgents(agentDefinitions, fs, execService);
+    expect(result.notDetected.some((a) => a.id === "hermes-agent")).toBe(true);
+    expect(result.needsSetup.some((a) => a.id === "hermes-agent")).toBe(false);
   });
 
   it("detects codex via detectBinary when directory does not exist", async () => {
@@ -1827,6 +1964,55 @@ describe("scanAgents", () => {
     }
   });
 
+  it("detects Hermes Agent from default config directory when binary is missing", async () => {
+    const originalHermesHome = process.env.HERMES_HOME;
+    delete process.env.HERMES_HOME;
+    try {
+      const { fs, execService } = createScanMocks({
+        detectedDirs: ["/home/test/.hermes"],
+      });
+      const result = await scanAgents(agentDefinitions, fs, execService);
+      expect(result.notDetected.some((a) => a.id === "hermes-agent")).toBe(
+        false,
+      );
+      expect(result.needsSetup.some((a) => a.id === "hermes-agent")).toBe(true);
+    } finally {
+      if (originalHermesHome !== undefined) {
+        process.env.HERMES_HOME = originalHermesHome;
+      }
+    }
+  });
+
+  it("categorizes Hermes Agent as alreadyConfigured when YAML config has GitHits", async () => {
+    const originalHermesHome = process.env.HERMES_HOME;
+    delete process.env.HERMES_HOME;
+    try {
+      const { fs, execService } = createScanMocks({
+        detectedDirs: ["/home/test/.hermes"],
+        configFiles: {
+          "/home/test/.hermes/config.yaml": [
+            "mcp_servers:",
+            "  GitHits:",
+            '    command: "npx"',
+            '    args: ["-y", "githits@latest", "mcp", "start"]',
+            "",
+          ].join("\n"),
+        },
+      });
+      const result = await scanAgents(agentDefinitions, fs, execService);
+      expect(
+        result.alreadyConfigured.some((a) => a.id === "hermes-agent"),
+      ).toBe(true);
+      expect(result.needsSetup.some((a) => a.id === "hermes-agent")).toBe(
+        false,
+      );
+    } finally {
+      if (originalHermesHome !== undefined) {
+        process.env.HERMES_HOME = originalHermesHome;
+      }
+    }
+  });
+
   it("categorizes undetected agent as notDetected", async () => {
     const { fs, execService } = createScanMocks({ detectedDirs: [] });
     const result = await scanAgents(agentDefinitions, fs, execService);
@@ -1913,6 +2099,7 @@ describe("scanAgents", () => {
       "/home/test/.codeium/windsurf",
       "/home/test/.cline",
       "/home/test/.gemini/antigravity",
+      "/home/test/.hermes",
     ];
     // Platform-dependent detect dirs
     const vscodePath = `${appDataPrefix}/Code`;
@@ -2000,6 +2187,13 @@ describe("scanAgents", () => {
           },
         },
       }),
+      "/home/test/.hermes/config.yaml": [
+        "mcp_servers:",
+        "  GitHits:",
+        '    command: "npx"',
+        '    args: ["-y", "githits@latest", "mcp", "start"]',
+        "",
+      ].join("\n"),
       "/home/test/.pi/agent/mcp.json": JSON.stringify({
         mcpServers: {
           GitHits: {
@@ -2061,6 +2255,11 @@ describe("scanAgents", () => {
         stdout: "/usr/bin/opencode\n",
         stderr: "",
       },
+      [`${whichCmd} hermes-agent`]: {
+        exitCode: 0,
+        stdout: "/usr/bin/hermes-agent\n",
+        stderr: "",
+      },
     };
 
     describe(`comprehensive all-agents scenarios (${platform})`, () => {
@@ -2087,7 +2286,7 @@ describe("scanAgents", () => {
           execResults: allCliConfigured,
         });
         const result = await scanAgents(agentDefinitions, fs, execService);
-        expect(result.alreadyConfigured).toHaveLength(11);
+        expect(result.alreadyConfigured).toHaveLength(12);
         expect(result.needsSetup).toHaveLength(0);
         expect(result.notDetected).toHaveLength(0);
       });
@@ -2110,6 +2309,7 @@ describe("scanAgents", () => {
           [`${opencodePath}/opencode.json`]: JSON.stringify({
             mcp: {},
           }),
+          "/home/test/.hermes/config.yaml": "mcp_servers: {}\n",
         };
         const { fs, execService } = createScanMocks({
           detectedDirs: allDetectDirs,
@@ -2140,11 +2340,16 @@ describe("scanAgents", () => {
               stdout: "/usr/bin/opencode\n",
               stderr: "",
             },
+            [`${whichCmd} hermes-agent`]: {
+              exitCode: 0,
+              stdout: "/usr/bin/hermes-agent\n",
+              stderr: "",
+            },
           },
         });
         const result = await scanAgents(agentDefinitions, fs, execService);
         expect(result.alreadyConfigured).toHaveLength(0);
-        expect(result.needsSetup).toHaveLength(11);
+        expect(result.needsSetup).toHaveLength(12);
         expect(result.notDetected).toHaveLength(0);
       });
 
@@ -2153,10 +2358,10 @@ describe("scanAgents", () => {
         const result = await scanAgents(agentDefinitions, fs, execService);
         expect(result.alreadyConfigured).toHaveLength(0);
         expect(result.needsSetup).toHaveLength(0);
-        expect(result.notDetected).toHaveLength(11);
+        expect(result.notDetected).toHaveLength(12);
       });
 
-      it("mixed: 3 configured, 4 unconfigured, 3 not detected", async () => {
+      it("mixed: 3 configured, 4 unconfigured, 5 not detected", async () => {
         const { fs, execService } = createScanMocks({
           detectedDirs: [
             // Configured: cursor, claude-desktop, claude-code
@@ -2166,7 +2371,7 @@ describe("scanAgents", () => {
             "/home/test/.codeium/windsurf",
             vscodePath,
             // CLI tools are detected via binary checks below
-            // Not detected: cline, pi, gemini-cli, google-antigravity
+            // Not detected: cline, pi, gemini-cli, google-antigravity, hermes-agent
           ],
           configFiles: {
             "/home/test/.cursor/mcp.json": JSON.stringify({
@@ -2215,7 +2420,7 @@ describe("scanAgents", () => {
         const result = await scanAgents(agentDefinitions, fs, execService);
         expect(result.alreadyConfigured).toHaveLength(3);
         expect(result.needsSetup).toHaveLength(4);
-        expect(result.notDetected).toHaveLength(4);
+        expect(result.notDetected).toHaveLength(5);
 
         expect(result.alreadyConfigured.map((a) => a.id).sort()).toEqual(
           ["claude-code", "claude-desktop", "cursor"].sort(),
@@ -2224,7 +2429,13 @@ describe("scanAgents", () => {
           ["codex-cli", "opencode", "vscode", "windsurf"].sort(),
         );
         expect(result.notDetected.map((a) => a.id).sort()).toEqual(
-          ["cline", "gemini-cli", "google-antigravity", "pi"].sort(),
+          [
+            "cline",
+            "gemini-cli",
+            "google-antigravity",
+            "hermes-agent",
+            "pi",
+          ].sort(),
         );
       });
 

--- a/src/commands/init/agent-definitions.ts
+++ b/src/commands/init/agent-definitions.ts
@@ -49,6 +49,8 @@ export interface CompositeUninstallStep {
   failureMode: "required" | "best-effort";
 }
 
+export type ConfigFileFormat = "json" | "yaml";
+
 /**
  * Setup configuration for agents that need config file editing.
  */
@@ -56,6 +58,8 @@ export interface ConfigFileSetup {
   method: "config-file";
   /** Absolute path to the config file */
   configPath: string;
+  /** Config file format. Omitted means JSON/JSONC for backward compatibility. */
+  format?: ConfigFileFormat;
   /** Key in the config where MCP servers live (e.g., "mcpServers") */
   serversKey: string;
   /** Server name to add */
@@ -209,6 +213,18 @@ function getPiAgentDir(fs: FileSystemService): string {
 
 function getPiMcpConfigPath(fs: FileSystemService): string {
   return fs.joinPath(getPiAgentDir(fs), "mcp.json");
+}
+
+function getHermesHomeDir(fs: FileSystemService): string {
+  const configuredDir = process.env.HERMES_HOME?.trim();
+  if (configuredDir) {
+    return expandHomePath(fs, configuredDir);
+  }
+  return fs.joinPath(fs.getHomeDir(), ".hermes");
+}
+
+function getHermesConfigPath(fs: FileSystemService): string {
+  return fs.joinPath(getHermesHomeDir(fs), "config.yaml");
 }
 
 function getOpenCodeDesktopDetectPaths(fs: FileSystemService): string[] {
@@ -693,6 +709,29 @@ const openCode: AgentDefinition = {
   }),
 };
 
+/** Hermes Agent: detected by hermes-agent executable or ~/.hermes, configured via YAML MCP config */
+const hermesAgent: AgentDefinition = {
+  name: "Hermes Agent",
+  id: "hermes-agent",
+  detectionMethod: "hybrid",
+  setupMethod: "config-file",
+  detectPaths: (fs) => [getHermesHomeDir(fs)],
+  // Probe hermes-agent specifically to avoid false positives from other
+  // toolchains that ship a generic `hermes` binary (e.g., Facebook Hermes).
+  detectBinary: async (exec) => isExecutableAvailable(exec, "hermes-agent"),
+  getSetupConfig: (fs) => ({
+    method: "config-file",
+    format: "yaml",
+    configPath: getHermesConfigPath(fs),
+    serversKey: "mcp_servers",
+    serverName: GITHITS_SERVER_NAME,
+    serverConfig: {
+      command: GITHITS_MCP_COMMAND,
+      args: [...GITHITS_MCP_ARGS],
+    },
+  }),
+};
+
 /**
  * All supported agent definitions, ordered by popularity/likelihood.
  * New agents should be added here.
@@ -710,6 +749,7 @@ export const agentDefinitions: AgentDefinition[] = [
   geminiCli,
   googleAntigravity,
   openCode,
+  hermesAgent,
 ];
 
 /**

--- a/src/commands/init/index.ts
+++ b/src/commands/init/index.ts
@@ -5,6 +5,7 @@ export {
   type CliCommand,
   type CliSetup,
   type CliUninstall,
+  type ConfigFileFormat,
   type ConfigFileSetup,
   detectAgents,
   isGeminiExtensionInstalledFromFilesystem,

--- a/src/commands/init/init.test.ts
+++ b/src/commands/init/init.test.ts
@@ -1024,7 +1024,7 @@ describe("initAction", () => {
     );
 
     // Includes Pi fallback global-bin probes when pi is not on PATH.
-    expect(execService.exec).toHaveBeenCalledTimes(13);
+    expect(execService.exec).toHaveBeenCalledTimes(14);
     expect(execService.exec).toHaveBeenCalledWith("claude", expect.any(Array));
   });
 
@@ -1105,7 +1105,7 @@ describe("initAction", () => {
     );
 
     // One PATH lookup is attempted for each binary-detected agent, plus Pi fallback probes.
-    expect(execService.exec).toHaveBeenCalledTimes(8);
+    expect(execService.exec).toHaveBeenCalledTimes(9);
     const logCalls = getLogOutput();
     expect(
       logCalls.some((msg) =>

--- a/src/commands/init/setup-handlers.test.ts
+++ b/src/commands/init/setup-handlers.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, mock } from "bun:test";
+import { parse as parseYaml } from "yaml";
 import {
   createMockExecService,
   createMockFileSystemService,
@@ -871,6 +872,156 @@ describe("mergeServerConfig", () => {
     const parsed = JSON.parse(content);
     expect(parsed.servers.GitHits).toEqual(vscodeConfig);
   });
+
+  it("adds server to empty YAML config", () => {
+    const result = mergeServerConfig(
+      "",
+      "mcp_servers",
+      "GitHits",
+      serverConfig,
+      "yaml",
+    );
+    const content = expectAdded(result);
+    const parsed = parseYaml(content);
+    expect(parsed.mcp_servers.GitHits).toEqual(serverConfig);
+  });
+
+  it("preserves unrelated YAML keys", () => {
+    const existing = [
+      "provider: openrouter",
+      "mcp_servers:",
+      "  other:",
+      '    command: "other"',
+      "",
+    ].join("\n");
+    const result = mergeServerConfig(
+      existing,
+      "mcp_servers",
+      "GitHits",
+      serverConfig,
+      "yaml",
+    );
+    const content = expectAdded(result);
+    const parsed = parseYaml(content);
+    expect(parsed.provider).toBe("openrouter");
+    expect(parsed.mcp_servers.other).toEqual({ command: "other" });
+    expect(parsed.mcp_servers.GitHits).toEqual(serverConfig);
+  });
+
+  it("treats null YAML servers section as missing and initializes it", () => {
+    const existing = ["mcp_servers:", "provider: openrouter", ""].join("\n");
+    const result = mergeServerConfig(
+      existing,
+      "mcp_servers",
+      "GitHits",
+      serverConfig,
+      "yaml",
+    );
+    const content = expectAdded(result);
+    const parsed = parseYaml(content);
+    expect(parsed.provider).toBe("openrouter");
+    expect(parsed.mcp_servers.GitHits).toEqual(serverConfig);
+  });
+
+  it("preserves YAML comments when adding GitHits", () => {
+    const existing = [
+      "# top comment",
+      "provider: openrouter",
+      "mcp_servers:",
+      "  # keep other",
+      "  other:",
+      "    command: other",
+      "",
+    ].join("\n");
+    const result = mergeServerConfig(
+      existing,
+      "mcp_servers",
+      "GitHits",
+      serverConfig,
+      "yaml",
+    );
+    const content = expectAdded(result);
+    expect(content).toContain("# top comment");
+    expect(content).toContain("# keep other");
+    expect(content).toContain("provider: openrouter");
+    expect(content).toContain("other:");
+    expect(content).toContain("GitHits:");
+  });
+
+  it("returns already_configured for matching YAML config", () => {
+    const existing = [
+      "mcp_servers:",
+      "  GitHits:",
+      '    command: "npx"',
+      '    args: ["-y", "githits@latest", "mcp", "start"]',
+      "",
+    ].join("\n");
+    const result = mergeServerConfig(
+      existing,
+      "mcp_servers",
+      "GitHits",
+      serverConfig,
+      "yaml",
+    );
+    expect(result.status).toBe("already_configured");
+  });
+
+  it("returns updated and normalizes lowercase githits key in YAML config", () => {
+    const existing = [
+      "mcp_servers:",
+      "  githits:",
+      '    command: "npx"',
+      '    args: ["-y", "githits@latest", "mcp", "start"]',
+      "",
+    ].join("\n");
+    const result = mergeServerConfig(
+      existing,
+      "mcp_servers",
+      "GitHits",
+      serverConfig,
+      "yaml",
+    );
+    const content = expectUpdated(result);
+    const parsed = parseYaml(content);
+    expect(parsed.mcp_servers.GitHits).toEqual(serverConfig);
+    expect(parsed.mcp_servers.githits).toBeUndefined();
+  });
+
+  it("returns parse_error for malformed YAML", () => {
+    const result = mergeServerConfig(
+      "mcp_servers:\n  GitHits: [unterminated",
+      "mcp_servers",
+      "GitHits",
+      serverConfig,
+      "yaml",
+    );
+    const error = expectParseError(result);
+    expect(error).toContain("Invalid YAML");
+  });
+
+  it("returns parse_error when YAML root is not an object", () => {
+    const result = mergeServerConfig(
+      "- one\n- two\n",
+      "mcp_servers",
+      "GitHits",
+      serverConfig,
+      "yaml",
+    );
+    const error = expectParseError(result);
+    expect(error).toContain("not a YAML object");
+  });
+
+  it("returns parse_error when YAML serversKey is not an object", () => {
+    const result = mergeServerConfig(
+      "mcp_servers: disabled\n",
+      "mcp_servers",
+      "GitHits",
+      serverConfig,
+      "yaml",
+    );
+    const error = expectParseError(result);
+    expect(error).toContain("not a YAML object");
+  });
 });
 
 describe("removeServerConfig", () => {
@@ -973,6 +1124,49 @@ describe("removeServerConfig", () => {
     expect(parsed.mcp.GitHits).toBeUndefined();
     expect(parsed.mcp.other).toEqual({});
   });
+
+  it("removes GitHits from YAML while preserving other servers", () => {
+    const existing = [
+      "mcp_servers:",
+      "  GitHits:",
+      '    command: "npx"',
+      "  other:",
+      '    command: "other"',
+      "setting: true",
+      "",
+    ].join("\n");
+    const content = expectRemoved(
+      removeServerConfig(existing, "mcp_servers", "GitHits", "yaml"),
+    );
+    const parsed = parseYaml(content);
+    expect(parsed.mcp_servers.GitHits).toBeUndefined();
+    expect(parsed.mcp_servers.other).toEqual({ command: "other" });
+    expect(parsed.setting).toBe(true);
+  });
+
+  it("removes lowercase GitHits key from YAML", () => {
+    const existing = [
+      "mcp_servers:",
+      "  githits:",
+      '    command: "npx"',
+      "",
+    ].join("\n");
+    const content = expectRemoved(
+      removeServerConfig(existing, "mcp_servers", "GitHits", "yaml"),
+    );
+    const parsed = parseYaml(content);
+    expect(parsed.mcp_servers.githits).toBeUndefined();
+  });
+
+  it("returns not_configured when YAML servers section is null", () => {
+    const result = removeServerConfig(
+      "mcp_servers:\nprovider: openrouter\n",
+      "mcp_servers",
+      "GitHits",
+      "yaml",
+    );
+    expect(result.status).toBe("not_configured");
+  });
 });
 
 // -- formatSetupPreview --
@@ -1026,6 +1220,24 @@ describe("formatSetupPreview", () => {
     expect(preview).toContain("Will add to /home/test/.cursor/mcp.json:");
     expect(preview).toContain('"GitHits"');
     expect(preview).toContain('"command"');
+  });
+
+  it("formats YAML config file setup with YAML snippet", () => {
+    const setup: ConfigFileSetup = {
+      method: "config-file",
+      format: "yaml",
+      configPath: "/home/test/.hermes/config.yaml",
+      serversKey: "mcp_servers",
+      serverName: "GitHits",
+      serverConfig: {
+        command: "npx",
+        args: ["-y", "githits@latest", "mcp", "start"],
+      },
+    };
+    const preview = formatSetupPreview(setup);
+    expect(preview).toContain("Will add to /home/test/.hermes/config.yaml:");
+    expect(preview).toContain("GitHits:");
+    expect(preview).toContain("command: npx");
   });
 
   it("formats composite setup with command and config previews", () => {
@@ -1082,6 +1294,28 @@ describe("hasServerConfigEntry", () => {
     expect(hasServerConfigEntry("{invalid", "mcpServers", "GitHits")).toBe(
       false,
     );
+  });
+
+  it("returns true for case-variant YAML GitHits entries", () => {
+    expect(
+      hasServerConfigEntry(
+        "mcp_servers:\n  githits:\n    command: npx\n",
+        "mcp_servers",
+        "GitHits",
+        "yaml",
+      ),
+    ).toBe(true);
+  });
+
+  it("returns false for YAML null servers section", () => {
+    expect(
+      hasServerConfigEntry(
+        "mcp_servers:\nprovider: openrouter\n",
+        "mcp_servers",
+        "GitHits",
+        "yaml",
+      ),
+    ).toBe(false);
   });
 });
 
@@ -1153,6 +1387,24 @@ describe("getConfigUninstallCheckStatus", () => {
     expect(result.status).toBe("failed");
     if (result.status !== "failed") throw new Error("unreachable");
     expect(result.message).toContain("Cannot read");
+  });
+
+  it("returns not_configured for YAML null servers section", async () => {
+    const fs = createMockFileSystemService({
+      readFile: mock(() =>
+        Promise.resolve("mcp_servers:\nprovider: openrouter\n"),
+      ),
+    });
+    const result = await getConfigUninstallCheckStatus(
+      {
+        ...configSetup,
+        configPath: "/home/test/.hermes/config.yaml",
+        serversKey: "mcp_servers",
+        format: "yaml",
+      },
+      fs,
+    );
+    expect(result.status).toBe("not_configured");
   });
 });
 
@@ -1830,6 +2082,120 @@ describe("executeConfigFileSetup", () => {
     expect(atomicWrite).toHaveBeenCalled();
     expect(writeFile).not.toHaveBeenCalled();
   });
+
+  it("writes YAML config for Hermes-style setup", async () => {
+    const hermesSetup: ConfigFileSetup = {
+      method: "config-file",
+      format: "yaml",
+      configPath: "/home/test/.hermes/config.yaml",
+      serversKey: "mcp_servers",
+      serverName: "GitHits",
+      serverConfig: configSetup.serverConfig,
+    };
+    const existing = "provider: openrouter\nmcp_servers: {}\n";
+    const atomicWrite = mock((_path: string, _content: string) =>
+      Promise.resolve(),
+    );
+    const fs = createMockFileSystemService({
+      readFile: mock(() => Promise.resolve(existing)),
+      getDirname: mock(() => "/home/test/.hermes"),
+      ensureDir: mock(() => Promise.resolve()),
+      atomicWriteFile: atomicWrite,
+    });
+
+    const result = await executeConfigFileSetup(hermesSetup, fs);
+    expect(result.status).toBe("success");
+    const writtenContent = atomicWrite.mock.calls[0]![1];
+    const parsed = parseYaml(writtenContent);
+    expect(parsed.provider).toBe("openrouter");
+    expect(parsed.mcp_servers.GitHits).toEqual(hermesSetup.serverConfig);
+  });
+
+  it("writes YAML config when servers section is null", async () => {
+    const hermesSetup: ConfigFileSetup = {
+      method: "config-file",
+      format: "yaml",
+      configPath: "/home/test/.hermes/config.yaml",
+      serversKey: "mcp_servers",
+      serverName: "GitHits",
+      serverConfig: configSetup.serverConfig,
+    };
+    const existing = "mcp_servers:\nprovider: openrouter\n";
+    const atomicWrite = mock((_path: string, _content: string) =>
+      Promise.resolve(),
+    );
+    const fs = createMockFileSystemService({
+      readFile: mock(() => Promise.resolve(existing)),
+      getDirname: mock(() => "/home/test/.hermes"),
+      ensureDir: mock(() => Promise.resolve()),
+      atomicWriteFile: atomicWrite,
+    });
+
+    const result = await executeConfigFileSetup(hermesSetup, fs);
+    expect(result.status).toBe("success");
+    const writtenContent = atomicWrite.mock.calls[0]![1];
+    const parsed = parseYaml(writtenContent);
+    expect(parsed.provider).toBe("openrouter");
+    expect(parsed.mcp_servers.GitHits).toEqual(hermesSetup.serverConfig);
+  });
+
+  it("does not rewrite matching YAML config", async () => {
+    const hermesSetup: ConfigFileSetup = {
+      method: "config-file",
+      format: "yaml",
+      configPath: "/home/test/.hermes/config.yaml",
+      serversKey: "mcp_servers",
+      serverName: "GitHits",
+      serverConfig: configSetup.serverConfig,
+    };
+    const existing = [
+      "mcp_servers:",
+      "  GitHits:",
+      '    command: "npx"',
+      '    args: ["-y", "githits@latest", "mcp", "start"]',
+      "",
+    ].join("\n");
+    const atomicWrite = mock((_path: string, _content: string) =>
+      Promise.resolve(),
+    );
+    const fs = createMockFileSystemService({
+      readFile: mock(() => Promise.resolve(existing)),
+      getDirname: mock(() => "/home/test/.hermes"),
+      ensureDir: mock(() => Promise.resolve()),
+      atomicWriteFile: atomicWrite,
+    });
+
+    const result = await executeConfigFileSetup(hermesSetup, fs);
+    expect(result.status).toBe("already_configured");
+    expect(atomicWrite).not.toHaveBeenCalled();
+  });
+
+  it("leaves YAML file unchanged on parse error", async () => {
+    const hermesSetup: ConfigFileSetup = {
+      method: "config-file",
+      format: "yaml",
+      configPath: "/home/test/.hermes/config.yaml",
+      serversKey: "mcp_servers",
+      serverName: "GitHits",
+      serverConfig: configSetup.serverConfig,
+    };
+    const atomicWrite = mock((_path: string, _content: string) =>
+      Promise.resolve(),
+    );
+    const fs = createMockFileSystemService({
+      readFile: mock(() =>
+        Promise.resolve("mcp_servers:\n  GitHits: [unterminated"),
+      ),
+      getDirname: mock(() => "/home/test/.hermes"),
+      ensureDir: mock(() => Promise.resolve()),
+      atomicWriteFile: atomicWrite,
+    });
+
+    const result = await executeConfigFileSetup(hermesSetup, fs);
+    expect(result.status).toBe("failed");
+    expect(result.message).toContain("Invalid YAML");
+    expect(atomicWrite).not.toHaveBeenCalled();
+  });
 });
 
 describe("executeCompositeSetup", () => {
@@ -2028,6 +2394,81 @@ describe("executeConfigFileUninstall", () => {
     const result = await executeConfigFileUninstall(configSetup, fs);
     expect(result.status).toBe("failed");
     expect(result.message).toContain("File left unchanged");
+    expect(fs.atomicWriteFile).not.toHaveBeenCalled();
+  });
+
+  it("removes GitHits from YAML config and preserves other entries", async () => {
+    const hermesSetup: ConfigFileSetup = {
+      method: "config-file",
+      format: "yaml",
+      configPath: "/home/test/.hermes/config.yaml",
+      serversKey: "mcp_servers",
+      serverName: "GitHits",
+      serverConfig: {},
+    };
+    const existing = [
+      "mcp_servers:",
+      "  GitHits:",
+      '    command: "npx"',
+      "  other:",
+      '    command: "other"',
+      "provider: openrouter",
+      "",
+    ].join("\n");
+    const atomicWrite = mock(() => Promise.resolve());
+    const fs = createMockFileSystemService({
+      readFile: mock(() => Promise.resolve(existing)),
+      atomicWriteFile: atomicWrite,
+    });
+
+    const result = await executeConfigFileUninstall(hermesSetup, fs);
+    expect(result.status).toBe("removed");
+    const calls = atomicWrite.mock.calls as unknown as [string, string][];
+    const writtenContent = calls[0]![1];
+    const parsed = parseYaml(writtenContent);
+    expect(parsed.mcp_servers.GitHits).toBeUndefined();
+    expect(parsed.mcp_servers.other).toEqual({ command: "other" });
+    expect(parsed.provider).toBe("openrouter");
+  });
+
+  it("returns not_configured for YAML null servers section during uninstall", async () => {
+    const hermesSetup: ConfigFileSetup = {
+      method: "config-file",
+      format: "yaml",
+      configPath: "/home/test/.hermes/config.yaml",
+      serversKey: "mcp_servers",
+      serverName: "GitHits",
+      serverConfig: {},
+    };
+    const fs = createMockFileSystemService({
+      readFile: mock(() =>
+        Promise.resolve("mcp_servers:\nprovider: openrouter\n"),
+      ),
+    });
+
+    const result = await executeConfigFileUninstall(hermesSetup, fs);
+    expect(result.status).toBe("not_configured");
+    expect(fs.atomicWriteFile).not.toHaveBeenCalled();
+  });
+
+  it("leaves YAML file unchanged on uninstall parse error", async () => {
+    const hermesSetup: ConfigFileSetup = {
+      method: "config-file",
+      format: "yaml",
+      configPath: "/home/test/.hermes/config.yaml",
+      serversKey: "mcp_servers",
+      serverName: "GitHits",
+      serverConfig: {},
+    };
+    const fs = createMockFileSystemService({
+      readFile: mock(() =>
+        Promise.resolve("mcp_servers:\n  GitHits: [unterminated"),
+      ),
+    });
+
+    const result = await executeConfigFileUninstall(hermesSetup, fs);
+    expect(result.status).toBe("failed");
+    expect(result.message).toContain("Invalid YAML");
     expect(fs.atomicWriteFile).not.toHaveBeenCalled();
   });
 

--- a/src/commands/init/setup-handlers.ts
+++ b/src/commands/init/setup-handlers.ts
@@ -3,6 +3,15 @@ import {
   parse as parseJsonc,
   printParseErrorCode,
 } from "jsonc-parser";
+import {
+  type Document,
+  isMap,
+  isScalar,
+  parseDocument,
+  parse as parseYaml,
+  stringify as stringifyYaml,
+  type YAMLMap,
+} from "yaml";
 import type { ExecService } from "../../services/exec-service.js";
 import type { FileSystemService } from "../../services/filesystem-service.js";
 import type {
@@ -11,6 +20,7 @@ import type {
   CliUninstall,
   CompositeSetup,
   CompositeUninstall,
+  ConfigFileFormat,
   ConfigFileSetup,
   SetupConfig,
   UninstallConfig,
@@ -69,11 +79,47 @@ type ParsedConfigResult =
       error: string;
     };
 
-function parseConfigObject(content: string): ParsedConfigResult {
-  let normalizedContent = content;
-  if (normalizedContent.charCodeAt(0) === 0xfeff) {
-    normalizedContent = normalizedContent.slice(1);
+type ParsedConfigObjectResult =
+  | {
+      value: Record<string, unknown>;
+    }
+  | {
+      error: string;
+    };
+
+type ParsedYamlDocumentResult =
+  | {
+      status: "ok";
+      doc: Document.Parsed;
+      root: YAMLMap<unknown, unknown>;
+    }
+  | {
+      status: "error";
+      error: string;
+    };
+
+type ParsedYamlServersMapResult =
+  | {
+      status: "ok";
+      serversMap: YAMLMap<unknown, unknown>;
+    }
+  | {
+      status: "not_configured";
+    }
+  | {
+      status: "error";
+      error: string;
+    };
+
+function normalizeConfigContent(content: string): string {
+  if (content.charCodeAt(0) === 0xfeff) {
+    return content.slice(1);
   }
+  return content;
+}
+
+function parseConfigObject(content: string): ParsedConfigResult {
+  const normalizedContent = normalizeConfigContent(content);
 
   const trimmed = normalizedContent.trim();
   if (trimmed === "") {
@@ -128,6 +174,293 @@ function parseConfigObject(content: string): ParsedConfigResult {
       value: parsed,
     };
   }
+}
+
+function parseYamlConfigObject(content: string): ParsedConfigObjectResult {
+  const normalizedContent = normalizeConfigContent(content);
+  if (normalizedContent.trim() === "") {
+    return { value: {} };
+  }
+
+  try {
+    const parsed = parseYaml(normalizedContent);
+    if (parsed === null || parsed === undefined) {
+      return { value: {} };
+    }
+    if (!isPlainObject(parsed)) {
+      return { error: "Config file root is not a YAML object" };
+    }
+    return { value: parsed as Record<string, unknown> };
+  } catch (err) {
+    return {
+      error: `Invalid YAML: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+}
+
+function formatYamlError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
+}
+
+function parseYamlConfigDocument(content: string): ParsedYamlDocumentResult {
+  const normalizedContent = normalizeConfigContent(content);
+  const source = normalizedContent.trim() === "" ? "{}\n" : normalizedContent;
+
+  let doc: Document.Parsed;
+  try {
+    doc = parseDocument(source);
+  } catch (err) {
+    return {
+      status: "error",
+      error: `Invalid YAML: ${formatYamlError(err)}`,
+    };
+  }
+
+  if (doc.errors.length > 0) {
+    const firstError = doc.errors[0];
+    return {
+      status: "error",
+      error: `Invalid YAML: ${formatYamlError(firstError)}`,
+    };
+  }
+
+  const contents = doc.contents;
+  if (!contents || !isMap(contents)) {
+    return {
+      status: "error",
+      error: "Config file root is not a YAML object",
+    };
+  }
+
+  return {
+    status: "ok",
+    doc,
+    root: contents,
+  };
+}
+
+function toYamlConfigShapeError(serversKey: string): string {
+  return `"${serversKey}" is not a YAML object`;
+}
+
+function toYamlKeyString(key: unknown): string | null {
+  if (typeof key === "string") {
+    return key;
+  }
+  if (!isScalar(key) || typeof key.value !== "string") {
+    return null;
+  }
+  return key.value;
+}
+
+function getYamlMatchingServerKeys(
+  serversMap: YAMLMap<unknown, unknown>,
+  serverName: string,
+): string[] {
+  const normalizedTarget = serverName.toLowerCase();
+  return serversMap.items
+    .map((pair) => toYamlKeyString(pair.key))
+    .filter(
+      (key): key is string =>
+        typeof key === "string" && key.toLowerCase() === normalizedTarget,
+    );
+}
+
+function yamlNodeToJsValue(value: unknown): unknown {
+  if (
+    typeof value === "object" &&
+    value !== null &&
+    "toJSON" in value &&
+    typeof value.toJSON === "function"
+  ) {
+    return value.toJSON();
+  }
+  return value;
+}
+
+function createEmptyYamlMapNode(): YAMLMap<unknown, unknown> {
+  const map = parseDocument("{}\n").contents;
+  if (!map || !isMap(map)) {
+    throw new Error("Failed to initialize YAML object node");
+  }
+  return map;
+}
+
+function ensureYamlServersMapForSetup(
+  root: YAMLMap<unknown, unknown>,
+  serversKey: string,
+): ParsedYamlServersMapResult {
+  const existingServers = root.get(serversKey, true);
+  if (
+    existingServers === undefined ||
+    existingServers === null ||
+    (isScalar(existingServers) && existingServers.value === null)
+  ) {
+    root.set(serversKey, createEmptyYamlMapNode());
+    const initializedServers = root.get(serversKey, true);
+    if (!initializedServers || !isMap(initializedServers)) {
+      return {
+        status: "error",
+        error: toYamlConfigShapeError(serversKey),
+      };
+    }
+    return {
+      status: "ok",
+      serversMap: initializedServers,
+    };
+  }
+
+  if (!isMap(existingServers)) {
+    return {
+      status: "error",
+      error: toYamlConfigShapeError(serversKey),
+    };
+  }
+
+  return {
+    status: "ok",
+    serversMap: existingServers,
+  };
+}
+
+function getYamlServersMapForUninstall(
+  root: YAMLMap<unknown, unknown>,
+  serversKey: string,
+): ParsedYamlServersMapResult {
+  const existingServers = root.get(serversKey, true);
+  if (
+    existingServers === undefined ||
+    existingServers === null ||
+    (isScalar(existingServers) && existingServers.value === null)
+  ) {
+    return { status: "not_configured" };
+  }
+  if (!isMap(existingServers)) {
+    return {
+      status: "error",
+      error: toYamlConfigShapeError(serversKey),
+    };
+  }
+  return {
+    status: "ok",
+    serversMap: existingServers,
+  };
+}
+
+function renderYamlDocument(doc: Document.Parsed): string {
+  const rendered = doc.toString();
+  return rendered.endsWith("\n") ? rendered : `${rendered}\n`;
+}
+
+function mergeYamlServerConfig(
+  existingContent: string,
+  serversKey: string,
+  serverName: string,
+  serverConfig: Record<string, unknown>,
+): MergeResult {
+  const parsed = parseYamlConfigDocument(existingContent);
+  if (parsed.status === "error") {
+    return { status: "parse_error", error: parsed.error };
+  }
+
+  const serversResult = ensureYamlServersMapForSetup(parsed.root, serversKey);
+  if (serversResult.status !== "ok") {
+    return {
+      status: "parse_error",
+      error:
+        serversResult.status === "error"
+          ? serversResult.error
+          : toYamlConfigShapeError(serversKey),
+    };
+  }
+
+  const { serversMap } = serversResult;
+  const matchingKeys = getYamlMatchingServerKeys(serversMap, serverName);
+  if (matchingKeys.length === 1 && matchingKeys[0] === serverName) {
+    const existingValue = yamlNodeToJsValue(serversMap.get(serverName, true));
+    if (isEquivalentConfiguredValue(existingValue, serverConfig)) {
+      return { status: "already_configured" };
+    }
+  }
+
+  for (const key of matchingKeys) {
+    serversMap.delete(key);
+  }
+  const hadExisting = matchingKeys.length > 0;
+  serversMap.set(serverName, serverConfig);
+
+  return {
+    status: hadExisting ? "updated" : "added",
+    content: renderYamlDocument(parsed.doc),
+  };
+}
+
+function removeYamlServerConfig(
+  existingContent: string,
+  serversKey: string,
+  serverName: string,
+): RemoveResult {
+  const parsed = parseYamlConfigDocument(existingContent);
+  if (parsed.status === "error") {
+    return { status: "parse_error", error: parsed.error };
+  }
+
+  const serversResult = getYamlServersMapForUninstall(parsed.root, serversKey);
+  if (serversResult.status === "not_configured") {
+    return { status: "not_configured" };
+  }
+  if (serversResult.status === "error") {
+    return {
+      status: "parse_error",
+      error: serversResult.error,
+    };
+  }
+
+  const matchingKeys = getYamlMatchingServerKeys(
+    serversResult.serversMap,
+    serverName,
+  );
+  if (matchingKeys.length === 0) {
+    return { status: "not_configured" };
+  }
+
+  for (const key of matchingKeys) {
+    serversResult.serversMap.delete(key);
+  }
+
+  return {
+    status: "removed",
+    content: renderYamlDocument(parsed.doc),
+  };
+}
+
+function parseConfigObjectForFormat(
+  content: string,
+  format: ConfigFileFormat = "json",
+): ParsedConfigObjectResult {
+  if (format === "yaml") {
+    return parseYamlConfigObject(content);
+  }
+
+  const parsed = parseConfigObject(content);
+  if (parsed.format === "invalid") {
+    return { error: parsed.error };
+  }
+  return { value: parsed.value };
+}
+
+function renderConfigObjectForFormat(
+  config: Record<string, unknown>,
+  format: ConfigFileFormat = "json",
+): string {
+  if (format === "yaml") {
+    const rendered = stringifyYaml(config);
+    return rendered.endsWith("\n") ? rendered : `${rendered}\n`;
+  }
+  return `${JSON.stringify(config, null, 2)}\n`;
 }
 
 /**
@@ -334,9 +667,19 @@ export function mergeServerConfig(
   serversKey: string,
   serverName: string,
   serverConfig: Record<string, unknown>,
+  format: ConfigFileFormat = "json",
 ): MergeResult {
-  const parsedConfig = parseConfigObject(existingContent);
-  if (parsedConfig.format === "invalid") {
+  if (format === "yaml") {
+    return mergeYamlServerConfig(
+      existingContent,
+      serversKey,
+      serverName,
+      serverConfig,
+    );
+  }
+
+  const parsedConfig = parseConfigObjectForFormat(existingContent, format);
+  if ("error" in parsedConfig) {
     return {
       status: "parse_error",
       error: parsedConfig.error,
@@ -382,7 +725,7 @@ export function mergeServerConfig(
 
   return {
     status: hadExisting ? "updated" : "added",
-    content: `${JSON.stringify(config, null, 2)}\n`,
+    content: renderConfigObjectForFormat(config, format),
   };
 }
 
@@ -394,9 +737,14 @@ export function removeServerConfig(
   existingContent: string,
   serversKey: string,
   serverName: string,
+  format: ConfigFileFormat = "json",
 ): RemoveResult {
-  const parsedConfig = parseConfigObject(existingContent);
-  if (parsedConfig.format === "invalid") {
+  if (format === "yaml") {
+    return removeYamlServerConfig(existingContent, serversKey, serverName);
+  }
+
+  const parsedConfig = parseConfigObjectForFormat(existingContent, format);
+  if ("error" in parsedConfig) {
     return {
       status: "parse_error",
       error: parsedConfig.error,
@@ -431,7 +779,7 @@ export function removeServerConfig(
 
   return {
     status: "removed",
-    content: `${JSON.stringify(config, null, 2)}\n`,
+    content: renderConfigObjectForFormat(config, format),
   };
 }
 
@@ -443,9 +791,10 @@ export function hasServerConfigEntry(
   existingContent: string,
   serversKey: string,
   serverName: string,
+  format: ConfigFileFormat = "json",
 ): boolean {
-  const parsedConfig = parseConfigObject(existingContent);
-  if (parsedConfig.format === "invalid") {
+  const parsedConfig = parseConfigObjectForFormat(existingContent, format);
+  if ("error" in parsedConfig) {
     return false;
   }
 
@@ -482,7 +831,14 @@ export function formatSetupPreview(config: SetupConfig): string {
     null,
     2,
   );
-  return `Will add to ${config.configPath}:\n\n${snippet}`;
+  const formattedSnippet =
+    config.format === "yaml"
+      ? renderConfigObjectForFormat(
+          { [config.serverName]: config.serverConfig },
+          "yaml",
+        ).trimEnd()
+      : snippet;
+  return `Will add to ${config.configPath}:\n\n${formattedSnippet}`;
 }
 
 /** Format an uninstall config for display to the user before confirmation. */
@@ -510,8 +866,8 @@ export async function isAlreadyConfigured(
 ): Promise<boolean> {
   try {
     const content = await fs.readFile(config.configPath);
-    const parsedConfig = parseConfigObject(content);
-    if (parsedConfig.format === "invalid") {
+    const parsedConfig = parseConfigObjectForFormat(content, config.format);
+    if ("error" in parsedConfig) {
       return false;
     }
     const parsed = parsedConfig.value;
@@ -563,8 +919,8 @@ export async function getConfigUninstallCheckStatus(
 ): Promise<ConfigUninstallCheckResult> {
   try {
     const content = await fs.readFile(config.configPath);
-    const parsedConfig = parseConfigObject(content);
-    if (parsedConfig.format === "invalid") {
+    const parsedConfig = parseConfigObjectForFormat(content, config.format);
+    if ("error" in parsedConfig) {
       return {
         status: "failed",
         message: `Cannot parse ${config.configPath}: ${parsedConfig.error}. File left unchanged.`,
@@ -572,7 +928,7 @@ export async function getConfigUninstallCheckStatus(
     }
 
     const servers = parsedConfig.value[config.serversKey];
-    if (servers === undefined) {
+    if (servers === undefined || servers === null) {
       return { status: "not_configured" };
     }
     if (
@@ -582,7 +938,7 @@ export async function getConfigUninstallCheckStatus(
     ) {
       return {
         status: "failed",
-        message: `Cannot parse ${config.configPath}: "${config.serversKey}" is not a JSON object. File left unchanged.`,
+        message: `Cannot parse ${config.configPath}: "${config.serversKey}" is not a ${config.format === "yaml" ? "YAML" : "JSON"} object. File left unchanged.`,
       };
     }
 
@@ -972,6 +1328,7 @@ export async function executeConfigFileSetup(
       setup.serversKey,
       setup.serverName,
       setup.serverConfig,
+      setup.format,
     );
 
     if (result.status === "already_configured") {
@@ -1069,6 +1426,7 @@ export async function executeConfigFileUninstall(
       existingContent,
       setup.serversKey,
       setup.serverName,
+      setup.format,
     );
 
     if (result.status === "not_configured") {


### PR DESCRIPTION
## Summary
- add Hermes Agent to init detection and setup using hermes-agent plus ~/.hermes/HERMES_HOME
- add YAML config-file support for Hermes mcp_servers while preserving comments and handling null sections
- document Hermes Agent support and cover setup/uninstall/check paths with tests

## Verification
- bun run typecheck
- bun run format:check
- bun test
- bun run build
- bun run lint
- bun run smoke:cli (skipped with AUTH_REQUIRED)