### PR TITLE
Fix empty optional MCP field handling

### DIFF
--- a/src/shared/package-changelog-request.test.ts
+++ b/src/shared/package-changelog-request.test.ts
@@ -22,6 +22,18 @@ describe("buildPackageChangelogParams — addressing XOR", () => {
     expect(params.packageName).toBeUndefined();
   });
 
+  it("treats blank spec fields as absent for repo-url input", () => {
+    const { params } = buildPackageChangelogParams({
+      registry: " ",
+      packageName: "\t",
+      repoUrl: "https://github.com/expressjs/express",
+    });
+
+    expect(params.repoUrl).toBe("https://github.com/expressjs/express");
+    expect(params.registry).toBeUndefined();
+    expect(params.packageName).toBeUndefined();
+  });
+
   it("rejects when both spec and repo-url are provided", () => {
     expect(() =>
       buildPackageChangelogParams({

--- a/src/shared/package-changelog-request.ts
+++ b/src/shared/package-changelog-request.ts
@@ -136,7 +136,8 @@ type ResolvedAddressing =
 function resolveAddressing(
   input: PackageChangelogRequestInput,
 ): ResolvedAddressing {
-  const hasSpec = Boolean(input.registry || input.packageName);
+  const hasSpec =
+    hasNonBlankValue(input.registry) || hasNonBlankValue(input.packageName);
   const hasRepoUrl = Boolean(input.repoUrl?.trim());
 
   if (hasSpec && hasRepoUrl) {
@@ -175,6 +176,10 @@ function resolveAddressing(
     normalisedRegistryArg as PkgseerRegistryArg,
   );
   return { registry, packageName };
+}
+
+function hasNonBlankValue(value: string | undefined): boolean {
+  return value !== undefined && value.trim().length > 0;
 }
 
 function normaliseGitRef(raw: string | undefined): string | undefined {

--- a/src/shared/package-upgrade-review-request.test.ts
+++ b/src/shared/package-upgrade-review-request.test.ts
@@ -2,7 +2,114 @@ import { describe, expect, it } from "bun:test";
 import { InvalidPackageSpecError } from "./package-spec.js";
 import { buildPackageUpgradeReviewRequest } from "./package-upgrade-review-request.js";
 
-describe("buildPackageUpgradeReviewRequest — Swift versions", () => {
+describe("buildPackageUpgradeReviewRequest", () => {
+  it("treats an empty packages array as absent for single-package mode", () => {
+    const { packages } = buildPackageUpgradeReviewRequest({
+      registry: "npm",
+      packageName: "express",
+      currentVersion: "4.18.0",
+      targetVersion: "5.0.0",
+      packages: [],
+    });
+
+    expect(packages).toHaveLength(1);
+    expect(packages[0]).toMatchObject({
+      registry: "NPM",
+      packageName: "express",
+      currentVersion: "4.18.0",
+      targetVersion: "5.0.0",
+    });
+  });
+
+  it("treats blank packages rows as absent for single-package mode", () => {
+    const { packages } = buildPackageUpgradeReviewRequest({
+      registry: "npm",
+      packageName: "express",
+      currentVersion: "4.18.0",
+      targetVersion: "5.0.0",
+      packages: [
+        {
+          registry: " ",
+          packageName: "",
+          currentVersion: "\t",
+          targetVersion: "",
+        },
+      ],
+    });
+
+    expect(packages).toHaveLength(1);
+    expect(packages[0]).toMatchObject({
+      registry: "NPM",
+      packageName: "express",
+      currentVersion: "4.18.0",
+      targetVersion: "5.0.0",
+    });
+  });
+
+  it("treats blank single-package fields as absent for batch mode", () => {
+    const { packages } = buildPackageUpgradeReviewRequest({
+      registry: "",
+      packageName: " ",
+      currentVersion: "",
+      targetVersion: "\t",
+      packages: [
+        {
+          registry: "npm",
+          packageName: "express",
+          currentVersion: "4.18.0",
+          targetVersion: "5.0.0",
+        },
+      ],
+    });
+
+    expect(packages).toHaveLength(1);
+    expect(packages[0]).toMatchObject({
+      registry: "NPM",
+      packageName: "express",
+      currentVersion: "4.18.0",
+      targetVersion: "5.0.0",
+    });
+  });
+
+  it("drops blank packages rows from batch mode", () => {
+    const { packages } = buildPackageUpgradeReviewRequest({
+      packages: [
+        {
+          registry: " ",
+          packageName: "",
+          currentVersion: "\t",
+          targetVersion: "",
+        },
+        {
+          registry: "npm",
+          packageName: "express",
+          currentVersion: "4.18.0",
+          targetVersion: "5.0.0",
+        },
+      ],
+    });
+
+    expect(packages).toHaveLength(1);
+    expect(packages[0]).toMatchObject({
+      registry: "NPM",
+      packageName: "express",
+      currentVersion: "4.18.0",
+      targetVersion: "5.0.0",
+    });
+  });
+
+  it("still rejects calls without a package target", () => {
+    expect(() =>
+      buildPackageUpgradeReviewRequest({
+        registry: "",
+        packageName: " ",
+        currentVersion: "",
+        targetVersion: "\t",
+        packages: [],
+      }),
+    ).toThrow(InvalidPackageSpecError);
+  });
+
   it("allows v-prefixed Swift versions", () => {
     const { packages } = buildPackageUpgradeReviewRequest({
       registry: "swift",

--- a/src/shared/package-upgrade-review-request.ts
+++ b/src/shared/package-upgrade-review-request.ts
@@ -60,13 +60,13 @@ const DEFAULT_CHANGELOG_LIMIT = 20;
 export function buildPackageUpgradeReviewRequest(
   input: PackageUpgradeReviewRequestInput,
 ): PackageUpgradeReviewRequestBuildResult {
-  const batch = input.packages;
-  const hasBatch = batch !== undefined;
+  const batch = input.packages?.filter((pkg) => !isBlankPackageInput(pkg));
+  const hasBatch = Array.isArray(batch) && batch.length > 0;
   const hasSingle =
-    input.registry !== undefined ||
-    input.packageName !== undefined ||
-    input.currentVersion !== undefined ||
-    input.targetVersion !== undefined;
+    hasNonBlankValue(input.registry) ||
+    hasNonBlankValue(input.packageName) ||
+    hasNonBlankValue(input.currentVersion) ||
+    hasNonBlankValue(input.targetVersion);
 
   if (hasBatch && hasSingle) {
     throw new InvalidPackageSpecError(
@@ -123,6 +123,19 @@ export function buildUpgradeDependencyProbeParams(
     includeDependencyIssues: options.includeDependencyIssues,
     includeDependencyChanges: options.includeDependencyChanges,
   };
+}
+
+function hasNonBlankValue(value: string | undefined): boolean {
+  return value !== undefined && value.trim().length > 0;
+}
+
+function isBlankPackageInput(input: UpgradeReviewPackageInput): boolean {
+  return !(
+    hasNonBlankValue(input.registry) ||
+    hasNonBlankValue(input.packageName) ||
+    hasNonBlankValue(input.currentVersion) ||
+    hasNonBlankValue(input.targetVersion)
+  );
 }
 
 function parseBatch(

--- a/src/shared/unified-search-request.test.ts
+++ b/src/shared/unified-search-request.test.ts
@@ -122,6 +122,18 @@ describe("buildUnifiedSearchParams", () => {
     ]);
   });
 
+  it("treats an empty targets array as absent when target is provided", () => {
+    const built = buildUnifiedSearchParams({
+      target: { registry: "NPM", packageName: "express" },
+      targets: [],
+      query: "router",
+    });
+
+    expect(built.params.targets).toEqual([
+      { registry: "NPM", packageName: "express" },
+    ]);
+  });
+
   it("accepts mixed package and repo targets", () => {
     const built = buildUnifiedSearchParams({
       targets: [

--- a/src/shared/unified-search-request.ts
+++ b/src/shared/unified-search-request.ts
@@ -80,13 +80,14 @@ function resolveTargets(
   target: CodeNavigationTarget | undefined,
   targets: CodeNavigationTarget[] | undefined,
 ): CodeNavigationTarget[] {
-  if (target && targets) {
+  const nonEmptyTargets = targets?.length ? targets : undefined;
+  if (target && nonEmptyTargets) {
     throw new InvalidArgumentError(
       "Provide either `target` for one search target or `targets` for multiple, not both.",
     );
   }
 
-  const resolved = target ? [target] : (targets ?? []);
+  const resolved = target ? [target] : (nonEmptyTargets ?? []);
   if (resolved.length === 0) {
     throw new InvalidArgumentError(
       "Provide either `target` for one search target or `targets` for multiple; neither was set.",

--- a/src/tools/code-navigation-shared.ts
+++ b/src/tools/code-navigation-shared.ts
@@ -92,8 +92,13 @@ export function resolveCodeTarget(
     }
   }
 
-  const hasPackageTarget = Boolean(target.registry || target.package_name);
-  const hasRepoTarget = Boolean(target.repo_url || target.git_ref);
+  const registry = normaliseOptionalValue(target.registry)?.toLowerCase();
+  const packageName = normaliseOptionalValue(target.package_name);
+  const version = normaliseOptionalValue(target.version);
+  const repoUrl = normaliseOptionalValue(target.repo_url);
+  const gitRef = normaliseOptionalValue(target.git_ref);
+  const hasPackageTarget = registry !== undefined || packageName !== undefined;
+  const hasRepoTarget = repoUrl !== undefined || gitRef !== undefined;
 
   if (hasPackageTarget && hasRepoTarget) {
     return invalidTargetResult(
@@ -108,29 +113,35 @@ export function resolveCodeTarget(
   }
 
   if (hasPackageTarget) {
-    if (!target.registry || !target.package_name) {
+    if (!registry || !packageName) {
       return invalidTargetResult(
         "Incomplete package target: both registry and package_name are required.",
       );
     }
 
     return {
-      registry: toCodeNavigationRegistry(target.registry),
-      packageName: target.package_name,
-      version: target.version,
+      registry: toCodeNavigationRegistry(registry as CodeNavigationRegistryArg),
+      packageName,
+      version,
     };
   }
 
-  if (!target.repo_url) {
+  if (!repoUrl) {
     return invalidTargetResult(
       "Incomplete repository target: repo_url is required.",
     );
   }
 
   return {
-    repoUrl: target.repo_url,
-    gitRef: target.git_ref,
+    repoUrl,
+    gitRef,
   };
+}
+
+function normaliseOptionalValue(value: string | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
 }
 
 function mappedInvalidTargetResult(error: unknown): ToolResult {

--- a/src/tools/grep-repo.test.ts
+++ b/src/tools/grep-repo.test.ts
@@ -113,6 +113,24 @@ describe("createGrepRepoTool — happy path", () => {
     });
   });
 
+  it("returns invalid argument for whitespace-only repo_url with git_ref", async () => {
+    const grepRepo = mock(() => Promise.resolve(defaultGrepRepoResult));
+    const service = createMockCodeNavigationService({ grepRepo });
+    const tool = createGrepRepoTool(service);
+
+    const result = await tool.handler(
+      {
+        target: { repo_url: " ", git_ref: "HEAD" },
+        pattern: "middleware",
+      },
+      {},
+    );
+
+    expect(result.isError).toBe(true);
+    expect(grepRepo).not.toHaveBeenCalled();
+    expect(parseText(result)).toMatchObject({ code: "INVALID_ARGUMENT" });
+  });
+
   it("passes symbol field hydration through to grepRepo", async () => {
     const grepRepo = mock(() => Promise.resolve(defaultGrepRepoResult));
     const tool = createGrepRepoTool(

--- a/src/tools/list-files.test.ts
+++ b/src/tools/list-files.test.ts
@@ -64,6 +64,37 @@ describe("createListFilesTool — happy path", () => {
     expect(calls[0]?.[0]?.target?.packageName).toBe("express");
   });
 
+  it("ignores blank repo fields on package targets", async () => {
+    const listFiles = mock(() => Promise.resolve(defaultListFilesResult));
+    const service = createMockCodeNavigationService({ listFiles });
+    const tool = createListFilesTool(service);
+
+    await tool.handler(
+      {
+        target: {
+          registry: "npm",
+          package_name: "express",
+          repo_url: " ",
+          git_ref: "\t",
+        },
+      },
+      {},
+    );
+
+    const calls = listFiles.mock.calls as unknown as Array<
+      [
+        {
+          target: { registry?: string; packageName?: string; repoUrl?: string };
+        },
+      ]
+    >;
+    expect(calls[0]?.[0]?.target).toMatchObject({
+      registry: "NPM",
+      packageName: "express",
+    });
+    expect(calls[0]?.[0]?.target?.repoUrl).toBeUndefined();
+  });
+
   it("accepts compact repo string targets", async () => {
     const listFiles = mock(() => Promise.resolve(defaultListFilesResult));
     const service = createMockCodeNavigationService({ listFiles });

--- a/src/tools/package-upgrade-review.test.ts
+++ b/src/tools/package-upgrade-review.test.ts
@@ -100,6 +100,73 @@ describe("createPackageUpgradeReviewTool", () => {
     });
   });
 
+  it("ignores empty optional mode fields emitted by tool-call harnesses", async () => {
+    const packageVulnerabilities = mock((params) =>
+      Promise.resolve(cleanVuln(params.version ?? "5.0.0")),
+    );
+    const packageUpgradeDependencyProbe = mock((params) =>
+      Promise.resolve(deps(params.version)),
+    );
+    const service = createMockPackageIntelligenceService({
+      packageVulnerabilities: packageVulnerabilities as never,
+      packageUpgradeDependencyProbe: packageUpgradeDependencyProbe as never,
+    });
+    const tool = createPackageUpgradeReviewTool(service);
+
+    const single = await tool.handler(
+      {
+        registry: "npm",
+        package_name: "express",
+        current_version: "4.18.0",
+        target_version: "5.0.0",
+        packages: [
+          {
+            registry: " ",
+            package_name: "",
+            current_version: "\t",
+            target_version: "",
+          },
+        ],
+        format: "json",
+      },
+      {},
+    );
+
+    const batch = await tool.handler(
+      {
+        registry: "",
+        package_name: " ",
+        current_version: "",
+        target_version: "\t",
+        packages: [
+          {
+            registry: " ",
+            package_name: "",
+            current_version: "\t",
+            target_version: "",
+          },
+          {
+            registry: "npm",
+            package_name: "express",
+            current_version: "4.18.0",
+            target_version: "5.0.0",
+          },
+        ],
+        format: "json",
+      },
+      {},
+    );
+
+    expect(single.isError).toBeUndefined();
+    expect(batch.isError).toBeUndefined();
+    expect(
+      (parseText(single) as { summary?: { total?: number } }).summary?.total,
+    ).toBe(1);
+    expect(
+      (parseText(batch) as { summary?: { total?: number } }).summary?.total,
+    ).toBe(1);
+  });
+
   it("returns text by default and JSON when requested", async () => {
     const service = createMockPackageIntelligenceService({
       packageVulnerabilities: mock((params) =>

--- a/src/tools/read-file.test.ts
+++ b/src/tools/read-file.test.ts
@@ -56,6 +56,24 @@ describe("createReadFileTool — happy path", () => {
     expect(calls[0]?.[0]?.filePath).toBe("src/index.js");
   });
 
+  it("returns invalid argument for whitespace-only package registry", async () => {
+    const readFile = mock(() => Promise.resolve(defaultReadFileResult));
+    const service = createMockCodeNavigationService({ readFile });
+    const tool = createReadFileTool(service);
+
+    const result = await tool.handler(
+      {
+        target: { registry: " " as never, package_name: "express" },
+        path: "src/index.js",
+      },
+      {},
+    );
+
+    expect(result.isError).toBe(true);
+    expect(readFile).not.toHaveBeenCalled();
+    expect(parseText(result)).toMatchObject({ code: "INVALID_ARGUMENT" });
+  });
+
   it("accepts compact package string targets", async () => {
     const readFile = mock(() => Promise.resolve(defaultReadFileResult));
     const service = createMockCodeNavigationService({ readFile });

--- a/src/tools/search.test.ts
+++ b/src/tools/search.test.ts
@@ -96,6 +96,82 @@ describe("searchTool", () => {
     ]);
   });
 
+  it("ignores blank singular target objects when targets are provided", async () => {
+    const search = mock((_: UnifiedSearchParams) =>
+      Promise.resolve(defaultUnifiedSearchOutcome),
+    );
+    const tool = createSearchTool(createMockCodeNavigationService({ search }));
+
+    await tool.handler(
+      {
+        query: "routing",
+        target: {
+          registry: " " as never,
+          package_name: "",
+          version: "\t",
+          repo_url: "",
+          git_ref: " ",
+        },
+        targets: [{ registry: "npm", package_name: "express" }],
+      },
+      {},
+    );
+
+    const call = search.mock.calls[0]?.[0];
+    expect(call?.targets).toEqual([
+      { registry: "NPM", packageName: "express" },
+    ]);
+  });
+
+  it("rejects whitespace-only required fields in structured targets", async () => {
+    const search = mock((_: UnifiedSearchParams) =>
+      Promise.resolve(defaultUnifiedSearchOutcome),
+    );
+    const tool = createSearchTool(createMockCodeNavigationService({ search }));
+
+    const result = await tool.handler(
+      {
+        query: "routing",
+        target: { repo_url: " ", git_ref: "HEAD" },
+      },
+      {},
+    );
+
+    expect(result.isError).toBe(true);
+    expect(search).not.toHaveBeenCalled();
+    expect(JSON.parse(result.content[0]?.text ?? "{}")).toMatchObject({
+      code: "INVALID_ARGUMENT",
+    });
+  });
+
+  it("ignores blank targets array entries", async () => {
+    const search = mock((_: UnifiedSearchParams) =>
+      Promise.resolve(defaultUnifiedSearchOutcome),
+    );
+    const tool = createSearchTool(createMockCodeNavigationService({ search }));
+
+    await tool.handler(
+      {
+        query: "routing",
+        targets: [
+          {
+            registry: " " as never,
+            package_name: "",
+            repo_url: "",
+            git_ref: "\t",
+          },
+          { repo_url: "https://github.com/expressjs/express" },
+        ],
+      },
+      {},
+    );
+
+    const call = search.mock.calls[0]?.[0];
+    expect(call?.targets).toEqual([
+      { repoUrl: "https://github.com/expressjs/express" },
+    ]);
+  });
+
   it("accepts compact package string targets", async () => {
     const search = mock((_: UnifiedSearchParams) =>
       Promise.resolve(defaultUnifiedSearchOutcome),

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -3,7 +3,10 @@ import type {
   CodeNavigationService,
   CodeNavigationTarget,
 } from "../services/index.js";
-import { toCodeNavigationRegistry } from "../shared/code-navigation.js";
+import {
+  type CodeNavigationRegistryArg,
+  toCodeNavigationRegistry,
+} from "../shared/code-navigation.js";
 import { mapCodeNavigationError } from "../shared/code-navigation-error-map.js";
 import {
   buildUnifiedSearchErrorPayload,
@@ -220,16 +223,22 @@ export function createSearchTool(
     annotations: { readOnlyHint: true },
     handler: async (args) => {
       try {
-        const resolvedTarget = args.target
-          ? resolveSearchTarget(args.target)
+        const effectiveTarget = isBlankSearchTarget(args.target)
+          ? undefined
+          : args.target;
+        const resolvedTarget = effectiveTarget
+          ? resolveSearchTarget(effectiveTarget)
           : undefined;
         if (resolvedTarget && "content" in resolvedTarget)
           return resolvedTarget;
 
-        const effectiveTargets = args.targets?.length
-          ? args.targets
+        const effectiveTargets = args.targets?.filter(
+          (target) => !isBlankSearchTarget(target),
+        );
+        const nonEmptyTargets = effectiveTargets?.length
+          ? effectiveTargets
           : undefined;
-        const resolvedTargets = effectiveTargets?.map((entry) =>
+        const resolvedTargets = nonEmptyTargets?.map((entry) =>
           resolveSearchTarget(entry),
         );
         const resolvedTargetsError = resolvedTargets?.find(
@@ -284,6 +293,26 @@ export function createSearchTool(
   };
 }
 
+function isBlankSearchTarget(
+  target: SearchArgs["target"] | undefined,
+): boolean {
+  if (target === undefined) return true;
+  if (typeof target === "string") return target.trim().length === 0;
+  return !(
+    normaliseOptionalValue(target.registry) ||
+    normaliseOptionalValue(target.package_name) ||
+    normaliseOptionalValue(target.version) ||
+    normaliseOptionalValue(target.repo_url) ||
+    normaliseOptionalValue(target.git_ref)
+  );
+}
+
+function normaliseOptionalValue(value: string | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
 function isResolvedSearchTarget(
   target: ReturnType<typeof resolveSearchTarget>,
 ): target is ResolvedSearchTarget {
@@ -309,8 +338,13 @@ function resolveSearchTarget(
     }
   }
 
-  const hasPackageTarget = Boolean(target.registry || target.package_name);
-  const hasRepoTarget = Boolean(target.repo_url || target.git_ref);
+  const registry = normaliseOptionalValue(target.registry)?.toLowerCase();
+  const packageName = normaliseOptionalValue(target.package_name);
+  const version = normaliseOptionalValue(target.version);
+  const repoUrl = normaliseOptionalValue(target.repo_url);
+  const gitRef = normaliseOptionalValue(target.git_ref);
+  const hasPackageTarget = registry !== undefined || packageName !== undefined;
+  const hasRepoTarget = repoUrl !== undefined || gitRef !== undefined;
   if (hasPackageTarget && hasRepoTarget) {
     return invalidSearchTargetResult(
       "Invalid target: provide either registry + package_name or repo_url with optional git_ref, not both.",
@@ -322,23 +356,23 @@ function resolveSearchTarget(
     );
   }
   if (hasPackageTarget) {
-    if (!target.registry || !target.package_name) {
+    if (!registry || !packageName) {
       return invalidSearchTargetResult(
         "Incomplete package target: both registry and package_name are required.",
       );
     }
     return {
-      registry: toCodeNavigationRegistry(target.registry),
-      packageName: target.package_name,
-      version: target.version,
+      registry: toCodeNavigationRegistry(registry as CodeNavigationRegistryArg),
+      packageName,
+      version,
     };
   }
-  if (!target.repo_url) {
+  if (!repoUrl) {
     return invalidSearchTargetResult(
       "Incomplete repository target: repo_url is required.",
     );
   }
-  return { repoUrl: target.repo_url, gitRef: target.git_ref };
+  return { repoUrl, gitRef };
 }
 
 function invalidSearchTargetResult(message: string): ToolResult {


### PR DESCRIPTION
## Summary
- Treat harness-filled empty arrays and blank strings as absent for optional union-shaped MCP inputs.
- Normalize structured code-navigation targets before mode/completeness checks.
- Add regression coverage for pkg_upgrade_review, search target/targets, pkg_changelog addressing, and code_* targets.

## Review
- Code reviewer initial pass found whitespace target normalization and blank packages[] row gaps.
- Addressed both findings and final reviewer pass reported no findings.

## Testing
- bun test src/shared/package-upgrade-review-request.test.ts src/tools/package-upgrade-review.test.ts src/tools/search.test.ts src/tools/read-file.test.ts src/tools/grep-repo.test.ts src/tools/list-files.test.ts src/shared/package-changelog-request.test.ts src/shared/unified-search-request.test.ts
- bun test src/tools/search-parity.test.ts src/tools/list-files-parity.test.ts src/tools/grep-repo-parity.test.ts src/tools/read-file-parity.test.ts src/tools/package-changelog-parity.test.ts src/tools/package-upgrade-review-parity.test.ts src/commands/pkg/upgrade-review.test.ts
- bun run typecheck
- bun run build
- bun run smoke:mcp
- bun run smoke:cli