### PR TITLE
refactor: move auth remediation to surfaces

### DIFF
--- a/scripts/cli-smoke.ts
+++ b/scripts/cli-smoke.ts
@@ -409,6 +409,29 @@ async function assertUnauthenticatedBehavior(): Promise<void> {
       },
       "unauthenticated languages JSON envelope",
     );
+
+    const terminalResult = await runCliWithEnv(["languages", "python"], env);
+    assert(
+      terminalResult.exitCode !== 0,
+      "unauthenticated terminal probe should fail",
+    );
+    const authGuidance = `${terminalResult.stderr}\n${terminalResult.stdout}`;
+    assertNotJson(
+      authGuidance.trim(),
+      "unauthenticated terminal auth guidance",
+    );
+    assert(
+      authGuidance.includes("Authentication required"),
+      "unauthenticated terminal probe missing auth guidance",
+    );
+    assert(
+      authGuidance.includes("githits login"),
+      "unauthenticated terminal probe missing login guidance",
+    );
+    assert(
+      !authGuidance.includes("tool call"),
+      "unauthenticated terminal probe used MCP-style auth guidance",
+    );
   } finally {
     if (env.HOME) {
       rmSync(env.HOME, { recursive: true, force: true });
@@ -428,9 +451,19 @@ async function assertLiveOrAuthRequired(): Promise<boolean> {
     result.exitCode !== 0,
     "languages auth probe: expected non-zero auth failure",
   );
-  // Auth guidance currently comes from requireAuth(), which writes friendly
-  // instructions to stdout before throwing. Accept either stream so this smoke
-  // gate validates guidance without forcing a broader CLI stream-policy change.
+  const jsonAuthPayload = assertCleanErrorEnvelope(
+    result.stderr,
+    "languages auth probe",
+  );
+  if (jsonAuthPayload.code === "AUTH_REQUIRED") {
+    console.log("AUTH_REQUIRED: live CLI smoke skipped");
+    return false;
+  }
+
+  // Non-JSON auth guidance currently comes from requireAuth(), which writes
+  // friendly instructions to stdout before throwing. Accept either stream so
+  // this smoke gate validates guidance without forcing a broader CLI
+  // stream-policy change.
   const authGuidance = `${result.stderr}\n${result.stdout}`.trim();
   assert(
     authGuidance.includes("Authentication required"),

--- a/src/commands/code/code-nav-cli-helpers.ts
+++ b/src/commands/code/code-nav-cli-helpers.ts
@@ -13,7 +13,6 @@ import type {
   CodeNavigationTarget,
 } from "../../services/index.js";
 import {
-  formatMappedErrorForTerminal,
   type MappedError,
   mapCodeNavigationError,
 } from "../../shared/code-navigation-error-map.js";
@@ -22,6 +21,10 @@ import {
   parsePackageSpec,
   toPkgseerRegistry,
 } from "../../shared/index.js";
+import {
+  buildCliMappedErrorPayload,
+  formatMappedErrorForTerminal,
+} from "../format-mapped-error.js";
 
 export { parseIntCliOption } from "../../shared/cli-options.js";
 
@@ -95,7 +98,7 @@ export function formatIndexingError(mapped: MappedError): string {
   if (mapped.code === "UPDATE_REQUIRED") {
     return formatMappedErrorForTerminal(mapped);
   }
-  if (mapped.code !== "INDEXING") return mapped.message;
+  if (mapped.code !== "INDEXING") return formatMappedErrorForTerminal(mapped);
   const detail = mapped.details ?? {};
   const lines = [mapped.message];
   if (detail.indexingRef) lines.push(`  indexingRef: ${detail.indexingRef}`);
@@ -201,14 +204,7 @@ export function handleCodeNavCommandError(
   const mapped = mapMappedError(mapCodeNavigationError(error));
   if (json) {
     // eslint-disable-next-line no-console
-    console.error(
-      JSON.stringify({
-        error: mapped.message,
-        code: mapped.code,
-        retryable: mapped.retryable ?? false,
-        ...(mapped.details ? { details: mapped.details } : {}),
-      }),
-    );
+    console.error(JSON.stringify(buildCliMappedErrorPayload(mapped)));
     process.exit(exitCode);
   }
   // eslint-disable-next-line no-console

--- a/src/commands/code/files.test.ts
+++ b/src/commands/code/files.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, mock, spyOn } from "bun:test";
+import { AuthenticationError } from "../../services/githits-service.js";
 import {
   CodeNavigationIndexingError,
   CodeNavigationTargetNotFoundError,
@@ -250,6 +251,62 @@ describe("pkgFilesAction", () => {
     expect(payload.total).toBe(2);
     expect(payload.files[0].path).toBe("src/index.js");
     logSpy.mockRestore();
+  });
+
+  it("preserves CLI auth remediation for service auth failures", async () => {
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+    const service = createMockCodeNavigationService({
+      listFiles: mock(() => Promise.reject(new AuthenticationError())),
+    });
+
+    try {
+      await pkgFilesAction(
+        "npm:express",
+        undefined,
+        {},
+        createDeps({ codeNavigationService: service }),
+      );
+    } catch {
+      // expected
+    }
+
+    expect(errorSpy.mock.calls[0]?.[0]).toBe(
+      "Authentication required. Run `githits login` to authenticate.",
+    );
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it("preserves CLI auth remediation in JSON service auth failures", async () => {
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+    const service = createMockCodeNavigationService({
+      listFiles: mock(() => Promise.reject(new AuthenticationError())),
+    });
+
+    try {
+      await pkgFilesAction(
+        "npm:express",
+        undefined,
+        { json: true },
+        createDeps({ codeNavigationService: service }),
+      );
+    } catch {
+      // expected
+    }
+
+    expect(JSON.parse(errorSpy.mock.calls[0]?.[0] as string)).toEqual({
+      error: "Authentication required.",
+      code: "AUTH_REQUIRED",
+      retryable: false,
+    });
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
   });
 
   it("echoes advanced filters in the JSON envelope", async () => {

--- a/src/commands/docs/list.ts
+++ b/src/commands/docs/list.ts
@@ -6,7 +6,6 @@ import {
   buildListPackageDocsParams,
   buildListPackageDocsSuccessPayload,
   formatListPackageDocsTerminal,
-  formatMappedErrorForTerminal,
   InvalidPackageSpecError,
   mapPackageIntelligenceError,
   parsePackageSpec,
@@ -14,6 +13,10 @@ import {
   SPINNER_MESSAGES,
   startSpinner,
 } from "../../shared/index.js";
+import {
+  buildCliMappedErrorPayload,
+  formatMappedErrorForTerminal,
+} from "../format-mapped-error.js";
 
 export interface DocsListCommandOptions {
   limit?: string;
@@ -99,14 +102,7 @@ function handleDocsListError(error: unknown, json: boolean): never {
   const mapped = mapPackageIntelligenceError(error);
 
   if (json) {
-    console.error(
-      JSON.stringify({
-        error: mapped.message,
-        code: mapped.code,
-        retryable: mapped.retryable ?? false,
-        ...(mapped.details ? { details: mapped.details } : {}),
-      }),
-    );
+    console.error(JSON.stringify(buildCliMappedErrorPayload(mapped)));
   } else {
     console.error(formatMappedErrorForTerminal(mapped));
   }

--- a/src/commands/docs/read.ts
+++ b/src/commands/docs/read.ts
@@ -4,7 +4,6 @@ import type { PackageIntelligenceService } from "../../services/index.js";
 import {
   buildReadPackageDocParams,
   buildReadPackageDocSuccessPayload,
-  formatMappedErrorForTerminal,
   formatReadPackageDocTerminal,
   InvalidPackageSpecError,
   mapPackageIntelligenceError,
@@ -14,6 +13,10 @@ import {
   shouldUseColors,
   startSpinner,
 } from "../../shared/index.js";
+import {
+  buildCliMappedErrorPayload,
+  formatMappedErrorForTerminal,
+} from "../format-mapped-error.js";
 
 export interface DocsReadCommandOptions {
   verbose?: boolean;
@@ -80,14 +83,7 @@ function handleDocsReadError(error: unknown, json: boolean): never {
   const mapped = mapPackageIntelligenceError(error);
 
   if (json) {
-    console.error(
-      JSON.stringify({
-        error: mapped.message,
-        code: mapped.code,
-        retryable: mapped.retryable ?? false,
-        ...(mapped.details ? { details: mapped.details } : {}),
-      }),
-    );
+    console.error(JSON.stringify(buildCliMappedErrorPayload(mapped)));
   } else {
     console.error(formatMappedErrorForTerminal(mapped));
   }

--- a/src/commands/example.test.ts
+++ b/src/commands/example.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, mock, spyOn } from "bun:test";
+import { AuthenticationError } from "../services/githits-service.js";
 import { createMockGitHitsService } from "../services/test-helpers.js";
 import { AuthRequiredError } from "../shared/require-auth.js";
 import { type ExampleDependencies, exampleAction } from "./example.js";
@@ -104,6 +105,54 @@ describe("exampleAction", () => {
     });
     expect(exitSpy).toHaveBeenCalledWith(1);
 
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it("preserves CLI auth remediation when service auth fails", async () => {
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+    const deps = createDeps({
+      githitsService: createMockGitHitsService({
+        search: mock(() => Promise.reject(new AuthenticationError())),
+      }),
+    });
+
+    await expect(exampleAction("test", {}, deps)).rejects.toThrow(
+      "process.exit",
+    );
+
+    expect(errorSpy.mock.calls[0]?.[0]).toBe(
+      "Authentication required. Run `githits login` to authenticate.",
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it("preserves CLI auth remediation in JSON when service auth fails", async () => {
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+    const deps = createDeps({
+      githitsService: createMockGitHitsService({
+        search: mock(() => Promise.reject(new AuthenticationError())),
+      }),
+    });
+
+    await expect(exampleAction("test", { json: true }, deps)).rejects.toThrow(
+      "process.exit",
+    );
+
+    expect(JSON.parse(errorSpy.mock.calls[0]?.[0] as string)).toEqual({
+      error: "Authentication required.",
+      code: "AUTH_REQUIRED",
+      retryable: false,
+    });
+    expect(exitSpy).toHaveBeenCalledWith(1);
     errorSpy.mockRestore();
     exitSpy.mockRestore();
   });

--- a/src/commands/example.ts
+++ b/src/commands/example.ts
@@ -9,6 +9,10 @@ import {
 } from "../shared/require-auth.js";
 import { startSpinner } from "../shared/spinner.js";
 import { SPINNER_MESSAGES } from "../shared/spinner-messages.js";
+import {
+  buildCliMappedErrorPayload,
+  formatMappedErrorForTerminal,
+} from "./format-mapped-error.js";
 
 export interface ExampleOptions {
   lang?: string;
@@ -59,11 +63,16 @@ export async function exampleAction(
       throw error;
     }
     if (error instanceof AuthenticationError) {
-      printExampleError(
-        "Authentication required. Run `githits login`, then retry this command.",
-        "AUTH_REQUIRED",
-        options.json ?? false,
-      );
+      const mapped = {
+        code: "AUTH_REQUIRED" as const,
+        message: error.message,
+        retryable: false,
+      };
+      if (options.json) {
+        console.error(JSON.stringify(buildCliMappedErrorPayload(mapped)));
+      } else {
+        console.error(formatMappedErrorForTerminal(mapped));
+      }
       process.exit(1);
     }
     printExampleError(

--- a/src/commands/feedback.test.ts
+++ b/src/commands/feedback.test.ts
@@ -256,4 +256,27 @@ describe("feedbackAction", () => {
     errorSpy.mockRestore();
     exitSpy.mockRestore();
   });
+
+  it("prints CLI auth remediation when service returns 401 in text mode", async () => {
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+    const deps = createDeps({
+      githitsService: createMockGitHitsService({
+        submitFeedback: mock(() => Promise.reject(new AuthenticationError())),
+      }),
+    });
+
+    await expect(
+      feedbackAction("abc-123", { accept: true }, deps),
+    ).rejects.toThrow("process.exit");
+
+    expect(errorSpy.mock.calls[0]?.[0]).toBe(
+      "Authentication required. Run `githits login` to authenticate.",
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
 });

--- a/src/commands/feedback.ts
+++ b/src/commands/feedback.ts
@@ -7,6 +7,10 @@ import {
   buildAuthRequiredErrorPayload,
   requireAuth,
 } from "../shared/require-auth.js";
+import {
+  buildCliMappedErrorPayload,
+  formatMappedErrorForTerminal,
+} from "./format-mapped-error.js";
 
 export interface FeedbackOptions {
   accept?: boolean;
@@ -68,8 +72,17 @@ export async function feedbackAction(
       console.log(result.message);
     }
   } catch (error) {
-    if (options.json && error instanceof AuthenticationError) {
-      console.error(JSON.stringify(toAuthRequiredPayload(error.message)));
+    if (error instanceof AuthenticationError) {
+      const mapped = {
+        code: "AUTH_REQUIRED" as const,
+        message: error.message,
+        retryable: false,
+      };
+      if (options.json) {
+        console.error(JSON.stringify(buildCliMappedErrorPayload(mapped)));
+      } else {
+        console.error(formatMappedErrorForTerminal(mapped));
+      }
       process.exit(1);
     }
     console.error(
@@ -77,14 +90,6 @@ export async function feedbackAction(
     );
     process.exit(1);
   }
-}
-
-function toAuthRequiredPayload(message: string): {
-  error: string;
-  code: "AUTH_REQUIRED";
-  retryable: false;
-} {
-  return { error: message, code: "AUTH_REQUIRED", retryable: false };
 }
 
 const FEEDBACK_DESCRIPTION = `Submit feedback on a tool result or the GitHits experience.

--- a/src/commands/format-mapped-error.test.ts
+++ b/src/commands/format-mapped-error.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "bun:test";
+import {
+  buildCliMappedErrorPayload,
+  formatMappedErrorForTerminal,
+} from "./format-mapped-error.js";
+
+describe("formatMappedErrorForTerminal", () => {
+  it("formats AUTH_REQUIRED with CLI terminal remediation", () => {
+    expect(
+      formatMappedErrorForTerminal({
+        code: "AUTH_REQUIRED",
+        message: "Authentication required.",
+        retryable: false,
+      }),
+    ).toBe("Authentication required. Run `githits login` to authenticate.");
+  });
+
+  it("leaves CLI JSON auth envelopes neutral", () => {
+    expect(
+      buildCliMappedErrorPayload({
+        code: "AUTH_REQUIRED",
+        message: "Authentication required.",
+        retryable: false,
+      }),
+    ).toEqual({
+      error: "Authentication required.",
+      code: "AUTH_REQUIRED",
+      retryable: false,
+    });
+  });
+
+  it("leaves non-auth non-update terminal errors unchanged", () => {
+    expect(
+      formatMappedErrorForTerminal({
+        code: "BACKEND_ERROR",
+        message: "No matching version found",
+        retryable: false,
+        details: { graphqlCode: "UNKNOWN_ERROR" },
+      }),
+    ).toBe("No matching version found");
+  });
+
+  it("formats UPDATE_REQUIRED with update command", () => {
+    expect(
+      formatMappedErrorForTerminal({
+        code: "UPDATE_REQUIRED",
+        message: "Update required: Backend protocol changed",
+        retryable: false,
+        details: { updateCommand: "npm i -g githits@latest" },
+      }),
+    ).toBe(
+      "Update required: Backend protocol changed\n\nUpdate with:\n  npm i -g githits@latest",
+    );
+  });
+});

--- a/src/commands/format-mapped-error.ts
+++ b/src/commands/format-mapped-error.ts
@@ -1,0 +1,37 @@
+import type { MappedError } from "../shared/code-navigation-error-map.js";
+
+const CLI_AUTH_ERROR_MESSAGE =
+  "Authentication required. Run `githits login` to authenticate.";
+
+interface CliErrorPayload {
+  error: string;
+  code: string;
+  retryable?: boolean;
+  details?: MappedError["details"] | Record<string, unknown>;
+}
+
+export function formatMappedErrorForTerminal(mapped: MappedError): string {
+  if (mapped.code === "AUTH_REQUIRED") {
+    return CLI_AUTH_ERROR_MESSAGE;
+  }
+  if (mapped.code !== "UPDATE_REQUIRED") {
+    return mapped.message;
+  }
+  const detail = mapped.details ?? {};
+  const updateCommand =
+    typeof detail.updateCommand === "string"
+      ? detail.updateCommand
+      : "npm i -g githits@latest";
+  return [mapped.message, "", "Update with:", `  ${updateCommand}`].join("\n");
+}
+
+export function buildCliMappedErrorPayload(
+  mapped: MappedError,
+): CliErrorPayload {
+  return {
+    error: mapped.message,
+    code: mapped.code,
+    retryable: mapped.retryable ?? false,
+    ...(mapped.details ? { details: mapped.details } : {}),
+  };
+}

--- a/src/commands/languages.test.ts
+++ b/src/commands/languages.test.ts
@@ -155,6 +155,29 @@ describe("languagesAction", () => {
     exitSpy.mockRestore();
   });
 
+  it("prints CLI auth remediation when service returns 401 in text mode", async () => {
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+    const deps = createDeps({
+      githitsService: createMockGitHitsService({
+        getLanguages: mock(() => Promise.reject(new AuthenticationError())),
+      }),
+    });
+
+    await expect(languagesAction(undefined, {}, deps)).rejects.toThrow(
+      "process.exit",
+    );
+
+    expect(errorSpy.mock.calls[0]?.[0]).toBe(
+      "Authentication required. Run `githits login` to authenticate.",
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
   it("calls getLanguages exactly once", async () => {
     const consoleSpy = spyOn(console, "log").mockImplementation(() => {});
     const deps = createDeps();

--- a/src/commands/languages.ts
+++ b/src/commands/languages.ts
@@ -12,6 +12,10 @@ import {
   buildAuthRequiredErrorPayload,
   requireAuth,
 } from "../shared/require-auth.js";
+import {
+  buildCliMappedErrorPayload,
+  formatMappedErrorForTerminal,
+} from "./format-mapped-error.js";
 
 export interface LanguagesOptions {
   json?: boolean;
@@ -65,8 +69,17 @@ export async function languagesAction(
       }
     }
   } catch (error) {
-    if (options.json && error instanceof AuthenticationError) {
-      console.error(JSON.stringify(toAuthRequiredPayload(error.message)));
+    if (error instanceof AuthenticationError) {
+      const mapped = {
+        code: "AUTH_REQUIRED" as const,
+        message: error.message,
+        retryable: false,
+      };
+      if (options.json) {
+        console.error(JSON.stringify(buildCliMappedErrorPayload(mapped)));
+      } else {
+        console.error(formatMappedErrorForTerminal(mapped));
+      }
       process.exit(1);
     }
     console.error(
@@ -74,14 +87,6 @@ export async function languagesAction(
     );
     process.exit(1);
   }
-}
-
-function toAuthRequiredPayload(message: string): {
-  error: string;
-  code: "AUTH_REQUIRED";
-  retryable: false;
-} {
-  return { error: message, code: "AUTH_REQUIRED", retryable: false };
 }
 
 const LANGUAGES_DESCRIPTION = `List supported programming languages.

--- a/src/commands/pkg/changelog.ts
+++ b/src/commands/pkg/changelog.ts
@@ -3,7 +3,6 @@ import { createContainer } from "../../container.js";
 import type { PackageIntelligenceService } from "../../services/index.js";
 import { shouldUseColors } from "../../shared/colors.js";
 import {
-  formatMappedErrorForTerminal,
   InvalidPackageSpecError,
   type MappedError,
   mapPackageIntelligenceError,
@@ -19,6 +18,10 @@ import {
   PKGSEER_REGISTRY_LIST,
   toPkgseerRegistryLowercase,
 } from "../../shared/pkgseer-registry.js";
+import {
+  buildCliMappedErrorPayload,
+  formatMappedErrorForTerminal,
+} from "../format-mapped-error.js";
 
 export interface PkgChangelogCommandOptions {
   repoUrl?: string;
@@ -134,14 +137,7 @@ function handlePkgChangelogCommandError(error: unknown, json: boolean): never {
   const mapped = mapPackageIntelligenceError(error);
 
   if (json) {
-    console.error(
-      JSON.stringify({
-        error: mapped.message,
-        code: mapped.code,
-        retryable: mapped.retryable ?? false,
-        ...(mapped.details ? { details: mapped.details } : {}),
-      }),
-    );
+    console.error(JSON.stringify(buildCliMappedErrorPayload(mapped)));
     process.exit(1);
   }
 
@@ -158,7 +154,9 @@ function formatChangelogTerminalError(mapped: MappedError): string {
   if (mapped.code === "UPDATE_REQUIRED") {
     return formatMappedErrorForTerminal(mapped);
   }
-  if (mapped.code !== "VERSION_NOT_FOUND") return mapped.message;
+  if (mapped.code !== "VERSION_NOT_FOUND") {
+    return formatMappedErrorForTerminal(mapped);
+  }
   const detail = mapped.details ?? {};
   const pkg = typeof detail.package === "string" ? detail.package : undefined;
   const requested =

--- a/src/commands/pkg/deps.ts
+++ b/src/commands/pkg/deps.ts
@@ -3,7 +3,6 @@ import { createContainer } from "../../container.js";
 import type { PackageIntelligenceService } from "../../services/index.js";
 import { shouldUseColors } from "../../shared/colors.js";
 import {
-  formatMappedErrorForTerminal,
   InvalidPackageSpecError,
   type MappedError,
   mapPackageIntelligenceError,
@@ -18,6 +17,10 @@ import {
   buildPackageDependenciesSuccessPayload,
   formatPackageDependenciesTerminal,
 } from "../../shared/package-dependencies-response.js";
+import {
+  buildCliMappedErrorPayload,
+  formatMappedErrorForTerminal,
+} from "../format-mapped-error.js";
 
 export interface PkgDepsCommandOptions {
   lifecycle?: string;
@@ -137,14 +140,7 @@ function handlePkgDepsCommandError(error: unknown, json: boolean): never {
   const mapped = mapPackageIntelligenceError(error);
 
   if (json) {
-    console.error(
-      JSON.stringify({
-        error: mapped.message,
-        code: mapped.code,
-        retryable: mapped.retryable ?? false,
-        ...(mapped.details ? { details: mapped.details } : {}),
-      }),
-    );
+    console.error(JSON.stringify(buildCliMappedErrorPayload(mapped)));
     process.exit(1);
   }
 
@@ -161,7 +157,9 @@ function formatDepsTerminalError(mapped: MappedError): string {
   if (mapped.code === "UPDATE_REQUIRED") {
     return formatMappedErrorForTerminal(mapped);
   }
-  if (mapped.code !== "VERSION_NOT_FOUND") return mapped.message;
+  if (mapped.code !== "VERSION_NOT_FOUND") {
+    return formatMappedErrorForTerminal(mapped);
+  }
   const detail = mapped.details ?? {};
   const pkg = typeof detail.package === "string" ? detail.package : undefined;
   const requested =

--- a/src/commands/pkg/info.test.ts
+++ b/src/commands/pkg/info.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, mock, spyOn } from "bun:test";
+import { AuthenticationError } from "../../services/githits-service.js";
 import { PackageIntelligenceTargetNotFoundError } from "../../services/index.js";
 import {
   createMockPackageIntelligenceService,
@@ -162,6 +163,60 @@ describe("pkgInfoAction", () => {
     const payload = JSON.parse(output);
     expect(payload.code).toBe("NOT_FOUND");
     expect(payload.error).toBe("Package not found");
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it("preserves CLI auth remediation for service auth failures", async () => {
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+    const service = createMockPackageIntelligenceService({
+      packageSummary: mock(() => Promise.reject(new AuthenticationError())),
+    });
+
+    try {
+      await pkgInfoAction(
+        "npm:express",
+        {},
+        createDeps({ packageIntelligenceService: service }),
+      );
+    } catch {
+      // expected
+    }
+
+    expect(errorSpy.mock.calls[0]?.[0]).toBe(
+      "Authentication required. Run `githits login` to authenticate.",
+    );
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it("preserves CLI auth remediation in JSON service auth failures", async () => {
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+    const service = createMockPackageIntelligenceService({
+      packageSummary: mock(() => Promise.reject(new AuthenticationError())),
+    });
+
+    try {
+      await pkgInfoAction(
+        "npm:express",
+        { json: true },
+        createDeps({ packageIntelligenceService: service }),
+      );
+    } catch {
+      // expected
+    }
+
+    expect(JSON.parse(errorSpy.mock.calls[0]?.[0] as string)).toEqual({
+      error: "Authentication required.",
+      code: "AUTH_REQUIRED",
+      retryable: false,
+    });
     errorSpy.mockRestore();
     exitSpy.mockRestore();
   });

--- a/src/commands/pkg/info.ts
+++ b/src/commands/pkg/info.ts
@@ -3,7 +3,6 @@ import { createContainer } from "../../container.js";
 import type { PackageIntelligenceService } from "../../services/index.js";
 import { shouldUseColors } from "../../shared/colors.js";
 import {
-  formatMappedErrorForTerminal,
   InvalidPackageSpecError,
   mapPackageIntelligenceError,
   parsePackageSpec,
@@ -15,6 +14,10 @@ import {
   formatPackageSummaryTerminal,
 } from "../../shared/package-summary-response.js";
 import { PKGSEER_REGISTRY_LIST } from "../../shared/pkgseer-registry.js";
+import {
+  buildCliMappedErrorPayload,
+  formatMappedErrorForTerminal,
+} from "../format-mapped-error.js";
 
 export interface PkgInfoCommandOptions {
   verbose?: boolean;
@@ -86,14 +89,7 @@ function handlePkgInfoCommandError(error: unknown, json: boolean): never {
   const mapped = mapPackageIntelligenceError(error);
 
   if (json) {
-    console.error(
-      JSON.stringify({
-        error: mapped.message,
-        code: mapped.code,
-        retryable: mapped.retryable ?? false,
-        ...(mapped.details ? { details: mapped.details } : {}),
-      }),
-    );
+    console.error(JSON.stringify(buildCliMappedErrorPayload(mapped)));
     process.exit(1);
   }
 

--- a/src/commands/pkg/upgrade-review.ts
+++ b/src/commands/pkg/upgrade-review.ts
@@ -5,13 +5,16 @@ import { shouldUseColors } from "../../shared/colors.js";
 import {
   buildPackageUpgradeReview,
   buildPackageUpgradeReviewRequest,
-  formatMappedErrorForTerminal,
   formatPackageUpgradeReviewTerminal,
   InvalidPackageSpecError,
   mapPackageIntelligenceError,
   parsePackageSpec,
   requireAuth,
 } from "../../shared/index.js";
+import {
+  buildCliMappedErrorPayload,
+  formatMappedErrorForTerminal,
+} from "../format-mapped-error.js";
 
 export interface PkgUpgradeReviewCommandOptions {
   to?: string;
@@ -83,14 +86,7 @@ function handlePkgUpgradeReviewCommandError(
 ): never {
   const mapped = mapPackageIntelligenceError(error);
   if (json) {
-    console.error(
-      JSON.stringify({
-        error: mapped.message,
-        code: mapped.code,
-        retryable: mapped.retryable ?? false,
-        ...(mapped.details ? { details: mapped.details } : {}),
-      }),
-    );
+    console.error(JSON.stringify(buildCliMappedErrorPayload(mapped)));
   } else {
     console.error(formatMappedErrorForTerminal(mapped));
   }

--- a/src/commands/pkg/vulns.ts
+++ b/src/commands/pkg/vulns.ts
@@ -3,7 +3,6 @@ import { createContainer } from "../../container.js";
 import type { PackageIntelligenceService } from "../../services/index.js";
 import { shouldUseColors } from "../../shared/colors.js";
 import {
-  formatMappedErrorForTerminal,
   InvalidPackageSpecError,
   type MappedError,
   mapPackageIntelligenceError,
@@ -15,6 +14,10 @@ import {
   buildPackageVulnerabilitiesSuccessPayload,
   formatPackageVulnerabilitiesTerminal,
 } from "../../shared/package-vulnerabilities-response.js";
+import {
+  buildCliMappedErrorPayload,
+  formatMappedErrorForTerminal,
+} from "../format-mapped-error.js";
 
 export interface PkgVulnsCommandOptions {
   severity?: string;
@@ -95,14 +98,7 @@ function handlePkgVulnsCommandError(error: unknown, json: boolean): never {
   const mapped = mapPackageIntelligenceError(error);
 
   if (json) {
-    console.error(
-      JSON.stringify({
-        error: mapped.message,
-        code: mapped.code,
-        retryable: mapped.retryable ?? false,
-        ...(mapped.details ? { details: mapped.details } : {}),
-      }),
-    );
+    console.error(JSON.stringify(buildCliMappedErrorPayload(mapped)));
     process.exit(1);
   }
 
@@ -122,7 +118,9 @@ function formatVulnsTerminalError(mapped: MappedError): string {
   if (mapped.code === "UPDATE_REQUIRED") {
     return formatMappedErrorForTerminal(mapped);
   }
-  if (mapped.code !== "VERSION_NOT_FOUND") return mapped.message;
+  if (mapped.code !== "VERSION_NOT_FOUND") {
+    return formatMappedErrorForTerminal(mapped);
+  }
   const detail = mapped.details ?? {};
   const pkg = typeof detail.package === "string" ? detail.package : undefined;
   const requested =

--- a/src/commands/search.test.ts
+++ b/src/commands/search.test.ts
@@ -6,6 +6,7 @@ import type {
   UnifiedSearchProgress,
   UnifiedSearchSessionStatus,
 } from "../services/code-navigation-service.js";
+import { AuthenticationError } from "../services/githits-service.js";
 import {
   createMockCodeNavigationService,
   defaultUnifiedSearchOutcome,
@@ -52,6 +53,31 @@ describe("searchAction", () => {
       ...overrides,
     };
   }
+
+  it("preserves CLI auth remediation when search service auth fails", async () => {
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+
+    await expect(
+      searchAction(
+        "router middleware",
+        { in: ["npm:express"] },
+        createDeps({
+          codeNavigationService: createMockCodeNavigationService({
+            search: mock(() => Promise.reject(new AuthenticationError())),
+          }),
+        }),
+      ),
+    ).rejects.toThrow("process.exit");
+
+    expect(errorSpy.mock.calls[0]?.[0]).toBe(
+      "Authentication required. Run `githits login` to authenticate.",
+    );
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
 
   it("calls unified search service with parsed targets and filters", async () => {
     const search = mock((_: UnifiedSearchParams) =>
@@ -741,6 +767,31 @@ describe("searchStatusAction", () => {
       ...overrides,
     };
   }
+
+  it("preserves CLI auth remediation when search-status service auth fails", async () => {
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+
+    await expect(
+      searchStatusAction(
+        "search-ref-123",
+        {},
+        createDeps({
+          codeNavigationService: createMockCodeNavigationService({
+            searchStatus: mock(() => Promise.reject(new AuthenticationError())),
+          }),
+        }),
+      ),
+    ).rejects.toThrow("process.exit");
+
+    expect(errorSpy.mock.calls[0]?.[0]).toBe(
+      "Authentication required. Run `githits login` to authenticate.",
+    );
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
 
   it("outputs progress for incomplete search refs", async () => {
     const consoleSpy = spyOn(console, "log").mockImplementation(() => {});

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -28,6 +28,7 @@ import {
   type UnifiedSearchStatusIncompletePayload,
   type UnifiedSearchStatusResultPayload,
 } from "../shared/index.js";
+import { formatMappedErrorForTerminal } from "./format-mapped-error.js";
 
 export interface SearchCommandOptions {
   in?: string[];
@@ -381,6 +382,13 @@ function formatSearchErrorTerminal(
   payload: { error: string; code: string },
   context: "search" | "status",
 ): string {
+  if (payload.code === "AUTH_REQUIRED") {
+    return formatMappedErrorForTerminal({
+      code: "AUTH_REQUIRED",
+      message: payload.error,
+      retryable: false,
+    });
+  }
   if (context === "status" && payload.code === "NOT_FOUND") {
     return `${payload.error}\n  Search sessions expire; run \`githits search ...\` to start a new one.`;
   }

--- a/src/services/code-navigation-service.ts
+++ b/src/services/code-navigation-service.ts
@@ -1806,9 +1806,7 @@ export class CodeNavigationServiceImpl implements CodeNavigationService {
     const detail = parseDetail(response.responseBody);
 
     if (status === 401) {
-      return new AuthenticationError(
-        "Authentication required. Run `githits login` to authenticate.",
-      );
+      return new AuthenticationError();
     }
 
     if (status === 403) {
@@ -1951,9 +1949,7 @@ export class CodeNavigationServiceImpl implements CodeNavigationService {
         return new CodeNavigationFeatureFlagRequiredError(message);
 
       case "UNAUTHORIZED":
-        return new AuthenticationError(
-          "Authentication required. Run `githits login` to authenticate.",
-        );
+        return new AuthenticationError();
 
       case "FORBIDDEN":
         return new CodeNavigationAccessError(

--- a/src/services/execute-with-token-refresh.ts
+++ b/src/services/execute-with-token-refresh.ts
@@ -16,9 +16,7 @@ export async function executeWithTokenRefresh<T>(
 ): Promise<T> {
   const token = await options.getToken();
   if (!token) {
-    throw new AuthenticationError(
-      "Authentication required. Run `githits login` to authenticate.",
-    );
+    throw new AuthenticationError();
   }
 
   try {

--- a/src/services/githits-service.ts
+++ b/src/services/githits-service.ts
@@ -6,11 +6,17 @@ import type { ClientHeaderBuilder } from "../shared/request-headers.js";
 import { withTelemetrySpan } from "../shared/telemetry.js";
 
 /**
+ * Neutral auth-required message for service/core errors. Surface layers append
+ * CLI- or MCP-specific recovery guidance when presenting the error.
+ */
+export const AUTHENTICATION_REQUIRED_MESSAGE = "Authentication required.";
+
+/**
  * Error thrown when the API returns 401 Unauthorized.
  * Used by RefreshingGitHitsService to detect auth failures and trigger token refresh.
  */
 export class AuthenticationError extends Error {
-  constructor(message: string) {
+  constructor(message: string = AUTHENTICATION_REQUIRED_MESSAGE) {
     super(message);
     this.name = "AuthenticationError";
   }
@@ -210,9 +216,7 @@ export class GitHitsServiceImpl implements GitHitsService {
 
     switch (status) {
       case 401:
-        return new AuthenticationError(
-          "Authentication required. Run `githits login` to authenticate.",
-        );
+        return new AuthenticationError();
       case 403:
         return new Error("Access denied.");
       case 404:

--- a/src/services/package-intelligence-service.ts
+++ b/src/services/package-intelligence-service.ts
@@ -1810,9 +1810,7 @@ export class PackageIntelligenceServiceImpl
     const detail = parseDetail(response.responseBody);
 
     if (status === 401) {
-      return new AuthenticationError(
-        "Authentication required. Run `githits login` to authenticate.",
-      );
+      return new AuthenticationError();
     }
 
     if (status === 403) {
@@ -1912,9 +1910,7 @@ export class PackageIntelligenceServiceImpl
         return new PackageIntelligenceFeatureFlagRequiredError(message);
 
       case "UNAUTHORIZED":
-        return new AuthenticationError(
-          "Authentication required. Run `githits login` to authenticate.",
-        );
+        return new AuthenticationError();
 
       case "FORBIDDEN":
         return new PackageIntelligenceAccessError(

--- a/src/shared/code-navigation-error-map.test.ts
+++ b/src/shared/code-navigation-error-map.test.ts
@@ -150,7 +150,6 @@ describe("mapCodeNavigationError", () => {
       code: "AUTH_REQUIRED",
       message: "Login required",
       retryable: false,
-      details: { action: "Run `githits login`, then retry this tool call." },
     });
   });
 

--- a/src/shared/code-navigation-error-map.ts
+++ b/src/shared/code-navigation-error-map.ts
@@ -191,10 +191,6 @@ function classify(error: unknown): MappedError {
       code: "AUTH_REQUIRED",
       message: error.message,
       retryable: false,
-      details:
-        error instanceof AuthenticationError
-          ? { action: "Run `githits login`, then retry this tool call." }
-          : undefined,
     };
   }
   if (error instanceof CodeNavigationNetworkError) {
@@ -254,18 +250,6 @@ export function buildUpdateRequiredError(
       ...(currentVersion ? { currentVersion } : {}),
     },
   };
-}
-
-export function formatMappedErrorForTerminal(mapped: MappedError): string {
-  if (mapped.code !== "UPDATE_REQUIRED") {
-    return mapped.message;
-  }
-  const detail = mapped.details ?? {};
-  const updateCommand =
-    typeof detail.updateCommand === "string"
-      ? detail.updateCommand
-      : "npm i -g githits@latest";
-  return [mapped.message, "", "Update with:", `  ${updateCommand}`].join("\n");
 }
 
 /**

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -20,7 +20,6 @@ export {
   MAX_WAIT_TIMEOUT_MS,
 } from "./code-navigation-defaults.js";
 export {
-  formatMappedErrorForTerminal,
   type MappedError,
   type MappedErrorCode,
   mapCodeNavigationError,

--- a/src/shared/package-intelligence-error-map.test.ts
+++ b/src/shared/package-intelligence-error-map.test.ts
@@ -102,7 +102,6 @@ describe("mapPackageIntelligenceError", () => {
       code: "AUTH_REQUIRED",
       message: "login required",
       retryable: false,
-      details: { action: "Run `githits login`, then retry this tool call." },
     });
   });
 

--- a/src/shared/package-intelligence-error-map.ts
+++ b/src/shared/package-intelligence-error-map.ts
@@ -115,10 +115,6 @@ function classify(error: unknown): MappedError {
       code: "AUTH_REQUIRED",
       message: error.message,
       retryable: false,
-      details:
-        error instanceof AuthenticationError
-          ? { action: "Run `githits login`, then retry this tool call." }
-          : undefined,
     };
   }
   if (error instanceof PackageIntelligenceNetworkError) {

--- a/src/tools/code-navigation-shared.ts
+++ b/src/tools/code-navigation-shared.ts
@@ -10,6 +10,7 @@ import {
   PKGSEER_REGISTRY_ARGS,
   PKGSEER_REGISTRY_LIST,
 } from "../shared/pkgseer-registry.js";
+import { mcpMappedErrorResult } from "./shared.js";
 import { errorResult, type ToolResult } from "./types.js";
 
 // Re-export the wait-timeout default so callers already importing this
@@ -146,14 +147,7 @@ function normaliseOptionalValue(value: string | undefined): string | undefined {
 
 function mappedInvalidTargetResult(error: unknown): ToolResult {
   const mapped = mapCodeNavigationError(error);
-  return errorResult(
-    JSON.stringify({
-      error: mapped.message,
-      code: mapped.code,
-      retryable: mapped.retryable ?? false,
-      ...(mapped.details ? { details: mapped.details } : {}),
-    }),
-  );
+  return mcpMappedErrorResult(mapped);
 }
 
 function invalidTargetResult(message: string): ToolResult {

--- a/src/tools/grep-repo.ts
+++ b/src/tools/grep-repo.ts
@@ -17,6 +17,7 @@ import {
   resolveCodeTarget,
 } from "./code-navigation-shared.js";
 import { CODE_GREP_GUARDRAIL } from "./guardrails.js";
+import { mcpMappedErrorResult } from "./shared.js";
 import { errorResult, type ToolDefinition, textResult } from "./types.js";
 
 export interface GrepRepoArgs {
@@ -164,14 +165,7 @@ export function createGrepRepoTool(
         return textResult(JSON.stringify(payload));
       } catch (error) {
         const mapped = mapCodeNavigationError(error);
-        return errorResult(
-          JSON.stringify({
-            error: mapped.message,
-            code: mapped.code,
-            retryable: mapped.retryable ?? false,
-            ...(mapped.details ? { details: mapped.details } : {}),
-          }),
-        );
+        return mcpMappedErrorResult(mapped);
       }
     },
   };

--- a/src/tools/list-files.ts
+++ b/src/tools/list-files.ts
@@ -11,6 +11,7 @@ import {
   codeTargetSchema,
   resolveCodeTarget,
 } from "./code-navigation-shared.js";
+import { mcpMappedErrorResult } from "./shared.js";
 import { errorResult, type ToolDefinition, textResult } from "./types.js";
 
 export interface ListFilesArgs {
@@ -185,14 +186,7 @@ export function createListFilesTool(
         return textResult(JSON.stringify(payload));
       } catch (error) {
         const mapped = mapCodeNavigationError(error);
-        return errorResult(
-          JSON.stringify({
-            error: mapped.message,
-            code: mapped.code,
-            retryable: mapped.retryable ?? false,
-            ...(mapped.details ? { details: mapped.details } : {}),
-          }),
-        );
+        return mcpMappedErrorResult(mapped);
       }
     },
   };

--- a/src/tools/list-package-docs.ts
+++ b/src/tools/list-package-docs.ts
@@ -6,6 +6,7 @@ import { renderListPackageDocsText } from "../shared/list-package-docs-text.js";
 import { mapPackageIntelligenceError } from "../shared/package-intelligence-error-map.js";
 import { PKGSEER_REGISTRY_LIST } from "../shared/pkgseer-registry.js";
 import { DOCS_GUARDRAIL } from "./guardrails.js";
+import { mcpMappedErrorResult } from "./shared.js";
 import { errorResult, type ToolDefinition, textResult } from "./types.js";
 
 export interface ListPackageDocsArgs {
@@ -78,14 +79,7 @@ export function createListPackageDocsTool(
         return textResult(JSON.stringify(payload));
       } catch (error) {
         const mapped = mapPackageIntelligenceError(error);
-        return errorResult(
-          JSON.stringify({
-            error: mapped.message,
-            code: mapped.code,
-            retryable: mapped.retryable ?? false,
-            ...(mapped.details ? { details: mapped.details } : {}),
-          }),
-        );
+        return mcpMappedErrorResult(mapped);
       }
     },
   };

--- a/src/tools/package-changelog.ts
+++ b/src/tools/package-changelog.ts
@@ -12,6 +12,7 @@ import {
   toPkgseerRegistryLowercase,
 } from "../shared/pkgseer-registry.js";
 import { PKG_CHANGELOG_GUARDRAIL } from "./guardrails.js";
+import { mcpMappedErrorResult } from "./shared.js";
 import { type ToolDefinition, textResult } from "./types.js";
 
 export interface PackageChangelogArgs {
@@ -185,20 +186,7 @@ export function createPackageChangelogTool(
         return textResult(JSON.stringify(payload));
       } catch (error) {
         const mapped = mapPackageIntelligenceError(error);
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify({
-                error: mapped.message,
-                code: mapped.code,
-                retryable: mapped.retryable ?? false,
-                ...(mapped.details ? { details: mapped.details } : {}),
-              }),
-            },
-          ],
-          isError: true,
-        };
+        return mcpMappedErrorResult(mapped);
       }
     },
   };

--- a/src/tools/package-dependencies.ts
+++ b/src/tools/package-dependencies.ts
@@ -9,6 +9,7 @@ import {
   formatPackageDependenciesTerminal,
 } from "../shared/package-dependencies-response.js";
 import { mapPackageIntelligenceError } from "../shared/package-intelligence-error-map.js";
+import { mcpMappedErrorResult } from "./shared.js";
 import { type ToolDefinition, textResult } from "./types.js";
 
 export interface PackageDependenciesArgs {
@@ -141,20 +142,7 @@ export function createPackageDependenciesTool(
         return textResult(JSON.stringify(payload));
       } catch (error) {
         const mapped = mapPackageIntelligenceError(error);
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify({
-                error: mapped.message,
-                code: mapped.code,
-                retryable: mapped.retryable ?? false,
-                ...(mapped.details ? { details: mapped.details } : {}),
-              }),
-            },
-          ],
-          isError: true,
-        };
+        return mcpMappedErrorResult(mapped);
       }
     },
   };

--- a/src/tools/package-summary.ts
+++ b/src/tools/package-summary.ts
@@ -8,6 +8,7 @@ import {
 } from "../shared/package-summary-response.js";
 import { PKGSEER_REGISTRY_LIST } from "../shared/pkgseer-registry.js";
 import { PKG_INFO_GUARDRAIL } from "./guardrails.js";
+import { mcpMappedErrorResult } from "./shared.js";
 import { type ToolDefinition, textResult } from "./types.js";
 
 export interface PackageSummaryArgs {
@@ -83,20 +84,7 @@ export function createPackageSummaryTool(
         return textResult(JSON.stringify(payload));
       } catch (error) {
         const mapped = mapPackageIntelligenceError(error);
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify({
-                error: mapped.message,
-                code: mapped.code,
-                retryable: mapped.retryable ?? false,
-                ...(mapped.details ? { details: mapped.details } : {}),
-              }),
-            },
-          ],
-          isError: true,
-        };
+        return mcpMappedErrorResult(mapped);
       }
     },
   };

--- a/src/tools/package-upgrade-review.ts
+++ b/src/tools/package-upgrade-review.ts
@@ -7,6 +7,7 @@ import {
   mapPackageIntelligenceError,
 } from "../shared/index.js";
 import { PKGSEER_REGISTRY_LIST } from "../shared/pkgseer-registry.js";
+import { mcpMappedErrorResult } from "./shared.js";
 import { type ToolDefinition, textResult } from "./types.js";
 
 export interface PackageUpgradeReviewArgs {
@@ -151,20 +152,7 @@ export function createPackageUpgradeReviewTool(
         );
       } catch (error) {
         const mapped = mapPackageIntelligenceError(error);
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify({
-                error: mapped.message,
-                code: mapped.code,
-                retryable: mapped.retryable ?? false,
-                ...(mapped.details ? { details: mapped.details } : {}),
-              }),
-            },
-          ],
-          isError: true,
-        };
+        return mcpMappedErrorResult(mapped);
       }
     },
   };

--- a/src/tools/package-vulnerabilities.ts
+++ b/src/tools/package-vulnerabilities.ts
@@ -7,6 +7,7 @@ import {
   formatPackageVulnerabilitiesTerminal,
 } from "../shared/package-vulnerabilities-response.js";
 import { PKG_VULNS_GUARDRAIL } from "./guardrails.js";
+import { mcpMappedErrorResult } from "./shared.js";
 import { type ToolDefinition, textResult } from "./types.js";
 
 export interface PackageVulnerabilitiesArgs {
@@ -126,20 +127,7 @@ export function createPackageVulnerabilitiesTool(
         return textResult(JSON.stringify(payload));
       } catch (error) {
         const mapped = mapPackageIntelligenceError(error);
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify({
-                error: mapped.message,
-                code: mapped.code,
-                retryable: mapped.retryable ?? false,
-                ...(mapped.details ? { details: mapped.details } : {}),
-              }),
-            },
-          ],
-          isError: true,
-        };
+        return mcpMappedErrorResult(mapped);
       }
     },
   };

--- a/src/tools/read-file.ts
+++ b/src/tools/read-file.ts
@@ -15,6 +15,7 @@ import {
   resolveCodeTarget,
 } from "./code-navigation-shared.js";
 import { CODE_READ_GUARDRAIL } from "./guardrails.js";
+import { mcpMappedErrorResult } from "./shared.js";
 import { errorResult, type ToolDefinition, textResult } from "./types.js";
 
 /**
@@ -189,14 +190,7 @@ export function createReadFileTool(
           mapCodeNavigationError(error),
           args.path,
         );
-        return errorResult(
-          JSON.stringify({
-            error: mapped.message,
-            code: mapped.code,
-            retryable: mapped.retryable ?? false,
-            ...(mapped.details ? { details: mapped.details } : {}),
-          }),
-        );
+        return mcpMappedErrorResult(mapped);
       }
     },
   };

--- a/src/tools/read-package-doc.ts
+++ b/src/tools/read-package-doc.ts
@@ -5,6 +5,7 @@ import { buildReadPackageDocParams } from "../shared/read-package-doc-request.js
 import { buildReadPackageDocSuccessPayload } from "../shared/read-package-doc-response.js";
 import { renderReadPackageDocText } from "../shared/read-package-doc-text.js";
 import { DOCS_GUARDRAIL } from "./guardrails.js";
+import { mcpMappedErrorResult } from "./shared.js";
 import { errorResult, type ToolDefinition, textResult } from "./types.js";
 
 export interface ReadPackageDocArgs {
@@ -74,14 +75,7 @@ export function createReadPackageDocTool(
         return textResult(JSON.stringify(payload));
       } catch (error) {
         const mapped = mapPackageIntelligenceError(error);
-        return errorResult(
-          JSON.stringify({
-            error: mapped.message,
-            code: mapped.code,
-            retryable: mapped.retryable ?? false,
-            ...(mapped.details ? { details: mapped.details } : {}),
-          }),
-        );
+        return mcpMappedErrorResult(mapped);
       }
     },
   };

--- a/src/tools/search-status.test.ts
+++ b/src/tools/search-status.test.ts
@@ -4,6 +4,7 @@ import type {
   UnifiedSearchProgress,
   UnifiedSearchSessionStatus,
 } from "../services/code-navigation-service.js";
+import { AuthenticationError } from "../services/githits-service.js";
 import {
   createMockCodeNavigationService,
   defaultUnifiedSearchOutcome,
@@ -63,6 +64,28 @@ describe("searchStatusTool", () => {
 
     expect(tool.description).toContain("partial hits");
     expect(tool.description).toContain("allow_partial_results");
+  });
+
+  it("adds local MCP auth remediation to auth errors", async () => {
+    const tool = createSearchStatusTool(
+      createMockCodeNavigationService({
+        searchStatus: mock(() => Promise.reject(new AuthenticationError())),
+      }),
+    );
+
+    const result = await tool.handler(
+      { search_ref: "search-ref-123", format: "json" },
+      {},
+    );
+    const payload = JSON.parse(result.content[0]?.text ?? "{}");
+
+    expect(result.isError).toBe(true);
+    expect(payload).toEqual({
+      error: "Authentication required.",
+      code: "AUTH_REQUIRED",
+      retryable: false,
+      details: { action: "Run `githits login`, then retry this tool call." },
+    });
   });
 
   it("returns completed payload without fabricating initial query echo", async () => {

--- a/src/tools/search-status.ts
+++ b/src/tools/search-status.ts
@@ -5,6 +5,7 @@ import {
   buildUnifiedSearchStatusPayload,
   renderUnifiedSearchStatusText,
 } from "../shared/index.js";
+import { addLocalMcpAuthAction } from "./shared.js";
 import { errorResult, type ToolDefinition, textResult } from "./types.js";
 
 export interface SearchStatusArgs {
@@ -49,7 +50,9 @@ export function createSearchStatusTool(
         return textResult(JSON.stringify(payload));
       } catch (error) {
         return errorResult(
-          JSON.stringify(buildUnifiedSearchErrorPayload(error)),
+          JSON.stringify(
+            addLocalMcpAuthAction(buildUnifiedSearchErrorPayload(error)),
+          ),
         );
       }
     },

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -24,6 +24,7 @@ import {
   structuredCodeTargetSchema,
 } from "./code-navigation-shared.js";
 import { SEARCH_GUARDRAIL } from "./guardrails.js";
+import { addLocalMcpAuthAction, mcpMappedErrorResult } from "./shared.js";
 import {
   errorResult,
   type ToolDefinition,
@@ -289,7 +290,9 @@ export function createSearchTool(
         }
         return textResult(JSON.stringify(payload));
       } catch (error) {
-        const payload = buildUnifiedSearchErrorPayload(error);
+        const payload = addLocalMcpAuthAction(
+          buildUnifiedSearchErrorPayload(error),
+        );
         if (isTextFormat(args.format)) {
           return errorResult(renderUnifiedSearchError(payload));
         }
@@ -333,14 +336,7 @@ function resolveSearchTarget(
       return parseUnifiedSearchTargetSpec(target);
     } catch (error) {
       const mapped = mapCodeNavigationError(error);
-      return errorResult(
-        JSON.stringify({
-          error: mapped.message,
-          code: mapped.code,
-          retryable: mapped.retryable ?? false,
-          ...(mapped.details ? { details: mapped.details } : {}),
-        }),
-      );
+      return mcpMappedErrorResult(mapped);
     }
   }
 

--- a/src/tools/shared.ts
+++ b/src/tools/shared.ts
@@ -1,5 +1,8 @@
 import { AuthenticationError } from "../services/githits-service.js";
+import type { MappedError } from "../shared/code-navigation-error-map.js";
 import { errorResult, type ToolResult } from "./types.js";
+
+const LOCAL_MCP_AUTH_ACTION = "Run `githits login`, then retry this tool call.";
 
 /**
  * Wraps a tool handler with the shared structured `{error, code,
@@ -22,7 +25,41 @@ interface ToolErrorEnvelope {
   error: string;
   code: string;
   retryable: boolean;
-  details?: { action: string };
+  details?: MappedError["details"] | { action: string };
+}
+
+interface MappableErrorPayload {
+  code: string;
+  details?: Record<string, unknown>;
+}
+
+export function mcpMappedErrorResult(mapped: MappedError): ToolResult {
+  return errorResult(JSON.stringify(buildMcpErrorPayload(mapped)));
+}
+
+export function buildMcpErrorPayload(mapped: MappedError): ToolErrorEnvelope {
+  return {
+    error: mapped.message,
+    code: mapped.code,
+    retryable: mapped.retryable ?? false,
+    ...(mapped.code === "AUTH_REQUIRED"
+      ? {
+          details: { ...(mapped.details ?? {}), action: LOCAL_MCP_AUTH_ACTION },
+        }
+      : mapped.details
+        ? { details: mapped.details }
+        : {}),
+  };
+}
+
+export function addLocalMcpAuthAction<T extends MappableErrorPayload>(
+  payload: T,
+): T {
+  if (payload.code !== "AUTH_REQUIRED") return payload;
+  return {
+    ...payload,
+    details: { ...(payload.details ?? {}), action: LOCAL_MCP_AUTH_ACTION },
+  };
 }
 
 function classify(operation: string, error: unknown): ToolErrorEnvelope {
@@ -31,7 +68,7 @@ function classify(operation: string, error: unknown): ToolErrorEnvelope {
       error: error.message,
       code: "AUTH_REQUIRED",
       retryable: false,
-      details: { action: "Run `githits login`, then retry this tool call." },
+      details: { action: LOCAL_MCP_AUTH_ACTION },
     };
   }
   const message = error instanceof Error ? error.message : "Unknown error";


### PR DESCRIPTION
## Summary
- neutralize service/shared auth errors so core layers no longer embed CLI/MCP remediation text
- move CLI terminal auth remediation into command-owned formatting while keeping CLI JSON auth envelopes neutral
- move MCP auth action details into MCP tool formatting and shared MCP error-result helpers
- add CLI/MCP regression coverage and tighten CLI smoke auth probes

## Verification
- code-reviewer: no findings after fixes
- plan-reviewer: no findings after fixes
- `bun test` (2136 passed)
- `bun run build`
- `bun run typecheck`
- `bun run format:check`
- `git diff --check`
- `bun run smoke:cli`
- `bun run smoke:mcp`

## Notes
- CLI JSON auth remains unchanged/neutral: `{"error":"Authentication required.","code":"AUTH_REQUIRED","retryable":false}`
- CLI terminal auth keeps login guidance
- MCP auth action remains MCP-owned
- local `docs/plans/` remains untracked and intentionally excluded from this PR