### PR TITLE
test: add smoke timing telemetry

### DIFF
--- a/scripts/cli-smoke.ts
+++ b/scripts/cli-smoke.ts
@@ -1,6 +1,12 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import {
+  formatCliCommand,
+  mapWithConcurrency,
+  printSmokeTimingSummary,
+  trackSmokeStep,
+} from "./smoke-telemetry.ts";
 
 interface CommandResult {
   command: string[];
@@ -24,6 +30,9 @@ interface JsonParityFixture {
 
 const DEFAULT_TEXT_LIMIT = 20_000;
 const AUTH_ENV_KEYS = ["GITHITS_API_TOKEN", "GITHITS_TOKEN"] as const;
+const JSON_PARITY_CONCURRENCY = 2;
+const SMOKE_PACKAGE_SPEC = "npm:express@5.2.1";
+
 const JSON_PARITY_FIXTURES: JsonParityFixture[] = [
   {
     name: "pkg_info",
@@ -77,11 +86,12 @@ const JSON_PARITY_FIXTURES: JsonParityFixture[] = [
   },
   {
     name: "docs_list",
-    cliArgs: ["docs", "list", "npm:express", "--limit", "2", "--json"],
+    cliArgs: ["docs", "list", SMOKE_PACKAGE_SPEC, "--limit", "2", "--json"],
     mcpTool: "docs_list",
     mcpArgs: {
       registry: "npm",
       package_name: "express",
+      version: "5.2.1",
       limit: 2,
       format: "json",
     },
@@ -91,7 +101,7 @@ const JSON_PARITY_FIXTURES: JsonParityFixture[] = [
     cliArgs: [
       "code",
       "files",
-      "npm:express",
+      SMOKE_PACKAGE_SPEC,
       "package.json",
       "--limit",
       "1",
@@ -99,7 +109,7 @@ const JSON_PARITY_FIXTURES: JsonParityFixture[] = [
     ],
     mcpTool: "code_files",
     mcpArgs: {
-      target: { registry: "npm", package_name: "express" },
+      target: { registry: "npm", package_name: "express", version: "5.2.1" },
       path_prefix: "package.json",
       limit: 1,
       format: "json",
@@ -110,7 +120,7 @@ const JSON_PARITY_FIXTURES: JsonParityFixture[] = [
     cliArgs: [
       "code",
       "read",
-      "npm:express",
+      SMOKE_PACKAGE_SPEC,
       "package.json",
       "--lines",
       "1-5",
@@ -118,7 +128,7 @@ const JSON_PARITY_FIXTURES: JsonParityFixture[] = [
     ],
     mcpTool: "code_read",
     mcpArgs: {
-      target: { registry: "npm", package_name: "express" },
+      target: { registry: "npm", package_name: "express", version: "5.2.1" },
       path: "package.json",
       start_line: 1,
       end_line: 5,
@@ -130,7 +140,7 @@ const JSON_PARITY_FIXTURES: JsonParityFixture[] = [
     cliArgs: [
       "code",
       "grep",
-      "npm:express",
+      SMOKE_PACKAGE_SPEC,
       "express",
       "package.json",
       "--limit",
@@ -139,7 +149,7 @@ const JSON_PARITY_FIXTURES: JsonParityFixture[] = [
     ],
     mcpTool: "code_grep",
     mcpArgs: {
-      target: { registry: "npm", package_name: "express" },
+      target: { registry: "npm", package_name: "express", version: "5.2.1" },
       pattern: "express",
       path_prefix: "package.json",
       max_matches: 1,
@@ -253,44 +263,48 @@ async function runCliWithEnv(
   args: string[],
   baseEnv: NodeJS.ProcessEnv | Record<string, string | undefined>,
 ): Promise<CommandResult> {
-  const proc = Bun.spawn(["bun", "run", "dev", ...args], {
-    stdout: "pipe",
-    stderr: "pipe",
-    env: {
-      ...baseEnv,
-      NO_COLOR: "1",
-    },
+  return trackSmokeStep(`cli ${formatCliCommand(args)}`, async () => {
+    const proc = Bun.spawn(["bun", "run", "dev", ...args], {
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        ...baseEnv,
+        NO_COLOR: "1",
+      },
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+    return { command: args, exitCode, stdout, stderr };
   });
-  const [stdout, stderr, exitCode] = await Promise.all([
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
-    proc.exited,
-  ]);
-  return { command: args, exitCode, stdout, stderr };
 }
 
 async function runMcpJson(
   toolName: string,
   args: Record<string, unknown>,
 ): Promise<unknown> {
-  const proc = Bun.spawn(
-    ["bun", "run", "scripts/mcp-call.ts", toolName, JSON.stringify(args)],
-    {
-      stdout: "pipe",
-      stderr: "pipe",
-      env: process.env,
-    },
-  );
-  const [stdout, stderr, exitCode] = await Promise.all([
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
-    proc.exited,
-  ]);
-  assert(
-    exitCode === 0,
-    `${toolName} MCP parity call failed (${exitCode})\n${stderr}`,
-  );
-  return parseJson(stdout, `${toolName} MCP parity`);
+  return trackSmokeStep(`mcp parity ${toolName}`, async () => {
+    const proc = Bun.spawn(
+      ["bun", "run", "scripts/mcp-call.ts", toolName, JSON.stringify(args)],
+      {
+        stdout: "pipe",
+        stderr: "pipe",
+        env: process.env,
+      },
+    );
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+    assert(
+      exitCode === 0,
+      `${toolName} MCP parity call failed (${exitCode})\n${stderr}`,
+    );
+    return parseJson(stdout, `${toolName} MCP parity`);
+  });
 }
 
 function assertDeepEqual(
@@ -330,21 +344,28 @@ function jsonContractShape(value: unknown): unknown {
 }
 
 async function assertJsonParity(): Promise<void> {
-  for (const fixture of JSON_PARITY_FIXTURES) {
-    const cliPayload = assertJsonOutput(
-      await runCli(fixture.cliArgs),
-      `${fixture.name} CLI parity`,
-    );
-    const mcpPayload = await runMcpJson(fixture.mcpTool, fixture.mcpArgs);
-    // Dev endpoints may return stale cached data first and refresh in the
-    // background, so sequential CLI/MCP calls can legitimately see different
-    // values. Parity still verifies both surfaces expose the same JSON contract.
-    assertDeepEqual(
-      jsonContractShape(mcpPayload),
-      jsonContractShape(cliPayload),
-      `${fixture.name} CLI/MCP JSON shape`,
-    );
-  }
+  await mapWithConcurrency(
+    JSON_PARITY_FIXTURES,
+    JSON_PARITY_CONCURRENCY,
+    async (fixture) => {
+      await trackSmokeStep(`json parity ${fixture.name}`, async () => {
+        const [cliPayload, mcpPayload] = await Promise.all([
+          runCli(fixture.cliArgs).then((result) =>
+            assertJsonOutput(result, `${fixture.name} CLI parity`),
+          ),
+          runMcpJson(fixture.mcpTool, fixture.mcpArgs),
+        ]);
+        // Dev endpoints may return stale cached data first and refresh in the
+        // background, so concurrent CLI/MCP calls can legitimately see different
+        // values. Parity still verifies both surfaces expose the same JSON contract.
+        assertDeepEqual(
+          jsonContractShape(mcpPayload),
+          jsonContractShape(cliPayload),
+          `${fixture.name} CLI/MCP JSON shape`,
+        );
+      });
+    },
+  );
 }
 
 function isolatedUnauthenticatedEnv(): Record<string, string> {
@@ -675,7 +696,7 @@ async function runLiveSmoke(): Promise<void> {
   }
 
   const docsText = assertTerminalOutput(
-    await runCli(["docs", "list", "npm:express", "--limit", "2"]),
+    await runCli(["docs", "list", SMOKE_PACKAGE_SPEC, "--limit", "2"]),
     "docs list terminal",
   );
   assert(
@@ -684,7 +705,14 @@ async function runLiveSmoke(): Promise<void> {
   );
 
   const docsJson = assertJsonOutput(
-    await runCli(["docs", "list", "npm:express", "--limit", "2", "--json"]),
+    await runCli([
+      "docs",
+      "list",
+      SMOKE_PACKAGE_SPEC,
+      "--limit",
+      "2",
+      "--json",
+    ]),
     "docs list json",
   );
   assertRecord(docsJson, "docs list json");
@@ -722,7 +750,7 @@ async function runLiveSmoke(): Promise<void> {
     await runCli([
       "code",
       "files",
-      "npm:express",
+      SMOKE_PACKAGE_SPEC,
       "package.json",
       "--limit",
       "1",
@@ -738,7 +766,7 @@ async function runLiveSmoke(): Promise<void> {
     await runCli([
       "code",
       "files",
-      "npm:express",
+      SMOKE_PACKAGE_SPEC,
       "package.json",
       "--limit",
       "1",
@@ -756,7 +784,7 @@ async function runLiveSmoke(): Promise<void> {
     await runCli([
       "code",
       "read",
-      "npm:express",
+      SMOKE_PACKAGE_SPEC,
       "package.json",
       "--lines",
       "1-5",
@@ -772,7 +800,7 @@ async function runLiveSmoke(): Promise<void> {
     await runCli([
       "code",
       "read",
-      "npm:express",
+      SMOKE_PACKAGE_SPEC,
       "package.json",
       "--lines",
       "1-5",
@@ -791,7 +819,7 @@ async function runLiveSmoke(): Promise<void> {
     await runCli([
       "code",
       "grep",
-      "npm:express",
+      SMOKE_PACKAGE_SPEC,
       "express",
       "package.json",
       "--limit",
@@ -808,7 +836,7 @@ async function runLiveSmoke(): Promise<void> {
     await runCli([
       "code",
       "grep",
-      "npm:express",
+      SMOKE_PACKAGE_SPEC,
       "express",
       "package.json",
       "--limit",
@@ -824,7 +852,14 @@ async function runLiveSmoke(): Promise<void> {
   );
 
   const searchText = assertTerminalOutput(
-    await runCli(["search", "router", "--in", "npm:express", "--limit", "1"]),
+    await runCli([
+      "search",
+      "router",
+      "--in",
+      SMOKE_PACKAGE_SPEC,
+      "--limit",
+      "1",
+    ]),
     "search terminal",
   );
   assert(
@@ -837,7 +872,7 @@ async function runLiveSmoke(): Promise<void> {
       "search",
       "router",
       "--in",
-      "npm:express",
+      SMOKE_PACKAGE_SPEC,
       "--limit",
       "1",
       "--json",
@@ -903,4 +938,8 @@ async function main(): Promise<void> {
   }
 }
 
-await main();
+try {
+  await main();
+} finally {
+  printSmokeTimingSummary();
+}

--- a/scripts/mcp-smoke.ts
+++ b/scripts/mcp-smoke.ts
@@ -3,6 +3,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import {
+  printSmokeTimingSummary,
+  summarizeMcpArgs,
+  trackSmokeStep,
+} from "./smoke-telemetry.ts";
 
 interface TextContent {
   type: "text";
@@ -40,6 +45,12 @@ const EXPECTED_TOOLS = [
 
 const DEFAULT_TEXT_LIMIT = 12_000;
 const AUTH_ENV_KEYS = ["GITHITS_API_TOKEN", "GITHITS_TOKEN"] as const;
+const SMOKE_PACKAGE_VERSION = "5.2.1";
+const SMOKE_PACKAGE_TARGET = {
+  registry: "npm",
+  package_name: "express",
+  version: SMOKE_PACKAGE_VERSION,
+} as const;
 
 function assert(condition: unknown, message: string): asserts condition {
   if (!condition) {
@@ -144,7 +155,11 @@ async function callTool(
   name: string,
   args: Record<string, unknown>,
 ): Promise<ToolCallResult> {
-  return (await client.callTool({ name, arguments: args })) as ToolCallResult;
+  return trackSmokeStep(
+    `mcp ${name}${summarizeMcpArgs(args)}`,
+    async () =>
+      (await client.callTool({ name, arguments: args })) as ToolCallResult,
+  );
 }
 
 function isolatedUnauthenticatedEnv(): Record<string, string> {
@@ -189,7 +204,10 @@ async function assertUnauthenticatedBehavior(): Promise<void> {
   const home = env.HOME;
   try {
     await withMcpClient(env, async (client) => {
-      const toolsResponse = await client.listTools();
+      const toolsResponse = await trackSmokeStep(
+        "mcp listTools unauthenticated",
+        () => client.listTools(),
+      );
       assert(
         toolsResponse.tools.length > 0,
         "unauthenticated listTools returned no tools",
@@ -586,8 +604,7 @@ async function runLiveSmoke(client: Client): Promise<void> {
 
   const docsText = assertDefaultText(
     await callTool(client, "docs_list", {
-      registry: "npm",
-      package_name: "express",
+      ...SMOKE_PACKAGE_TARGET,
       limit: 2,
     }),
     "docs_list default",
@@ -599,8 +616,7 @@ async function runLiveSmoke(client: Client): Promise<void> {
 
   const docsJson = assertJsonResult(
     await callTool(client, "docs_list", {
-      registry: "npm",
-      package_name: "express",
+      ...SMOKE_PACKAGE_TARGET,
       limit: 2,
       format: "json",
     }),
@@ -641,7 +657,7 @@ async function runLiveSmoke(client: Client): Promise<void> {
 
   const codeFilesText = assertDefaultText(
     await callTool(client, "code_files", {
-      target: { registry: "npm", package_name: "express" },
+      target: SMOKE_PACKAGE_TARGET,
       path_prefix: "package.json",
       limit: 1,
     }),
@@ -654,7 +670,7 @@ async function runLiveSmoke(client: Client): Promise<void> {
 
   const codeFilesJson = assertJsonResult(
     await callTool(client, "code_files", {
-      target: { registry: "npm", package_name: "express" },
+      target: SMOKE_PACKAGE_TARGET,
       path_prefix: "package.json",
       limit: 1,
       format: "json",
@@ -669,7 +685,7 @@ async function runLiveSmoke(client: Client): Promise<void> {
 
   const codeReadText = assertDefaultText(
     await callTool(client, "code_read", {
-      target: { registry: "npm", package_name: "express" },
+      target: SMOKE_PACKAGE_TARGET,
       path: "package.json",
       start_line: 1,
       end_line: 5,
@@ -680,7 +696,7 @@ async function runLiveSmoke(client: Client): Promise<void> {
 
   const codeReadJson = assertJsonResult(
     await callTool(client, "code_read", {
-      target: { registry: "npm", package_name: "express" },
+      target: SMOKE_PACKAGE_TARGET,
       path: "package.json",
       start_line: 1,
       end_line: 5,
@@ -693,7 +709,7 @@ async function runLiveSmoke(client: Client): Promise<void> {
 
   const codeGrepText = assertDefaultText(
     await callTool(client, "code_grep", {
-      target: { registry: "npm", package_name: "express" },
+      target: SMOKE_PACKAGE_TARGET,
       pattern: "express",
       path: "package.json",
       max_matches: 1,
@@ -707,7 +723,7 @@ async function runLiveSmoke(client: Client): Promise<void> {
 
   const codeGrepJson = assertJsonResult(
     await callTool(client, "code_grep", {
-      target: { registry: "npm", package_name: "express" },
+      target: SMOKE_PACKAGE_TARGET,
       pattern: "express",
       path: "package.json",
       max_matches: 1,
@@ -723,7 +739,7 @@ async function runLiveSmoke(client: Client): Promise<void> {
 
   const searchText = assertDefaultText(
     await callTool(client, "search", {
-      target: { registry: "npm", package_name: "express" },
+      target: SMOKE_PACKAGE_TARGET,
       query: "router",
       limit: 1,
     }),
@@ -738,7 +754,7 @@ async function runLiveSmoke(client: Client): Promise<void> {
 
   const searchJson = assertJsonResult(
     await callTool(client, "search", {
-      target: { registry: "npm", package_name: "express" },
+      target: SMOKE_PACKAGE_TARGET,
       query: "router",
       limit: 1,
       format: "json",
@@ -788,7 +804,9 @@ async function runLiveSmoke(client: Client): Promise<void> {
 async function main(): Promise<void> {
   await assertUnauthenticatedBehavior();
   await withMcpClient(undefined, async (client) => {
-    const toolsResponse = await client.listTools();
+    const toolsResponse = await trackSmokeStep("mcp listTools", () =>
+      client.listTools(),
+    );
     const toolNames = new Set(toolsResponse.tools.map((tool) => tool.name));
     for (const expected of EXPECTED_TOOLS) {
       assert(toolNames.has(expected), `listTools missing ${expected}`);
@@ -801,4 +819,8 @@ async function main(): Promise<void> {
   });
 }
 
-await main();
+try {
+  await main();
+} finally {
+  printSmokeTimingSummary();
+}

--- a/scripts/smoke-telemetry.ts
+++ b/scripts/smoke-telemetry.ts
@@ -1,0 +1,102 @@
+interface SmokeTiming {
+  name: string;
+  elapsedMs: number;
+}
+
+const smokeTimings: SmokeTiming[] = [];
+const smokeStartedAt = Date.now();
+
+function logSmoke(message: string): void {
+  process.stderr.write(`[smoke] ${message}\n`);
+}
+
+function formatMs(ms: number): string {
+  return `${ms}ms`;
+}
+
+export function formatCliCommand(args: string[]): string {
+  const redacted = [...args];
+  for (let index = 0; index < redacted.length - 1; index += 1) {
+    if (["--token", "--api-token"].includes(redacted[index] ?? "")) {
+      redacted[index + 1] = "<redacted>";
+    }
+  }
+  return `githits ${redacted.join(" ")}`;
+}
+
+export function summarizeMcpArgs(args: Record<string, unknown>): string {
+  const summary: Record<string, unknown> = {};
+  for (const key of [
+    "registry",
+    "package_name",
+    "version",
+    "query",
+    "language",
+    "path",
+    "path_prefix",
+    "format",
+    "limit",
+    "lifecycle",
+    "advisory_scope",
+    "search_ref",
+  ]) {
+    if (key in args) summary[key] = args[key];
+  }
+  if ("target" in args) summary.target = args.target;
+  return Object.keys(summary).length > 0 ? ` ${JSON.stringify(summary)}` : "";
+}
+
+export async function trackSmokeStep<T>(
+  name: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const start = Date.now();
+  logSmoke(`START ${name}`);
+  try {
+    const result = await fn();
+    const elapsedMs = Date.now() - start;
+    smokeTimings.push({ name, elapsedMs });
+    logSmoke(`END ${name} ${formatMs(elapsedMs)}`);
+    return result;
+  } catch (error) {
+    const elapsedMs = Date.now() - start;
+    smokeTimings.push({ name, elapsedMs });
+    logSmoke(`FAIL ${name} ${formatMs(elapsedMs)}`);
+    throw error;
+  }
+}
+
+export function printSmokeTimingSummary(): void {
+  if (smokeTimings.length === 0) return;
+  const totalMs = smokeTimings.reduce(
+    (sum, timing) => sum + timing.elapsedMs,
+    0,
+  );
+  logSmoke(
+    `Timing summary: ${smokeTimings.length} steps, wall ${formatMs(Date.now() - smokeStartedAt)}, cumulative ${formatMs(totalMs)}`,
+  );
+  for (const timing of [...smokeTimings]
+    .sort((left, right) => right.elapsedMs - left.elapsedMs)
+    .slice(0, 10)) {
+    logSmoke(`Slowest: ${timing.name} ${formatMs(timing.elapsedMs)}`);
+  }
+}
+
+export async function mapWithConcurrency<T>(
+  items: T[],
+  concurrency: number,
+  worker: (item: T) => Promise<void>,
+): Promise<void> {
+  const workerCount = Math.min(Math.max(1, concurrency), items.length);
+  await Promise.all(
+    Array.from({ length: workerCount }, async (_, workerIndex) => {
+      for (
+        let index = workerIndex;
+        index < items.length;
+        index += workerCount
+      ) {
+        await worker(items[index] as T);
+      }
+    }),
+  );
+}


### PR DESCRIPTION
## Summary
- add shared smoke telemetry helper with per-step progress and timing summaries
- pin index-backed smoke fixtures to npm:express@5.2.1
- run CLI/MCP JSON parity checks with bounded concurrency

## Validation
- code-reviewer: no findings
- bun run typecheck
- bun run lint
- GITHITS_MCP_URL=https://mcp-dev.githits.com GITHITS_API_URL=https://api-dev.githits.com PKGSEER_URL=https://pkgseer-backend-dev.fly.dev bun run smoke:mcp
- GITHITS_MCP_URL=https://mcp-dev.githits.com GITHITS_API_URL=https://api-dev.githits.com PKGSEER_URL=https://pkgseer-backend-dev.fly.dev bun run smoke:cli