### PR TITLE
chore: prepare 0.4.10 release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "GitHits plugins for Claude Code - code examples from global open source",
-    "version": "0.4.9"
+    "version": "0.4.10"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "description": "Code examples from global open source for developers and AI assistants",
   "author": {
     "name": "GitHits"

--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "description": "Code examples from global open source for developers and AI assistants",
   "author": {
     "name": "GitHits"

--- a/README.md
+++ b/README.md
@@ -184,6 +184,10 @@ To inspect the current auth setup, run:
 githits auth status
 ```
 
+For redacted environment/configuration diagnostics when GitHits behaves
+differently across terminals or agents, run `githits doctor` or
+`githits doctor --json`.
+
 ## Commands
 
 ```
@@ -194,6 +198,7 @@ githits logout           Remove stored credentials
 githits mcp              Show setup instructions in a terminal; starts MCP server when piped
 githits mcp start        Always start MCP server (for use in MCP config files)
 githits auth status      Show current authentication status
+githits doctor           Print redacted diagnostics for config/auth troubleshooting
 githits example          Get canonical code examples from global open source
 githits languages        List or filter supported language names
 githits feedback         Send feedback on a result, command, or session

--- a/docs/implementation/auth.md
+++ b/docs/implementation/auth.md
@@ -171,6 +171,7 @@ The MCP server starts without a synchronous auth gate. Tool calls resolve tokens
 ## Troubleshooting
 
 - **"Authentication required" from a command or MCP tool** — No valid token found. Run `githits login` or set `GITHITS_API_TOKEN`.
+- **Different auth behavior across terminals or agents** — Run `githits doctor` or `githits doctor --json` to compare redacted runtime, environment, config, and auth-storage diagnostics without exposing token values.
 - **"Already logged in."** — Token is still valid. Use `githits login --force` to re-authenticate.
 - **Port conflicts on login** — The callback server uses the port from the stored client registration. On first login, a random port (8000–9999) is chosen and saved. Use `--port <port>` to change it (triggers re-registration).
 - **Token refresh fails silently** — By design. The token manager first reloads storage in case another process refreshed credentials. If the expired token is still unchanged, it clears that stale token and later calls prompt re-login.
@@ -194,6 +195,7 @@ The MCP server starts without a synchronous auth gate. Tool calls resolve tokens
 | `src/services/locked-auth-storage.ts` | Cross-process auth-storage lock and conditional write serialization |
 | `src/services/auth-config.ts` | `config.toml` and `GITHITS_AUTH_STORAGE` parsing |
 | `src/services/app-config-paths.ts` | Platform-specific config/auth path resolution |
+| `src/commands/doctor.ts` | Redacted runtime/config/auth diagnostics for support and environment comparisons |
 | `src/services/mode-aware-file-auth-storage.ts` | File-write guard for `auth.storage` policy |
 | `src/services/keyring-service.ts` | `KeyringService` interface wrapping `@napi-rs/keyring` |
 | `src/services/chunking-keyring-service.ts` | `KeyringService` decorator for chunked storage (Windows 2560-char limit) |

--- a/docs/implementation/cli-commands.md
+++ b/docs/implementation/cli-commands.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-The CLI exposes `example`, `languages`, `feedback`, top-level indexed `search` / `search-status`, and the `code`, `docs`, and `pkg` command groups by default. All of these commands share business logic with the MCP tools through the same service interfaces and shared utilities, but format output for terminal consumption instead of MCP tool results.
+The CLI exposes setup/auth commands, `doctor`, `example`, `languages`, `feedback`, top-level indexed `search` / `search-status`, and the `code`, `docs`, and `pkg` command groups by default. MCP-parity commands share business logic with the MCP tools through the same service interfaces and shared utilities, but format output for terminal consumption instead of MCP tool results.
 
 ## Commands
 
@@ -15,9 +15,10 @@ The CLI exposes `example`, `languages`, `feedback`, top-level indexed `search` /
 | `search-status <search-ref>` | `<search-ref>` | `--json` | Check progress, fetch partial hits, or fetch final results for a prior unified search |
 | `languages [query]` | — | `--json` | List or filter supported languages |
 | `feedback [solution_id]` | `--accept` or `--reject` | `-m, --message <text>`, `--tool <name>`, `--json` | Submit solution-tied or generic session feedback |
+| `doctor` | — | `--json` | Print redacted diagnostics for GitHits runtime, environment, service URLs, config, and auth storage |
 | `pkg info <spec>` | package spec | `--verbose`, `--json` | Show a package overview (latest version, downloads, license, vulnerabilities) |
-| `pkg vulns <spec>` | package spec (optional `@version`) | `--severity`, `--scope`, `--include-withdrawn`, `--verbose`, `--json` | List known vulnerabilities for a package (npm/pypi/hex/crates/nuget/maven/packagist/rubygems/go) |
-| `pkg deps <spec>` | package spec (optional `@version`) | `--lifecycle`, `--transitive`, `--depth`, `--verbose`, `--json` | Analyse dependencies: direct runtime deps, structured groups, optional transitive graph (npm/pypi/hex/crates/vcpkg/zig/rubygems/go) |
+| `pkg vulns <spec>` | package spec (optional `@version`) | `--severity`, `--scope`, `--include-withdrawn`, `--verbose`, `--json` | List known vulnerabilities for a package (npm/pypi/hex/crates/nuget/maven/packagist/rubygems/go/swift) |
+| `pkg deps <spec>` | package spec (optional `@version`) | `--lifecycle`, `--transitive`, `--depth`, `--verbose`, `--json` | Analyse dependencies: direct runtime deps, structured groups, optional transitive graph (npm/pypi/hex/crates/vcpkg/zig/rubygems/go/swift) |
 | `pkg changelog [spec]` | package spec OR `--repo-url` | `--from`, `--to`, `--limit`, `--git-ref`, `--no-body`, `--verbose`, `--json` | Release notes / changelog entries for a package or GitHub repo (GitHub Releases, CHANGELOG.md, or HexDocs). Default shows each entry with a 10-line body preview; `--verbose` uncaps, `--no-body` drops. |
 | `pkg upgrade-review [spec]` | single package spec with current version plus `--to`, OR repeatable `--package` ranges | `--to`, repeatable `--package`, `--no-transitive-security`, `--dependency-issues`, `--min-severity`, `--verbose`, `--json` | Compare current and target versions for upgrade evidence: vulnerabilities, changelog entries, deprecation metadata, peer changes, dependency changes, and optional transitive evidence. Reports facts only. |
 | `docs list <spec>` | package spec (optional `@version`) | `--limit`, `--after`, `--verbose`, `--json` | List hosted/crawled and repository-backed documentation pages for a package. Entries include page IDs for `docs read`; JSON includes exact repo-file follow-up metadata when available. |
@@ -43,7 +44,7 @@ Authenticates with GitHits (via OAuth in the browser), then scans for available 
 
 When `init` is run without a TTY, it prints agent onboarding guidance and exits without scanning, writing config, prompting, or authenticating. Non-interactive `--yes` is rejected for safety because it can configure tools without explicit per-tool user approval. Agentic onboarding must use the staged flow instead: `npx -y githits@latest init --detect-agents` first, then `npx -y githits@latest init --install-agents <ids>` after the user approves the exact detected IDs. Agent-facing guidance explicitly forbids `githits init -y` / `githits init --yes` unless the user asks to configure every detected tool, and tells agents to verify successful staged installs with `--detect-agents --json` instead of running init again. `--install-agents` rescans, rejects unknown or currently undetected IDs before writing, installs only the requested agents, verifies setup, and does not authenticate. After successful or already-configured outcomes it instructs agents to ask before running the separate `npx -y githits@latest login` command; if every install fails, it reports installation errors and suppresses auth guidance. `--json` is supported for the staged detect/install modes so agents do not need to scrape prose.
 
-Supports Claude Code, Cursor, Windsurf, VS Code / Copilot, Cline, Claude Desktop, Codex CLI, Pi, Gemini CLI, Google Antigravity, and OpenCode. Uses plugin install (Claude Code), CLI commands (Codex, Gemini CLI), Pi adapter setup plus Pi-owned MCP config writes (Pi), and atomic config file writes (Cursor, Windsurf, VS Code, Cline, Claude Desktop, Google Antigravity, OpenCode). CLI agents use read-only check commands (e.g., `claude plugin list`) to determine configuration status before prompting.
+Supports Claude Code, Cursor, Windsurf, VS Code / Copilot, Cline, Claude Desktop, Codex CLI, Pi, Gemini CLI, Google Antigravity, OpenCode, and Hermes Agent. Uses plugin install (Claude Code), CLI commands (Codex, Gemini CLI), Pi adapter setup plus Pi-owned MCP config writes (Pi), and atomic config file writes (Cursor, Windsurf, VS Code, Cline, Claude Desktop, Google Antigravity, OpenCode, Hermes Agent). CLI agents use read-only check commands (e.g., `claude plugin list`) to determine configuration status before prompting.
 
 The command uses `createContainer()` lazily for the login step. Tool detection and configuration use lightweight dependencies that don't require auth.
 
@@ -124,6 +125,15 @@ githits feedback --reject --tool search -m "missing kotlin support"
 ```
 
 Passing `[solution_id]` anchors feedback to a prior `githits example` result. Omitting it creates generic feedback for the current CLI/MCP session via the `x-githits-session-id` header; `--tool` records the command or MCP tool that produced the result being rated. `--accept` and `--reject` are mutually exclusive (enforced by Commander's `.conflicts()` API). At least one must be provided (validated in the action function). JSON output is `{ "success": true, "message": "..." }`.
+
+### `githits doctor`
+
+```
+githits doctor
+githits doctor --json
+```
+
+Prints redacted diagnostics for comparing GitHits behavior across terminals or agents. The report includes CLI/runtime identity, selected environment variables, service URL sources, config file status, active and legacy auth storage locations, token/client/metadata presence and timestamps, and recommendations. Secret-bearing values such as tokens, client secrets, API tokens, and proxy credentials are never printed; presence is reported as `set` / `present` only. JSON output uses `schemaVersion: 1` for support tooling.
 
 ### `githits pkg info`
 

--- a/docs/implementation/config.md
+++ b/docs/implementation/config.md
@@ -28,7 +28,7 @@ The container (`src/container.ts`) resolves authentication in priority order:
 
 2. **Stored OAuth JWT** — Loaded from the configured auth store. If expired, the container automatically attempts a refresh using the stored refresh token. If refresh fails, auth is cleared silently.
 
-3. **Unauthenticated** — No token available. Auth-required CLI commands fail on use, and the MCP server can start but every authenticated tool call will fail. Commands like `auth status` still work to help the user diagnose the issue.
+3. **Unauthenticated** — No token available. Auth-required CLI commands fail on use, and the MCP server can start but every authenticated tool call will fail. Commands like `auth status` and `doctor` still work to help the user diagnose the issue.
 
 ### Auth Mode Capabilities
 
@@ -50,6 +50,7 @@ Package/source access uses the package/source service URL from `GITHITS_CODE_NAV
 | `GITHITS_API_TOKEN` | API token for authentication | `ghi-abc123...` |
 | `GITHITS_AUTH_STORAGE` | Override OAuth credential storage for the current process (`keychain` or `file`) | `file` |
 | `GITHITS_TELEMETRY` | Emit end-of-run timing spans to stderr for local profiling | `1` |
+| `GITHITS_DISABLE_UPDATE_CHECK` | Disable npm latest-version update notices | `1` |
 
 ## Local Storage
 
@@ -126,6 +127,7 @@ Commands receive the full `Dependencies` object. Services receive only what they
 - **Custom environment not working** — Make sure both `GITHITS_MCP_URL` and `GITHITS_API_URL` are set. They point to different services.
 - **Tokens from wrong environment** — Tokens are stored per MCP URL. If you switched `GITHITS_MCP_URL`, you need to re-authenticate for the new URL.
 - **System keychain unavailable** — Default keychain mode fails rather than writing plaintext OAuth credentials. Use `GITHITS_API_TOKEN`, fix/unlock the keychain, or set `auth.storage = "file"` / `GITHITS_AUTH_STORAGE=file` if unencrypted file storage is acceptable.
+- **Environment-specific failures** — Run `githits doctor --json` in each terminal or agent and compare `runtime`, `environment`, `services`, `config`, and `auth` fields. The report redacts token and secret values.
 
 ### Init config parsing behavior
 
@@ -148,4 +150,5 @@ Commands receive the full `Dependencies` object. Services receive only what they
 | `src/services/filesystem-service.ts` | File system abstraction for testable storage |
 | `src/services/update-check-service.ts` | Non-secret update-check cache and npm latest lookup |
 | `src/commands/auth-status.ts` | Diagnosing current auth state (reached via `githits auth status`) |
+| `src/commands/doctor.ts` | Redacted diagnostics for runtime, environment, config, and auth storage |
 | `src/commands/mcp.ts` | MCP tool registration and deferred-auth startup behavior |

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "description": "Code examples from global open source for developers and AI assistants.",
   "mcpServers": {
     "githits": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "githits",
   "description": "CLI companion for GitHits - code examples from global open source for developers and AI assistants",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "type": "module",
   "files": [
     "dist",

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "description": "Code examples from global open source for developers and AI assistants",
   "author": {
     "name": "GitHits"


### PR DESCRIPTION
## Summary
- Bump package and plugin manifests to 0.4.10
- Document doctor diagnostics, Hermes Agent setup, Swift package support, and release-relevant config
- Collected user-visible changelog since v0.4.9

## User-visible changelog
- Added `githits doctor` redacted diagnostics for runtime/config/auth troubleshooting
- Added Swift registry support across package intelligence surfaces
- Simplified `search` source selection so callers can omit source for auto-routing
- Improved auth/timeout JSON error preservation
- Added request timeouts to prevent hung backend calls
- Strengthened example provenance guidance

## Verification
- `bun test src/plugin-version-consistency.test.ts src/commands/doctor.test.ts`
- `bun test`
- `bun run build`
- `bun run smoke:cli`
- `bun run smoke:mcp` passed on retry; first run hit live `get_example` 60s MCP client timeout
- `bun run agent:e2e --agent claude --server local --workload eval/agentic/workloads/express-router.md --timeout 300`
- `bun run agent:e2e --agent codex --server local --workload eval/agentic/workloads/express-router.md --timeout 300`
- `git diff --check`