### PR TITLE
fix: serialize token refresh across agents

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "GitHits plugins for Claude Code - code examples from global open source",
-    "version": "0.4.11"
+    "version": "0.4.12"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "description": "Code examples from global open source for developers and AI assistants",
   "author": {
     "name": "GitHits"

--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "description": "Code examples from global open source for developers and AI assistants",
   "author": {
     "name": "GitHits"

--- a/docs/implementation/auth.md
+++ b/docs/implementation/auth.md
@@ -42,8 +42,9 @@ Tokens are JWTs with a configurable expiration (typically 1 hour). The CLI handl
 - **Proactive refresh** — When 90% of the token lifetime has elapsed (e.g., at ~54 minutes for a 1-hour token), the `TokenManager` refreshes before expiry. This avoids a stale-token window.
 - **Reactive refresh** — If the token is already expired, refresh is attempted immediately.
 - **401 retry** — The `RefreshingGitHitsService` decorator wraps `GitHitsServiceImpl` and retries once on `AuthenticationError`, calling `forceRefresh()` to handle clock skew or server-side revocation.
+- **Refresh token rotation** — Refresh tokens are single-use; after one refresh call spends a token, concurrent refresh calls with the same stored token will fail.
 - **Shared retry helper** — GitHits REST calls and package/source service calls both use the same token-refresh/retry flow, so auth drift is handled consistently across both service families.
-- **Concurrent coalescing** — Soft refreshes from `getToken()` coalesce with each other, and strict refreshes from `forceRefresh()` coalesce with each other. A strict refresh waits for any in-flight soft refresh to finish, then refreshes the latest stored token instead of reusing a soft result that may not have hit the token endpoint. Once a strict refresh is active, later `getToken()` calls join it instead of serving cached credentials, even if the cached token still looks time-valid. Storage writes use compare-and-swap helpers so a failed refresh cannot overwrite or clear credentials another process already updated. Before refreshing a cached token, the manager reloads storage so long-running MCP servers use credentials written by a separate login/refresh. If a successful refresh returns a rotated refresh token after same-lineage storage changed mid-refresh, the rotated token is persisted with another compare-and-swap so storage does not keep an invalidated refresh token.
+- **Concurrent coalescing** — Soft refreshes from `getToken()` coalesce with each other, and strict refreshes from `forceRefresh()` coalesce with each other. A strict refresh waits for any in-flight soft refresh to finish, then refreshes the latest stored token instead of reusing a soft result that may not have hit the token endpoint. Once a strict refresh is active, later `getToken()` calls join it instead of serving cached credentials, even if the cached token still looks time-valid. Refresh attempts run inside the auth storage lock, covering storage reload, token endpoint refresh, and token save/clear as one cross-process transaction. This prevents parallel agents from spending the same rotating refresh token at the same time. Storage writes still use compare-and-swap helpers as a defensive guard. Before refreshing a cached token, the manager reloads storage so long-running MCP servers use credentials written by a separate login/refresh.
 - **At login** (`src/commands/login.ts`) — Checks if existing token is still valid before starting the OAuth flow. Respects `--force` flag to re-authenticate regardless.
 - **At init** (`src/commands/init/init.ts`) — Resolves auth through `createContainer()` at the login step so standard token refresh runs before falling back to browser login.
 - **At auth status** (`src/commands/auth-status.ts`) — Attempts refresh before reporting "Token expired".
@@ -132,7 +133,7 @@ The configured target write must succeed before the source entry is deleted. Tok
 
 ```
 Container (createAuthStorage)
-  └─ LockedAuthStorage (cross-process write lock)
+  └─ LockedAuthStorage (cross-process auth mutation/refresh lock)
        └─ MigratingAuthStorage (decorator)
             ├─ KeychainAuthStorage
             │    └─ ChunkingKeyringService (Windows only, decorator)
@@ -144,7 +145,7 @@ Container (createAuthStorage)
 
 All credential types are keyed by normalized MCP base URL (trailing slashes stripped), supporting multiple environments simultaneously.
 
-`LockedAuthStorage` serializes mutating auth operations across CLI processes and long-running MCP servers with an `auth.lock` directory under the platform config path. The lock records PID and process start time so dead-owner locks can be reclaimed without stealing live locks.
+`LockedAuthStorage` serializes mutating auth operations and token refresh transactions across CLI processes and long-running MCP servers with an `auth.lock` directory under the platform config path. The lock records PID and process start time so dead-owner locks can be reclaimed without stealing live locks. Token refresh holds this lock while it reloads stored credentials, calls the token endpoint, and saves or clears the result.
 
 ## How Auth Flows Through the System
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "description": "Code examples from global open source for developers and AI assistants.",
   "mcpServers": {
     "githits": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "githits",
   "description": "CLI companion for GitHits - code examples from global open source for developers and AI assistants",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "type": "module",
   "files": [
     "dist",

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "description": "Code examples from global open source for developers and AI assistants",
   "author": {
     "name": "GitHits"

--- a/src/commands/auth-status.ts
+++ b/src/commands/auth-status.ts
@@ -1,10 +1,10 @@
 import type { Command } from "commander";
 import { createAuthStatusDependencies } from "../container.js";
-import type { AuthService, AuthStorage } from "../services/index.js";
+import type { AuthService, LockingAuthStorage } from "../services/index.js";
 import { refreshExpiredToken } from "../services/index.js";
 
 export interface AuthStatusDependencies {
-  authStorage: AuthStorage;
+  authStorage: LockingAuthStorage;
   authService: AuthService;
   mcpUrl: string;
   envApiToken: string | undefined;

--- a/src/container.ts
+++ b/src/container.ts
@@ -5,7 +5,6 @@ import {
   AuthServiceImpl,
   type AuthSessionMetadata,
   AuthSessionMetadataStorage,
-  type AuthStorage,
   AuthStorageImpl,
   type AuthStorageMode,
   type BrowserService,
@@ -26,6 +25,7 @@ import {
   KeychainAuthStorage,
   KeyringServiceImpl,
   LockedAuthStorage,
+  type LockingAuthStorage,
   loadAuthConfig,
   MigratingAuthStorage,
   ModeAwareFileAuthStorage,
@@ -51,7 +51,7 @@ const USER_AGENT = `${BASE_CLIENT_NAME}/${version}`;
  */
 async function createAuthStorage(
   fileSystemService: FileSystemService,
-): Promise<AuthStorage> {
+): Promise<LockingAuthStorage> {
   return withTelemetrySpan("container.create-auth-storage", async () => {
     const authConfig = await loadAuthConfig(fileSystemService);
     return createAuthStorageForMode(
@@ -66,7 +66,7 @@ function createAuthStorageForMode(
   fileSystemService: FileSystemService,
   mode: AuthStorageMode,
   configPath = "your GitHits config.toml",
-): AuthStorage {
+): LockingAuthStorage {
   const fileStorage = new ModeAwareFileAuthStorage(
     new AuthStorageImpl(
       fileSystemService,
@@ -133,7 +133,7 @@ export async function clearAutoLoginAuthSessionMetadata(): Promise<void> {
 }
 
 export interface AuthCommandDependencies {
-  authStorage: AuthStorage;
+  authStorage: LockingAuthStorage;
   authService: AuthService;
   browserService: BrowserService;
   fileSystemService: FileSystemService;
@@ -179,7 +179,7 @@ export async function createAuthStatusDependencies(): Promise<AuthCommandDepende
  * Dependencies required by the application.
  */
 export interface Dependencies {
-  authStorage: AuthStorage;
+  authStorage: LockingAuthStorage;
   authService: AuthService;
   browserService: BrowserService;
   fileSystemService: FileSystemService;

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -138,6 +138,7 @@ export {
   KeychainUnavailableError,
   KeyringServiceImpl,
 } from "./keyring-service.js";
+export type { LockingAuthStorage } from "./locked-auth-storage.js";
 export {
   AuthStorageLockTimeoutError,
   LockedAuthStorage,

--- a/src/services/locked-auth-storage.test.ts
+++ b/src/services/locked-auth-storage.test.ts
@@ -52,6 +52,22 @@ describe("LockedAuthStorage", () => {
     expect(["first", "second"]).toContain(finalToken?.accessToken ?? "");
   });
 
+  it("allows nested storage writes inside a scoped lock", async () => {
+    const { fs, fsWithHome, configDir } = await createStoragePaths();
+    const storage = new LockedAuthStorage(
+      new AuthStorageImpl(fs, configDir),
+      fsWithHome,
+      { lockTimeoutMs: 100 },
+    );
+    const token = createValidTokenData({ accessToken: "nested" });
+
+    await storage.withAuthStorageLock(async () => {
+      await storage.saveTokens(baseUrl, token);
+    });
+
+    expect(await storage.loadTokens(baseUrl)).toEqual(token);
+  });
+
   it("reclaims stale lock directories", async () => {
     const { fs, fsWithHome, configDir, lockPath } = await createStoragePaths();
     await mkdir(lockPath, { recursive: true, mode: 0o700 });

--- a/src/services/locked-auth-storage.ts
+++ b/src/services/locked-auth-storage.ts
@@ -1,8 +1,10 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import { execFile } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import { promisify } from "node:util";
+import { DEFAULT_FETCH_TIMEOUT_MS } from "../shared/fetch-timeout.js";
 import { getAppConfigDir } from "./app-config-paths.js";
 import type {
   AuthStorage,
@@ -12,7 +14,7 @@ import type {
 import type { FileSystemService } from "./filesystem-service.js";
 
 const LOCK_DIR = "auth.lock";
-const LOCK_TIMEOUT_MS = 10_000;
+const LOCK_TIMEOUT_MS = DEFAULT_FETCH_TIMEOUT_MS * 2 + 10_000;
 const LOCK_RETRY_MS = 25;
 const ORPHANED_LOCK_MS = 5_000;
 const OWNER_FILE = "owner.json";
@@ -32,13 +34,27 @@ export class AuthStorageLockTimeoutError extends Error {
   }
 }
 
-export class LockedAuthStorage implements AuthStorage {
+export interface AuthStorageLockProvider {
+  withAuthStorageLock<T>(fn: () => Promise<T>): Promise<T>;
+}
+
+export type LockingAuthStorage = AuthStorage & AuthStorageLockProvider;
+
+export function withAuthStorageLock<T>(
+  storage: LockingAuthStorage,
+  fn: () => Promise<T>,
+): Promise<T> {
+  return storage.withAuthStorageLock(fn);
+}
+
+export class LockedAuthStorage implements AuthStorage, AuthStorageLockProvider {
   private readonly lockPath: string;
   private readonly lockTimeoutMs: number;
   private readonly isOwnerAlive: (
     pid: number,
     processStartedAt: string | null,
   ) => Promise<boolean>;
+  private readonly lockContext = new AsyncLocalStorage<string>();
   private currentOwner: LockOwner | null = null;
 
   constructor(
@@ -65,7 +81,9 @@ export class LockedAuthStorage implements AuthStorage {
   }
 
   saveTokens(baseUrl: string, data: TokenData): Promise<void> {
-    return this.withLock(() => this.storage.saveTokens(baseUrl, data));
+    return this.withAuthStorageLock(() =>
+      this.storage.saveTokens(baseUrl, data),
+    );
   }
 
   saveTokensIfUnchanged(
@@ -73,20 +91,20 @@ export class LockedAuthStorage implements AuthStorage {
     expected: TokenData | null,
     data: TokenData,
   ): Promise<boolean> {
-    return this.withLock(() =>
+    return this.withAuthStorageLock(() =>
       this.storage.saveTokensIfUnchanged(baseUrl, expected, data),
     );
   }
 
   clearTokens(baseUrl: string): Promise<void> {
-    return this.withLock(() => this.storage.clearTokens(baseUrl));
+    return this.withAuthStorageLock(() => this.storage.clearTokens(baseUrl));
   }
 
   clearTokensIfUnchanged(
     baseUrl: string,
     expected: TokenData | null,
   ): Promise<boolean> {
-    return this.withLock(() =>
+    return this.withAuthStorageLock(() =>
       this.storage.clearTokensIfUnchanged(baseUrl, expected),
     );
   }
@@ -96,11 +114,13 @@ export class LockedAuthStorage implements AuthStorage {
   }
 
   saveClient(baseUrl: string, data: ClientRegistration): Promise<void> {
-    return this.withLock(() => this.storage.saveClient(baseUrl, data));
+    return this.withAuthStorageLock(() =>
+      this.storage.saveClient(baseUrl, data),
+    );
   }
 
   clearClient(baseUrl: string): Promise<void> {
-    return this.withLock(() => this.storage.clearClient(baseUrl));
+    return this.withAuthStorageLock(() => this.storage.clearClient(baseUrl));
   }
 
   saveAuthSession(
@@ -108,37 +128,51 @@ export class LockedAuthStorage implements AuthStorage {
     client: ClientRegistration,
     tokens: TokenData,
   ): Promise<void> {
-    return this.withLock(() =>
+    return this.withAuthStorageLock(() =>
       this.storage.saveAuthSession(baseUrl, client, tokens),
     );
   }
 
   clearAuthSession(baseUrl: string): Promise<void> {
-    return this.withLock(() => this.storage.clearAuthSession(baseUrl));
+    return this.withAuthStorageLock(() =>
+      this.storage.clearAuthSession(baseUrl),
+    );
   }
 
   getStorageLocation(): string {
     return this.storage.getStorageLocation();
   }
 
-  private async withLock<T>(fn: () => Promise<T>): Promise<T> {
+  async withAuthStorageLock<T>(fn: () => Promise<T>): Promise<T> {
+    const ownerId = this.lockContext.getStore();
+    if (ownerId && this.currentOwner?.id === ownerId) {
+      return fn();
+    }
+
     await this.acquireLock();
+    const acquiredOwnerId = this.currentOwner?.id;
     try {
-      return await fn();
+      return await this.lockContext.run(acquiredOwnerId ?? "", fn);
     } finally {
       await this.releaseLock();
     }
   }
 
   private async acquireLock(): Promise<void> {
+    const processStartedAt = await getProcessStartedAt(process.pid);
     const startedAt = Date.now();
     await mkdir(dirname(this.lockPath), { recursive: true, mode: 0o700 });
     while (true) {
       try {
         await mkdir(this.lockPath, { recursive: false, mode: 0o700 });
         try {
-          await this.writeOwner();
+          await this.writeOwner(processStartedAt);
         } catch (error) {
+          this.currentOwner = null;
+          if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+            await sleep(LOCK_RETRY_MS);
+            continue;
+          }
           await rm(this.lockPath, { recursive: true, force: true }).catch(
             () => undefined,
           );
@@ -158,15 +192,18 @@ export class LockedAuthStorage implements AuthStorage {
     }
   }
 
-  private async writeOwner(): Promise<void> {
+  private async writeOwner(processStartedAt: string | null): Promise<void> {
     const owner: LockOwner = {
       id: randomUUID(),
       pid: process.pid,
       createdAt: new Date().toISOString(),
-      processStartedAt: await getProcessStartedAt(process.pid),
+      processStartedAt,
     };
+    await writeFile(this.ownerPath(), JSON.stringify(owner), {
+      mode: 0o600,
+      flag: "wx",
+    });
     this.currentOwner = owner;
-    await writeFile(this.ownerPath(), JSON.stringify(owner), { mode: 0o600 });
   }
 
   private async reclaimStaleLock(): Promise<void> {

--- a/src/services/test-helpers.ts
+++ b/src/services/test-helpers.ts
@@ -6,11 +6,7 @@ import type {
   PkceParams,
   TokenResponse,
 } from "./auth-service.js";
-import type {
-  AuthStorage,
-  ClientRegistration,
-  TokenData,
-} from "./auth-storage.js";
+import type { ClientRegistration, TokenData } from "./auth-storage.js";
 import type { BrowserService } from "./browser-service.js";
 import type {
   CodeNavigationService,
@@ -21,6 +17,7 @@ import type { ExecResult, ExecService } from "./exec-service.js";
 import type { FileSystemService } from "./filesystem-service.js";
 import type { GitHitsService } from "./githits-service.js";
 import type { KeyringService } from "./keyring-service.js";
+import type { LockingAuthStorage } from "./locked-auth-storage.js";
 import type {
   ChangelogReport,
   DependencyReport,
@@ -182,8 +179,8 @@ export const defaultUnifiedSearchOutcome: UnifiedSearchOutcome = {
  * Creates a mock AuthStorage with default implementations.
  */
 export function createMockAuthStorage(
-  impl: Partial<AuthStorage> = {},
-): AuthStorage {
+  impl: Partial<LockingAuthStorage> = {},
+): LockingAuthStorage {
   return {
     loadTokens: mock(() => Promise.resolve(null)),
     saveTokens: mock(() => Promise.resolve()),
@@ -196,6 +193,7 @@ export function createMockAuthStorage(
     saveAuthSession: mock(() => Promise.resolve()),
     clearAuthSession: mock(() => Promise.resolve()),
     getStorageLocation: mock(() => "/mock/.githits"),
+    withAuthStorageLock: <T>(fn: () => Promise<T>) => fn(),
     ...impl,
   };
 }

--- a/src/services/token-manager.integration.test.ts
+++ b/src/services/token-manager.integration.test.ts
@@ -25,7 +25,7 @@ describe("TokenManager file-backed integration", () => {
     );
   });
 
-  it("preserves one rotated refresh token when two managers refresh the same stored token", async () => {
+  it("reuses one rotated refresh token when two managers refresh the same stored token", async () => {
     const { firstStorage, secondStorage } = await createRealStorages();
     const initial = createExpiredToken({
       accessToken: "initial-access-token",
@@ -66,7 +66,7 @@ describe("TokenManager file-backed integration", () => {
       firstManager.getToken(),
       secondManager.getToken(),
     ]);
-    await refreshGate.waitForCalls(2);
+    await refreshGate.waitForCalls(1);
     refreshGate.resolveAll();
 
     const [firstResult, secondResult] = await results;
@@ -74,22 +74,185 @@ describe("TokenManager file-backed integration", () => {
 
     expect(stored).not.toBeNull();
     if (!stored) throw new Error("Expected stored token after refresh race");
-    expect(["first-access-token", "second-access-token"]).toContain(
-      stored.accessToken,
-    );
-    expect(stored.refreshToken).toBe(
-      stored.accessToken === "first-access-token"
-        ? "first-refresh-token"
-        : "second-refresh-token",
-    );
-    // The losing refresh must reload storage and return the persisted winner.
+    expect(stored.accessToken).toBe("first-access-token");
+    expect(stored.refreshToken).toBe("first-refresh-token");
+    // The waiting manager must reload storage and return the persisted winner.
     expect(firstResult).toBe(stored.accessToken);
     expect(secondResult).toBe(stored.accessToken);
-    expect(refreshGate.refreshAccessToken).toHaveBeenCalledTimes(2);
+    expect(refreshGate.refreshAccessToken).toHaveBeenCalledTimes(1);
     expect(firstStorage.getStorageLocation()).toContain(
       join("githits", "auth"),
     );
   });
+
+  it("serializes endpoint refresh when rotation invalidates concurrent refreshes", async () => {
+    const { firstStorage, secondStorage } = await createRealStorages();
+    const initial = createExpiredToken({
+      accessToken: "initial-access-token",
+      refreshToken: "initial-refresh-token",
+    });
+    await firstStorage.saveAuthSession(
+      baseUrl,
+      defaultClientRegistration,
+      initial,
+    );
+
+    let resolveFirstRefresh!: (response: RefreshTokenResponse) => void;
+    let resolveFirstRefreshStarted!: () => void;
+    const firstRefreshStarted = new Promise<void>((resolve) => {
+      resolveFirstRefreshStarted = resolve;
+    });
+    let resolveSecondRefreshStarted!: () => void;
+    const secondRefreshStarted = new Promise<void>((resolve) => {
+      resolveSecondRefreshStarted = resolve;
+    });
+    let refreshCall = 0;
+    const refreshAccessToken = mock(() => {
+      refreshCall++;
+      if (refreshCall === 1) {
+        resolveFirstRefreshStarted();
+        return new Promise<RefreshTokenResponse>((resolve) => {
+          resolveFirstRefresh = resolve;
+        });
+      }
+      resolveSecondRefreshStarted();
+      return Promise.reject(new Error("invalid_grant"));
+    });
+    const authService = createMockAuthService({ refreshAccessToken });
+    const firstManager = new TokenManager({
+      authService,
+      authStorage: firstStorage,
+      mcpUrl: baseUrl,
+    });
+    const secondManager = new TokenManager({
+      authService,
+      authStorage: secondStorage,
+      mcpUrl: baseUrl,
+    });
+
+    const results = Promise.all([
+      firstManager.getToken(),
+      secondManager.getToken(),
+    ]);
+    await firstRefreshStarted;
+    await Promise.race([secondRefreshStarted, sleep(100)]);
+
+    resolveFirstRefresh({
+      accessToken: "refreshed-access-token",
+      refreshToken: "refreshed-refresh-token",
+      expiresIn: 3600,
+    });
+
+    await expect(results).resolves.toEqual([
+      "refreshed-access-token",
+      "refreshed-access-token",
+    ]);
+    expect(refreshAccessToken).toHaveBeenCalledTimes(1);
+    expect(await firstStorage.loadTokens(baseUrl)).toEqual(
+      expect.objectContaining({
+        accessToken: "refreshed-access-token",
+        refreshToken: "refreshed-refresh-token",
+      }),
+    );
+  });
+
+  it("makes one endpoint refresh for many simultaneous expired-token agents", async () => {
+    const storageCount = 12;
+    const storages = await createRealStorageSet(storageCount);
+    const initial = createExpiredToken({
+      accessToken: "initial-access-token",
+      refreshToken: "initial-refresh-token",
+    });
+    await storages[0]?.saveAuthSession(
+      baseUrl,
+      defaultClientRegistration,
+      initial,
+    );
+    const refreshGate = createRefreshGate([
+      {
+        accessToken: "refreshed-access-token",
+        refreshToken: "refreshed-refresh-token",
+        expiresIn: 3600,
+      },
+    ]);
+    const authService = createMockAuthService({
+      refreshAccessToken: refreshGate.refreshAccessToken,
+    });
+    const managers = storages.map(
+      (authStorage) =>
+        new TokenManager({ authService, authStorage, mcpUrl: baseUrl }),
+    );
+
+    const results = Promise.all(managers.map((manager) => manager.getToken()));
+    await refreshGate.waitForCalls(1);
+    await Promise.race([refreshGate.waitForCalls(2), sleep(100)]);
+    refreshGate.resolveAll();
+
+    await expect(results).resolves.toEqual(
+      Array.from({ length: storageCount }, () => "refreshed-access-token"),
+    );
+    expect(refreshGate.refreshAccessToken).toHaveBeenCalledTimes(1);
+    expect(await storages[0]?.loadTokens(baseUrl)).toEqual(
+      expect.objectContaining({
+        accessToken: "refreshed-access-token",
+        refreshToken: "refreshed-refresh-token",
+      }),
+    );
+  }, 20_000);
+
+  it("makes one endpoint refresh for many simultaneous force refresh retries", async () => {
+    const storageCount = 12;
+    const storages = await createRealStorageSet(storageCount);
+    const initial = createValidTokenData({
+      accessToken: "rejected-access-token",
+      refreshToken: "initial-refresh-token",
+      createdAt: new Date(Date.now() - 60_000).toISOString(),
+      expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+    });
+    await storages[0]?.saveAuthSession(
+      baseUrl,
+      defaultClientRegistration,
+      initial,
+    );
+    const refreshGate = createRefreshGate([
+      {
+        accessToken: "retry-access-token",
+        refreshToken: "retry-refresh-token",
+        expiresIn: 3600,
+      },
+    ]);
+    const authService = createMockAuthService({
+      refreshAccessToken: refreshGate.refreshAccessToken,
+    });
+    const managers = storages.map(
+      (authStorage) =>
+        new TokenManager({ authService, authStorage, mcpUrl: baseUrl }),
+    );
+
+    await expect(
+      Promise.all(managers.map((manager) => manager.getToken())),
+    ).resolves.toEqual(
+      Array.from({ length: storageCount }, () => "rejected-access-token"),
+    );
+
+    const results = Promise.all(
+      managers.map((manager) => manager.forceRefresh()),
+    );
+    await refreshGate.waitForCalls(1);
+    await Promise.race([refreshGate.waitForCalls(2), sleep(100)]);
+    refreshGate.resolveAll();
+
+    await expect(results).resolves.toEqual(
+      Array.from({ length: storageCount }, () => "retry-access-token"),
+    );
+    expect(refreshGate.refreshAccessToken).toHaveBeenCalledTimes(1);
+    expect(await storages[0]?.loadTokens(baseUrl)).toEqual(
+      expect.objectContaining({
+        accessToken: "retry-access-token",
+        refreshToken: "retry-refresh-token",
+      }),
+    );
+  }, 20_000);
 
   it("does not overwrite an external login written while refresh is in flight", async () => {
     const { firstStorage, secondStorage } = await createRealStorages();
@@ -125,14 +288,15 @@ describe("TokenManager file-backed integration", () => {
 
     const result = manager.getToken();
     await refreshGate.waitForCalls(1);
-    await secondStorage.saveAuthSession(
+    const externalLoginWrite = secondStorage.saveAuthSession(
       baseUrl,
       defaultClientRegistration,
       externalLogin,
     );
     refreshGate.resolveAll();
 
-    expect(await result).toBe("external-login-access-token");
+    expect(await result).toBe("rotated-access-token");
+    await externalLoginWrite;
     expect(await firstStorage.loadTokens(baseUrl)).toEqual(externalLogin);
     expect(refreshGate.refreshAccessToken).toHaveBeenCalledTimes(1);
   });
@@ -174,14 +338,15 @@ describe("TokenManager file-backed integration", () => {
 
     const result = manager.getToken();
     await refreshStarted;
-    await secondStorage.saveAuthSession(
+    const externalLoginWrite = secondStorage.saveAuthSession(
       baseUrl,
       defaultClientRegistration,
       externalLogin,
     );
     rejectRefresh(new Error("refresh failed"));
 
-    expect(await result).toBe("external-login-access-token");
+    expect(await result).toBeUndefined();
+    await externalLoginWrite;
     expect(await firstStorage.loadTokens(baseUrl)).toEqual(externalLogin);
     expect(refreshAccessToken).toHaveBeenCalledTimes(1);
   });
@@ -190,6 +355,16 @@ describe("TokenManager file-backed integration", () => {
     firstStorage: LockedAuthStorage;
     secondStorage: LockedAuthStorage;
   }> {
+    const [firstStorage, secondStorage] = await createRealStorageSet(2);
+    if (!firstStorage || !secondStorage) {
+      throw new Error("Expected two real storages");
+    }
+    return { firstStorage, secondStorage };
+  }
+
+  async function createRealStorageSet(
+    count: number,
+  ): Promise<LockedAuthStorage[]> {
     const root = await mkdtemp(join(tmpdir(), "githits-token-manager-"));
     tempDirs.push(root);
     const fs = new FileSystemServiceImpl();
@@ -199,16 +374,13 @@ describe("TokenManager file-backed integration", () => {
     }) as FileSystemServiceImpl;
     const configRoot = join(root, "config");
     const configDir = join(configRoot, "githits", "auth");
-    return withConfigRoot(configRoot, () => ({
-      firstStorage: new LockedAuthStorage(
-        new AuthStorageImpl(fs, configDir),
-        fsWithHome,
+    return withConfigRoot(configRoot, () =>
+      Array.from(
+        { length: count },
+        () =>
+          new LockedAuthStorage(new AuthStorageImpl(fs, configDir), fsWithHome),
       ),
-      secondStorage: new LockedAuthStorage(
-        new AuthStorageImpl(fs, configDir),
-        fsWithHome,
-      ),
-    }));
+    );
   }
 
   function withConfigRoot<T>(configRoot: string, create: () => T): T {
@@ -267,5 +439,9 @@ describe("TokenManager file-backed integration", () => {
         }
       },
     };
+  }
+
+  function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
   }
 });

--- a/src/services/token-manager.test.ts
+++ b/src/services/token-manager.test.ts
@@ -542,12 +542,12 @@ describe("TokenManager", () => {
       expect(refreshAccessToken).toHaveBeenCalledTimes(1);
       loadTokens.mockImplementation(() => Promise.resolve(freshToken));
       const recovered = await manager.forceRefresh();
-      expect(refreshAccessToken).toHaveBeenCalledTimes(2);
+      expect(refreshAccessToken).toHaveBeenCalledTimes(1);
       const next = await manager.getToken();
 
       expect(recovered).toBe("fresh-access-token");
       expect(next).toBe("fresh-access-token");
-      expect(refreshAccessToken).toHaveBeenCalledTimes(2);
+      expect(refreshAccessToken).toHaveBeenCalledTimes(1);
     });
 
     it("refreshes externally updated tokens that are already expired", async () => {
@@ -766,6 +766,63 @@ describe("TokenManager", () => {
 
       expect(await forceResult).toBe("force-access-token");
       expect(await getTokenDuringForce).toBe("force-access-token");
+      expect(refreshAccessToken).toHaveBeenCalledTimes(1);
+    });
+
+    it("getToken joins forceRefresh that starts during its initial storage load", async () => {
+      const tokenData = createValidTokenData({
+        accessToken: "initial-access-token",
+        refreshToken: "initial-refresh-token",
+        createdAt: new Date(Date.now() - 60_000).toISOString(),
+        expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+      });
+      let resolveInitialLoad!: (value: TokenData) => void;
+      const initialLoad = new Promise<TokenData>((resolve) => {
+        resolveInitialLoad = resolve;
+      });
+      let loadCall = 0;
+      const loadTokens = mock(() => {
+        loadCall++;
+        return loadCall === 1 ? initialLoad : Promise.resolve(tokenData);
+      });
+      let resolveRefresh!: (value: typeof defaultTokenResponse) => void;
+      const refreshResponse = new Promise<typeof defaultTokenResponse>(
+        (resolve) => {
+          resolveRefresh = resolve;
+        },
+      );
+      let resolveRefreshStarted!: () => void;
+      const refreshStarted = new Promise<void>((resolve) => {
+        resolveRefreshStarted = resolve;
+      });
+      const refreshAccessToken = mock(() => {
+        resolveRefreshStarted();
+        return refreshResponse;
+      });
+      const authStorage = createMockAuthStorage({
+        loadTokens,
+        loadClient: mock(() => Promise.resolve(defaultClientRegistration)),
+      });
+      const manager = new TokenManager({
+        authService: createMockAuthService({ refreshAccessToken }),
+        authStorage,
+        mcpUrl: MCP_URL,
+      });
+
+      const getTokenResult = manager.getToken();
+      const forceResult = manager.forceRefresh();
+      await refreshStarted;
+
+      resolveInitialLoad(tokenData);
+      resolveRefresh({
+        accessToken: "force-access-token",
+        refreshToken: "force-refresh-token",
+        expiresIn: 3600,
+      });
+
+      await expect(Promise.all([getTokenResult, forceResult])).resolves.toEqual(
+        ["force-access-token", "force-access-token"],
+      );
       expect(refreshAccessToken).toHaveBeenCalledTimes(1);
     });
 

--- a/src/services/token-manager.ts
+++ b/src/services/token-manager.ts
@@ -1,6 +1,10 @@
 import { withTelemetrySpan } from "../shared/telemetry.js";
 import type { AuthService, RefreshTokenResponse } from "./auth-service.js";
-import type { AuthStorage, TokenData } from "./auth-storage.js";
+import type { TokenData } from "./auth-storage.js";
+import {
+  type LockingAuthStorage,
+  withAuthStorageLock,
+} from "./locked-auth-storage.js";
 
 /**
  * Ratio of token lifetime at which proactive refresh triggers.
@@ -24,7 +28,7 @@ export interface TokenProvider {
  */
 export interface TokenManagerDeps {
   authService: AuthService;
-  authStorage: AuthStorage;
+  authStorage: LockingAuthStorage;
   mcpUrl: string;
 }
 
@@ -73,7 +77,7 @@ export function shouldRefreshToken(
  */
 export async function refreshExpiredToken(
   authService: AuthService,
-  authStorage: AuthStorage,
+  authStorage: LockingAuthStorage,
   mcpUrl: string,
 ): Promise<string | undefined> {
   const manager = new TokenManager({ authService, authStorage, mcpUrl });
@@ -86,7 +90,7 @@ export async function refreshExpiredToken(
  */
 export class TokenManager implements TokenProvider {
   private readonly authService: AuthService;
-  private readonly authStorage: AuthStorage;
+  private readonly authStorage: LockingAuthStorage;
   private readonly mcpUrl: string;
   private cachedToken: TokenData | null = null;
   private softRefreshPromise: Promise<RefreshResult> | null = null;
@@ -100,16 +104,24 @@ export class TokenManager implements TokenProvider {
 
   async getToken(): Promise<string | undefined> {
     return withTelemetrySpan("token-manager.get-token", async () => {
-      if (this.forceRefreshPromise) {
-        return (await this.forceRefreshPromise).accessToken;
+      const activeForceRefresh = this.forceRefreshPromise;
+      if (activeForceRefresh) {
+        return (await activeForceRefresh).accessToken;
       }
 
       // Load from storage on first call
       if (!this.cachedToken) {
-        this.cachedToken = await withTelemetrySpan(
+        const storedToken = await withTelemetrySpan(
           "token-manager.load-tokens",
           () => this.authStorage.loadTokens(this.mcpUrl),
         );
+        const startedForceRefresh = this.forceRefreshPromise;
+        if (startedForceRefresh) {
+          return (await startedForceRefresh).accessToken;
+        }
+        if (!this.cachedToken) {
+          this.cachedToken = storedToken;
+        }
         if (!this.cachedToken) return undefined;
       }
 
@@ -125,9 +137,7 @@ export class TokenManager implements TokenProvider {
       }
 
       // Attempt refresh (coalesced if already in-flight)
-      const refreshedToken = await this.doRefresh({
-        allowFreshExternalToken: true,
-      });
+      const refreshedToken = await this.refreshFromGetToken();
 
       if (refreshedToken) {
         return refreshedToken;
@@ -145,49 +155,20 @@ export class TokenManager implements TokenProvider {
 
   async forceRefresh(): Promise<string | undefined> {
     return withTelemetrySpan("token-manager.force-refresh", () =>
-      this.doRefresh({ allowFreshExternalToken: false }),
+      this.refreshAfterAuthFailure(),
     );
   }
 
-  /**
-   * Execute a refresh, coalescing concurrent requests.
-   */
-  private async doRefresh(options: {
-    allowFreshExternalToken: boolean;
-  }): Promise<string | undefined> {
-    const result = await this.doRefreshResult(options);
+  private async refreshFromGetToken(): Promise<string | undefined> {
+    const result = await this.softRefresh();
     return result.accessToken;
   }
 
-  private async doRefreshResult(options: {
-    allowFreshExternalToken: boolean;
-  }): Promise<RefreshResult> {
-    if (!options.allowFreshExternalToken) {
-      if (this.forceRefreshPromise) return this.forceRefreshPromise;
-
-      this.forceRefreshPromise = (async () => {
-        // A force refresh must not reuse a softer getToken refresh that may
-        // return externally written credentials without hitting the token
-        // endpoint, but later getToken calls should join this stricter work.
-        const softResult = await this.softRefreshPromise?.catch(
-          () => undefined,
-        );
-        if (softResult?.accessToken && softResult.refreshedViaEndpoint) {
-          return softResult;
-        }
-        return this.executeRefresh(options);
-      })();
-      try {
-        return await this.forceRefreshPromise;
-      } finally {
-        this.forceRefreshPromise = null;
-      }
-    }
-
+  private async softRefresh(): Promise<RefreshResult> {
     if (this.forceRefreshPromise) return this.forceRefreshPromise;
     if (this.softRefreshPromise) return this.softRefreshPromise;
 
-    this.softRefreshPromise = this.executeRefresh(options);
+    this.softRefreshPromise = this.executeRefresh();
     try {
       return await this.softRefreshPromise;
     } finally {
@@ -195,109 +176,138 @@ export class TokenManager implements TokenProvider {
     }
   }
 
-  private async executeRefresh(options: {
-    allowFreshExternalToken: boolean;
-  }): Promise<RefreshResult> {
-    return withTelemetrySpan("token-manager.refresh", async () => {
-      const candidate = await this.loadRefreshCandidate();
-      if (!candidate) return refreshResult(undefined, false);
-      if (candidate.externallyUpdated && options.allowFreshExternalToken) {
-        const { shouldRefresh } = shouldRefreshToken(
-          candidate.tokens,
-          PROACTIVE_REFRESH_RATIO,
-          new Date(),
-        );
-        if (!shouldRefresh)
-          return refreshResult(candidate.tokens.accessToken, false);
+  private async refreshAfterAuthFailure(): Promise<string | undefined> {
+    const result = await this.forceEndpointRefresh();
+    return result.accessToken;
+  }
+
+  private async forceEndpointRefresh(): Promise<RefreshResult> {
+    if (this.forceRefreshPromise) return this.forceRefreshPromise;
+
+    this.forceRefreshPromise = (async () => {
+      // A force refresh must not reuse a softer getToken refresh that may
+      // return externally written credentials without hitting the token
+      // endpoint, but later getToken calls should join this stricter work.
+      const softResult = await this.softRefreshPromise?.catch(() => undefined);
+      if (softResult?.accessToken && softResult.refreshedViaEndpoint) {
+        return softResult;
       }
-      const tokens = candidate.tokens;
+      return this.executeRefresh();
+    })();
+    try {
+      return await this.forceRefreshPromise;
+    } finally {
+      this.forceRefreshPromise = null;
+    }
+  }
 
-      const client = await withTelemetrySpan("token-manager.load-client", () =>
-        this.authStorage.loadClient(this.mcpUrl),
-      );
-      if (!client) return refreshResult(undefined, false);
-
-      let response: RefreshTokenResponse;
-      try {
-        const metadata = await withTelemetrySpan(
-          "token-manager.discover-endpoints",
-          () => this.authService.discoverEndpoints(this.mcpUrl),
-        );
-        response = await withTelemetrySpan(
-          "token-manager.refresh-access-token",
-          () =>
-            this.authService.refreshAccessToken({
-              tokenEndpoint: metadata.tokenEndpoint,
-              clientId: client.clientId,
-              clientSecret: client.clientSecret,
-              refreshToken: tokens.refreshToken,
-            }),
-        );
-      } catch {
-        const reloadedToken = await this.loadExternallyUpdatedToken(tokens);
-        if (reloadedToken)
-          return refreshResult(reloadedToken.accessToken, false);
-
-        const isExpired = tokens.expiresAt
-          ? new Date() >= new Date(tokens.expiresAt)
-          : false;
-        if (candidate.externallyUpdated && !isExpired) {
-          return refreshResult(tokens.accessToken, false);
-        }
-
-        // Only clear tokens if they are actually expired and still match the
-        // failed in-memory refresh token. A separate `githits login` may have
-        // already written fresh tokens for long-running MCP servers.
-        if (isExpired) {
-          const currentStoredTokens =
-            await this.loadExternallyUpdatedToken(tokens);
-          if (currentStoredTokens) {
-            return refreshResult(currentStoredTokens.accessToken, false);
-          }
-
-          const cleared = await withTelemetrySpan(
-            "token-manager.clear-tokens-if-unchanged",
-            () => this.authStorage.clearTokensIfUnchanged(this.mcpUrl, tokens),
+  private async executeRefresh(): Promise<RefreshResult> {
+    return withAuthStorageLock(this.authStorage, () =>
+      withTelemetrySpan("token-manager.refresh", async () => {
+        const candidate = await this.loadRefreshCandidate();
+        if (!candidate) return refreshResult(undefined, false);
+        if (candidate.externallyUpdated) {
+          const { shouldRefresh } = shouldRefreshToken(
+            candidate.tokens,
+            PROACTIVE_REFRESH_RATIO,
+            new Date(),
           );
-          if (!cleared) {
-            const currentToken = await this.authStorage.loadTokens(this.mcpUrl);
-            this.cachedToken = currentToken;
-            return refreshResult(currentToken?.accessToken, false);
-          }
-          this.cachedToken = null;
+          if (!shouldRefresh)
+            return refreshResult(candidate.tokens.accessToken, false);
         }
-        return refreshResult(undefined, false);
-      }
+        const tokens = candidate.tokens;
 
-      const newTokenData: TokenData = {
-        accessToken: response.accessToken,
-        refreshToken: response.refreshToken ?? tokens.refreshToken,
-        expiresAt: new Date(
-          Date.now() + response.expiresIn * 1000,
-        ).toISOString(),
-        // Refresh starts a new token lifetime window. Keeping the
-        // original createdAt makes a freshly refreshed token look
-        // permanently near expiry, which triggers immediate re-refresh.
-        createdAt: new Date().toISOString(),
-      };
-
-      const saved = await withTelemetrySpan("token-manager.save-tokens", () =>
-        this.authStorage.saveTokensIfUnchanged(
-          this.mcpUrl,
-          tokens,
-          newTokenData,
-        ),
-      );
-      if (!saved) {
-        return this.resolveSuccessfulRefreshConflict(
-          tokens,
-          response,
-          newTokenData,
+        const client = await withTelemetrySpan(
+          "token-manager.load-client",
+          () => this.authStorage.loadClient(this.mcpUrl),
         );
-      }
-      this.cachedToken = newTokenData;
-      return refreshResult(response.accessToken, true);
-    });
+        if (!client) return refreshResult(undefined, false);
+
+        let response: RefreshTokenResponse;
+        try {
+          const metadata = await withTelemetrySpan(
+            "token-manager.discover-endpoints",
+            () => this.authService.discoverEndpoints(this.mcpUrl),
+          );
+          response = await withTelemetrySpan(
+            "token-manager.refresh-access-token",
+            () =>
+              this.authService.refreshAccessToken({
+                tokenEndpoint: metadata.tokenEndpoint,
+                clientId: client.clientId,
+                clientSecret: client.clientSecret,
+                refreshToken: tokens.refreshToken,
+              }),
+          );
+        } catch {
+          const reloadedToken = await this.loadExternallyUpdatedToken(tokens);
+          if (reloadedToken)
+            return refreshResult(reloadedToken.accessToken, false);
+
+          const isExpired = tokens.expiresAt
+            ? new Date() >= new Date(tokens.expiresAt)
+            : false;
+          if (candidate.externallyUpdated && !isExpired) {
+            return refreshResult(tokens.accessToken, false);
+          }
+
+          // Only clear tokens if they are actually expired and still match the
+          // failed in-memory refresh token. A separate `githits login` may have
+          // already written fresh tokens for long-running MCP servers.
+          if (isExpired) {
+            const currentStoredTokens =
+              await this.loadExternallyUpdatedToken(tokens);
+            if (currentStoredTokens) {
+              return refreshResult(currentStoredTokens.accessToken, false);
+            }
+
+            const cleared = await withTelemetrySpan(
+              "token-manager.clear-tokens-if-unchanged",
+              () =>
+                this.authStorage.clearTokensIfUnchanged(this.mcpUrl, tokens),
+            );
+            if (!cleared) {
+              const currentToken = await this.authStorage.loadTokens(
+                this.mcpUrl,
+              );
+              this.cachedToken = currentToken;
+              return refreshResult(currentToken?.accessToken, false);
+            }
+            this.cachedToken = null;
+          }
+          return refreshResult(undefined, false);
+        }
+
+        const newTokenData: TokenData = {
+          accessToken: response.accessToken,
+          refreshToken: response.refreshToken ?? tokens.refreshToken,
+          expiresAt: new Date(
+            Date.now() + response.expiresIn * 1000,
+          ).toISOString(),
+          // Refresh starts a new token lifetime window. Keeping the
+          // original createdAt makes a freshly refreshed token look
+          // permanently near expiry, which triggers immediate re-refresh.
+          createdAt: new Date().toISOString(),
+        };
+
+        const saved = await withTelemetrySpan("token-manager.save-tokens", () =>
+          this.authStorage.saveTokensIfUnchanged(
+            this.mcpUrl,
+            tokens,
+            newTokenData,
+          ),
+        );
+        if (!saved) {
+          return this.resolveSuccessfulRefreshConflict(
+            tokens,
+            response,
+            newTokenData,
+          );
+        }
+        this.cachedToken = newTokenData;
+        return refreshResult(response.accessToken, true);
+      }),
+    );
   }
 
   private async resolveSuccessfulRefreshConflict(


### PR DESCRIPTION
## Root cause

Supabase refresh tokens are single-use. Once one refresh request spends the stored refresh token, another refresh request using the same token fails. Multiple CLI or MCP agents could observe the same stored token and enter refresh at the same time. The existing compare-and-swap storage writes protected the final write, but they did not prevent simultaneous token endpoint calls.

## Changes

- Run the full refresh transaction under the shared auth storage lock: reload stored token, discover endpoint, call refresh, then save or clear the result.
- Require lock-capable storage for `TokenManager` and `refreshExpiredToken()` so refresh paths cannot silently bypass the lock.
- Keep in-process coalescing for soft and forced refreshes, with waiters re-reading stored credentials instead of rotating again.
- Harden lock ownership and timeout behavior for refresh transactions.
- Add regression and stress coverage for simultaneous agents sharing one stored token.

## Verification

- `bun test src/services/token-manager.test.ts src/services/token-manager.integration.test.ts src/services/locked-auth-storage.test.ts src/services/auth-storage.test.ts src/services/keychain-auth-storage.test.ts src/services/migrating-auth-storage.test.ts src/services/mode-aware-file-auth-storage.test.ts src/services/refreshing-githits-service.test.ts src/commands/auth-status.test.ts`
- `bun run typecheck`
- `git diff --check`