### PR TITLE
refactor: inject runtime client headers

### DIFF
--- a/src/commands/mcp.test.ts
+++ b/src/commands/mcp.test.ts
@@ -1,14 +1,10 @@
-import { afterEach, describe, expect, it } from "bun:test";
+import { describe, expect, it, mock } from "bun:test";
 import { createMcpServer, getMcpToolDefinitions } from "../mcp/server.js";
 import {
   createMockCodeNavigationService,
   createMockGitHitsService,
   createMockPackageIntelligenceService,
 } from "../services/test-helpers.js";
-import {
-  buildClientHeaders,
-  resetRequestHeadersState,
-} from "../shared/request-headers.js";
 import type { McpToolServices } from "../tools/tool-services.js";
 import { startMcpServer } from "./mcp.js";
 
@@ -144,14 +140,6 @@ describe("createMcpServer", () => {
 });
 
 describe("startMcpServer", () => {
-  // `startMcpServer` mutates module-level state in `request-headers.ts`
-  // (sets `clientName = "githits-cli/mcp"` and registers the lazy MCP
-  // client-version provider). Reset after each test so later test
-  // files inherit the default state.
-  afterEach(() => {
-    resetRequestHeadersState();
-  });
-
   it("starts successfully with service-only dependencies", async () => {
     const services = createTestServices();
 
@@ -160,42 +148,13 @@ describe("startMcpServer", () => {
     await expect(startMcpServer(services)).resolves.toBeUndefined();
   });
 
-  it("sets clientMode to githits-cli/mcp", async () => {
-    // After startMcpServer runs, subsequent buildClientHeaders calls
-    // tag the client as MCP-mode. Pins the telemetry contract.
+  it("exposes the created server to callers for clientInfo telemetry wiring", async () => {
     const services = createTestServices();
-    await startMcpServer(services);
-    const headers = buildClientHeaders({});
-    expect(headers["x-githits-client-name"]).toBe("githits-cli/mcp");
-  });
+    const onServerCreated = mock((_server: unknown) => undefined);
 
-  it("registers a lazy MCP clientInfo provider (read at request time, not via race-prone notification)", async () => {
-    // The MCP SDK dispatches `oninitialized` via an async notification
-    // that can race the first tool call. The provider pattern reads
-    // clientInfo synchronously on every buildClientHeaders call,
-    // eliminating the race. This test pins the provider-based flow.
-    const services = createTestServices();
-    await startMcpServer(services);
+    await startMcpServer(services, { onServerCreated });
 
-    // Before the initialize handshake lands, the provider returns
-    // undefined — `buildClientHeaders` falls back to env detection
-    // (none in the test env), so no x-githits-agent header.
-    const headersBefore = buildClientHeaders({});
-    expect(headersBefore["x-githits-agent"]).toBeUndefined();
-
-    // Simulate the SDK's _oninitialize landing: `_clientVersion` is
-    // set synchronously inside the SDK before the initialize response
-    // is returned. A tool call reaching buildClientHeaders after that
-    // point should see the agent header populated. We can't easily
-    // reach into the real SDK's private state from here, so this
-    // test pins the *mechanism* (provider registration) rather than
-    // the end-to-end race; the provider's correctness is exercised
-    // in request-headers.test.ts.
-    // At this point the provider is registered but returns undefined —
-    // confirm the fallback path to env detection also works.
-    const headersWithAgent = buildClientHeaders({
-      GITHITS_AGENT: "test-harness/1.0.0",
-    });
-    expect(headersWithAgent["x-githits-agent"]).toBe("test-harness/1.0.0");
+    expect(onServerCreated).toHaveBeenCalledTimes(1);
+    expect(onServerCreated.mock.calls[0]?.[0]).toBeDefined();
   });
 });

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -4,61 +4,79 @@ import { version } from "../../package.json";
 import { createContainer } from "../container.js";
 import { createMcpServer } from "../mcp/server.js";
 import { dim, highlight, shouldUseColors } from "../shared/colors.js";
-import {
-  setClientMode,
-  setMcpClientVersionProvider,
-} from "../shared/request-headers.js";
+import type { AgentInfo } from "../shared/request-headers.js";
 import type { McpToolServices } from "../tools/tool-services.js";
 
 const LOCAL_MCP_SERVER_METADATA = { name: "githits", version };
+
+type LocalMcpServer = ReturnType<typeof createMcpServer>;
+
+export interface StartMcpServerOptions {
+  onServerCreated?: (server: LocalMcpServer) => void;
+}
 
 /**
  * Start the MCP server. Exported for testability.
  *
  * Telemetry wiring:
- * - `setClientMode("mcp")` tags every subsequent API request with
- *   `x-githits-client-name: githits-cli/mcp` so backend telemetry
- *   can distinguish MCP-driven traffic from direct-CLI traffic.
- * - `setMcpClientVersionProvider` registers a lazy reader that
- *   pulls the connecting client's `clientInfo` (cursor,
- *   claude-code, etc.) on every request. The MCP SDK sets
- *   `_clientVersion` synchronously inside `_oninitialize` before
- *   the initialize response is sent back, so every tool call that
- *   arrives after the handshake sees a populated value —
- *   eliminating the race the older `oninitialized` callback
- *   pattern had where the first tool call could slip through
- *   before the notification dispatched.
+ * Telemetry headers are built by the services injected into this server.
+ * The CLI command passes `githits-cli/mcp` plus a lazy reader for the
+ * connecting client's `clientInfo` when it creates those services.
  */
-export async function startMcpServer(services: McpToolServices): Promise<void> {
-  setClientMode("mcp");
-
+export async function startMcpServer(
+  services: McpToolServices,
+  options: StartMcpServerOptions = {},
+): Promise<void> {
   const server = createMcpServer(services, LOCAL_MCP_SERVER_METADATA);
   const transport = new StdioServerTransport();
 
-  setMcpClientVersionProvider(() => {
-    try {
-      const clientVersion = server.server.getClientVersion();
-      if (
-        !clientVersion?.name ||
-        typeof clientVersion.name !== "string" ||
-        clientVersion.name.trim().length === 0
-      ) {
-        return undefined;
-      }
-      const name = clientVersion.name.trim();
-      const rawVersion = clientVersion.version;
-      const versionOut =
-        typeof rawVersion === "string" && rawVersion.trim().length > 0
-          ? rawVersion.trim()
-          : undefined;
-      return { name, version: versionOut };
-    } catch {
-      // Agent header is optional — never block the request.
-      return undefined;
-    }
-  });
+  options.onServerCreated?.(server);
 
   await server.connect(transport);
+}
+
+function readMcpClientVersion(
+  server: LocalMcpServer | undefined,
+): AgentInfo | undefined {
+  if (!server) return undefined;
+  try {
+    const clientVersion = server.server.getClientVersion();
+    if (
+      !clientVersion?.name ||
+      typeof clientVersion.name !== "string" ||
+      clientVersion.name.trim().length === 0
+    ) {
+      return undefined;
+    }
+    const name = clientVersion.name.trim();
+    const rawVersion = clientVersion.version;
+    const versionOut =
+      typeof rawVersion === "string" && rawVersion.trim().length > 0
+        ? rawVersion.trim()
+        : undefined;
+    return { name, version: versionOut };
+  } catch {
+    // Agent header is optional — never block the request.
+    return undefined;
+  }
+}
+
+async function createMcpCommandStartup(): Promise<{
+  services: McpToolServices;
+  onServerCreated: (server: LocalMcpServer) => void;
+}> {
+  let server: LocalMcpServer | undefined;
+  const services = await createContainer({
+    resolveStoredToken: false,
+    clientName: "githits-cli/mcp",
+    agentProvider: () => readMcpClientVersion(server),
+  });
+  return {
+    services,
+    onServerCreated: (created: LocalMcpServer) => {
+      server = created;
+    },
+  };
 }
 
 /**
@@ -111,8 +129,10 @@ Authenticated tool calls require a valid GitHits token.`,
         showMcpSetupInstructions();
         return;
       }
-      const deps = await createContainer({ resolveStoredToken: false });
-      await startMcpServer(deps);
+      const startup = await createMcpCommandStartup();
+      await startMcpServer(startup.services, {
+        onServerCreated: startup.onServerCreated,
+      });
     });
 
   mcpCommand
@@ -125,7 +145,9 @@ This command explicitly starts the server and is intended for use
 in MCP configuration files. Use 'githits mcp' for interactive setup.`,
     )
     .action(async () => {
-      const deps = await createContainer({ resolveStoredToken: false });
-      await startMcpServer(deps);
+      const startup = await createMcpCommandStartup();
+      await startMcpServer(startup.services, {
+        onServerCreated: startup.onServerCreated,
+      });
     });
 }

--- a/src/container.test.ts
+++ b/src/container.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, mock } from "bun:test";
 import {
   createAuthCommandDependencies,
   createAuthStatusDependencies,
+  createContainer,
 } from "./container.js";
 import { AuthConfigError } from "./services/auth-config.js";
 
@@ -62,6 +63,47 @@ describe("container auth dependencies", () => {
           AuthConfigError,
         );
       });
+    });
+  });
+});
+
+describe("createContainer", () => {
+  it("threads explicit client telemetry into constructed services", async () => {
+    await withApiToken("ghi-test", async () => {
+      const originalFetch = globalThis.fetch;
+      let capturedHeaders: Record<string, string> | undefined;
+      const fetchFn = mock((_url: string, init?: RequestInit) => {
+        capturedHeaders = init?.headers as Record<string, string>;
+        return Promise.resolve(
+          new Response(JSON.stringify([]), {
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      });
+      globalThis.fetch = fetchFn as unknown as typeof fetch;
+
+      try {
+        const deps = await createContainer({
+          resolveStoredToken: false,
+          clientName: "githits-cli/mcp",
+          agentProvider: () => ({ name: "cursor", version: "1.0.0" }),
+        });
+
+        await deps.githitsService.getLanguages();
+
+        expect(capturedHeaders?.Authorization).toBe("Bearer ghi-test");
+        expect(capturedHeaders?.["User-Agent"]).toMatch(/^githits-cli\/\S+$/);
+        expect(capturedHeaders?.["x-githits-client-name"]).toBe(
+          "githits-cli/mcp",
+        );
+        expect(capturedHeaders?.["x-githits-client-version"]).toMatch(/^\S+$/);
+        expect(capturedHeaders?.["x-githits-agent"]).toBe("cursor/1.0.0");
+        expect(capturedHeaders?.["x-githits-session-id"]).toMatch(
+          /^[0-9a-f]{16}$/,
+        );
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
     });
   });
 });

--- a/src/container.ts
+++ b/src/container.ts
@@ -1,3 +1,4 @@
+import { version } from "../package.json";
 import type { GitHitsService } from "./services/index.js";
 import {
   type AuthService,
@@ -35,7 +36,14 @@ import {
   type TokenProvider,
   WINDOWS_MAX_ENTRY_SIZE,
 } from "./services/index.js";
+import {
+  type AgentInfo,
+  createClientHeaderBuilder,
+} from "./shared/request-headers.js";
 import { withTelemetrySpan } from "./shared/telemetry.js";
+
+const BASE_CLIENT_NAME = "githits-cli";
+const USER_AGENT = `${BASE_CLIENT_NAME}/${version}`;
 
 /**
  * Create an AuthStorage instance using the configured auth storage mode.
@@ -201,6 +209,10 @@ export interface Dependencies {
 export interface CreateContainerOptions {
   /** Resolve stored OAuth immediately. Disable for MCP startup to avoid keychain prompts until first tool use. */
   resolveStoredToken?: boolean;
+  /** Client name for telemetry headers. Defaults to direct CLI mode. */
+  clientName?: string;
+  /** Optional per-request/client agent identity provider. */
+  agentProvider?: () => AgentInfo | undefined;
 }
 
 function createStaticTokenProvider(token: string): TokenProvider {
@@ -225,6 +237,16 @@ export async function createContainer(
     const fileSystemService = new FileSystemServiceImpl();
     const authService = new AuthServiceImpl();
     const browserService = new BrowserServiceImpl();
+    const clientHeaders = createClientHeaderBuilder({
+      clientName: options.clientName ?? BASE_CLIENT_NAME,
+      clientVersion: version,
+      agentProvider: options.agentProvider,
+    });
+    const serviceRuntime = {
+      clientHeaders,
+      userAgent: USER_AGENT,
+      clientVersion: version,
+    };
 
     // Check for env API token first
     const envToken = getEnvApiToken();
@@ -237,10 +259,14 @@ export async function createContainer(
       const codeNavigationService = new CodeNavigationServiceImpl(
         codeNavigationUrl,
         tokenProvider,
+        globalThis.fetch,
+        serviceRuntime,
       );
       const packageIntelligenceService = new PackageIntelligenceServiceImpl(
         codeNavigationUrl,
         tokenProvider,
+        globalThis.fetch,
+        serviceRuntime,
       );
 
       return {
@@ -256,7 +282,13 @@ export async function createContainer(
         codeNavigationUrl,
         codeNavigationService,
         packageIntelligenceService,
-        githitsService: new GitHitsServiceImpl(apiUrl, envToken),
+        githitsService: new GitHitsServiceImpl(
+          apiUrl,
+          envToken,
+          undefined,
+          undefined,
+          serviceRuntime,
+        ),
       };
     }
 
@@ -274,10 +306,14 @@ export async function createContainer(
     const codeNavigationService = new CodeNavigationServiceImpl(
       codeNavigationUrl,
       tokenManager,
+      globalThis.fetch,
+      serviceRuntime,
     );
     const packageIntelligenceService = new PackageIntelligenceServiceImpl(
       codeNavigationUrl,
       tokenManager,
+      globalThis.fetch,
+      serviceRuntime,
     );
 
     return {
@@ -293,7 +329,12 @@ export async function createContainer(
       codeNavigationUrl,
       codeNavigationService,
       packageIntelligenceService,
-      githitsService: new RefreshingGitHitsService(apiUrl, tokenManager),
+      githitsService: new RefreshingGitHitsService(
+        apiUrl,
+        tokenManager,
+        undefined,
+        serviceRuntime,
+      ),
     };
   });
 }

--- a/src/services/client-update-required-error.ts
+++ b/src/services/client-update-required-error.ts
@@ -1,12 +1,10 @@
-import { version } from "../../package.json";
-
 export const CLIENT_UPDATE_REQUIRED_REASON = "Backend protocol changed";
 
 export class ClientUpdateRequiredError extends Error {
   constructor(
     message = `Update required: ${CLIENT_UPDATE_REQUIRED_REASON}`,
     public readonly reason = CLIENT_UPDATE_REQUIRED_REASON,
-    public readonly currentVersion = version,
+    public readonly currentVersion?: string,
   ) {
     super(message);
     this.name = "ClientUpdateRequiredError";

--- a/src/services/code-navigation-service.ts
+++ b/src/services/code-navigation-service.ts
@@ -7,6 +7,7 @@ import {
   postPkgseerGraphql,
 } from "../shared/pkgseer-graphql.js";
 import type { PkgseerRegistry } from "../shared/pkgseer-registry.js";
+import type { ClientHeaderBuilder } from "../shared/request-headers.js";
 import {
   ClientUpdateRequiredError,
   isClientUpdateRequiredGraphQLError,
@@ -1596,6 +1597,11 @@ export class CodeNavigationServiceImpl implements CodeNavigationService {
     private readonly codeNavigationUrl: string,
     private readonly tokenProvider: TokenProvider,
     private readonly fetchFn: typeof fetch = globalThis.fetch,
+    private readonly runtime: {
+      clientHeaders?: ClientHeaderBuilder;
+      userAgent?: string;
+      clientVersion?: string;
+    } = {},
   ) {}
 
   private async postGraphqlWithTargetResolutionFallback(input: {
@@ -1609,6 +1615,8 @@ export class CodeNavigationServiceImpl implements CodeNavigationService {
       query: input.query,
       variables: input.variables,
       fetchFn: this.fetchFn,
+      clientHeaders: this.runtime.clientHeaders,
+      userAgent: this.runtime.userAgent,
     });
     if (response.status < 200 || response.status >= 300) return response;
     if (!hasSchemaMismatchErrors(response.parsedBody)) return response;
@@ -1625,6 +1633,8 @@ export class CodeNavigationServiceImpl implements CodeNavigationService {
         query: fallbackQuery,
         variables: input.variables,
         fetchFn: this.fetchFn,
+        clientHeaders: this.runtime.clientHeaders,
+        userAgent: this.runtime.userAgent,
       });
       if (!hasSchemaMismatchErrors(fallbackResponse.parsedBody)) {
         return fallbackResponse;
@@ -1851,7 +1861,11 @@ export class CodeNavigationServiceImpl implements CodeNavigationService {
     const indexingRef = getGraphQLIndexingRef(errors);
 
     if (isClientUpdateRequiredGraphQLError({ message, code })) {
-      return new ClientUpdateRequiredError();
+      return new ClientUpdateRequiredError(
+        undefined,
+        undefined,
+        this.runtime.clientVersion,
+      );
     }
 
     if (isGraphQLSchemaMismatchError({ message, code })) {

--- a/src/services/githits-service.test.ts
+++ b/src/services/githits-service.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 import { FetchTimeoutError } from "../shared/fetch-timeout.js";
+import { createClientHeaderBuilder } from "../shared/request-headers.js";
 import { AuthenticationError, GitHitsServiceImpl } from "./githits-service.js";
 
 // Helper to mock global fetch with proper typing
@@ -22,7 +23,15 @@ describe("GitHitsServiceImpl", () => {
   let originalFetch: typeof globalThis.fetch;
 
   beforeEach(() => {
-    service = new GitHitsServiceImpl(API_URL, TOKEN);
+    service = new GitHitsServiceImpl(API_URL, TOKEN, undefined, undefined, {
+      clientHeaders: createClientHeaderBuilder({
+        clientName: "githits-cli",
+        clientVersion: "1.2.3",
+        env: {},
+        ppid: 42,
+      }),
+      userAgent: "githits-cli/1.2.3",
+    });
     originalFetch = globalThis.fetch;
   });
 
@@ -68,8 +77,9 @@ describe("GitHitsServiceImpl", () => {
       const call = fn.mock.calls[0] as unknown as [string, RequestInit];
       const headers = call[1].headers as Record<string, string>;
       expect(headers["x-githits-client-name"]).toBe("githits-cli");
-      expect(headers["x-githits-client-version"]).toMatch(/^\S+$/);
+      expect(headers["x-githits-client-version"]).toBe("1.2.3");
       expect(headers["x-githits-session-id"]).toMatch(/^[0-9a-f]{16}$/);
+      expect(headers["User-Agent"]).toBe("githits-cli/1.2.3");
     });
 
     it("passes custom license_mode", async () => {

--- a/src/services/githits-service.ts
+++ b/src/services/githits-service.ts
@@ -1,9 +1,8 @@
-import { version } from "../../package.json";
 import {
   DEFAULT_FETCH_TIMEOUT_MS,
   fetchWithTimeout,
 } from "../shared/fetch-timeout.js";
-import { buildClientHeaders } from "../shared/request-headers.js";
+import type { ClientHeaderBuilder } from "../shared/request-headers.js";
 import { withTelemetrySpan } from "../shared/telemetry.js";
 
 /**
@@ -58,7 +57,7 @@ export interface SearchParams {
  *
  * Feedback can target an example, a solution, or the current CLI/MCP
  * session. When neither `exampleId` nor `solutionId` is present, the
- * backend uses the `x-githits-session-id` header from `buildClientHeaders()`
+ * backend uses the `x-githits-session-id` header from injected client headers
  * to create generic session feedback.
  */
 export interface FeedbackParams {
@@ -75,6 +74,11 @@ export interface FeedbackParams {
 export interface FeedbackResult {
   success: boolean;
   message: string;
+}
+
+export interface GitHitsServiceRuntimeOptions {
+  clientHeaders?: ClientHeaderBuilder;
+  userAgent?: string;
 }
 
 /**
@@ -100,6 +104,7 @@ export class GitHitsServiceImpl implements GitHitsService {
     private readonly token: string,
     private readonly fetchFn?: typeof fetch,
     private readonly fetchTimeoutMs: number = DEFAULT_FETCH_TIMEOUT_MS,
+    private readonly runtime: GitHitsServiceRuntimeOptions = {},
   ) {}
 
   async search(params: SearchParams): Promise<string> {
@@ -149,7 +154,7 @@ export class GitHitsServiceImpl implements GitHitsService {
     return withTelemetrySpan("githits.feedback.request", async () => {
       // For generic feedback, omit body targets entirely. The backend
       // then uses the valid x-githits-session-id header emitted by
-      // buildClientHeaders() as the feedback target.
+      // the injected client headers as the feedback target.
       const response = await fetchWithTimeout(
         `${this.apiUrl}/feedbacks`,
         {
@@ -182,10 +187,10 @@ export class GitHitsServiceImpl implements GitHitsService {
 
   private headers(): Record<string, string> {
     return {
-      ...buildClientHeaders(),
+      ...this.runtime.clientHeaders?.(),
       Authorization: `Bearer ${this.token}`,
       "Content-Type": "application/json",
-      "User-Agent": `githits-cli/${version}`,
+      "User-Agent": this.runtime.userAgent ?? "githits-cli",
     };
   }
 

--- a/src/services/package-intelligence-service.ts
+++ b/src/services/package-intelligence-service.ts
@@ -25,6 +25,7 @@ import {
   postPkgseerGraphql,
 } from "../shared/pkgseer-graphql.js";
 import type { PkgseerRegistry } from "../shared/pkgseer-registry.js";
+import type { ClientHeaderBuilder } from "../shared/request-headers.js";
 import { withTelemetrySpan } from "../shared/telemetry.js";
 import {
   ClientUpdateRequiredError,
@@ -1736,6 +1737,11 @@ export class PackageIntelligenceServiceImpl
     private readonly endpointUrl: string,
     private readonly tokenProvider: TokenProvider,
     private readonly fetchFn: typeof fetch = globalThis.fetch,
+    private readonly runtime: {
+      clientHeaders?: ClientHeaderBuilder;
+      userAgent?: string;
+      clientVersion?: string;
+    } = {},
   ) {}
 
   async packageSummary(params: PackageSummaryParams): Promise<PackageSummary> {
@@ -1764,6 +1770,8 @@ export class PackageIntelligenceServiceImpl
           name: params.packageName,
         },
         fetchFn: this.fetchFn,
+        clientHeaders: this.runtime.clientHeaders,
+        userAgent: this.runtime.userAgent,
       });
     } catch (cause) {
       if (cause instanceof PkgseerTransportError) {
@@ -1854,7 +1862,11 @@ export class PackageIntelligenceServiceImpl
         : undefined;
 
     if (isClientUpdateRequiredGraphQLError({ message, code })) {
-      return new ClientUpdateRequiredError();
+      return new ClientUpdateRequiredError(
+        undefined,
+        undefined,
+        this.runtime.clientVersion,
+      );
     }
 
     if (isGraphQLSchemaMismatchError({ message, code })) {
@@ -2111,6 +2123,8 @@ export class PackageIntelligenceServiceImpl
           after,
         },
         fetchFn: this.fetchFn,
+        clientHeaders: this.runtime.clientHeaders,
+        userAgent: this.runtime.userAgent,
       });
     } catch (cause) {
       if (cause instanceof PkgseerTransportError) {
@@ -2260,6 +2274,8 @@ export class PackageIntelligenceServiceImpl
           minSeverity: params.minSeverity,
         },
         fetchFn: this.fetchFn,
+        clientHeaders: this.runtime.clientHeaders,
+        userAgent: this.runtime.userAgent,
       });
     } catch (cause) {
       if (cause instanceof PkgseerTransportError) {
@@ -2320,6 +2336,8 @@ export class PackageIntelligenceServiceImpl
               : undefined,
         },
         fetchFn: this.fetchFn,
+        clientHeaders: this.runtime.clientHeaders,
+        userAgent: this.runtime.userAgent,
       });
     } catch (cause) {
       if (cause instanceof PkgseerTransportError) {
@@ -2635,6 +2653,8 @@ export class PackageIntelligenceServiceImpl
           limit: params.limit,
         },
         fetchFn: this.fetchFn,
+        clientHeaders: this.runtime.clientHeaders,
+        userAgent: this.runtime.userAgent,
       });
     } catch (cause) {
       if (cause instanceof PkgseerTransportError) {
@@ -2751,6 +2771,8 @@ export class PackageIntelligenceServiceImpl
           after: params.after,
         },
         fetchFn: this.fetchFn,
+        clientHeaders: this.runtime.clientHeaders,
+        userAgent: this.runtime.userAgent,
       });
     } catch (cause) {
       if (cause instanceof PkgseerTransportError) {
@@ -2849,6 +2871,8 @@ export class PackageIntelligenceServiceImpl
           pageId: params.pageId,
         },
         fetchFn: this.fetchFn,
+        clientHeaders: this.runtime.clientHeaders,
+        userAgent: this.runtime.userAgent,
       });
     } catch (cause) {
       if (cause instanceof PkgseerTransportError) {

--- a/src/services/refreshing-githits-service.ts
+++ b/src/services/refreshing-githits-service.ts
@@ -5,6 +5,7 @@ import {
   type FeedbackResult,
   type GitHitsService,
   GitHitsServiceImpl,
+  type GitHitsServiceRuntimeOptions,
   type Language,
   type SearchParams,
 } from "./githits-service.js";
@@ -24,8 +25,8 @@ export class RefreshingGitHitsService implements GitHitsService {
   constructor(
     private readonly apiUrl: string,
     private readonly tokenProvider: TokenProvider,
-    private readonly serviceFactory: ServiceFactory = (url, token) =>
-      new GitHitsServiceImpl(url, token),
+    private readonly serviceFactory?: ServiceFactory,
+    private readonly runtime: GitHitsServiceRuntimeOptions = {},
   ) {}
 
   async search(params: SearchParams): Promise<string> {
@@ -52,7 +53,15 @@ export class RefreshingGitHitsService implements GitHitsService {
       forceRefresh: () => this.tokenProvider.forceRefresh(),
       shouldRefresh: (error) => error instanceof AuthenticationError,
       executeWithToken: async (token) => {
-        const service = this.serviceFactory(this.apiUrl, token);
+        const service = this.serviceFactory
+          ? this.serviceFactory(this.apiUrl, token)
+          : new GitHitsServiceImpl(
+              this.apiUrl,
+              token,
+              undefined,
+              undefined,
+              this.runtime,
+            );
         return operation(service);
       },
     });

--- a/src/shared/pkgseer-graphql.test.ts
+++ b/src/shared/pkgseer-graphql.test.ts
@@ -4,6 +4,7 @@ import {
   PkgseerTransportError,
   postPkgseerGraphql,
 } from "./pkgseer-graphql.js";
+import { createClientHeaderBuilder } from "./request-headers.js";
 
 function makeResponse(
   body: string,
@@ -80,6 +81,7 @@ describe("postPkgseerGraphql", () => {
       query: "query { x }",
       variables: {},
       fetchFn: asFetchFn(fetchFn),
+      userAgent: "githits-cli/1.2.3",
     });
 
     expect(result.status).toBe(200);
@@ -99,6 +101,7 @@ describe("postPkgseerGraphql", () => {
       query: "query { x }",
       variables: {},
       fetchFn: asFetchFn(fetchFn),
+      userAgent: "githits-cli/1.2.3",
     });
 
     expect(result.status).toBe(502);
@@ -122,6 +125,7 @@ describe("postPkgseerGraphql", () => {
       query: "query { x }",
       variables: {},
       fetchFn: asFetchFn(fetchFn),
+      userAgent: "githits-cli/1.2.3",
     });
 
     expect(result.status).toBe(500);
@@ -142,11 +146,12 @@ describe("postPkgseerGraphql", () => {
       query: "query { x }",
       variables: {},
       fetchFn: asFetchFn(fetchFn),
+      userAgent: "githits-cli/1.2.3",
     });
 
     expect(capturedHeaders?.Authorization).toBe(`Bearer ${TOKEN}`);
     expect(capturedHeaders?.["Content-Type"]).toBe("application/json");
-    expect(capturedHeaders?.["User-Agent"]).toMatch(/^githits-cli\/\S+$/);
+    expect(capturedHeaders?.["User-Agent"]).toBe("githits-cli/1.2.3");
   });
 
   it("sends x-githits-* telemetry headers from buildClientHeaders", async () => {
@@ -165,10 +170,16 @@ describe("postPkgseerGraphql", () => {
       query: "query { x }",
       variables: {},
       fetchFn: asFetchFn(fetchFn),
+      clientHeaders: createClientHeaderBuilder({
+        clientName: "githits-cli",
+        clientVersion: "1.2.3",
+        env: {},
+        ppid: 42,
+      }),
     });
 
     expect(capturedHeaders?.["x-githits-client-name"]).toBe("githits-cli");
-    expect(capturedHeaders?.["x-githits-client-version"]).toMatch(/^\S+$/);
+    expect(capturedHeaders?.["x-githits-client-version"]).toBe("1.2.3");
     expect(capturedHeaders?.["x-githits-session-id"]).toMatch(/^[0-9a-f]{16}$/);
     // Authorization still wins over any hypothetical x-githits-*
     // collision — spread order (headers first, hardcoded second)

--- a/src/shared/pkgseer-graphql.ts
+++ b/src/shared/pkgseer-graphql.ts
@@ -23,10 +23,9 @@
  *   {@link PkgseerTransportError} preserving the rejection `cause`.
  */
 
-import { version } from "../../package.json";
 import { debugLog } from "./debug-log.js";
 import { DEFAULT_FETCH_TIMEOUT_MS, fetchWithTimeout } from "./fetch-timeout.js";
-import { buildClientHeaders } from "./request-headers.js";
+import type { ClientHeaderBuilder } from "./request-headers.js";
 
 export interface PkgseerGraphqlRequest {
   /** Full base URL for the package/source service. Trailing slashes tolerated. */
@@ -41,8 +40,10 @@ export interface PkgseerGraphqlRequest {
   fetchFn?: typeof fetch;
   /** Per-request timeout in milliseconds. Defaults to 120s. */
   timeoutMs?: number;
-  /** Override `User-Agent`. Defaults to `githits-cli/<version>`. */
+  /** Override `User-Agent`. Production callers inject `githits-cli/<version>`. */
   userAgent?: string;
+  /** Optional per-runtime GitHits telemetry headers. */
+  clientHeaders?: ClientHeaderBuilder;
 }
 
 export interface PkgseerGraphqlResponse {
@@ -86,7 +87,7 @@ function baseUrl(endpointUrl: string): string {
 export async function postPkgseerGraphql(
   request: PkgseerGraphqlRequest,
 ): Promise<PkgseerGraphqlResponse> {
-  const userAgent = request.userAgent ?? `githits-cli/${version}`;
+  const userAgent = request.userAgent ?? "githits-cli";
   const timeoutMs = request.timeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS;
 
   let response: Response;
@@ -96,7 +97,7 @@ export async function postPkgseerGraphql(
       {
         method: "POST",
         headers: {
-          ...buildClientHeaders(),
+          ...request.clientHeaders?.(),
           Authorization: `Bearer ${request.token}`,
           "Content-Type": "application/json",
           "User-Agent": userAgent,

--- a/src/shared/request-headers.test.ts
+++ b/src/shared/request-headers.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from "bun:test";
 import { createHash } from "node:crypto";
 import {
   buildClientHeaders,
+  createClientHeaderBuilder,
   getSessionId,
   parseAgentString,
   resetRequestHeadersState,
@@ -10,6 +11,7 @@ import {
   sanitizeHeaderValue,
   setAgentInfo,
   setClientMode,
+  setClientVersion,
   setMcpClientVersionProvider,
 } from "./request-headers.js";
 
@@ -346,11 +348,17 @@ describe("sanitizeHeaderValue", () => {
 
 describe("buildClientHeaders", () => {
   it("includes base headers without agent when no agent env is set", () => {
+    setClientVersion("1.2.3");
     const headers = buildClientHeaders({}, 42);
     expect(headers["x-githits-client-name"]).toBe("githits-cli");
-    expect(headers["x-githits-client-version"]).toMatch(/^\d+\.\d+\.\d+/);
+    expect(headers["x-githits-client-version"]).toBe("1.2.3");
     expect(headers["x-githits-session-id"]).toMatch(/^[0-9a-f]{16}$/);
     expect(headers["x-githits-agent"]).toBeUndefined();
+  });
+
+  it("omits client version when no version is configured", () => {
+    const headers = buildClientHeaders({}, 42);
+    expect(headers["x-githits-client-version"]).toBeUndefined();
   });
 
   it("includes agent header when agent env is set", () => {
@@ -391,11 +399,13 @@ describe("buildClientHeaders", () => {
   });
 
   it("returns three headers when no agent detected", () => {
+    setClientVersion("1.2.3");
     const headers = buildClientHeaders({}, 42);
     expect(Object.keys(headers)).toHaveLength(3);
   });
 
   it("returns four headers when agent is detected", () => {
+    setClientVersion("1.2.3");
     const headers = buildClientHeaders({ OPENCODE: "1" }, 42);
     expect(Object.keys(headers)).toHaveLength(4);
   });
@@ -428,6 +438,37 @@ describe("buildClientHeaders", () => {
   it("still produces a session-id when PPID is NaN", () => {
     const headers = buildClientHeaders({}, NaN);
     expect(headers["x-githits-session-id"]).toMatch(/^[0-9a-f]{16}$/);
+  });
+});
+
+describe("createClientHeaderBuilder", () => {
+  it("builds isolated headers from explicit runtime metadata", () => {
+    const build = createClientHeaderBuilder({
+      clientName: "githits-cli/mcp",
+      clientVersion: "9.8.7",
+      agentProvider: () => ({ name: "cursor", version: "1.0.0" }),
+      env: {},
+      ppid: 42,
+    });
+
+    const headers = build();
+
+    expect(headers["x-githits-client-name"]).toBe("githits-cli/mcp");
+    expect(headers["x-githits-client-version"]).toBe("9.8.7");
+    expect(headers["x-githits-agent"]).toBe("cursor/1.0.0");
+    expect(headers["x-githits-session-id"]).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it("does not share legacy module-level client mode", () => {
+    setClientMode("mcp");
+    const build = createClientHeaderBuilder({
+      clientName: "remote-mcp",
+      clientVersion: "1.0.0",
+      env: {},
+      ppid: 42,
+    });
+
+    expect(build()["x-githits-client-name"]).toBe("remote-mcp");
   });
 });
 

--- a/src/shared/request-headers.ts
+++ b/src/shared/request-headers.ts
@@ -1,5 +1,4 @@
 import { createHash, randomUUID } from "node:crypto";
-import { version } from "../../package.json";
 
 /**
  * Maximum byte length for a header value.
@@ -315,6 +314,7 @@ export function sanitizeHeaderValue(
 const BASE_CLIENT_NAME = "githits-cli";
 
 let clientName = BASE_CLIENT_NAME;
+let clientVersion: string | undefined;
 
 /**
  * Set the client mode suffix (e.g. `"mcp"`).
@@ -322,6 +322,44 @@ let clientName = BASE_CLIENT_NAME;
  */
 export function setClientMode(mode: string): void {
   clientName = `${BASE_CLIENT_NAME}/${mode}`;
+}
+
+/**
+ * Set the client package version used by the legacy module-level builder.
+ * Prefer `createClientHeaderBuilder()` for new service code.
+ */
+export function setClientVersion(version: string | undefined): void {
+  clientVersion = version;
+}
+
+export type ClientHeaderBuilder = () => Record<string, string>;
+
+export interface CreateClientHeaderBuilderOptions {
+  clientName: string;
+  clientVersion?: string;
+  agentProvider?: () => AgentInfo | undefined;
+  env?: Record<string, string | undefined>;
+  ppid?: number;
+}
+
+/**
+ * Create an isolated, per-runtime client header builder.
+ *
+ * This is the package-boundary-safe API: callers provide their package
+ * metadata and any request/client identity provider explicitly instead of
+ * relying on module-level CLI state.
+ */
+export function createClientHeaderBuilder(
+  options: CreateClientHeaderBuilderOptions,
+): ClientHeaderBuilder {
+  return () =>
+    buildClientHeadersWithContext({
+      clientName: options.clientName,
+      clientVersion: options.clientVersion,
+      agentProvider: options.agentProvider,
+      env: options.env,
+      ppid: options.ppid,
+    });
 }
 
 // ---------------------------------------------------------------------------
@@ -344,20 +382,41 @@ export function buildClientHeaders(
   env?: Record<string, string | undefined>,
   ppid?: number,
 ): Record<string, string> {
+  return buildClientHeadersWithContext({
+    clientName,
+    clientVersion,
+    env,
+    ppid,
+    agentProvider: () => getAgentInfo(env),
+  });
+}
+
+interface BuildClientHeadersContext {
+  clientName: string;
+  clientVersion?: string;
+  agentProvider?: () => AgentInfo | undefined;
+  env?: Record<string, string | undefined>;
+  ppid?: number;
+}
+
+function buildClientHeadersWithContext(
+  context: BuildClientHeadersContext,
+): Record<string, string> {
   try {
     const headers: Record<string, string> = {};
 
-    const name = sanitizeHeaderValue(clientName);
+    const name = sanitizeHeaderValue(context.clientName);
     if (name) {
       headers["x-githits-client-name"] = name;
     }
 
-    const clientVersion = sanitizeHeaderValue(version);
-    if (clientVersion) {
-      headers["x-githits-client-version"] = clientVersion;
+    const safeClientVersion = sanitizeHeaderValue(context.clientVersion);
+    if (safeClientVersion) {
+      headers["x-githits-client-version"] = safeClientVersion;
     }
 
-    const agentInfo = getAgentInfo(env);
+    const agentInfo =
+      context.agentProvider?.() ?? resolveAgentInfo(context.env);
     if (agentInfo) {
       const agentValue = sanitizeHeaderValue(formatAgentInfo(agentInfo));
       if (agentValue) {
@@ -365,7 +424,9 @@ export function buildClientHeaders(
       }
     }
 
-    const sessionId = sanitizeHeaderValue(getSessionId(env, ppid));
+    const sessionId = sanitizeHeaderValue(
+      getSessionId(context.env, context.ppid),
+    );
     if (sessionId) {
       headers["x-githits-session-id"] = sessionId;
     }
@@ -391,4 +452,5 @@ export function resetRequestHeadersState(): void {
   agentInfoExplicitlySet = false;
   mcpClientVersionProvider = undefined;
   clientName = BASE_CLIENT_NAME;
+  clientVersion = undefined;
 }


### PR DESCRIPTION
## Summary
- add explicit client header builders so services no longer read package metadata or telemetry state from shared globals
- thread runtime headers/user-agent through the production container and service implementations
- preserve local MCP telemetry by passing `githits-cli/mcp` and lazy clientInfo through container options

## Verification
- `bun test src/container.test.ts src/shared/request-headers.test.ts src/services/githits-service.test.ts src/shared/pkgseer-graphql.test.ts src/commands/mcp.test.ts src/services/refreshing-githits-service.test.ts`
- `bun run typecheck`
- `bun test src/services/code-navigation-service.test.ts src/services/package-intelligence-service.test.ts src/services/refreshing-githits-service.test.ts src/container.test.ts`
- `bun run build`
- `bun test`
- `bun run smoke:mcp`
- `bun run smoke:cli`
- `bun run format:check`
- `git diff --check`

## Notes
- `docs/plans/workspace-restructure.md` remains local/untracked for continued planning and is intentionally not included in this implementation PR.