### PR TITLE
fix: harden CLI auth and timeout errors

### DIFF
--- a/docs/implementation/mcp-cli-parity.md
+++ b/docs/implementation/mcp-cli-parity.md
@@ -34,6 +34,7 @@ The dual-surface tools today are:
 - `pkg_vulns` ↔ `githits pkg vulns`
 - `pkg_deps` ↔ `githits pkg deps`
 - `pkg_changelog` ↔ `githits pkg changelog`
+- `pkg_upgrade_review` ↔ `githits pkg upgrade-review`
 - `docs_list` ↔ `githits docs list`
 - `docs_read` ↔ `githits docs read`
 

--- a/scripts/cli-smoke.ts
+++ b/scripts/cli-smoke.ts
@@ -392,14 +392,22 @@ async function assertUnauthenticatedBehavior(): Promise<void> {
   try {
     const result = await runCliWithEnv(["languages", "python", "--json"], env);
     assert(result.exitCode !== 0, "unauthenticated languages should fail");
-    const output = `${result.stdout}\n${result.stderr}`;
     assert(
-      output.includes("Authentication required"),
-      "unauthenticated probe missing authentication guidance",
+      result.stdout.trim() === "",
+      "unauthenticated JSON probe should keep stdout clean",
     );
-    assert(
-      output.includes("githits login"),
-      "unauthenticated probe missing login guidance",
+    const payload = assertCleanErrorEnvelope(
+      result.stderr,
+      "unauthenticated languages",
+    );
+    assertDeepEqual(
+      payload,
+      {
+        error: "Authentication required.",
+        code: "AUTH_REQUIRED",
+        retryable: false,
+      },
+      "unauthenticated languages JSON envelope",
     );
   } finally {
     if (env.HOME) {

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -429,6 +429,46 @@ describe("root CLI preAction", () => {
     logSpy.mockRestore();
     errorSpy.mockRestore();
   });
+
+  it("emits JSON when interactive --json auto-login fails", async () => {
+    const logSpy = spyOn(console, "log").mockImplementation(() => {});
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    const createContainer = mock(() => Promise.resolve(createLoginDeps()));
+    const loginFlow = mock(() =>
+      Promise.resolve({
+        status: "failed" as const,
+        message: "Authentication timed out.",
+      }),
+    );
+    const exit = mock(() => {
+      throw new Error("process.exit");
+    });
+    const program = createProgramWithRootPreAction({
+      createContainer,
+      loginFlow,
+      exit,
+    });
+
+    program
+      .command("example")
+      .option("--json", "Output JSON")
+      .action(() => {});
+
+    await expect(
+      program.parseAsync(["node", "githits", "example", "--json"]),
+    ).rejects.toThrow("process.exit");
+
+    expect(logSpy).not.toHaveBeenCalled();
+    expect(JSON.parse(String(errorSpy.mock.calls[0]?.[0]))).toEqual({
+      error: "Authentication timed out.",
+      code: "AUTH_REQUIRED",
+      retryable: false,
+    });
+    expect(exit).toHaveBeenCalledWith(1);
+
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
 });
 
 describe("CLI help surface", () => {

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, mock, spyOn } from "bun:test";
 import { Command } from "commander";
 import {
   registerCodeCommandGroup,
+  registerDocsCommandGroup,
   registerExampleCommand,
   registerFeedbackCommand,
   registerLanguagesCommand,
@@ -114,6 +115,7 @@ async function createProgramForHelpSurface(options: {
   registerFeedbackCommand(program);
   await registerUnifiedSearchCommands(program, options);
   await registerCodeCommandGroup(program, options);
+  await registerDocsCommandGroup(program, options);
   await registerPkgCommandGroup(program, options);
 
   return program;
@@ -442,6 +444,7 @@ describe("CLI help surface", () => {
     expect(help).toMatch(/^\s{2}feedback\b/m);
     expect(help).not.toMatch(/^\s{2}search\b/m);
     expect(help).not.toMatch(/^\s{2}code\b/m);
+    expect(help).not.toMatch(/^\s{2}docs\b/m);
     expect(help).not.toMatch(/^\s{2}pkg\b/m);
   });
 
@@ -454,6 +457,7 @@ describe("CLI help surface", () => {
 
     expect(help).toMatch(/^\s{2}search\b/m);
     expect(help).toMatch(/^\s{2}code\b/m);
+    expect(help).toMatch(/^\s{2}docs\b/m);
     expect(help).toMatch(/^\s{2}pkg\b/m);
   });
 });

--- a/src/cli/errors.test.ts
+++ b/src/cli/errors.test.ts
@@ -11,19 +11,28 @@ describe("handleCliError", () => {
     }) as (code: number) => never;
 
     expect(() =>
-      handleCliError(new AuthRequiredError("Authentication required"), {
-        stderr: {
-          write: (chunk: string | Uint8Array) => {
-            stderrWrites.push(String(chunk));
-            return true;
+      handleCliError(
+        new AuthRequiredError(
+          "Authentication required.",
+          "https://mcp.githits.com",
+        ),
+        {
+          stderr: {
+            write: (chunk: string | Uint8Array) => {
+              stderrWrites.push(String(chunk));
+              return true;
+            },
           },
+          exit,
         },
-        exit,
-      }),
+      ),
     ).toThrow("process.exit:1");
 
-    expect(stderrWrites.join("")).not.toContain("AuthRequiredError");
-    expect(stderrWrites.join("")).not.toContain("at ");
+    const output = stderrWrites.join("");
+    expect(output).toContain("Authentication required.");
+    expect(output).toContain("githits login");
+    expect(output).not.toContain("AuthRequiredError");
+    expect(output).not.toContain("at ");
   });
 
   it("prints lock timeout errors without an uncaught stack trace", () => {

--- a/src/cli/errors.ts
+++ b/src/cli/errors.ts
@@ -3,7 +3,10 @@ import {
   AuthStorageLockTimeoutError,
   AuthStoragePolicyError,
 } from "../services/index.js";
-import { AuthRequiredError } from "../shared/require-auth.js";
+import {
+  AuthRequiredError,
+  formatAuthRequiredForTerminal,
+} from "../shared/require-auth.js";
 
 export interface CliErrorHandlerDeps {
   stderr: Pick<NodeJS.WriteStream, "write">;
@@ -15,6 +18,7 @@ export function handleCliError(
   deps: CliErrorHandlerDeps,
 ): never {
   if (error instanceof AuthRequiredError) {
+    deps.stderr.write(`${formatAuthRequiredForTerminal(error)}\n`);
     deps.exit(1);
   }
 

--- a/src/commands/auth-json.test.ts
+++ b/src/commands/auth-json.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it, spyOn } from "bun:test";
+import {
+  createMockCodeNavigationService,
+  createMockGitHitsService,
+  createMockPackageIntelligenceService,
+} from "../services/test-helpers.js";
+import { pkgFilesAction } from "./code/files.js";
+import { pkgGrepAction } from "./code/grep.js";
+import { pkgReadAction } from "./code/read.js";
+import { docsListAction } from "./docs/list.js";
+import { docsReadAction } from "./docs/read.js";
+import { exampleAction } from "./example.js";
+import { feedbackAction } from "./feedback.js";
+import { languagesAction } from "./languages.js";
+import { pkgChangelogAction } from "./pkg/changelog.js";
+import { pkgDepsAction } from "./pkg/deps.js";
+import { pkgInfoAction } from "./pkg/info.js";
+import { pkgUpgradeReviewAction } from "./pkg/upgrade-review.js";
+import { pkgVulnsAction } from "./pkg/vulns.js";
+import { searchAction, searchStatusAction } from "./search.js";
+
+const missingAuth = {
+  hasValidToken: false,
+  mcpUrl: "https://mcp.githits.com",
+} as const;
+
+const gitHitsDeps = {
+  ...missingAuth,
+  githitsService: createMockGitHitsService(),
+};
+
+const codeDeps = {
+  ...missingAuth,
+  codeNavigationUrl: "https://pkgseer.dev",
+  codeNavigationService: createMockCodeNavigationService(),
+};
+
+const packageDeps = {
+  ...missingAuth,
+  codeNavigationUrl: "https://pkgseer.dev",
+  packageIntelligenceService: createMockPackageIntelligenceService(),
+};
+
+describe("authenticated command JSON auth failures", () => {
+  const cases: Array<{ name: string; run: () => Promise<void> }> = [
+    {
+      name: "example",
+      run: () => exampleAction("router", { json: true }, gitHitsDeps),
+    },
+    {
+      name: "languages",
+      run: () => languagesAction(undefined, { json: true }, gitHitsDeps),
+    },
+    {
+      name: "feedback",
+      run: () =>
+        feedbackAction(undefined, { accept: true, json: true }, gitHitsDeps),
+    },
+    {
+      name: "search",
+      run: () =>
+        searchAction("router", { in: ["npm:express"], json: true }, codeDeps),
+    },
+    {
+      name: "search-status",
+      run: () => searchStatusAction("search-ref", { json: true }, codeDeps),
+    },
+    {
+      name: "code files",
+      run: () =>
+        pkgFilesAction("npm:express", undefined, { json: true }, codeDeps),
+    },
+    {
+      name: "code read",
+      run: () =>
+        pkgReadAction("npm:express", "src/index.js", { json: true }, codeDeps),
+    },
+    {
+      name: "code grep",
+      run: () =>
+        pkgGrepAction(
+          "npm:express",
+          "router",
+          undefined,
+          { json: true },
+          codeDeps,
+        ),
+    },
+    {
+      name: "docs list",
+      run: () => docsListAction("npm:express", { json: true }, packageDeps),
+    },
+    {
+      name: "docs read",
+      run: () => docsReadAction("page-id", { json: true }, packageDeps),
+    },
+    {
+      name: "pkg info",
+      run: () => pkgInfoAction("npm:express", { json: true }, packageDeps),
+    },
+    {
+      name: "pkg vulns",
+      run: () => pkgVulnsAction("npm:express", { json: true }, packageDeps),
+    },
+    {
+      name: "pkg deps",
+      run: () => pkgDepsAction("npm:express", { json: true }, packageDeps),
+    },
+    {
+      name: "pkg changelog",
+      run: () => pkgChangelogAction("npm:express", { json: true }, packageDeps),
+    },
+    {
+      name: "pkg upgrade-review",
+      run: () =>
+        pkgUpgradeReviewAction(
+          "npm:express@4.18.0",
+          { to: "5.0.0", json: true },
+          packageDeps,
+        ),
+    },
+  ];
+
+  it.each(cases)("emits AUTH_REQUIRED JSON for $name", async ({ run }) => {
+    const logSpy = spyOn(console, "log").mockImplementation(() => {});
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+
+    try {
+      await expect(run()).rejects.toThrow("process.exit");
+
+      expect(logSpy).not.toHaveBeenCalled();
+      const payload = JSON.parse(String(errorSpy.mock.calls[0]?.[0]));
+      expect(payload).toEqual({
+        error: "Authentication required.",
+        code: "AUTH_REQUIRED",
+        retryable: false,
+      });
+    } finally {
+      logSpy.mockRestore();
+      errorSpy.mockRestore();
+      exitSpy.mockRestore();
+    }
+  });
+});

--- a/src/commands/code/code-nav-cli-helpers.ts
+++ b/src/commands/code/code-nav-cli-helpers.ts
@@ -23,6 +23,8 @@ import {
   toPkgseerRegistry,
 } from "../../shared/index.js";
 
+export { parseIntCliOption } from "../../shared/cli-options.js";
+
 /**
  * Fields every indexed `code` command shares.
  */
@@ -79,33 +81,6 @@ export function resolveCliCodeNavTarget(
     repoUrl: options.repoUrl,
     gitRef: options.gitRef,
   };
-}
-
-/**
- * Parse an optional `--flag N` integer option with bounds.
- * Returns `undefined` when the caller didn't supply the flag.
- * Throws `InvalidPackageSpecError` on non-integer or out-of-range
- * input so the error classifier routes to `INVALID_ARGUMENT`.
- */
-export function parseIntCliOption(
-  raw: string | undefined,
-  name: string,
-  min: number,
-  max: number,
-): number | undefined {
-  if (raw === undefined) return undefined;
-  if (!/^-?\d+$/.test(raw.trim())) {
-    throw new InvalidPackageSpecError(
-      `${name} expects an integer between ${min} and ${max}. Got '${raw}'.`,
-    );
-  }
-  const parsed = Number.parseInt(raw, 10);
-  if (parsed < min || parsed > max) {
-    throw new InvalidPackageSpecError(
-      `${name} expects an integer between ${min} and ${max}. Got ${parsed}.`,
-    );
-  }
-  return parsed;
 }
 
 /**

--- a/src/commands/code/files.ts
+++ b/src/commands/code/files.ts
@@ -74,7 +74,13 @@ export async function pkgFilesAction(
   options: PkgFilesCommandOptions,
   deps: PkgFilesCommandDependencies,
 ): Promise<void> {
-  requireAuth(deps);
+  try {
+    requireAuth(deps);
+  } catch (error) {
+    if (options.json)
+      handleCodeNavCommandError(error, true, formatIndexingError);
+    throw error;
+  }
 
   try {
     if (!deps.codeNavigationUrl || !deps.codeNavigationService) {

--- a/src/commands/code/grep.ts
+++ b/src/commands/code/grep.ts
@@ -62,7 +62,14 @@ export async function pkgGrepAction(
   options: PkgGrepCommandOptions,
   deps: PkgGrepCommandDependencies,
 ): Promise<void> {
-  requireAuth(deps);
+  try {
+    requireAuth(deps);
+  } catch (error) {
+    if (options.json) {
+      handleCodeNavCommandError(error, true, formatFileErrorWithFilesHint, 2);
+    }
+    throw error;
+  }
 
   try {
     if (!deps.codeNavigationUrl || !deps.codeNavigationService) {

--- a/src/commands/code/read.ts
+++ b/src/commands/code/read.ts
@@ -64,9 +64,16 @@ export async function pkgReadAction(
   options: PkgReadCommandOptions,
   deps: PkgReadCommandDependencies,
 ): Promise<void> {
-  requireAuth(deps);
-
   let requestedFilePath = "";
+
+  try {
+    requireAuth(deps);
+  } catch (error) {
+    if (options.json) {
+      handleCodeNavCommandError(error, true, formatFileErrorWithFilesHint);
+    }
+    throw error;
+  }
 
   try {
     if (!deps.codeNavigationUrl || !deps.codeNavigationService) {

--- a/src/commands/docs/list.ts
+++ b/src/commands/docs/list.ts
@@ -34,7 +34,12 @@ export async function docsListAction(
   options: DocsListCommandOptions,
   deps: DocsListCommandDependencies,
 ): Promise<void> {
-  requireAuth(deps);
+  try {
+    requireAuth(deps);
+  } catch (error) {
+    if (options.json) handleDocsListError(error, true);
+    throw error;
+  }
 
   try {
     if (!deps.codeNavigationUrl || !deps.packageIntelligenceService) {

--- a/src/commands/docs/read.ts
+++ b/src/commands/docs/read.ts
@@ -33,7 +33,12 @@ export async function docsReadAction(
   options: DocsReadCommandOptions,
   deps: DocsReadCommandDependencies,
 ): Promise<void> {
-  requireAuth(deps);
+  try {
+    requireAuth(deps);
+  } catch (error) {
+    if (options.json) handleDocsReadError(error, true);
+    throw error;
+  }
 
   try {
     if (!deps.codeNavigationUrl || !deps.packageIntelligenceService) {

--- a/src/commands/example.test.ts
+++ b/src/commands/example.test.ts
@@ -98,8 +98,7 @@ describe("exampleAction", () => {
 
     const output = errorSpy.mock.calls[0]?.[0] as string;
     expect(JSON.parse(output)).toEqual({
-      error:
-        "Authentication required. Run `githits login`, then retry this command.",
+      error: "Authentication required.",
       code: "AUTH_REQUIRED",
       retryable: false,
     });

--- a/src/commands/example.ts
+++ b/src/commands/example.ts
@@ -2,7 +2,11 @@ import { type Command, Option } from "commander";
 import type { GitHitsService } from "../services/githits-service.js";
 import { AuthenticationError } from "../services/githits-service.js";
 import { extractSolutionId } from "../shared/extract-solution-id.js";
-import { AuthRequiredError, requireAuth } from "../shared/require-auth.js";
+import {
+  AuthRequiredError,
+  buildAuthRequiredErrorPayload,
+  requireAuth,
+} from "../shared/require-auth.js";
 import { startSpinner } from "../shared/spinner.js";
 import { SPINNER_MESSAGES } from "../shared/spinner-messages.js";
 
@@ -24,18 +28,9 @@ export async function exampleAction(
   options: ExampleOptions,
   deps: ExampleDependencies,
 ): Promise<void> {
-  if (!deps.hasValidToken && options.json) {
-    printExampleError(
-      "Authentication required. Run `githits login`, then retry this command.",
-      "AUTH_REQUIRED",
-      true,
-    );
-    process.exit(1);
-  }
-
-  requireAuth(deps);
-
   try {
+    requireAuth(deps);
+
     const spinner = startSpinner(SPINNER_MESSAGES.example, !options.json);
     const result = await deps.githitsService
       .search({
@@ -56,6 +51,13 @@ export async function exampleAction(
       console.log(result);
     }
   } catch (error) {
+    if (error instanceof AuthRequiredError) {
+      if (options.json) {
+        console.error(JSON.stringify(buildAuthRequiredErrorPayload(error)));
+        process.exit(1);
+      }
+      throw error;
+    }
     if (error instanceof AuthenticationError) {
       printExampleError(
         "Authentication required. Run `githits login`, then retry this command.",
@@ -110,13 +112,8 @@ export function registerExampleCommand(program: Command) {
     .option("--explain", "Include AI-generated explanation")
     .option("--json", "Output as JSON for piping")
     .action(async (query: string, options: ExampleOptions) => {
-      try {
-        const deps = await loadContainer();
-        await exampleAction(query, options, deps);
-      } catch (error) {
-        if (error instanceof AuthRequiredError) process.exit(1);
-        throw error;
-      }
+      const deps = await loadContainer();
+      await exampleAction(query, options, deps);
     });
 }
 

--- a/src/commands/feedback.test.ts
+++ b/src/commands/feedback.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, mock, spyOn } from "bun:test";
+import { AuthenticationError } from "../services/githits-service.js";
 import { createMockGitHitsService } from "../services/test-helpers.js";
 import { AuthRequiredError } from "../shared/require-auth.js";
 import { type FeedbackDependencies, feedbackAction } from "./feedback.js";
@@ -224,6 +225,33 @@ describe("feedbackAction", () => {
     const output = errorSpy.mock.calls.map((c) => c[0]).join("\n");
     expect(output).toContain("Failed to submit feedback");
     expect(output).toContain("Auth required");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it("emits JSON auth envelope when service returns 401 in JSON mode", async () => {
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+    const deps = createDeps({
+      githitsService: createMockGitHitsService({
+        submitFeedback: mock(() =>
+          Promise.reject(new AuthenticationError("Authentication required.")),
+        ),
+      }),
+    });
+
+    await expect(
+      feedbackAction("abc-123", { accept: true, json: true }, deps),
+    ).rejects.toThrow("process.exit");
+
+    expect(JSON.parse(String(errorSpy.mock.calls[0]?.[0]))).toEqual({
+      error: "Authentication required.",
+      code: "AUTH_REQUIRED",
+      retryable: false,
+    });
     expect(exitSpy).toHaveBeenCalledWith(1);
     errorSpy.mockRestore();
     exitSpy.mockRestore();

--- a/src/commands/feedback.ts
+++ b/src/commands/feedback.ts
@@ -1,7 +1,11 @@
 import { type Command, Option } from "commander";
 import { createContainer } from "../container.js";
 import type { GitHitsService } from "../services/githits-service.js";
-import { AuthRequiredError, requireAuth } from "../shared/require-auth.js";
+import {
+  AuthRequiredError,
+  buildAuthRequiredErrorPayload,
+  requireAuth,
+} from "../shared/require-auth.js";
 
 export interface FeedbackOptions {
   accept?: boolean;
@@ -30,7 +34,15 @@ export async function feedbackAction(
   options: FeedbackOptions,
   deps: FeedbackDependencies,
 ): Promise<void> {
-  requireAuth(deps);
+  try {
+    requireAuth(deps);
+  } catch (error) {
+    if (options.json && error instanceof AuthRequiredError) {
+      console.error(JSON.stringify(buildAuthRequiredErrorPayload(error)));
+      process.exit(1);
+    }
+    throw error;
+  }
 
   if (!options.accept && !options.reject) {
     console.error("Error: Specify either --accept or --reject.");
@@ -101,13 +113,8 @@ export function registerFeedbackCommand(program: Command) {
     .option("--json", "Output as JSON for piping")
     .action(
       async (solutionId: string | undefined, options: FeedbackOptions) => {
-        try {
-          const deps = await createContainer();
-          await feedbackAction(solutionId, options, deps);
-        } catch (error) {
-          if (error instanceof AuthRequiredError) process.exit(1);
-          throw error;
-        }
+        const deps = await createContainer();
+        await feedbackAction(solutionId, options, deps);
       },
     );
 }

--- a/src/commands/feedback.ts
+++ b/src/commands/feedback.ts
@@ -1,6 +1,7 @@
 import { type Command, Option } from "commander";
 import { createContainer } from "../container.js";
 import type { GitHitsService } from "../services/githits-service.js";
+import { AuthenticationError } from "../services/githits-service.js";
 import {
   AuthRequiredError,
   buildAuthRequiredErrorPayload,
@@ -67,11 +68,23 @@ export async function feedbackAction(
       console.log(result.message);
     }
   } catch (error) {
+    if (options.json && error instanceof AuthenticationError) {
+      console.error(JSON.stringify(toAuthRequiredPayload(error.message)));
+      process.exit(1);
+    }
     console.error(
       `Failed to submit feedback: ${error instanceof Error ? error.message : error}`,
     );
     process.exit(1);
   }
+}
+
+function toAuthRequiredPayload(message: string): {
+  error: string;
+  code: "AUTH_REQUIRED";
+  retryable: false;
+} {
+  return { error: message, code: "AUTH_REQUIRED", retryable: false };
 }
 
 const FEEDBACK_DESCRIPTION = `Submit feedback on a tool result or the GitHits experience.

--- a/src/commands/languages.test.ts
+++ b/src/commands/languages.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, mock, spyOn } from "bun:test";
+import { AuthenticationError } from "../services/githits-service.js";
 import { createMockGitHitsService } from "../services/test-helpers.js";
 import { AuthRequiredError } from "../shared/require-auth.js";
 import { type LanguagesDependencies, languagesAction } from "./languages.js";
@@ -122,6 +123,33 @@ describe("languagesAction", () => {
     const output = errorSpy.mock.calls.map((c) => c[0]).join("\n");
     expect(output).toContain("Failed to list languages");
     expect(output).toContain("API error");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it("emits JSON auth envelope when service returns 401 in JSON mode", async () => {
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+    const deps = createDeps({
+      githitsService: createMockGitHitsService({
+        getLanguages: mock(() =>
+          Promise.reject(new AuthenticationError("Authentication required.")),
+        ),
+      }),
+    });
+
+    await expect(
+      languagesAction(undefined, { json: true }, deps),
+    ).rejects.toThrow("process.exit");
+
+    expect(JSON.parse(String(errorSpy.mock.calls[0]?.[0]))).toEqual({
+      error: "Authentication required.",
+      code: "AUTH_REQUIRED",
+      retryable: false,
+    });
     expect(exitSpy).toHaveBeenCalledWith(1);
     errorSpy.mockRestore();
     exitSpy.mockRestore();

--- a/src/commands/languages.ts
+++ b/src/commands/languages.ts
@@ -1,6 +1,7 @@
 import type { Command } from "commander";
 import { createContainer } from "../container.js";
 import type { GitHitsService } from "../services/githits-service.js";
+import { AuthenticationError } from "../services/githits-service.js";
 import { colorize, dim, shouldUseColors } from "../shared/colors.js";
 import {
   filterLanguages,
@@ -64,11 +65,23 @@ export async function languagesAction(
       }
     }
   } catch (error) {
+    if (options.json && error instanceof AuthenticationError) {
+      console.error(JSON.stringify(toAuthRequiredPayload(error.message)));
+      process.exit(1);
+    }
     console.error(
       `Failed to list languages: ${error instanceof Error ? error.message : error}`,
     );
     process.exit(1);
   }
+}
+
+function toAuthRequiredPayload(message: string): {
+  error: string;
+  code: "AUTH_REQUIRED";
+  retryable: false;
+} {
+  return { error: message, code: "AUTH_REQUIRED", retryable: false };
 }
 
 const LANGUAGES_DESCRIPTION = `List supported programming languages.

--- a/src/commands/languages.ts
+++ b/src/commands/languages.ts
@@ -6,7 +6,11 @@ import {
   filterLanguages,
   type LanguageMatch,
 } from "../shared/language-filter.js";
-import { AuthRequiredError, requireAuth } from "../shared/require-auth.js";
+import {
+  AuthRequiredError,
+  buildAuthRequiredErrorPayload,
+  requireAuth,
+} from "../shared/require-auth.js";
 
 export interface LanguagesOptions {
   json?: boolean;
@@ -26,7 +30,15 @@ export async function languagesAction(
   options: LanguagesOptions,
   deps: LanguagesDependencies,
 ): Promise<void> {
-  requireAuth(deps);
+  try {
+    requireAuth(deps);
+  } catch (error) {
+    if (options.json && error instanceof AuthRequiredError) {
+      console.error(JSON.stringify(buildAuthRequiredErrorPayload(error)));
+      process.exit(1);
+    }
+    throw error;
+  }
 
   try {
     const allLanguages = await deps.githitsService.getLanguages();
@@ -81,12 +93,7 @@ export function registerLanguagesCommand(program: Command) {
     .argument("[query]", "Filter by name, display name, or alias")
     .option("--json", "Output as JSON for piping")
     .action(async (query: string | undefined, options: LanguagesOptions) => {
-      try {
-        const deps = await createContainer();
-        await languagesAction(query, options, deps);
-      } catch (error) {
-        if (error instanceof AuthRequiredError) process.exit(1);
-        throw error;
-      }
+      const deps = await createContainer();
+      await languagesAction(query, options, deps);
     });
 }

--- a/src/commands/pkg/changelog.ts
+++ b/src/commands/pkg/changelog.ts
@@ -52,7 +52,12 @@ export async function pkgChangelogAction(
   options: PkgChangelogCommandOptions,
   deps: PkgChangelogCommandDependencies,
 ): Promise<void> {
-  requireAuth(deps);
+  try {
+    requireAuth(deps);
+  } catch (error) {
+    if (options.json) handlePkgChangelogCommandError(error, true);
+    throw error;
+  }
 
   try {
     if (!deps.codeNavigationUrl || !deps.packageIntelligenceService) {

--- a/src/commands/pkg/deps.ts
+++ b/src/commands/pkg/deps.ts
@@ -49,7 +49,12 @@ export async function pkgDepsAction(
   options: PkgDepsCommandOptions,
   deps: PkgDepsCommandDependencies,
 ): Promise<void> {
-  requireAuth(deps);
+  try {
+    requireAuth(deps);
+  } catch (error) {
+    if (options.json) handlePkgDepsCommandError(error, true);
+    throw error;
+  }
 
   try {
     if (!deps.codeNavigationUrl || !deps.packageIntelligenceService) {

--- a/src/commands/pkg/info.ts
+++ b/src/commands/pkg/info.ts
@@ -38,7 +38,12 @@ export async function pkgInfoAction(
   options: PkgInfoCommandOptions,
   deps: PkgInfoCommandDependencies,
 ): Promise<void> {
-  requireAuth(deps);
+  try {
+    requireAuth(deps);
+  } catch (error) {
+    if (options.json) handlePkgInfoCommandError(error, true);
+    throw error;
+  }
 
   try {
     if (!deps.codeNavigationUrl || !deps.packageIntelligenceService) {

--- a/src/commands/pkg/upgrade-review.ts
+++ b/src/commands/pkg/upgrade-review.ts
@@ -35,7 +35,13 @@ export async function pkgUpgradeReviewAction(
   options: PkgUpgradeReviewCommandOptions,
   deps: PkgUpgradeReviewCommandDependencies,
 ): Promise<void> {
-  requireAuth(deps);
+  try {
+    requireAuth(deps);
+  } catch (error) {
+    if (options.json) handlePkgUpgradeReviewCommandError(error, true);
+    throw error;
+  }
+
   try {
     if (!deps.codeNavigationUrl || !deps.packageIntelligenceService) {
       throw new InvalidPackageSpecError(
@@ -67,21 +73,28 @@ export async function pkgUpgradeReviewAction(
       }),
     );
   } catch (error) {
-    const mapped = mapPackageIntelligenceError(error);
-    if (options.json) {
-      console.error(
-        JSON.stringify({
-          error: mapped.message,
-          code: mapped.code,
-          retryable: mapped.retryable ?? false,
-          ...(mapped.details ? { details: mapped.details } : {}),
-        }),
-      );
-    } else {
-      console.error(formatMappedErrorForTerminal(mapped));
-    }
-    process.exit(1);
+    handlePkgUpgradeReviewCommandError(error, options.json ?? false);
   }
+}
+
+function handlePkgUpgradeReviewCommandError(
+  error: unknown,
+  json: boolean,
+): never {
+  const mapped = mapPackageIntelligenceError(error);
+  if (json) {
+    console.error(
+      JSON.stringify({
+        error: mapped.message,
+        code: mapped.code,
+        retryable: mapped.retryable ?? false,
+        ...(mapped.details ? { details: mapped.details } : {}),
+      }),
+    );
+  } else {
+    console.error(formatMappedErrorForTerminal(mapped));
+  }
+  process.exit(1);
 }
 
 function parseSingleSpec(

--- a/src/commands/pkg/vulns.ts
+++ b/src/commands/pkg/vulns.ts
@@ -42,7 +42,12 @@ export async function pkgVulnsAction(
   options: PkgVulnsCommandOptions,
   deps: PkgVulnsCommandDependencies,
 ): Promise<void> {
-  requireAuth(deps);
+  try {
+    requireAuth(deps);
+  } catch (error) {
+    if (options.json) handlePkgVulnsCommandError(error, true);
+    throw error;
+  }
 
   try {
     if (!deps.codeNavigationUrl || !deps.packageIntelligenceService) {

--- a/src/commands/search.test.ts
+++ b/src/commands/search.test.ts
@@ -158,6 +158,35 @@ describe("searchAction", () => {
     consoleSpy.mockRestore();
   });
 
+  it.each([
+    [{ limit: "10abc" }, "--limit"],
+    [{ limit: "5.5" }, "--limit"],
+    [{ offset: "2.5" }, "--offset"],
+    [{ wait: "1szzz" }, "--wait"],
+  ] as const)("rejects partial numeric option %p", async (partial, flag) => {
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+
+    try {
+      await expect(
+        searchAction(
+          "router middleware",
+          { in: ["npm:express"], json: true, ...partial },
+          createDeps(),
+        ),
+      ).rejects.toThrow("process.exit");
+
+      const payload = JSON.parse(String(errorSpy.mock.calls[0]?.[0]));
+      expect(payload.code).toBe("INVALID_ARGUMENT");
+      expect(payload.error).toContain(flag);
+    } finally {
+      errorSpy.mockRestore();
+      exitSpy.mockRestore();
+    }
+  });
+
   it("does not send a file-intent filter unless the caller explicitly set one", async () => {
     const search = mock<
       (

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -16,6 +16,7 @@ import {
   InvalidArgumentError,
   knownSymbolCategoryList,
   knownSymbolKindList,
+  parseIntCliOption,
   parseUnifiedSearchTargetSpec,
   requireAuth,
   SPINNER_MESSAGES,
@@ -68,7 +69,12 @@ export async function searchAction(
   options: SearchCommandOptions,
   deps: SearchCommandDependencies,
 ): Promise<void> {
-  requireAuth(deps);
+  try {
+    requireAuth(deps);
+  } catch (error) {
+    if (options.json) handleSearchError(error, true);
+    throw error;
+  }
 
   try {
     const service = requireSearchService(deps);
@@ -116,7 +122,12 @@ export async function searchStatusAction(
   options: SearchStatusCommandOptions,
   deps: SearchCommandDependencies,
 ): Promise<void> {
-  requireAuth(deps);
+  try {
+    requireAuth(deps);
+  } catch (error) {
+    if (options.json) handleSearchError(error, true, "status");
+    throw error;
+  }
 
   try {
     const service = requireSearchService(deps);
@@ -328,25 +339,19 @@ function parseOptionalInt(
   min: number,
   max = Number.MAX_SAFE_INTEGER,
 ): number | undefined {
-  if (value === undefined) return undefined;
-  const parsed = Number.parseInt(value, 10);
-  if (!Number.isFinite(parsed) || parsed < min || parsed > max) {
-    throw new InvalidArgumentError(
-      `${flag} must be an integer between ${min} and ${max}.`,
-    );
-  }
-  return parsed;
+  return parseIntCliOption(value, flag, min, max);
 }
 
 function parseWaitMs(value: string | undefined): number | undefined {
   if (value === undefined) return undefined;
-  const trimmed = value.trim().replace(/s$/i, "");
-  const seconds = Number.parseInt(trimmed, 10);
-  if (!Number.isFinite(seconds) || seconds < 0 || seconds > 60) {
+  const match = /^(?<seconds>-?\d+)s?$/i.exec(value.trim());
+  if (!match?.groups?.seconds) {
     throw new InvalidArgumentError(
       "--wait must be an integer between 0 and 60 seconds.",
     );
   }
+  const seconds = parseIntCliOption(match.groups.seconds, "--wait", 0, 60);
+  if (seconds === undefined) return undefined;
   return seconds * 1000;
 }
 

--- a/src/services/auth-service.test.ts
+++ b/src/services/auth-service.test.ts
@@ -1,6 +1,13 @@
 import { afterEach, describe, expect, it, mock } from "bun:test";
 import { createServer } from "node:http";
+import { FetchTimeoutError } from "../shared/fetch-timeout.js";
 import { AuthServiceImpl, evaluateCallback } from "./auth-service.js";
+
+function asFetchFn<T extends (...args: never[]) => unknown>(
+  fn: T,
+): typeof fetch {
+  return fn as unknown as typeof fetch;
+}
 
 describe("AuthServiceImpl", () => {
   const service = new AuthServiceImpl();
@@ -57,6 +64,15 @@ describe("AuthServiceImpl", () => {
         service.discoverEndpoints("http://127.0.0.1:1"),
       ).rejects.toThrow();
     });
+
+    it("times out stalled discovery requests", async () => {
+      const fetchFn = mock(() => new Promise<Response>(() => {}));
+      const timeoutService = new AuthServiceImpl(asFetchFn(fetchFn), 1);
+
+      await expect(
+        timeoutService.discoverEndpoints("https://mcp.example.com"),
+      ).rejects.toThrow(FetchTimeoutError);
+    });
   });
 
   describe("startCallbackServer", () => {
@@ -111,6 +127,20 @@ describe("AuthServiceImpl", () => {
         refreshToken: undefined,
         expiresIn: 60,
       });
+    });
+
+    it("times out stalled token refresh requests", async () => {
+      const fetchFn = mock(() => new Promise<Response>(() => {}));
+      const timeoutService = new AuthServiceImpl(asFetchFn(fetchFn), 1);
+
+      await expect(
+        timeoutService.refreshAccessToken({
+          tokenEndpoint: "https://auth.example.com/oauth/token",
+          clientId: "client-id",
+          clientSecret: "client-secret",
+          refreshToken: "refresh-token",
+        }),
+      ).rejects.toThrow(FetchTimeoutError);
     });
   });
 

--- a/src/services/auth-service.ts
+++ b/src/services/auth-service.ts
@@ -4,6 +4,10 @@ import {
   generateCodeVerifier,
   generateState,
 } from "../auth/pkce.js";
+import {
+  DEFAULT_FETCH_TIMEOUT_MS,
+  fetchWithTimeout,
+} from "../shared/fetch-timeout.js";
 
 /**
  * OAuth Authorization Server metadata from .well-known endpoint.
@@ -152,9 +156,14 @@ export interface CallbackServerHandle {
  * Production implementation of AuthService using OAuth PKCE with DCR.
  */
 export class AuthServiceImpl implements AuthService {
+  constructor(
+    private readonly fetchFn?: typeof fetch,
+    private readonly fetchTimeoutMs: number = DEFAULT_FETCH_TIMEOUT_MS,
+  ) {}
+
   async discoverEndpoints(mcpBaseUrl: string): Promise<OAuthMetadata> {
     const url = `${mcpBaseUrl}/.well-known/oauth-authorization-server`;
-    const response = await fetch(url);
+    const response = await fetchWithTimeout(url, {}, this.fetchOptions());
 
     if (!response.ok) {
       throw new Error(
@@ -181,17 +190,21 @@ export class AuthServiceImpl implements AuthService {
   async registerClient(
     params: RegisterClientParams,
   ): Promise<{ clientId: string; clientSecret: string }> {
-    const response = await fetch(params.registrationEndpoint, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        client_name: "GitHits CLI",
-        redirect_uris: [params.redirectUri],
-        grant_types: ["authorization_code", "refresh_token"],
-        response_types: ["code"],
-        token_endpoint_auth_method: "client_secret_post",
-      }),
-    });
+    const response = await fetchWithTimeout(
+      params.registrationEndpoint,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          client_name: "GitHits CLI",
+          redirect_uris: [params.redirectUri],
+          grant_types: ["authorization_code", "refresh_token"],
+          response_types: ["code"],
+          token_endpoint_auth_method: "client_secret_post",
+        }),
+      },
+      this.fetchOptions(),
+    );
 
     if (!response.ok) {
       const error = await response.text();
@@ -325,11 +338,15 @@ export class AuthServiceImpl implements AuthService {
       redirect_uri: params.redirectUri,
     });
 
-    const response = await fetch(params.tokenEndpoint, {
-      method: "POST",
-      headers: { "Content-Type": "application/x-www-form-urlencoded" },
-      body: body.toString(),
-    });
+    const response = await fetchWithTimeout(
+      params.tokenEndpoint,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: body.toString(),
+      },
+      this.fetchOptions(),
+    );
 
     if (!response.ok) {
       const error = await response.text();
@@ -349,11 +366,15 @@ export class AuthServiceImpl implements AuthService {
       refresh_token: params.refreshToken,
     });
 
-    const response = await fetch(params.tokenEndpoint, {
-      method: "POST",
-      headers: { "Content-Type": "application/x-www-form-urlencoded" },
-      body: body.toString(),
-    });
+    const response = await fetchWithTimeout(
+      params.tokenEndpoint,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: body.toString(),
+      },
+      this.fetchOptions(),
+    );
 
     if (!response.ok) {
       const error = await response.text();
@@ -361,6 +382,16 @@ export class AuthServiceImpl implements AuthService {
     }
 
     return parseRefreshTokenResponse(await response.json());
+  }
+
+  private fetchOptions(): {
+    fetchFn?: typeof fetch;
+    timeoutMs: number;
+  } {
+    return {
+      fetchFn: this.fetchFn,
+      timeoutMs: this.fetchTimeoutMs,
+    };
   }
 }
 

--- a/src/services/code-navigation-service.test.ts
+++ b/src/services/code-navigation-service.test.ts
@@ -7,6 +7,7 @@ import {
   mock,
   spyOn,
 } from "bun:test";
+import { FetchTimeoutError } from "../shared/fetch-timeout.js";
 import {
   CodeNavigationBackendError,
   CodeNavigationFileNotFoundError,
@@ -169,6 +170,27 @@ describe("CodeNavigationServiceImpl", () => {
       limit: 25,
       waitTimeoutMs: 1234,
     });
+  });
+
+  it("classifies client-side timeouts as CodeNavigationBackendError TIMEOUT", async () => {
+    globalThis.fetch = mock(() =>
+      Promise.reject(new FetchTimeoutError(1)),
+    ) as unknown as typeof fetch;
+    const service = new CodeNavigationServiceImpl(
+      BASE_URL,
+      createMockTokenProvider(),
+    );
+
+    try {
+      await service.listFiles({
+        target: { registry: "NPM", packageName: "express" },
+      });
+      throw new Error("expected timeout error");
+    } catch (error) {
+      expect(error).toBeInstanceOf(CodeNavigationBackendError);
+      expect((error as CodeNavigationBackendError).graphqlCode).toBe("TIMEOUT");
+      expect((error as CodeNavigationBackendError).retryable).toBe(true);
+    }
   });
 
   it("throws CodeNavigationIndexingError for data-path INDEXING sentinel on listFiles", async () => {

--- a/src/services/code-navigation-service.ts
+++ b/src/services/code-navigation-service.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { debugLog, isDebugAreaEnabled } from "../shared/debug-log.js";
+import { isFetchTimeoutError } from "../shared/fetch-timeout.js";
 import {
   type PkgseerGraphqlResponse,
   PkgseerTransportError,
@@ -1689,10 +1690,7 @@ export class CodeNavigationServiceImpl implements CodeNavigationService {
       });
     } catch (cause) {
       if (cause instanceof PkgseerTransportError) {
-        throw new CodeNavigationNetworkError(
-          "Could not reach the code navigation service. Check your connection or set GITHITS_CODE_NAV_URL.",
-          { cause },
-        );
+        throw this.createTransportError(cause);
       }
       throw cause;
     }
@@ -1740,10 +1738,7 @@ export class CodeNavigationServiceImpl implements CodeNavigationService {
       });
     } catch (cause) {
       if (cause instanceof PkgseerTransportError) {
-        throw new CodeNavigationNetworkError(
-          "Could not reach the code navigation service. Check your connection or set GITHITS_CODE_NAV_URL.",
-          { cause },
-        );
+        throw this.createTransportError(cause);
       }
       throw cause;
     }
@@ -1824,6 +1819,21 @@ export class CodeNavigationServiceImpl implements CodeNavigationService {
     return new CodeNavigationBackendError(
       detail ?? `Request failed with status ${status}`,
       status,
+    );
+  }
+
+  private createTransportError(error: PkgseerTransportError): Error {
+    if (isFetchTimeoutError(error.cause)) {
+      return new CodeNavigationBackendError(
+        "Code navigation request timed out.",
+        undefined,
+        "TIMEOUT",
+        true,
+      );
+    }
+    return new CodeNavigationNetworkError(
+      "Could not reach the code navigation service. Check your connection or set GITHITS_CODE_NAV_URL.",
+      { cause: error },
     );
   }
 
@@ -2224,10 +2234,7 @@ export class CodeNavigationServiceImpl implements CodeNavigationService {
       });
     } catch (cause) {
       if (cause instanceof PkgseerTransportError) {
-        throw new CodeNavigationNetworkError(
-          "Could not reach the code navigation service. Check your connection or set GITHITS_CODE_NAV_URL.",
-          { cause },
-        );
+        throw this.createTransportError(cause);
       }
       throw cause;
     }
@@ -2318,10 +2325,7 @@ export class CodeNavigationServiceImpl implements CodeNavigationService {
       });
     } catch (cause) {
       if (cause instanceof PkgseerTransportError) {
-        throw new CodeNavigationNetworkError(
-          "Could not reach the code navigation service. Check your connection or set GITHITS_CODE_NAV_URL.",
-          { cause },
-        );
+        throw this.createTransportError(cause);
       }
       throw cause;
     }
@@ -2415,10 +2419,7 @@ export class CodeNavigationServiceImpl implements CodeNavigationService {
       });
     } catch (cause) {
       if (cause instanceof PkgseerTransportError) {
-        throw new CodeNavigationNetworkError(
-          "Could not reach the code navigation service. Check your connection or set GITHITS_CODE_NAV_URL.",
-          { cause },
-        );
+        throw this.createTransportError(cause);
       }
       throw cause;
     }

--- a/src/services/githits-service.test.ts
+++ b/src/services/githits-service.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { FetchTimeoutError } from "../shared/fetch-timeout.js";
 import { AuthenticationError, GitHitsServiceImpl } from "./githits-service.js";
 
 // Helper to mock global fetch with proper typing
@@ -6,6 +7,12 @@ function mockFetch(impl: () => Promise<Response>) {
   const fn = mock(impl);
   globalThis.fetch = fn as unknown as typeof fetch;
   return fn;
+}
+
+function asFetchFn<T extends (...args: never[]) => unknown>(
+  fn: T,
+): typeof fetch {
+  return fn as unknown as typeof fetch;
 }
 
 describe("GitHitsServiceImpl", () => {
@@ -77,6 +84,20 @@ describe("GitHitsServiceImpl", () => {
       const call = fn.mock.calls[0] as unknown as [string, RequestInit];
       const body = JSON.parse(call[1].body as string);
       expect(body.license_mode).toBe("yolo");
+    });
+
+    it("times out stalled requests", async () => {
+      const fetchFn = mock(() => new Promise<Response>(() => {}));
+      const timeoutService = new GitHitsServiceImpl(
+        API_URL,
+        TOKEN,
+        asFetchFn(fetchFn),
+        1,
+      );
+
+      await expect(timeoutService.search({ query: "probe" })).rejects.toThrow(
+        FetchTimeoutError,
+      );
     });
 
     it("omits language from JSON when not provided", async () => {

--- a/src/services/githits-service.ts
+++ b/src/services/githits-service.ts
@@ -1,4 +1,8 @@
 import { version } from "../../package.json";
+import {
+  DEFAULT_FETCH_TIMEOUT_MS,
+  fetchWithTimeout,
+} from "../shared/fetch-timeout.js";
 import { buildClientHeaders } from "../shared/request-headers.js";
 import { withTelemetrySpan } from "../shared/telemetry.js";
 
@@ -94,20 +98,26 @@ export class GitHitsServiceImpl implements GitHitsService {
   constructor(
     private readonly apiUrl: string,
     private readonly token: string,
+    private readonly fetchFn?: typeof fetch,
+    private readonly fetchTimeoutMs: number = DEFAULT_FETCH_TIMEOUT_MS,
   ) {}
 
   async search(params: SearchParams): Promise<string> {
     return withTelemetrySpan("githits.search.request", async () => {
-      const response = await fetch(`${this.apiUrl}/search`, {
-        method: "POST",
-        headers: this.headers(),
-        body: JSON.stringify({
-          query: params.query,
-          language: params.language,
-          license_mode: params.licenseMode ?? "strict",
-          include_explanation: params.includeExplanation ?? false,
-        }),
-      });
+      const response = await fetchWithTimeout(
+        `${this.apiUrl}/search`,
+        {
+          method: "POST",
+          headers: this.headers(),
+          body: JSON.stringify({
+            query: params.query,
+            language: params.language,
+            license_mode: params.licenseMode ?? "strict",
+            include_explanation: params.includeExplanation ?? false,
+          }),
+        },
+        this.fetchOptions(),
+      );
 
       if (!response.ok) {
         throw await this.createError(response);
@@ -119,9 +129,13 @@ export class GitHitsServiceImpl implements GitHitsService {
 
   async getLanguages(): Promise<Language[]> {
     return withTelemetrySpan("githits.languages.request", async () => {
-      const response = await fetch(`${this.apiUrl}/languages`, {
-        headers: this.headers(),
-      });
+      const response = await fetchWithTimeout(
+        `${this.apiUrl}/languages`,
+        {
+          headers: this.headers(),
+        },
+        this.fetchOptions(),
+      );
 
       if (!response.ok) {
         throw await this.createError(response);
@@ -136,23 +150,27 @@ export class GitHitsServiceImpl implements GitHitsService {
       // For generic feedback, omit body targets entirely. The backend
       // then uses the valid x-githits-session-id header emitted by
       // buildClientHeaders() as the feedback target.
-      const response = await fetch(`${this.apiUrl}/feedbacks`, {
-        method: "POST",
-        headers: this.headers(),
-        body: JSON.stringify({
-          ...(params.exampleId !== undefined && {
-            example_id: params.exampleId,
+      const response = await fetchWithTimeout(
+        `${this.apiUrl}/feedbacks`,
+        {
+          method: "POST",
+          headers: this.headers(),
+          body: JSON.stringify({
+            ...(params.exampleId !== undefined && {
+              example_id: params.exampleId,
+            }),
+            ...(params.solutionId !== undefined && {
+              solution_id: params.solutionId,
+            }),
+            accepted: params.accepted,
+            feedback_text: params.feedbackText ?? null,
+            ...(params.toolName !== undefined && {
+              tool_name: params.toolName,
+            }),
           }),
-          ...(params.solutionId !== undefined && {
-            solution_id: params.solutionId,
-          }),
-          accepted: params.accepted,
-          feedback_text: params.feedbackText ?? null,
-          ...(params.toolName !== undefined && {
-            tool_name: params.toolName,
-          }),
-        }),
-      });
+        },
+        this.fetchOptions(),
+      );
 
       if (!response.ok) {
         throw await this.createError(response);
@@ -168,6 +186,16 @@ export class GitHitsServiceImpl implements GitHitsService {
       Authorization: `Bearer ${this.token}`,
       "Content-Type": "application/json",
       "User-Agent": `githits-cli/${version}`,
+    };
+  }
+
+  private fetchOptions(): {
+    fetchFn?: typeof fetch;
+    timeoutMs: number;
+  } {
+    return {
+      fetchFn: this.fetchFn,
+      timeoutMs: this.fetchTimeoutMs,
     };
   }
 

--- a/src/services/package-intelligence-service.test.ts
+++ b/src/services/package-intelligence-service.test.ts
@@ -7,6 +7,7 @@ import {
   mock,
   spyOn,
 } from "bun:test";
+import { FetchTimeoutError } from "../shared/fetch-timeout.js";
 import { AuthenticationError } from "./githits-service.js";
 import {
   MalformedPackageIntelligenceResponseError,
@@ -588,6 +589,26 @@ describe("PackageIntelligenceServiceImpl", () => {
     } catch (error) {
       expect(error).toBeInstanceOf(PackageIntelligenceNetworkError);
       expect((error as PackageIntelligenceNetworkError).cause).toBeDefined();
+    }
+  });
+
+  it("classifies client-side timeouts as PackageIntelligenceBackendError TIMEOUT", async () => {
+    const fetchFn = mock(() => Promise.reject(new FetchTimeoutError(1)));
+    const service = new PackageIntelligenceServiceImpl(
+      ENDPOINT,
+      createMockTokenProvider(),
+      asFetchFn(fetchFn),
+    );
+
+    try {
+      await service.packageSummary({ registry: "NPM", packageName: "x" });
+      throw new Error("expected timeout error");
+    } catch (error) {
+      expect(error).toBeInstanceOf(PackageIntelligenceBackendError);
+      expect((error as PackageIntelligenceBackendError).graphqlCode).toBe(
+        "TIMEOUT",
+      );
+      expect((error as PackageIntelligenceBackendError).retryable).toBe(true);
     }
   });
 });

--- a/src/services/package-intelligence-service.ts
+++ b/src/services/package-intelligence-service.ts
@@ -18,6 +18,7 @@
 
 import { z } from "zod";
 import { debugLog, isDebugAreaEnabled } from "../shared/debug-log.js";
+import { isFetchTimeoutError } from "../shared/fetch-timeout.js";
 import {
   type PkgseerGraphqlResponse,
   PkgseerTransportError,
@@ -1766,10 +1767,7 @@ export class PackageIntelligenceServiceImpl
       });
     } catch (cause) {
       if (cause instanceof PkgseerTransportError) {
-        throw new PackageIntelligenceNetworkError(
-          "Could not reach the package intelligence service. Check your connection or set GITHITS_CODE_NAV_URL.",
-          { cause },
-        );
+        throw this.createTransportError(cause);
       }
       throw cause;
     }
@@ -1825,6 +1823,21 @@ export class PackageIntelligenceServiceImpl
     return new PackageIntelligenceBackendError(
       detail ?? `Request failed with status ${status}`,
       status,
+    );
+  }
+
+  private createTransportError(error: PkgseerTransportError): Error {
+    if (isFetchTimeoutError(error.cause)) {
+      return new PackageIntelligenceBackendError(
+        "Package intelligence request timed out.",
+        undefined,
+        "TIMEOUT",
+        true,
+      );
+    }
+    return new PackageIntelligenceNetworkError(
+      "Could not reach the package intelligence service. Check your connection or set GITHITS_CODE_NAV_URL.",
+      { cause: error },
     );
   }
 
@@ -2101,10 +2114,7 @@ export class PackageIntelligenceServiceImpl
       });
     } catch (cause) {
       if (cause instanceof PkgseerTransportError) {
-        throw new PackageIntelligenceNetworkError(
-          "Could not reach the package intelligence service. Check your connection or set GITHITS_CODE_NAV_URL.",
-          { cause },
-        );
+        throw this.createTransportError(cause);
       }
       throw cause;
     }
@@ -2253,10 +2263,7 @@ export class PackageIntelligenceServiceImpl
       });
     } catch (cause) {
       if (cause instanceof PkgseerTransportError) {
-        throw new PackageIntelligenceNetworkError(
-          "Could not reach the package intelligence service. Check your connection or set GITHITS_CODE_NAV_URL.",
-          { cause },
-        );
+        throw this.createTransportError(cause);
       }
       throw cause;
     }
@@ -2316,10 +2323,7 @@ export class PackageIntelligenceServiceImpl
       });
     } catch (cause) {
       if (cause instanceof PkgseerTransportError) {
-        throw new PackageIntelligenceNetworkError(
-          "Could not reach the package intelligence service. Check your connection or set GITHITS_CODE_NAV_URL.",
-          { cause },
-        );
+        throw this.createTransportError(cause);
       }
       throw cause;
     }
@@ -2634,10 +2638,7 @@ export class PackageIntelligenceServiceImpl
       });
     } catch (cause) {
       if (cause instanceof PkgseerTransportError) {
-        throw new PackageIntelligenceNetworkError(
-          "Could not reach the package intelligence service. Check your connection or set GITHITS_CODE_NAV_URL.",
-          { cause },
-        );
+        throw this.createTransportError(cause);
       }
       throw cause;
     }
@@ -2753,10 +2754,7 @@ export class PackageIntelligenceServiceImpl
       });
     } catch (cause) {
       if (cause instanceof PkgseerTransportError) {
-        throw new PackageIntelligenceNetworkError(
-          "Could not reach the package intelligence service. Check your connection or set GITHITS_CODE_NAV_URL.",
-          { cause },
-        );
+        throw this.createTransportError(cause);
       }
       throw cause;
     }
@@ -2854,10 +2852,7 @@ export class PackageIntelligenceServiceImpl
       });
     } catch (cause) {
       if (cause instanceof PkgseerTransportError) {
-        throw new PackageIntelligenceNetworkError(
-          "Could not reach the package intelligence service. Check your connection or set GITHITS_CODE_NAV_URL.",
-          { cause },
-        );
+        throw this.createTransportError(cause);
       }
       throw cause;
     }

--- a/src/services/token-manager.test.ts
+++ b/src/services/token-manager.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, mock } from "bun:test";
+import { FetchTimeoutError } from "../shared/fetch-timeout.js";
 import type { TokenData } from "./auth-storage.js";
 import {
   createMockAuthService,
@@ -277,6 +278,29 @@ describe("TokenManager", () => {
       expect(result2).toBe(tokenData.accessToken);
     });
 
+    it("returns current token when proactive endpoint discovery times out", async () => {
+      const tokenData = createValidTokenData({
+        createdAt: new Date(Date.now() - 58 * 60_000).toISOString(),
+        expiresAt: new Date(Date.now() + 2 * 60_000).toISOString(),
+      });
+      const authService = createMockAuthService({
+        discoverEndpoints: mock(() => Promise.reject(new FetchTimeoutError(1))),
+      });
+      const { manager, authStorage } = createTokenManager({
+        authService,
+        authStorage: createMockAuthStorage({
+          loadTokens: mock(() => Promise.resolve(tokenData)),
+          loadClient: mock(() => Promise.resolve(defaultClientRegistration)),
+        }),
+      });
+
+      const result = await manager.getToken();
+
+      expect(result).toBe(tokenData.accessToken);
+      expect(authService.discoverEndpoints).toHaveBeenCalledWith(MCP_URL);
+      expect(authStorage.clearTokensIfUnchanged).not.toHaveBeenCalled();
+    });
+
     it("returns undefined when expired token refresh fails", async () => {
       const tokenData = createValidTokenData({
         createdAt: new Date(Date.now() - 7200_000).toISOString(),
@@ -295,6 +319,32 @@ describe("TokenManager", () => {
       });
 
       const result = await manager.getToken();
+      expect(result).toBeUndefined();
+      expect(authStorage.clearTokensIfUnchanged).toHaveBeenCalledWith(
+        MCP_URL,
+        tokenData,
+      );
+    });
+
+    it("clears expired tokens when forced refresh times out", async () => {
+      const tokenData = createValidTokenData({
+        createdAt: new Date(Date.now() - 7200_000).toISOString(),
+        expiresAt: new Date(Date.now() - 60_000).toISOString(),
+      });
+      const { manager, authStorage } = createTokenManager({
+        authService: createMockAuthService({
+          refreshAccessToken: mock(() =>
+            Promise.reject(new FetchTimeoutError(1)),
+          ),
+        }),
+        authStorage: createMockAuthStorage({
+          loadTokens: mock(() => Promise.resolve(tokenData)),
+          loadClient: mock(() => Promise.resolve(defaultClientRegistration)),
+        }),
+      });
+
+      const result = await manager.forceRefresh();
+
       expect(result).toBeUndefined();
       expect(authStorage.clearTokensIfUnchanged).toHaveBeenCalledWith(
         MCP_URL,

--- a/src/shared/auto-login.test.ts
+++ b/src/shared/auto-login.test.ts
@@ -109,6 +109,7 @@ describe("isAutoLoginEligibleCommand", () => {
       ["pkg", "vulns"],
       ["pkg", "deps"],
       ["pkg", "changelog"],
+      ["pkg", "upgrade-review"],
     ]) {
       expect(
         isAutoLoginEligibleCommand(createCommand(path), {

--- a/src/shared/auto-login.ts
+++ b/src/shared/auto-login.ts
@@ -4,23 +4,8 @@ import type {
   LoginOptions,
 } from "../commands/login.js";
 import type { AuthSessionMetadata } from "../services/auth-session-metadata-storage.js";
+import { getAuthenticatedCommandMetadata } from "./command-metadata.js";
 
-const AUTO_LOGIN_ELIGIBLE_COMMANDS = new Set([
-  "example",
-  "languages",
-  "feedback",
-  "search",
-  "search-status",
-  "code files",
-  "code read",
-  "code grep",
-  "docs list",
-  "docs read",
-  "pkg info",
-  "pkg vulns",
-  "pkg deps",
-  "pkg changelog",
-]);
 const AUTH_METADATA_TRUST_WINDOW_MS = 10 * 60 * 1000;
 
 export interface CommandLike {
@@ -76,7 +61,8 @@ export function isAutoLoginEligibleCommand(
   },
 ): boolean {
   const commandPath = getCommandPath(command).join(" ");
-  if (!AUTO_LOGIN_ELIGIBLE_COMMANDS.has(commandPath)) {
+  const metadata = getAuthenticatedCommandMetadata(commandPath);
+  if (!metadata?.autoLoginEligible) {
     return false;
   }
 

--- a/src/shared/cli-options.ts
+++ b/src/shared/cli-options.ts
@@ -1,0 +1,26 @@
+import { InvalidPackageSpecError } from "./package-spec.js";
+
+/**
+ * Parse an optional CLI integer string exactly. `parseInt` is deliberately
+ * avoided because it silently accepts partial values such as `10abc`.
+ */
+export function parseIntCliOption(
+  raw: string | undefined,
+  name: string,
+  min: number,
+  max: number,
+): number | undefined {
+  if (raw === undefined) return undefined;
+  if (!/^-?\d+$/.test(raw.trim())) {
+    throw new InvalidPackageSpecError(
+      `${name} expects an integer between ${min} and ${max}. Got '${raw}'.`,
+    );
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (parsed < min || parsed > max) {
+    throw new InvalidPackageSpecError(
+      `${name} expects an integer between ${min} and ${max}. Got ${parsed}.`,
+    );
+  }
+  return parsed;
+}

--- a/src/shared/code-navigation-error-map.ts
+++ b/src/shared/code-navigation-error-map.ts
@@ -21,6 +21,7 @@ import {
 } from "../services/code-navigation-service.js";
 import { AuthenticationError } from "../services/githits-service.js";
 import { debugLog } from "./debug-log.js";
+import { AuthRequiredError } from "./require-auth.js";
 
 export type MappedErrorCode =
   | "NOT_FOUND"
@@ -182,12 +183,18 @@ function classify(error: unknown): MappedError {
       retryable: false,
     };
   }
-  if (error instanceof AuthenticationError) {
+  if (
+    error instanceof AuthenticationError ||
+    error instanceof AuthRequiredError
+  ) {
     return {
       code: "AUTH_REQUIRED",
       message: error.message,
       retryable: false,
-      details: { action: "Run `githits login`, then retry this tool call." },
+      details:
+        error instanceof AuthenticationError
+          ? { action: "Run `githits login`, then retry this tool call." }
+          : undefined,
     };
   }
   if (error instanceof CodeNavigationNetworkError) {

--- a/src/shared/command-metadata.test.ts
+++ b/src/shared/command-metadata.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "bun:test";
+import {
+  AUTHENTICATED_COMMANDS,
+  getAuthenticatedCommandMetadata,
+} from "./command-metadata.js";
+
+describe("authenticated command metadata", () => {
+  it("covers all authenticated JSON-capable commands", () => {
+    expect(AUTHENTICATED_COMMANDS.map((entry) => entry.path)).toEqual([
+      "example",
+      "languages",
+      "feedback",
+      "search",
+      "search-status",
+      "code files",
+      "code read",
+      "code grep",
+      "docs list",
+      "docs read",
+      "pkg info",
+      "pkg vulns",
+      "pkg deps",
+      "pkg changelog",
+      "pkg upgrade-review",
+    ]);
+  });
+
+  it("marks pkg upgrade-review as auto-login eligible", () => {
+    expect(getAuthenticatedCommandMetadata("pkg upgrade-review")).toMatchObject(
+      {
+        autoLoginEligible: true,
+        jsonCapable: true,
+        postLoginMessage: "Authentication complete. Running command...",
+      },
+    );
+  });
+});

--- a/src/shared/command-metadata.ts
+++ b/src/shared/command-metadata.ts
@@ -1,0 +1,53 @@
+export interface AuthenticatedCommandMetadata {
+  path: string;
+  autoLoginEligible: boolean;
+  postLoginMessage?: string;
+  jsonCapable?: boolean;
+}
+
+export const AUTHENTICATED_COMMANDS = [
+  {
+    path: "example",
+    autoLoginEligible: true,
+    postLoginMessage: "Authentication complete. Running example search...",
+    jsonCapable: true,
+  },
+  {
+    path: "languages",
+    autoLoginEligible: true,
+    postLoginMessage: "Authentication complete. Loading supported languages...",
+    jsonCapable: true,
+  },
+  {
+    path: "feedback",
+    autoLoginEligible: true,
+    postLoginMessage: "Authentication complete. Submitting feedback...",
+    jsonCapable: true,
+  },
+  "search",
+  "search-status",
+  "code files",
+  "code read",
+  "code grep",
+  "docs list",
+  "docs read",
+  "pkg info",
+  "pkg vulns",
+  "pkg deps",
+  "pkg changelog",
+  "pkg upgrade-review",
+].map((entry): AuthenticatedCommandMetadata => {
+  if (typeof entry !== "string") return entry;
+  return {
+    path: entry,
+    autoLoginEligible: true,
+    postLoginMessage: "Authentication complete. Running command...",
+    jsonCapable: true,
+  };
+});
+
+export function getAuthenticatedCommandMetadata(
+  path: string,
+): AuthenticatedCommandMetadata | undefined {
+  return AUTHENTICATED_COMMANDS.find((entry) => entry.path === path);
+}

--- a/src/shared/fetch-timeout.test.ts
+++ b/src/shared/fetch-timeout.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, mock } from "bun:test";
+import { FetchTimeoutError, fetchWithTimeout } from "./fetch-timeout.js";
+
+function asFetchFn<T extends (...args: never[]) => unknown>(
+  fn: T,
+): typeof fetch {
+  return fn as unknown as typeof fetch;
+}
+
+describe("fetchWithTimeout", () => {
+  it("passes a timeout signal to fetch", async () => {
+    const fetchFn = mock((_url: string, init?: RequestInit) => {
+      expect(init?.signal).toBeInstanceOf(AbortSignal);
+      return Promise.resolve(new Response("ok"));
+    });
+
+    const response = await fetchWithTimeout(
+      "https://example.com",
+      {},
+      {
+        fetchFn: asFetchFn(fetchFn),
+        timeoutMs: 100,
+      },
+    );
+
+    expect(await response.text()).toBe("ok");
+  });
+
+  it("rejects with FetchTimeoutError when the timeout expires", async () => {
+    const fetchFn = mock(() => new Promise<Response>(() => {}));
+
+    await expect(
+      fetchWithTimeout(
+        "https://example.com",
+        {},
+        {
+          fetchFn: asFetchFn(fetchFn),
+          timeoutMs: 1,
+        },
+      ),
+    ).rejects.toThrow(FetchTimeoutError);
+  });
+
+  it("preserves caller aborts", async () => {
+    const controller = new AbortController();
+    const cause = new Error("caller aborted");
+    const fetchFn = mock((_url: string, init?: RequestInit) => {
+      init?.signal?.addEventListener("abort", () => {});
+      return Promise.reject(cause);
+    });
+    controller.abort();
+
+    await expect(
+      fetchWithTimeout(
+        "https://example.com",
+        { signal: controller.signal },
+        { fetchFn: asFetchFn(fetchFn), timeoutMs: 10_000 },
+      ),
+    ).rejects.toBe(cause);
+  });
+});

--- a/src/shared/fetch-timeout.ts
+++ b/src/shared/fetch-timeout.ts
@@ -1,4 +1,4 @@
-export const DEFAULT_FETCH_TIMEOUT_MS = 30_000;
+export const DEFAULT_FETCH_TIMEOUT_MS = 120_000;
 
 export class FetchTimeoutError extends Error {
   readonly timeoutMs: number;

--- a/src/shared/fetch-timeout.ts
+++ b/src/shared/fetch-timeout.ts
@@ -1,0 +1,53 @@
+export const DEFAULT_FETCH_TIMEOUT_MS = 30_000;
+
+export class FetchTimeoutError extends Error {
+  readonly timeoutMs: number;
+
+  constructor(timeoutMs: number, options?: { cause?: unknown }) {
+    super(`Request timed out after ${timeoutMs}ms.`, options);
+    this.name = "FetchTimeoutError";
+    this.timeoutMs = timeoutMs;
+  }
+}
+
+export interface FetchWithTimeoutOptions {
+  fetchFn?: typeof fetch;
+  timeoutMs?: number;
+}
+
+export async function fetchWithTimeout(
+  input: Parameters<typeof fetch>[0],
+  init: RequestInit = {},
+  options: FetchWithTimeoutOptions = {},
+): Promise<Response> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS;
+  const timeoutSignal = AbortSignal.timeout(timeoutMs);
+  const signal = init.signal
+    ? AbortSignal.any([init.signal, timeoutSignal])
+    : timeoutSignal;
+  const fetchFn = options.fetchFn ?? globalThis.fetch;
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => {
+      reject(new FetchTimeoutError(timeoutMs));
+    }, timeoutMs);
+  });
+
+  try {
+    return await Promise.race([fetchFn(input, { ...init, signal }), timeout]);
+  } catch (cause) {
+    if (cause instanceof FetchTimeoutError) throw cause;
+    if (timeoutSignal.aborted && !init.signal?.aborted) {
+      throw new FetchTimeoutError(timeoutMs, { cause });
+    }
+    throw cause;
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId);
+  }
+}
+
+export function isFetchTimeoutError(
+  error: unknown,
+): error is FetchTimeoutError {
+  return error instanceof FetchTimeoutError;
+}

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -1,3 +1,4 @@
+export { parseIntCliOption } from "./cli-options.js";
 export {
   type CodeNavigationRegistryArg,
   type FileIntentArg,
@@ -198,7 +199,12 @@ export {
   type LeanPackageDocEnvelope,
 } from "./read-package-doc-response.js";
 export { renderReadPackageDocText } from "./read-package-doc-text.js";
-export { AuthRequiredError, requireAuth } from "./require-auth.js";
+export {
+  AuthRequiredError,
+  buildAuthRequiredErrorPayload,
+  formatAuthRequiredForTerminal,
+  requireAuth,
+} from "./require-auth.js";
 export {
   createRootCliPreAction,
   type RootCliPreActionDependencies,

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -42,6 +42,12 @@ export { debugLog } from "./debug-log.js";
 export { lowerDocSourceKind } from "./docs-follow-up.js";
 export { extractSolutionId } from "./extract-solution-id.js";
 export {
+  DEFAULT_FETCH_TIMEOUT_MS,
+  FetchTimeoutError,
+  fetchWithTimeout,
+  isFetchTimeoutError,
+} from "./fetch-timeout.js";
+export {
   buildCodeReadCommand,
   buildDocsReadCommand,
   buildSearchHitFollowUpCommand,

--- a/src/shared/package-intelligence-error-map.ts
+++ b/src/shared/package-intelligence-error-map.ts
@@ -29,6 +29,7 @@ import type {
 } from "./code-navigation-error-map.js";
 import { buildUpdateRequiredError } from "./code-navigation-error-map.js";
 import { debugLog } from "./debug-log.js";
+import { AuthRequiredError } from "./require-auth.js";
 
 // Re-export for caller convenience — callers of
 // `mapPackageIntelligenceError` use the same envelope type as code-nav
@@ -106,12 +107,18 @@ function classify(error: unknown): MappedError {
       retryable: false,
     };
   }
-  if (error instanceof AuthenticationError) {
+  if (
+    error instanceof AuthenticationError ||
+    error instanceof AuthRequiredError
+  ) {
     return {
       code: "AUTH_REQUIRED",
       message: error.message,
       retryable: false,
-      details: { action: "Run `githits login`, then retry this tool call." },
+      details:
+        error instanceof AuthenticationError
+          ? { action: "Run `githits login`, then retry this tool call." }
+          : undefined,
     };
   }
   if (error instanceof PackageIntelligenceNetworkError) {

--- a/src/shared/pkgseer-graphql.test.ts
+++ b/src/shared/pkgseer-graphql.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { FetchTimeoutError } from "./fetch-timeout.js";
 import {
   PkgseerTransportError,
   postPkgseerGraphql,
@@ -224,6 +225,27 @@ describe("postPkgseerGraphql", () => {
     } catch (error) {
       expect(error).toBeInstanceOf(PkgseerTransportError);
       expect((error as PkgseerTransportError).cause).toBe(cause);
+    }
+  });
+
+  it("throws PkgseerTransportError with timeout cause when fetch stalls", async () => {
+    const fetchFn = mock(() => new Promise<Response>(() => {}));
+
+    try {
+      await postPkgseerGraphql({
+        endpointUrl: ENDPOINT,
+        token: TOKEN,
+        query: "query { x }",
+        variables: {},
+        fetchFn: asFetchFn(fetchFn),
+        timeoutMs: 1,
+      });
+      throw new Error("expected PkgseerTransportError");
+    } catch (error) {
+      expect(error).toBeInstanceOf(PkgseerTransportError);
+      expect((error as PkgseerTransportError).cause).toBeInstanceOf(
+        FetchTimeoutError,
+      );
     }
   });
 

--- a/src/shared/pkgseer-graphql.ts
+++ b/src/shared/pkgseer-graphql.ts
@@ -39,7 +39,7 @@ export interface PkgseerGraphqlRequest {
   variables: Record<string, unknown>;
   /** Fetch implementation — defaults to `globalThis.fetch`. Injected for tests. */
   fetchFn?: typeof fetch;
-  /** Per-request timeout in milliseconds. Defaults to 30s. */
+  /** Per-request timeout in milliseconds. Defaults to 120s. */
   timeoutMs?: number;
   /** Override `User-Agent`. Defaults to `githits-cli/<version>`. */
   userAgent?: string;

--- a/src/shared/pkgseer-graphql.ts
+++ b/src/shared/pkgseer-graphql.ts
@@ -25,6 +25,7 @@
 
 import { version } from "../../package.json";
 import { debugLog } from "./debug-log.js";
+import { DEFAULT_FETCH_TIMEOUT_MS, fetchWithTimeout } from "./fetch-timeout.js";
 import { buildClientHeaders } from "./request-headers.js";
 
 export interface PkgseerGraphqlRequest {
@@ -38,6 +39,8 @@ export interface PkgseerGraphqlRequest {
   variables: Record<string, unknown>;
   /** Fetch implementation — defaults to `globalThis.fetch`. Injected for tests. */
   fetchFn?: typeof fetch;
+  /** Per-request timeout in milliseconds. Defaults to 30s. */
+  timeoutMs?: number;
   /** Override `User-Agent`. Defaults to `githits-cli/<version>`. */
   userAgent?: string;
 }
@@ -83,24 +86,28 @@ function baseUrl(endpointUrl: string): string {
 export async function postPkgseerGraphql(
   request: PkgseerGraphqlRequest,
 ): Promise<PkgseerGraphqlResponse> {
-  const fetchFn = request.fetchFn ?? globalThis.fetch;
   const userAgent = request.userAgent ?? `githits-cli/${version}`;
+  const timeoutMs = request.timeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS;
 
   let response: Response;
   try {
-    response = await fetchFn(`${baseUrl(request.endpointUrl)}/api/graphql`, {
-      method: "POST",
-      headers: {
-        ...buildClientHeaders(),
-        Authorization: `Bearer ${request.token}`,
-        "Content-Type": "application/json",
-        "User-Agent": userAgent,
+    response = await fetchWithTimeout(
+      `${baseUrl(request.endpointUrl)}/api/graphql`,
+      {
+        method: "POST",
+        headers: {
+          ...buildClientHeaders(),
+          Authorization: `Bearer ${request.token}`,
+          "Content-Type": "application/json",
+          "User-Agent": userAgent,
+        },
+        body: JSON.stringify({
+          query: request.query,
+          variables: request.variables,
+        }),
       },
-      body: JSON.stringify({
-        query: request.query,
-        variables: request.variables,
-      }),
-    });
+      { fetchFn: request.fetchFn, timeoutMs },
+    );
   } catch (cause) {
     debugLog("pkg-graphql", {
       event: "transport-error",

--- a/src/shared/require-auth.test.ts
+++ b/src/shared/require-auth.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it, spyOn } from "bun:test";
-import { AuthRequiredError, requireAuth } from "./require-auth.js";
+import {
+  AuthRequiredError,
+  buildAuthRequiredErrorPayload,
+  formatAuthRequiredForTerminal,
+  requireAuth,
+} from "./require-auth.js";
 
 describe("requireAuth", () => {
   it("does nothing when token is valid", () => {
@@ -9,48 +14,59 @@ describe("requireAuth", () => {
   it("throws AuthRequiredError when token is missing", () => {
     const consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 
-    expect(() =>
+    let thrown: unknown;
+    try {
       requireAuth({
         hasValidToken: false,
         mcpUrl: "https://mcp.githits.com",
-      }),
-    ).toThrow(AuthRequiredError);
+      });
+    } catch (error) {
+      thrown = error;
+    }
 
-    const output = consoleSpy.mock.calls.map((c) => c[0]).join("\n");
-    expect(output).toContain("Authentication required");
-    expect(output).toContain("githits login");
-    expect(output).toContain("support@githits.com");
+    expect(thrown).toBeInstanceOf(AuthRequiredError);
+    expect(consoleSpy).not.toHaveBeenCalled();
     consoleSpy.mockRestore();
   });
 
   it("includes context in message when provided", () => {
-    const consoleSpy = spyOn(console, "log").mockImplementation(() => {});
-
     expect(() =>
       requireAuth(
         { hasValidToken: false, mcpUrl: "https://mcp.githits.com" },
         "to start MCP server",
       ),
-    ).toThrow(AuthRequiredError);
-
-    const output = consoleSpy.mock.calls.map((c) => c[0]).join("\n");
-    expect(output).toContain("Authentication required to start MCP server.");
-    consoleSpy.mockRestore();
+    ).toThrow("Authentication required to start MCP server.");
   });
 
-  it("shows custom environment when not default", () => {
-    const consoleSpy = spyOn(console, "log").mockImplementation(() => {});
-
-    expect(() =>
+  it("formats terminal recovery text", () => {
+    let thrown: unknown;
+    try {
       requireAuth({
         hasValidToken: false,
         mcpUrl: "https://custom.example.com",
-      }),
-    ).toThrow(AuthRequiredError);
+      });
+    } catch (error) {
+      thrown = error;
+    }
 
-    const output = consoleSpy.mock.calls.map((c) => c[0]).join("\n");
+    expect(thrown).toBeInstanceOf(AuthRequiredError);
+    const output = formatAuthRequiredForTerminal(thrown as AuthRequiredError);
     expect(output).toContain("custom.example.com");
     expect(output).toContain("custom environment");
-    consoleSpy.mockRestore();
+    expect(output).toContain("githits login");
+    expect(output).toContain("support@githits.com");
+  });
+
+  it("builds the JSON error envelope", () => {
+    const error = new AuthRequiredError(
+      "Authentication required.",
+      "https://mcp.githits.com",
+    );
+
+    expect(buildAuthRequiredErrorPayload(error)).toEqual({
+      error: "Authentication required.",
+      code: "AUTH_REQUIRED",
+      retryable: false,
+    });
   });
 });

--- a/src/shared/require-auth.ts
+++ b/src/shared/require-auth.ts
@@ -3,15 +3,25 @@
  * Caught at the CLI boundary to trigger process.exit(1).
  */
 export class AuthRequiredError extends Error {
-  constructor(message: string) {
+  readonly mcpUrl: string;
+
+  constructor(message: string, mcpUrl: string) {
     super(message);
     this.name = "AuthRequiredError";
+    this.mcpUrl = mcpUrl;
   }
 }
 
+export interface AuthRequiredErrorPayload {
+  error: string;
+  code: "AUTH_REQUIRED";
+  retryable: false;
+}
+
 /**
- * Print friendly message when auth is missing and throw AuthRequiredError.
- * Shared between MCP server startup and CLI commands.
+ * Throw AuthRequiredError when auth is missing.
+ * Rendering belongs to the CLI/MCP boundary so JSON callers never receive
+ * terminal prose on stdout.
  *
  * @param context - Optional context appended to the message (e.g., "to start MCP server")
  * @throws AuthRequiredError - Always throws when hasValidToken is false
@@ -26,17 +36,32 @@ export function requireAuth(
   if (deps.hasValidToken) return;
 
   const suffix = context ? ` ${context}` : "";
-  console.log(`Authentication required${suffix}.\n`);
+  throw new AuthRequiredError(`Authentication required${suffix}.`, deps.mcpUrl);
+}
 
-  if (deps.mcpUrl !== "https://mcp.githits.com") {
-    console.log(`  Environment: ${deps.mcpUrl}`);
-    console.log("  You're using a custom environment.\n");
+export function buildAuthRequiredErrorPayload(
+  error: AuthRequiredError,
+): AuthRequiredErrorPayload {
+  return {
+    error: error.message,
+    code: "AUTH_REQUIRED",
+    retryable: false,
+  };
+}
+
+export function formatAuthRequiredForTerminal(
+  error: AuthRequiredError,
+): string {
+  const lines = [`${error.message}\n`];
+
+  if (error.mcpUrl !== "https://mcp.githits.com") {
+    lines.push(`  Environment: ${error.mcpUrl}`);
+    lines.push("  You're using a custom environment.\n");
   }
 
-  console.log("To authenticate:");
-  console.log("  githits login\n");
-  console.log("Or set GITHITS_API_TOKEN environment variable.");
-  console.log("\nNeed help? support@githits.com");
-
-  throw new AuthRequiredError(`Authentication required${suffix}`);
+  lines.push("To authenticate:");
+  lines.push("  githits login\n");
+  lines.push("Or set GITHITS_API_TOKEN environment variable.");
+  lines.push("\nNeed help? support@githits.com");
+  return lines.join("\n");
 }

--- a/src/shared/root-cli-pre-action.ts
+++ b/src/shared/root-cli-pre-action.ts
@@ -50,10 +50,29 @@ export function createRootCliPreAction(
     }
 
     const failureMessage = authResult.message ?? "Authentication failed.";
+    if (shouldRenderJsonAuthFailure(command)) {
+      console.error(
+        JSON.stringify({
+          error: failureMessage,
+          code: "AUTH_REQUIRED",
+          retryable: false,
+        }),
+      );
+      (deps.exit ?? process.exit)(1);
+      return;
+    }
+
     console.error(`${failureMessage}\n`);
     printAutoLoginRecoveryHint(failureMessage);
     (deps.exit ?? process.exit)(1);
   };
+}
+
+function shouldRenderJsonAuthFailure(command: Command): boolean {
+  const metadata = getAuthenticatedCommandMetadata(
+    getCommandPath(command).join(" "),
+  );
+  return metadata?.jsonCapable === true && command.opts().json === true;
 }
 
 function getPostLoginContinuationMessage(command: Command): string | undefined {

--- a/src/shared/root-cli-pre-action.ts
+++ b/src/shared/root-cli-pre-action.ts
@@ -7,6 +7,7 @@ import {
 } from "../commands/login.js";
 import type { AuthSessionMetadata } from "../services/auth-session-metadata-storage.js";
 import { getCommandPath, maybeAutoLoginBeforeCommand } from "./auto-login.js";
+import { getAuthenticatedCommandMetadata } from "./command-metadata.js";
 
 export interface RootCliPreActionDependencies {
   loadAuthSessionMetadata?: () => Promise<AuthSessionMetadata | null>;
@@ -56,26 +57,6 @@ export function createRootCliPreAction(
 }
 
 function getPostLoginContinuationMessage(command: Command): string | undefined {
-  switch (getCommandPath(command).join(" ")) {
-    case "example":
-      return "Authentication complete. Running example search...";
-    case "languages":
-      return "Authentication complete. Loading supported languages...";
-    case "feedback":
-      return "Authentication complete. Submitting feedback...";
-    case "search":
-    case "search-status":
-    case "code files":
-    case "code read":
-    case "code grep":
-    case "docs list":
-    case "docs read":
-    case "pkg info":
-    case "pkg vulns":
-    case "pkg deps":
-    case "pkg changelog":
-      return "Authentication complete. Running command...";
-    default:
-      return undefined;
-  }
+  return getAuthenticatedCommandMetadata(getCommandPath(command).join(" "))
+    ?.postLoginMessage;
 }

--- a/src/tools/feedback-parity.test.ts
+++ b/src/tools/feedback-parity.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, mock, spyOn } from "bun:test";
+import { feedbackAction } from "../commands/feedback.js";
+import { createMockGitHitsService } from "../services/test-helpers.js";
+import { createFeedbackTool } from "./feedback.js";
+
+async function cliText(): Promise<string> {
+  const logSpy = spyOn(console, "log").mockImplementation(() => {});
+  try {
+    await feedbackAction(
+      "sol_123",
+      { accept: true },
+      {
+        githitsService: createMockGitHitsService({
+          submitFeedback: mock(() =>
+            Promise.resolve({ success: true, message: "Feedback submitted" }),
+          ),
+        }),
+        hasValidToken: true,
+        mcpUrl: "https://mcp.example.com",
+      },
+    );
+    return String(logSpy.mock.calls[0]?.[0]);
+  } finally {
+    logSpy.mockRestore();
+  }
+}
+
+async function mcpText(): Promise<string> {
+  const tool = createFeedbackTool(
+    createMockGitHitsService({
+      submitFeedback: mock(() =>
+        Promise.resolve({ success: true, message: "Feedback submitted" }),
+      ),
+    }),
+  );
+  const result = await tool.handler(
+    { solution_id: "sol_123", accepted: true },
+    {},
+  );
+  return result.content[0]?.text ?? "";
+}
+
+describe("feedback parity", () => {
+  it("matches success text without hitting live services", async () => {
+    expect(await cliText()).toBe(await mcpText());
+  });
+});

--- a/src/tools/get-example-parity.test.ts
+++ b/src/tools/get-example-parity.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, mock, spyOn } from "bun:test";
+import { exampleAction } from "../commands/example.js";
+import { createMockGitHitsService } from "../services/test-helpers.js";
+import { createGetExampleTool } from "./get-example.js";
+
+async function cliJson(markdown: string): Promise<unknown> {
+  const logSpy = spyOn(console, "log").mockImplementation(() => {});
+  try {
+    await exampleAction(
+      "router",
+      { json: true },
+      {
+        githitsService: createMockGitHitsService({
+          search: mock(() => Promise.resolve(markdown)),
+        }),
+        hasValidToken: true,
+        mcpUrl: "https://mcp.example.com",
+      },
+    );
+    return JSON.parse(String(logSpy.mock.calls[0]?.[0]));
+  } finally {
+    logSpy.mockRestore();
+  }
+}
+
+async function mcpJson(markdown: string): Promise<unknown> {
+  const tool = createGetExampleTool(
+    createMockGitHitsService({
+      search: mock(() => Promise.resolve(markdown)),
+    }),
+  );
+  const result = await tool.handler({ query: "router", format: "json" }, {});
+  return JSON.parse(result.content[0]?.text ?? "");
+}
+
+describe("get_example parity", () => {
+  it("PARITY-JSON-KEYS: CLI === MCP", async () => {
+    const markdown =
+      "# Example\n\n```ts\nrouter();\n```\n\nSolution ID: sol_123";
+
+    expect(await cliJson(markdown)).toEqual(await mcpJson(markdown));
+  });
+});

--- a/src/tools/grep-repo-parity.test.ts
+++ b/src/tools/grep-repo-parity.test.ts
@@ -13,6 +13,7 @@ import {
   defaultGrepRepoResult,
 } from "../services/test-helpers.js";
 import { createGrepRepoTool } from "./grep-repo.js";
+import { isProcessExitSentinel } from "./parity-test-helpers.js";
 
 function cliDeps(
   overrides: Partial<PkgGrepCommandDependencies> = {},
@@ -47,8 +48,8 @@ async function cliJson(
         { ...options, json: true },
         deps,
       );
-    } catch {
-      /* error paths call process.exit — caught */
+    } catch (error) {
+      if (!isProcessExitSentinel(error)) throw error;
     }
     const raw =
       (logSpy.mock.calls[0]?.[0] as string | undefined) ??

--- a/src/tools/list-files-parity.test.ts
+++ b/src/tools/list-files-parity.test.ts
@@ -20,6 +20,7 @@ import {
   defaultListFilesResult,
 } from "../services/test-helpers.js";
 import { createListFilesTool } from "./list-files.js";
+import { isProcessExitSentinel } from "./parity-test-helpers.js";
 
 function cliDeps(
   overrides: Partial<PkgFilesCommandDependencies> = {},
@@ -52,8 +53,8 @@ async function cliJson(
       const first = hasRepoUrl ? pathPrefix : spec;
       const second = hasRepoUrl ? undefined : pathPrefix;
       await pkgFilesAction(first, second, { ...options, json: true }, deps);
-    } catch {
-      /* error paths call process.exit — caught */
+    } catch (error) {
+      if (!isProcessExitSentinel(error)) throw error;
     }
     const raw =
       (logSpy.mock.calls[0]?.[0] as string | undefined) ??

--- a/src/tools/list-package-docs-parity.test.ts
+++ b/src/tools/list-package-docs-parity.test.ts
@@ -9,6 +9,7 @@ import {
   defaultPackageDocsList,
 } from "../services/test-helpers.js";
 import { createListPackageDocsTool } from "./list-package-docs.js";
+import { isProcessExitSentinel } from "./parity-test-helpers.js";
 
 function cliDeps(
   overrides: Partial<DocsListCommandDependencies> = {},
@@ -34,8 +35,8 @@ async function cliJson(
   try {
     try {
       await docsListAction(spec, { json: true }, deps);
-    } catch {
-      // expected on error paths
+    } catch (error) {
+      if (!isProcessExitSentinel(error)) throw error;
     }
     const raw =
       (logSpy.mock.calls[0]?.[0] as string | undefined) ??

--- a/src/tools/package-changelog-parity.test.ts
+++ b/src/tools/package-changelog-parity.test.ts
@@ -31,6 +31,7 @@ import {
   defaultChangelogReport,
 } from "../services/test-helpers.js";
 import { createPackageChangelogTool } from "./package-changelog.js";
+import { isProcessExitSentinel } from "./parity-test-helpers.js";
 
 function cliDeps(
   overrides: Partial<PkgChangelogCommandDependencies> = {},
@@ -57,8 +58,8 @@ async function cliJson(
   try {
     try {
       await pkgChangelogAction(spec, { ...options, json: true }, deps);
-    } catch {
-      /* CLI error paths call process.exit — caught. */
+    } catch (error) {
+      if (!isProcessExitSentinel(error)) throw error;
     }
     const fromLog = logSpy.mock.calls[0]?.[0] as string | undefined;
     const fromErr = errSpy.mock.calls[0]?.[0] as string | undefined;

--- a/src/tools/package-dependencies-parity.test.ts
+++ b/src/tools/package-dependencies-parity.test.ts
@@ -32,6 +32,7 @@ import {
   zeroDepDependencyReport,
 } from "../services/test-helpers.js";
 import { createPackageDependenciesTool } from "./package-dependencies.js";
+import { isProcessExitSentinel } from "./parity-test-helpers.js";
 
 function cliDeps(
   overrides: Partial<PkgDepsCommandDependencies> = {},
@@ -58,8 +59,8 @@ async function cliJson(
   try {
     try {
       await pkgDepsAction(spec, { ...options, json: true }, deps);
-    } catch {
-      // CLI error paths call process.exit — caught.
+    } catch (error) {
+      if (!isProcessExitSentinel(error)) throw error;
     }
     const fromLog = logSpy.mock.calls[0]?.[0] as string | undefined;
     const fromErr = errSpy.mock.calls[0]?.[0] as string | undefined;

--- a/src/tools/package-summary-parity.test.ts
+++ b/src/tools/package-summary-parity.test.ts
@@ -30,6 +30,7 @@ import {
 } from "../services/index.js";
 import { createMockPackageIntelligenceService } from "../services/test-helpers.js";
 import { createPackageSummaryTool } from "./package-summary.js";
+import { isProcessExitSentinel } from "./parity-test-helpers.js";
 
 function cliDeps(
   overrides: Partial<PkgInfoCommandDependencies> = {},
@@ -55,8 +56,8 @@ async function cliJson(
   try {
     try {
       await pkgInfoAction(spec, { json: true }, deps);
-    } catch {
-      // CLI error paths call process.exit — caught.
+    } catch (error) {
+      if (!isProcessExitSentinel(error)) throw error;
     }
     const fromLog = logSpy.mock.calls[0]?.[0] as string | undefined;
     const fromErr = errSpy.mock.calls[0]?.[0] as string | undefined;

--- a/src/tools/package-upgrade-review-parity.test.ts
+++ b/src/tools/package-upgrade-review-parity.test.ts
@@ -13,6 +13,7 @@ import {
 import type { PackageIntelligenceService } from "../services/index.js";
 import { createMockPackageIntelligenceService } from "../services/test-helpers.js";
 import { createPackageUpgradeReviewTool } from "./package-upgrade-review.js";
+import { isProcessExitSentinel } from "./parity-test-helpers.js";
 
 function cliDeps(
   overrides: Partial<PkgUpgradeReviewCommandDependencies> = {},
@@ -39,8 +40,8 @@ async function cliJson(
   try {
     try {
       await pkgUpgradeReviewAction(spec, { ...options, json: true }, deps);
-    } catch {
-      /* CLI error paths call process.exit — caught. */
+    } catch (error) {
+      if (!isProcessExitSentinel(error)) throw error;
     }
     const fromLog = logSpy.mock.calls[0]?.[0] as string | undefined;
     const fromErr = errSpy.mock.calls[0]?.[0] as string | undefined;

--- a/src/tools/package-vulnerabilities-parity.test.ts
+++ b/src/tools/package-vulnerabilities-parity.test.ts
@@ -34,6 +34,7 @@ import {
   defaultVulnerabilityReport,
 } from "../services/test-helpers.js";
 import { createPackageVulnerabilitiesTool } from "./package-vulnerabilities.js";
+import { isProcessExitSentinel } from "./parity-test-helpers.js";
 
 function cliDeps(
   overrides: Partial<PkgVulnsCommandDependencies> = {},
@@ -60,8 +61,8 @@ async function cliJson(
   try {
     try {
       await pkgVulnsAction(spec, { ...options, json: true }, deps);
-    } catch {
-      // CLI error paths call process.exit — caught.
+    } catch (error) {
+      if (!isProcessExitSentinel(error)) throw error;
     }
     const fromLog = logSpy.mock.calls[0]?.[0] as string | undefined;
     const fromErr = errSpy.mock.calls[0]?.[0] as string | undefined;

--- a/src/tools/parity-test-helpers.ts
+++ b/src/tools/parity-test-helpers.ts
@@ -1,0 +1,3 @@
+export function isProcessExitSentinel(error: unknown): boolean {
+  return error instanceof Error && error.message === "process.exit";
+}

--- a/src/tools/read-file-parity.test.ts
+++ b/src/tools/read-file-parity.test.ts
@@ -17,6 +17,7 @@ import {
   createMockCodeNavigationService,
   defaultReadFileResult,
 } from "../services/test-helpers.js";
+import { isProcessExitSentinel } from "./parity-test-helpers.js";
 import { createReadFileTool } from "./read-file.js";
 
 function cliDeps(
@@ -45,8 +46,8 @@ async function cliJson(
   try {
     try {
       await pkgReadAction(spec, path, { ...options, json: true }, deps);
-    } catch {
-      /* error paths call process.exit — caught */
+    } catch (error) {
+      if (!isProcessExitSentinel(error)) throw error;
     }
     const raw =
       (logSpy.mock.calls[0]?.[0] as string | undefined) ??

--- a/src/tools/read-package-doc-parity.test.ts
+++ b/src/tools/read-package-doc-parity.test.ts
@@ -5,6 +5,7 @@ import {
 } from "../commands/docs/read.js";
 import { PackageIntelligenceTargetNotFoundError } from "../services/index.js";
 import { createMockPackageIntelligenceService } from "../services/test-helpers.js";
+import { isProcessExitSentinel } from "./parity-test-helpers.js";
 import { createReadPackageDocTool } from "./read-package-doc.js";
 
 function cliDeps(
@@ -31,8 +32,8 @@ async function cliJson(
   try {
     try {
       await docsReadAction(pageId, { json: true }, deps);
-    } catch {
-      // expected on error paths
+    } catch (error) {
+      if (!isProcessExitSentinel(error)) throw error;
     }
     const raw =
       (logSpy.mock.calls[0]?.[0] as string | undefined) ??

--- a/src/tools/search-language-parity.test.ts
+++ b/src/tools/search-language-parity.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, mock, spyOn } from "bun:test";
+import { languagesAction } from "../commands/languages.js";
+import { createMockGitHitsService } from "../services/test-helpers.js";
+import { createSearchLanguageTool } from "./search-language.js";
+
+const languages = [
+  {
+    id: "1",
+    name: "typescript",
+    display_name: "TypeScript",
+    aliases: ["ts"],
+  },
+  {
+    id: "2",
+    name: "python",
+    display_name: "Python",
+    aliases: ["py"],
+  },
+];
+
+async function cliJson(): Promise<unknown> {
+  const logSpy = spyOn(console, "log").mockImplementation(() => {});
+  try {
+    await languagesAction(
+      "type",
+      { json: true },
+      {
+        githitsService: createMockGitHitsService({
+          getLanguages: mock(() => Promise.resolve(languages)),
+        }),
+        hasValidToken: true,
+        mcpUrl: "https://mcp.example.com",
+      },
+    );
+    return JSON.parse(String(logSpy.mock.calls[0]?.[0]));
+  } finally {
+    logSpy.mockRestore();
+  }
+}
+
+async function mcpJson(): Promise<unknown> {
+  const tool = createSearchLanguageTool(
+    createMockGitHitsService({
+      getLanguages: mock(() => Promise.resolve(languages)),
+    }),
+  );
+  const result = await tool.handler({ query: "type", format: "json" }, {});
+  return JSON.parse(result.content[0]?.text ?? "");
+}
+
+describe("search_language parity", () => {
+  it("PARITY-JSON-KEYS: CLI === MCP", async () => {
+    expect(await cliJson()).toEqual(await mcpJson());
+  });
+});

--- a/src/tools/search-parity.test.ts
+++ b/src/tools/search-parity.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, mock, spyOn } from "bun:test";
+import { searchAction } from "../commands/search.js";
+import {
+  createMockCodeNavigationService,
+  defaultUnifiedSearchOutcome,
+} from "../services/test-helpers.js";
+import { createSearchTool } from "./search.js";
+
+async function cliJson(): Promise<unknown> {
+  const logSpy = spyOn(console, "log").mockImplementation(() => {});
+  try {
+    await searchAction(
+      "router",
+      { in: ["npm:express"], json: true },
+      {
+        codeNavigationService: createMockCodeNavigationService({
+          search: mock(() => Promise.resolve(defaultUnifiedSearchOutcome)),
+        }),
+        codeNavigationUrl: "https://pkgseer.dev",
+        hasValidToken: true,
+        mcpUrl: "https://mcp.example.com",
+      },
+    );
+    return JSON.parse(String(logSpy.mock.calls[0]?.[0]));
+  } finally {
+    logSpy.mockRestore();
+  }
+}
+
+async function mcpJson(): Promise<unknown> {
+  const tool = createSearchTool(
+    createMockCodeNavigationService({
+      search: mock(() => Promise.resolve(defaultUnifiedSearchOutcome)),
+    }),
+  );
+  const result = await tool.handler(
+    { target: "npm:express", query: "router", format: "json" },
+    {},
+  );
+  return JSON.parse(result.content[0]?.text ?? "");
+}
+
+describe("search parity", () => {
+  it("PARITY-JSON-KEYS: CLI === MCP", async () => {
+    expect(await cliJson()).toEqual(await mcpJson());
+  });
+});


### PR DESCRIPTION
## Summary
- Normalize CLI JSON auth failures across preflight auth, service-level 401s, and failed interactive auto-login.
- Add request timeouts for REST, OAuth, and pkgseer GraphQL calls with timeout-specific error classification.
- Expand CLI/MCP parity coverage and smoke expectations for auth JSON behavior.

## Verification
- bun test
- bun run typecheck
- bun run format:check
- bun run build
- bun run smoke:cli
- bun run smoke:mcp
- code-reviewer: no findings