### PR TITLE
refactor: narrow MCP tool dependencies

### DIFF
--- a/eval/mock-mcp/server.ts
+++ b/eval/mock-mcp/server.ts
@@ -28,7 +28,6 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
 import { buildMcpInstructions } from "../../src/commands/mcp-instructions.js";
-import type { Dependencies } from "../../src/container.js";
 import {
   CODE_READ_GUARDRAIL,
   DOCS_GUARDRAIL,
@@ -72,7 +71,7 @@ function withGuardrail(base: string, addendum: string): string {
 // external-content posture so we can control whether it's included
 // per cell. Production always inherits the shared block; the eval
 // needs `--guardrail=off` to be a clean baseline.
-const baseInstructions = buildMcpInstructions({} as Dependencies, {
+const baseInstructions = buildMcpInstructions({
   includeExternalContentPosture: false,
 });
 const instructions = includeShared

--- a/src/commands/mcp-instructions.test.ts
+++ b/src/commands/mcp-instructions.test.ts
@@ -1,29 +1,17 @@
 import { describe, expect, it } from "bun:test";
-import type { Dependencies } from "../container.js";
 import {
-  createMockAuthService,
-  createMockAuthStorage,
-  createMockBrowserService,
   createMockCodeNavigationService,
-  createMockFileSystemService,
   createMockGitHitsService,
   createMockPackageIntelligenceService,
 } from "../services/test-helpers.js";
+import type { McpToolServices } from "../tools/tool-services.js";
 import { getMcpToolDefinitions } from "./mcp.js";
 import { buildMcpInstructions } from "./mcp-instructions.js";
 
-function createTestDeps(overrides: Partial<Dependencies> = {}): Dependencies {
+function createTestServices(
+  overrides: Partial<McpToolServices> = {},
+): McpToolServices {
   return {
-    authStorage: createMockAuthStorage(),
-    authService: createMockAuthService(),
-    browserService: createMockBrowserService(),
-    fileSystemService: createMockFileSystemService(),
-    mcpUrl: "https://mcp.githits.com",
-    apiUrl: "https://api.githits.com",
-    apiToken: "test-token",
-    hasValidToken: true,
-    envApiToken: undefined,
-    codeNavigationUrl: "https://pkgseer.dev",
     codeNavigationService: createMockCodeNavigationService(),
     packageIntelligenceService: createMockPackageIntelligenceService(),
     githitsService: createMockGitHitsService(),
@@ -59,14 +47,13 @@ function mentionedTools(instructions: string): Set<string> {
   return mentioned;
 }
 
-function registeredTools(deps: Dependencies): Set<string> {
-  return new Set(getMcpToolDefinitions(deps).map((tool) => tool.name));
+function registeredTools(services: McpToolServices): Set<string> {
+  return new Set(getMcpToolDefinitions(services).map((tool) => tool.name));
 }
 
 describe("buildMcpInstructions", () => {
   it("returns core + package/code tools section by default", () => {
-    const deps = createTestDeps();
-    const instructions = buildMcpInstructions(deps);
+    const instructions = buildMcpInstructions();
 
     expect(instructions).toContain("GitHits provides verified");
     expect(instructions).toContain("Indexed package/source tools");
@@ -84,8 +71,7 @@ describe("buildMcpInstructions", () => {
   });
 
   it("includes the external-content posture by default", () => {
-    const deps = createTestDeps();
-    const instructions = buildMcpInstructions(deps);
+    const instructions = buildMcpInstructions();
 
     expect(instructions).toContain("External-content posture");
     expect(instructions).toContain("tool-owned reference/provenance sections");
@@ -95,8 +81,7 @@ describe("buildMcpInstructions", () => {
     // The eval mock MCP server opts out so it can control whether the
     // shared block is included per cell, comparing baseline vs
     // guardrailed cohorts cleanly. Production never opts out.
-    const deps = createTestDeps();
-    const instructions = buildMcpInstructions(deps, {
+    const instructions = buildMcpInstructions({
       includeExternalContentPosture: false,
     });
 
@@ -107,8 +92,7 @@ describe("buildMcpInstructions", () => {
   });
 
   it("steers file enumeration to code_files instead of directory probes", () => {
-    const deps = createTestDeps();
-    const instructions = buildMcpInstructions(deps);
+    const instructions = buildMcpInstructions();
 
     expect(instructions).toContain(
       "First choice for file-listing/path-enumeration tasks",
@@ -123,15 +107,13 @@ describe("buildMcpInstructions", () => {
   });
 
   it("expands core trigger criteria to cover comparative cross-OSS questions", () => {
-    const deps = createTestDeps();
-    const instructions = buildMcpInstructions(deps);
+    const instructions = buildMcpInstructions();
     expect(instructions).toContain("comparative across OSS projects");
     expect(instructions).toContain("how a real codebase implements");
   });
 
   it("keeps the core block first", () => {
-    const deps = createTestDeps();
-    const instructions = buildMcpInstructions(deps);
+    const instructions = buildMcpInstructions();
 
     const coreIdx = instructions.indexOf("GitHits provides verified");
     const packageToolsIdx = instructions.indexOf(
@@ -142,9 +124,9 @@ describe("buildMcpInstructions", () => {
   });
 
   it("keeps mentioned package/code tools aligned with registration", () => {
-    const deps = createTestDeps();
-    const mentioned = mentionedTools(buildMcpInstructions(deps));
-    const registered = registeredTools(deps);
+    const services = createTestServices();
+    const mentioned = mentionedTools(buildMcpInstructions());
+    const registered = registeredTools(services);
 
     for (const name of mentioned) {
       expect(registered.has(name)).toBe(true);
@@ -171,8 +153,7 @@ describe("buildMcpInstructions", () => {
   });
 
   it("ships a decision tree mentioning all three workflow tools in the core block", () => {
-    const deps = createTestDeps();
-    const instructions = buildMcpInstructions(deps);
+    const instructions = buildMcpInstructions();
     const coreEnd = instructions.indexOf("Indexed package/source tools");
     const coreSection = instructions.slice(0, coreEnd);
 
@@ -183,8 +164,7 @@ describe("buildMcpInstructions", () => {
   });
 
   it("tells agents to report get_example source repositories", () => {
-    const deps = createTestDeps();
-    const instructions = buildMcpInstructions(deps);
+    const instructions = buildMcpInstructions();
 
     expect(instructions).toContain("source repository provenance");
     expect(instructions).toContain("source repositories/citations");
@@ -194,8 +174,7 @@ describe("buildMcpInstructions", () => {
   });
 
   it("orders package-section bullets by agent decision flow", () => {
-    const deps = createTestDeps();
-    const instructions = buildMcpInstructions(deps);
+    const instructions = buildMcpInstructions();
 
     const positions = {
       search: instructions.indexOf("- `search` —"),
@@ -233,8 +212,7 @@ describe("buildMcpInstructions", () => {
   });
 
   it("places the strategy tip after the bullets and the delegation tip before them", () => {
-    const deps = createTestDeps();
-    const instructions = buildMcpInstructions(deps);
+    const instructions = buildMcpInstructions();
 
     const delegationIdx = instructions.indexOf(
       "Delegate multi-call work to a sub-agent",

--- a/src/commands/mcp-instructions.ts
+++ b/src/commands/mcp-instructions.ts
@@ -1,4 +1,3 @@
-import type { Dependencies } from "../container.js";
 import { EXTERNAL_CONTENT_POSTURE } from "../tools/guardrails.js";
 
 /**
@@ -95,7 +94,6 @@ export interface BuildMcpInstructionsOptions {
 }
 
 export function buildMcpInstructions(
-  _deps: Dependencies,
   options: BuildMcpInstructionsOptions = {},
 ): string {
   const includeExternalContentPosture =

--- a/src/commands/mcp.test.ts
+++ b/src/commands/mcp.test.ts
@@ -1,11 +1,6 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import type { Dependencies } from "../container.js";
 import {
-  createMockAuthService,
-  createMockAuthStorage,
-  createMockBrowserService,
   createMockCodeNavigationService,
-  createMockFileSystemService,
   createMockGitHitsService,
   createMockPackageIntelligenceService,
 } from "../services/test-helpers.js";
@@ -13,24 +8,17 @@ import {
   buildClientHeaders,
   resetRequestHeadersState,
 } from "../shared/request-headers.js";
+import type { McpToolServices } from "../tools/tool-services.js";
 import {
   createMcpServer,
   getMcpToolDefinitions,
   startMcpServer,
 } from "./mcp.js";
 
-function createTestDeps(overrides: Partial<Dependencies> = {}): Dependencies {
+function createTestServices(
+  overrides: Partial<McpToolServices> = {},
+): McpToolServices {
   return {
-    authStorage: createMockAuthStorage(),
-    authService: createMockAuthService(),
-    browserService: createMockBrowserService(),
-    fileSystemService: createMockFileSystemService(),
-    mcpUrl: "https://mcp.githits.com",
-    apiUrl: "https://api.githits.com",
-    apiToken: "test-token",
-    hasValidToken: true,
-    envApiToken: undefined,
-    codeNavigationUrl: "https://pkgseer.dev",
     codeNavigationService: createMockCodeNavigationService(),
     packageIntelligenceService: createMockPackageIntelligenceService(),
     githitsService: createMockGitHitsService(),
@@ -38,10 +26,36 @@ function createTestDeps(overrides: Partial<Dependencies> = {}): Dependencies {
   };
 }
 
+const EXPECTED_TOOL_NAMES = [
+  "get_example",
+  "search_language",
+  "feedback",
+  "search",
+  "search_status",
+  "code_files",
+  "code_read",
+  "code_grep",
+  "docs_list",
+  "docs_read",
+  "pkg_info",
+  "pkg_vulns",
+  "pkg_deps",
+  "pkg_changelog",
+  "pkg_upgrade_review",
+] as const;
+
 describe("createMcpServer", () => {
+  it("constructs tools from service-only dependencies", () => {
+    const services = createTestServices();
+
+    const tools = getMcpToolDefinitions(services);
+
+    expect(tools.map((tool) => tool.name)).toEqual([...EXPECTED_TOOL_NAMES]);
+  });
+
   it("creates server with default tools registered", () => {
-    const deps = createTestDeps();
-    const server = createMcpServer(deps);
+    const services = createTestServices();
+    const server = createMcpServer(services);
 
     // McpServer should be created without error
     expect(server).toBeDefined();
@@ -52,16 +66,16 @@ describe("createMcpServer", () => {
     // in the instructions pipeline (composer import, SDK options
     // shape) surfaces here even though the SDK hides `instructions`
     // behind a private field.
-    const deps = createTestDeps();
-    const server = createMcpServer(deps);
+    const services = createTestServices();
+    const server = createMcpServer(services);
 
     expect(server).toBeDefined();
   });
 
   it("adds unified search tools by default", () => {
-    const deps = createTestDeps();
+    const services = createTestServices();
 
-    const tools = getMcpToolDefinitions(deps);
+    const tools = getMcpToolDefinitions(services);
     const names = tools.map((tool) => tool.name);
     for (const name of [
       "get_example",
@@ -78,18 +92,18 @@ describe("createMcpServer", () => {
   });
 
   it("adds package_summary by default", () => {
-    const deps = createTestDeps();
+    const services = createTestServices();
 
-    const tools = getMcpToolDefinitions(deps);
+    const tools = getMcpToolDefinitions(services);
     expect(tools.map((tool) => tool.name)).toContain("docs_list");
     expect(tools.map((tool) => tool.name)).toContain("docs_read");
     expect(tools.map((tool) => tool.name)).toContain("pkg_info");
   });
 
   it("advertises package_summary with unified search", () => {
-    const deps = createTestDeps();
+    const services = createTestServices();
 
-    const names = getMcpToolDefinitions(deps).map((t) => t.name);
+    const names = getMcpToolDefinitions(services).map((t) => t.name);
     if (names.includes("pkg_info")) {
       expect(names).toContain("search");
       expect(names).toContain("search_status");
@@ -97,32 +111,32 @@ describe("createMcpServer", () => {
   });
 
   it("adds package_vulnerabilities by default", () => {
-    const deps = createTestDeps();
+    const services = createTestServices();
 
-    const tools = getMcpToolDefinitions(deps);
+    const tools = getMcpToolDefinitions(services);
     expect(tools.map((tool) => tool.name)).toContain("pkg_vulns");
   });
 
   it("advertises package_summary and package_vulnerabilities together (shared predicate)", () => {
-    const deps = createTestDeps();
+    const services = createTestServices();
 
-    const names = getMcpToolDefinitions(deps).map((t) => t.name);
+    const names = getMcpToolDefinitions(services).map((t) => t.name);
     if (names.includes("pkg_info")) {
       expect(names).toContain("pkg_vulns");
     }
   });
 
   it("adds package_dependencies by default", () => {
-    const deps = createTestDeps();
+    const services = createTestServices();
 
-    const tools = getMcpToolDefinitions(deps);
+    const tools = getMcpToolDefinitions(services);
     expect(tools.map((tool) => tool.name)).toContain("pkg_deps");
   });
 
   it("advertises every package tool together (shared predicate covers deps too)", () => {
-    const deps = createTestDeps();
+    const services = createTestServices();
 
-    const names = getMcpToolDefinitions(deps).map((t) => t.name);
+    const names = getMcpToolDefinitions(services).map((t) => t.name);
     if (names.includes("pkg_info")) {
       expect(names).toContain("pkg_vulns");
       expect(names).toContain("pkg_deps");
@@ -139,19 +153,19 @@ describe("startMcpServer", () => {
     resetRequestHeadersState();
   });
 
-  it("starts successfully without a valid token", async () => {
-    const deps = createTestDeps({ hasValidToken: false });
+  it("starts successfully with service-only dependencies", async () => {
+    const services = createTestServices();
 
     // Server should start and connect transport without throwing.
     // Auth errors are deferred to individual tool calls.
-    await expect(startMcpServer(deps)).resolves.toBeUndefined();
+    await expect(startMcpServer(services)).resolves.toBeUndefined();
   });
 
   it("sets clientMode to githits-cli/mcp", async () => {
     // After startMcpServer runs, subsequent buildClientHeaders calls
     // tag the client as MCP-mode. Pins the telemetry contract.
-    const deps = createTestDeps({ hasValidToken: false });
-    await startMcpServer(deps);
+    const services = createTestServices();
+    await startMcpServer(services);
     const headers = buildClientHeaders({});
     expect(headers["x-githits-client-name"]).toBe("githits-cli/mcp");
   });
@@ -161,8 +175,8 @@ describe("startMcpServer", () => {
     // that can race the first tool call. The provider pattern reads
     // clientInfo synchronously on every buildClientHeaders call,
     // eliminating the race. This test pins the provider-based flow.
-    const deps = createTestDeps({ hasValidToken: false });
-    await startMcpServer(deps);
+    const services = createTestServices();
+    await startMcpServer(services);
 
     // Before the initialize handshake lands, the provider returns
     // undefined — `buildClientHeaders` falls back to env detection

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -2,7 +2,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import type { Command } from "commander";
 import { version } from "../../package.json";
-import { createContainer, type Dependencies } from "../container.js";
+import { createContainer } from "../container.js";
 import { dim, highlight, shouldUseColors } from "../shared/colors.js";
 import {
   setClientMode,
@@ -27,47 +27,52 @@ import {
   type ToolDefinition,
   type ZodRawShape,
 } from "../tools/index.js";
+import type { McpToolServices } from "../tools/tool-services.js";
 import { buildMcpInstructions } from "./mcp-instructions.js";
 
 /**
  * Returns the MCP tools enabled for the current startup state.
  */
 export function getMcpToolDefinitions(
-  deps: Dependencies,
+  services: McpToolServices,
 ): ToolDefinition<unknown>[] {
   const tools: ToolDefinition<unknown>[] = [
-    eraseTool(createGetExampleTool(deps.githitsService)),
-    eraseTool(createSearchLanguageTool(deps.githitsService)),
-    eraseTool(createFeedbackTool(deps.githitsService)),
+    eraseTool(createGetExampleTool(services.githitsService)),
+    eraseTool(createSearchLanguageTool(services.githitsService)),
+    eraseTool(createFeedbackTool(services.githitsService)),
   ];
 
-  tools.push(eraseTool(createSearchTool(deps.codeNavigationService)));
-  tools.push(eraseTool(createSearchStatusTool(deps.codeNavigationService)));
-  tools.push(eraseTool(createListFilesTool(deps.codeNavigationService)));
-  tools.push(eraseTool(createReadFileTool(deps.codeNavigationService)));
-  tools.push(eraseTool(createGrepRepoTool(deps.codeNavigationService)));
+  tools.push(eraseTool(createSearchTool(services.codeNavigationService)));
+  tools.push(eraseTool(createSearchStatusTool(services.codeNavigationService)));
+  tools.push(eraseTool(createListFilesTool(services.codeNavigationService)));
+  tools.push(eraseTool(createReadFileTool(services.codeNavigationService)));
+  tools.push(eraseTool(createGrepRepoTool(services.codeNavigationService)));
   tools.push(
-    eraseTool(createListPackageDocsTool(deps.packageIntelligenceService)),
+    eraseTool(createListPackageDocsTool(services.packageIntelligenceService)),
   );
   tools.push(
-    eraseTool(createReadPackageDocTool(deps.packageIntelligenceService)),
+    eraseTool(createReadPackageDocTool(services.packageIntelligenceService)),
   );
   tools.push(
-    eraseTool(createPackageSummaryTool(deps.packageIntelligenceService)),
+    eraseTool(createPackageSummaryTool(services.packageIntelligenceService)),
   );
   tools.push(
     eraseTool(
-      createPackageVulnerabilitiesTool(deps.packageIntelligenceService),
+      createPackageVulnerabilitiesTool(services.packageIntelligenceService),
     ),
   );
   tools.push(
-    eraseTool(createPackageDependenciesTool(deps.packageIntelligenceService)),
+    eraseTool(
+      createPackageDependenciesTool(services.packageIntelligenceService),
+    ),
   );
   tools.push(
-    eraseTool(createPackageChangelogTool(deps.packageIntelligenceService)),
+    eraseTool(createPackageChangelogTool(services.packageIntelligenceService)),
   );
   tools.push(
-    eraseTool(createPackageUpgradeReviewTool(deps.packageIntelligenceService)),
+    eraseTool(
+      createPackageUpgradeReviewTool(services.packageIntelligenceService),
+    ),
   );
 
   return tools;
@@ -85,18 +90,18 @@ function eraseTool<TArgs, TSchema extends ZodRawShape>(
 /**
  * Creates the MCP server with injected dependencies.
  */
-export function createMcpServer(deps: Dependencies): McpServer {
+export function createMcpServer(services: McpToolServices): McpServer {
   const server = new McpServer(
     {
       name: "githits",
       version,
     },
     {
-      instructions: buildMcpInstructions(deps),
+      instructions: buildMcpInstructions(),
     },
   );
 
-  const tools = getMcpToolDefinitions(deps);
+  const tools = getMcpToolDefinitions(services);
 
   for (const tool of tools) {
     server.registerTool(
@@ -130,10 +135,10 @@ export function createMcpServer(deps: Dependencies): McpServer {
  *   pattern had where the first tool call could slip through
  *   before the notification dispatched.
  */
-export async function startMcpServer(deps: Dependencies): Promise<void> {
+export async function startMcpServer(services: McpToolServices): Promise<void> {
   setClientMode("mcp");
 
-  const server = createMcpServer(deps);
+  const server = createMcpServer(services);
   const transport = new StdioServerTransport();
 
   setMcpClientVersionProvider(() => {

--- a/src/tools/tool-services.ts
+++ b/src/tools/tool-services.ts
@@ -1,0 +1,17 @@
+import type {
+  CodeNavigationService,
+  GitHitsService,
+  PackageIntelligenceService,
+} from "../services/index.js";
+
+/**
+ * Services required to construct the MCP tool surface.
+ *
+ * Keep this seam narrower than the CLI container so remote MCP/server
+ * integrations do not inherit local auth, filesystem, browser, or CLI state.
+ */
+export interface McpToolServices {
+  githitsService: GitHitsService;
+  codeNavigationService: CodeNavigationService;
+  packageIntelligenceService: PackageIntelligenceService;
+}


### PR DESCRIPTION
## Summary
- add a narrow McpToolServices seam for MCP tool/server construction
- remove the unused CLI container dependency from MCP instruction building
- update MCP tests and eval mock server to use service-only dependencies

## Verification
- bun test src/commands/mcp.test.ts src/commands/mcp-instructions.test.ts
- bun run typecheck
- bun test
- bun run build
- bun run smoke:mcp

## Review
- Plan reviewer: no blocking issues
- Code reviewer: no findings

Note: agent:e2e was not run because this changed the instruction builder signature, not instruction content or tool descriptions.