### PR TITLE
fix: use npx for skipped init guidance

### DIFF
--- a/src/commands/init/init.test.ts
+++ b/src/commands/init/init.test.ts
@@ -569,6 +569,11 @@ describe("initAction", () => {
 
     const logCalls = getLogOutput();
     expect(logCalls.some((msg) => msg.includes("No changes made"))).toBe(true);
+    expect(
+      logCalls.some((msg) =>
+        msg.includes("Run `npx githits@latest init` whenever you're ready"),
+      ),
+    ).toBe(true);
     expect(execService.exec).not.toHaveBeenCalled();
     expect(fs.atomicWriteFile).not.toHaveBeenCalled();
   });

--- a/src/commands/init/init.ts
+++ b/src/commands/init/init.ts
@@ -1584,7 +1584,7 @@ export async function initAction(
     }
     if (intent === "later") {
       console.log(
-        "\n  No changes made. Run `githits init` whenever you're ready.\n",
+        "\n  No changes made. Run `npx githits@latest init` whenever you're ready.\n",
       );
       return;
     }


### PR DESCRIPTION
## Summary
- Update the interactive init skip message to recommend `npx githits@latest init`
- Add test coverage for the Later-flow guidance

## Tests
- `bun test src/commands/init/init.test.ts`
- commit hook: `biome check --write --no-errors-on-unmatched`
- commit hook: `bun run typecheck`