### PR TITLE
refactor: remove internal service barrel imports

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -18,7 +18,20 @@
   },
   "linter": {
     "rules": {
-      "recommended": true
+      "recommended": true,
+      "style": {
+        "noRestrictedImports": {
+          "level": "error",
+          "options": {
+            "patterns": [
+              {
+                "group": ["**/services/index.js"],
+                "message": "Import from the defining service module instead of the services barrel."
+              }
+            ]
+          }
+        }
+      }
     }
   },
   "overrides": [

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,10 +29,8 @@ import {
   createContainer,
   loadAutoLoginAuthSessionMetadata,
 } from "./container.js";
-import {
-  FileSystemServiceImpl,
-  NpmRegistryUpdateCheckService,
-} from "./services/index.js";
+import { FileSystemServiceImpl } from "./services/filesystem-service.js";
+import { NpmRegistryUpdateCheckService } from "./services/update-check-service.js";
 import { colorizeBrand, shouldUseColors } from "./shared/colors.js";
 import {
   createRootCliPreAction,

--- a/src/cli/errors.test.ts
+++ b/src/cli/errors.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { AuthStorageLockTimeoutError } from "../services/index.js";
+import { AuthStorageLockTimeoutError } from "../services/locked-auth-storage.js";
 import { AuthRequiredError } from "../shared/require-auth.js";
 import { handleCliError } from "./errors.js";
 

--- a/src/cli/errors.ts
+++ b/src/cli/errors.ts
@@ -1,8 +1,6 @@
-import {
-  AuthConfigError,
-  AuthStorageLockTimeoutError,
-  AuthStoragePolicyError,
-} from "../services/index.js";
+import { AuthConfigError } from "../services/auth-config.js";
+import { AuthStorageLockTimeoutError } from "../services/locked-auth-storage.js";
+import { AuthStoragePolicyError } from "../services/mode-aware-file-auth-storage.js";
 import {
   AuthRequiredError,
   formatAuthRequiredForTerminal,

--- a/src/cli/update-check.ts
+++ b/src/cli/update-check.ts
@@ -2,13 +2,13 @@ import type {
   RequiredUpdateNotice,
   UpdateCheckNotice,
   UpdateCheckService,
-} from "../services/index.js";
+} from "../services/update-check-service.js";
 import {
   formatRequiredUpdateNotice,
   formatUpdateNotice,
   shouldRunRequiredUpdateEnforcement,
   shouldRunUpdateCheck,
-} from "../services/index.js";
+} from "../services/update-check-service.js";
 
 export interface UpdateCheckTask {
   promise: Promise<UpdateCheckNotice | undefined>;

--- a/src/commands/auth-status.ts
+++ b/src/commands/auth-status.ts
@@ -1,7 +1,8 @@
 import type { Command } from "commander";
 import { createAuthStatusDependencies } from "../container.js";
-import type { AuthService, AuthStorage } from "../services/index.js";
-import { refreshExpiredToken } from "../services/index.js";
+import type { AuthService } from "../services/auth-service.js";
+import type { AuthStorage } from "../services/auth-storage.js";
+import { refreshExpiredToken } from "../services/token-manager.js";
 
 export interface AuthStatusDependencies {
   authStorage: AuthStorage;

--- a/src/commands/code/code-nav-cli-helpers.ts
+++ b/src/commands/code/code-nav-cli-helpers.ts
@@ -11,7 +11,7 @@
 import type {
   CodeNavigationService,
   CodeNavigationTarget,
-} from "../../services/index.js";
+} from "../../services/code-navigation-service.js";
 import {
   type MappedError,
   mapCodeNavigationError,

--- a/src/commands/code/files.test.ts
+++ b/src/commands/code/files.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it, mock, spyOn } from "bun:test";
-import { AuthenticationError } from "../../services/githits-service.js";
 import {
   CodeNavigationIndexingError,
   CodeNavigationTargetNotFoundError,
-} from "../../services/index.js";
+} from "../../services/code-navigation-service.js";
+import { AuthenticationError } from "../../services/githits-service.js";
 import {
   createMockCodeNavigationService,
   defaultListFilesResult,

--- a/src/commands/code/files.ts
+++ b/src/commands/code/files.ts
@@ -1,6 +1,6 @@
 import type { Command } from "commander";
 import { createContainer } from "../../container.js";
-import type { CodeNavigationService } from "../../services/index.js";
+import type { CodeNavigationService } from "../../services/code-navigation-service.js";
 import {
   DEFAULT_WAIT_TIMEOUT_MS,
   MAX_WAIT_TIMEOUT_MS,

--- a/src/commands/code/grep.ts
+++ b/src/commands/code/grep.ts
@@ -1,5 +1,5 @@
 import type { Command } from "commander";
-import type { CodeNavigationService } from "../../services/index.js";
+import type { CodeNavigationService } from "../../services/code-navigation-service.js";
 import {
   DEFAULT_WAIT_TIMEOUT_MS,
   MAX_WAIT_TIMEOUT_MS,

--- a/src/commands/code/read.test.ts
+++ b/src/commands/code/read.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, it, mock, spyOn } from "bun:test";
 import {
   CodeNavigationFileNotFoundError,
   CodeNavigationIndexingError,
-} from "../../services/index.js";
+  CodeNavigationTargetNotFoundError,
+} from "../../services/code-navigation-service.js";
 import {
   createMockCodeNavigationService,
   defaultReadFileResult,
@@ -339,9 +340,6 @@ describe("pkgReadAction", () => {
     const exitSpy = spyOn(process, "exit").mockImplementation(() => {
       throw new Error("process.exit");
     });
-    const { CodeNavigationTargetNotFoundError } = await import(
-      "../../services/index.js"
-    );
     const service = createMockCodeNavigationService({
       readFile: mock(() =>
         Promise.reject(

--- a/src/commands/code/read.ts
+++ b/src/commands/code/read.ts
@@ -1,6 +1,6 @@
 import type { Command } from "commander";
 import { createContainer } from "../../container.js";
-import type { CodeNavigationService } from "../../services/index.js";
+import type { CodeNavigationService } from "../../services/code-navigation-service.js";
 import {
   DEFAULT_WAIT_TIMEOUT_MS,
   MAX_WAIT_TIMEOUT_MS,

--- a/src/commands/docs/list.test.ts
+++ b/src/commands/docs/list.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, mock, spyOn } from "bun:test";
-import { PackageIntelligenceTargetNotFoundError } from "../../services/index.js";
+import { PackageIntelligenceTargetNotFoundError } from "../../services/package-intelligence-service.js";
 import {
   createMockPackageIntelligenceService,
   defaultPackageDocsList,

--- a/src/commands/docs/list.ts
+++ b/src/commands/docs/list.ts
@@ -1,6 +1,6 @@
 import type { Command } from "commander";
 import { createContainer } from "../../container.js";
-import type { PackageIntelligenceService } from "../../services/index.js";
+import type { PackageIntelligenceService } from "../../services/package-intelligence-service.js";
 import { shouldUseColors } from "../../shared/colors.js";
 import {
   buildListPackageDocsParams,

--- a/src/commands/docs/read.test.ts
+++ b/src/commands/docs/read.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, mock, spyOn } from "bun:test";
-import { PackageIntelligenceTargetNotFoundError } from "../../services/index.js";
+import { PackageIntelligenceTargetNotFoundError } from "../../services/package-intelligence-service.js";
 import {
   createMockPackageIntelligenceService,
   defaultPackageDocResult,

--- a/src/commands/docs/read.ts
+++ b/src/commands/docs/read.ts
@@ -1,6 +1,6 @@
 import type { Command } from "commander";
 import { createContainer } from "../../container.js";
-import type { PackageIntelligenceService } from "../../services/index.js";
+import type { PackageIntelligenceService } from "../../services/package-intelligence-service.js";
 import {
   buildReadPackageDocParams,
   buildReadPackageDocSuccessPayload,

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -3,23 +3,31 @@ import type { Command } from "commander";
 import { parse as parseToml } from "smol-toml";
 import { version } from "../../package.json";
 import {
-  type AuthStorageMode,
-  type ClientRegistration,
-  DEFAULT_API_URL,
-  DEFAULT_CODE_NAV_URL,
-  DEFAULT_MCP_URL,
-  type FileSystemService,
-  FileSystemServiceImpl,
   getAppConfigDirForEnv,
   getAuthConfigPathForEnv,
   getAuthFileStorageDirForEnv,
   getLegacyAuthStorageDirForEnv,
   getLegacyMacAuthConfigPathForEnv,
   getLegacyMacAuthFileStorageDirForEnv,
-  normalizeBaseUrl,
+} from "../services/app-config-paths.js";
+import {
+  type AuthStorageMode,
   parseAuthStorageMode,
+} from "../services/auth-config.js";
+import {
+  type ClientRegistration,
+  normalizeBaseUrl,
   type TokenData,
-} from "../services/index.js";
+} from "../services/auth-storage.js";
+import {
+  DEFAULT_API_URL,
+  DEFAULT_CODE_NAV_URL,
+  DEFAULT_MCP_URL,
+} from "../services/config.js";
+import {
+  type FileSystemService,
+  FileSystemServiceImpl,
+} from "../services/filesystem-service.js";
 
 type ProbeStatus =
   | "present"

--- a/src/commands/gated-command-group.ts
+++ b/src/commands/gated-command-group.ts
@@ -1,4 +1,4 @@
-import { getCodeNavigationUrl } from "../services/index.js";
+import { getCodeNavigationUrl } from "../services/config.js";
 
 export interface GatedCommandGroupOptions {
   codeNavigationUrl?: string;

--- a/src/commands/init/agent-definitions.ts
+++ b/src/commands/init/agent-definitions.ts
@@ -1,5 +1,5 @@
 import type { ExecService } from "../../services/exec-service.js";
-import type { FileSystemService } from "../../services/index.js";
+import type { FileSystemService } from "../../services/filesystem-service.js";
 import {
   type CliCheckCommand,
   getCliCheckStatus,

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -1,10 +1,8 @@
 import type { Command } from "commander";
 import { createAuthCommandDependencies } from "../container.js";
-import type {
-  AuthService,
-  AuthStorage,
-  BrowserService,
-} from "../services/index.js";
+import type { AuthService } from "../services/auth-service.js";
+import type { AuthStorage } from "../services/auth-storage.js";
+import type { BrowserService } from "../services/browser-service.js";
 
 export interface LoginOptions {
   browser?: boolean;

--- a/src/commands/logout.ts
+++ b/src/commands/logout.ts
@@ -1,6 +1,6 @@
 import type { Command } from "commander";
 import { createAuthCommandDependencies } from "../container.js";
-import type { AuthStorage } from "../services/index.js";
+import type { AuthStorage } from "../services/auth-storage.js";
 
 export interface LogoutDependencies {
   authStorage: AuthStorage;

--- a/src/commands/pkg/changelog.test.ts
+++ b/src/commands/pkg/changelog.test.ts
@@ -3,7 +3,7 @@ import {
   PackageIntelligenceChangelogSourceNotFoundError,
   PackageIntelligenceTargetNotFoundError,
   PackageIntelligenceVersionNotFoundError,
-} from "../../services/index.js";
+} from "../../services/package-intelligence-service.js";
 import {
   createMockPackageIntelligenceService,
   defaultChangelogReport,

--- a/src/commands/pkg/changelog.ts
+++ b/src/commands/pkg/changelog.ts
@@ -1,6 +1,6 @@
 import type { Command } from "commander";
 import { createContainer } from "../../container.js";
-import type { PackageIntelligenceService } from "../../services/index.js";
+import type { PackageIntelligenceService } from "../../services/package-intelligence-service.js";
 import { shouldUseColors } from "../../shared/colors.js";
 import {
   InvalidPackageSpecError,

--- a/src/commands/pkg/deps.test.ts
+++ b/src/commands/pkg/deps.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, mock, spyOn } from "bun:test";
 import {
   PackageIntelligenceTargetNotFoundError,
   PackageIntelligenceVersionNotFoundError,
-} from "../../services/index.js";
+} from "../../services/package-intelligence-service.js";
 import {
   createMockPackageIntelligenceService,
   defaultDependencyReport,

--- a/src/commands/pkg/deps.ts
+++ b/src/commands/pkg/deps.ts
@@ -1,6 +1,6 @@
 import type { Command } from "commander";
 import { createContainer } from "../../container.js";
-import type { PackageIntelligenceService } from "../../services/index.js";
+import type { PackageIntelligenceService } from "../../services/package-intelligence-service.js";
 import { shouldUseColors } from "../../shared/colors.js";
 import {
   InvalidPackageSpecError,

--- a/src/commands/pkg/info.test.ts
+++ b/src/commands/pkg/info.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, mock, spyOn } from "bun:test";
 import { AuthenticationError } from "../../services/githits-service.js";
-import { PackageIntelligenceTargetNotFoundError } from "../../services/index.js";
+import { PackageIntelligenceTargetNotFoundError } from "../../services/package-intelligence-service.js";
 import {
   createMockPackageIntelligenceService,
   defaultPackageSummary,

--- a/src/commands/pkg/info.ts
+++ b/src/commands/pkg/info.ts
@@ -1,6 +1,6 @@
 import type { Command } from "commander";
 import { createContainer } from "../../container.js";
-import type { PackageIntelligenceService } from "../../services/index.js";
+import type { PackageIntelligenceService } from "../../services/package-intelligence-service.js";
 import { shouldUseColors } from "../../shared/colors.js";
 import {
   InvalidPackageSpecError,

--- a/src/commands/pkg/upgrade-review.ts
+++ b/src/commands/pkg/upgrade-review.ts
@@ -1,6 +1,6 @@
 import type { Command } from "commander";
 import { createContainer } from "../../container.js";
-import type { PackageIntelligenceService } from "../../services/index.js";
+import type { PackageIntelligenceService } from "../../services/package-intelligence-service.js";
 import { shouldUseColors } from "../../shared/colors.js";
 import {
   buildPackageUpgradeReview,

--- a/src/commands/pkg/vulns.test.ts
+++ b/src/commands/pkg/vulns.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, mock, spyOn } from "bun:test";
 import {
   PackageIntelligenceTargetNotFoundError,
   PackageIntelligenceVersionNotFoundError,
-} from "../../services/index.js";
+} from "../../services/package-intelligence-service.js";
 import {
   createMockPackageIntelligenceService,
   defaultVulnerabilityReport,

--- a/src/commands/pkg/vulns.ts
+++ b/src/commands/pkg/vulns.ts
@@ -1,6 +1,6 @@
 import type { Command } from "commander";
 import { createContainer } from "../../container.js";
-import type { PackageIntelligenceService } from "../../services/index.js";
+import type { PackageIntelligenceService } from "../../services/package-intelligence-service.js";
 import { shouldUseColors } from "../../shared/colors.js";
 import {
   InvalidPackageSpecError,

--- a/src/container.ts
+++ b/src/container.ts
@@ -1,41 +1,56 @@
 import { version } from "../package.json";
-import type { GitHitsService } from "./services/index.js";
 import {
-  type AuthService,
-  AuthServiceImpl,
-  type AuthSessionMetadata,
-  AuthSessionMetadataStorage,
-  type AuthStorage,
-  AuthStorageImpl,
-  type AuthStorageMode,
-  type BrowserService,
-  BrowserServiceImpl,
-  ChunkingKeyringService,
-  type CodeNavigationService,
-  CodeNavigationServiceImpl,
-  type FileSystemService,
-  FileSystemServiceImpl,
-  GitHitsServiceImpl,
-  getApiUrl,
   getAuthFileStorageDir,
-  getCodeNavigationUrl,
-  getEnvApiToken,
   getLegacyAuthStorageDir,
   getLegacyMacAuthFileStorageDir,
-  getMcpUrl,
-  KeychainAuthStorage,
-  KeyringServiceImpl,
-  LockedAuthStorage,
+} from "./services/app-config-paths.js";
+import {
+  type AuthStorageMode,
   loadAuthConfig,
-  MigratingAuthStorage,
-  ModeAwareFileAuthStorage,
+} from "./services/auth-config.js";
+import { type AuthService, AuthServiceImpl } from "./services/auth-service.js";
+import {
+  type AuthSessionMetadata,
+  AuthSessionMetadataStorage,
+} from "./services/auth-session-metadata-storage.js";
+import { type AuthStorage, AuthStorageImpl } from "./services/auth-storage.js";
+import {
+  type BrowserService,
+  BrowserServiceImpl,
+} from "./services/browser-service.js";
+import {
+  ChunkingKeyringService,
+  WINDOWS_MAX_ENTRY_SIZE,
+} from "./services/chunking-keyring-service.js";
+import {
+  type CodeNavigationService,
+  CodeNavigationServiceImpl,
+} from "./services/code-navigation-service.js";
+import {
+  getApiUrl,
+  getCodeNavigationUrl,
+  getEnvApiToken,
+  getMcpUrl,
+} from "./services/config.js";
+import {
+  type FileSystemService,
+  FileSystemServiceImpl,
+} from "./services/filesystem-service.js";
+import {
+  type GitHitsService,
+  GitHitsServiceImpl,
+} from "./services/githits-service.js";
+import { KeychainAuthStorage } from "./services/keychain-auth-storage.js";
+import { KeyringServiceImpl } from "./services/keyring-service.js";
+import { LockedAuthStorage } from "./services/locked-auth-storage.js";
+import { MigratingAuthStorage } from "./services/migrating-auth-storage.js";
+import { ModeAwareFileAuthStorage } from "./services/mode-aware-file-auth-storage.js";
+import {
   type PackageIntelligenceService,
   PackageIntelligenceServiceImpl,
-  RefreshingGitHitsService,
-  TokenManager,
-  type TokenProvider,
-  WINDOWS_MAX_ENTRY_SIZE,
-} from "./services/index.js";
+} from "./services/package-intelligence-service.js";
+import { RefreshingGitHitsService } from "./services/refreshing-githits-service.js";
+import { TokenManager, type TokenProvider } from "./services/token-manager.js";
 import {
   type AgentInfo,
   createClientHeaderBuilder,

--- a/src/shared/code-navigation-defaults.ts
+++ b/src/shared/code-navigation-defaults.ts
@@ -1,3 +1,5 @@
+import type { FileIntent } from "../services/code-navigation-service.js";
+
 /**
  * Default indexing wait time for any code-navigation request issued
  * by the CLI or MCP surfaces. Both surfaces import this so defaults
@@ -33,7 +35,4 @@ export const FILE_INTENT_ALL = Symbol("FILE_INTENT_ALL");
  * User-facing file_intent input: either a specific intent, the
  * `FILE_INTENT_ALL` sentinel, or `undefined` (no filter requested).
  */
-export type FileIntentInput =
-  | import("../services/index.js").FileIntent
-  | typeof FILE_INTENT_ALL
-  | undefined;
+export type FileIntentInput = FileIntent | typeof FILE_INTENT_ALL | undefined;

--- a/src/shared/code-navigation-target.ts
+++ b/src/shared/code-navigation-target.ts
@@ -1,4 +1,4 @@
-import type { CodeNavigationTarget } from "../services/index.js";
+import type { CodeNavigationTarget } from "../services/code-navigation-service.js";
 import { toCodeNavigationRegistry } from "./code-navigation.js";
 import { InvalidArgumentError, parsePackageSpec } from "./package-spec.js";
 

--- a/src/shared/code-navigation.ts
+++ b/src/shared/code-navigation.ts
@@ -2,7 +2,7 @@ import type {
   FileIntent,
   SymbolCategory,
   SymbolKind,
-} from "../services/index.js";
+} from "../services/code-navigation-service.js";
 import {
   type PkgseerRegistryArg,
   toPkgseerRegistry,

--- a/src/shared/docs-follow-up.ts
+++ b/src/shared/docs-follow-up.ts
@@ -1,4 +1,4 @@
-import type { PackageDocSourceKind } from "../services/index.js";
+import type { PackageDocSourceKind } from "../services/package-intelligence-service.js";
 
 export function lowerDocSourceKind(
   value: PackageDocSourceKind | undefined,

--- a/src/shared/grep-repo-request.test.ts
+++ b/src/shared/grep-repo-request.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import type { CodeNavigationTarget } from "../services/index.js";
+import type { CodeNavigationTarget } from "../services/code-navigation-service.js";
 import {
   buildGrepRepoParams,
   GREP_REPO_PATTERN_NOTE,

--- a/src/shared/grep-repo-request.ts
+++ b/src/shared/grep-repo-request.ts
@@ -2,7 +2,7 @@ import type {
   CodeNavigationTarget,
   GrepPathSelectorKind,
   GrepRepoParams,
-} from "../services/index.js";
+} from "../services/code-navigation-service.js";
 import {
   DEFAULT_WAIT_TIMEOUT_MS,
   MAX_WAIT_TIMEOUT_MS,

--- a/src/shared/grep-repo-response.test.ts
+++ b/src/shared/grep-repo-response.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import type { GrepRepoResult } from "../services/index.js";
+import type { GrepRepoResult } from "../services/code-navigation-service.js";
 import {
   buildGrepRepoSuccessPayload,
   formatGrepRepoTerminal,

--- a/src/shared/grep-repo-response.ts
+++ b/src/shared/grep-repo-response.ts
@@ -1,4 +1,7 @@
-import type { GrepRepoMatch, GrepRepoResult } from "../services/index.js";
+import type {
+  GrepRepoMatch,
+  GrepRepoResult,
+} from "../services/code-navigation-service.js";
 import { colorize, dim, highlightRanges } from "./colors.js";
 import { shellQuote } from "./shell-quote.js";
 import {

--- a/src/shared/list-files-request.test.ts
+++ b/src/shared/list-files-request.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import type { CodeNavigationTarget } from "../services/index.js";
+import type { CodeNavigationTarget } from "../services/code-navigation-service.js";
 import { buildListFilesParams } from "./list-files-request.js";
 
 const packageTarget: CodeNavigationTarget = {

--- a/src/shared/list-files-request.ts
+++ b/src/shared/list-files-request.ts
@@ -11,7 +11,7 @@ import type {
   FileIntent,
   GrepRepoPathSelector,
   ListFilesParams,
-} from "../services/index.js";
+} from "../services/code-navigation-service.js";
 import {
   isKnownFileIntent,
   knownFileIntentList,

--- a/src/shared/list-files-response.test.ts
+++ b/src/shared/list-files-response.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import type { ListFilesResult } from "../services/index.js";
+import type { ListFilesResult } from "../services/code-navigation-service.js";
 import {
   buildListFilesSuccessPayload,
   formatListFilesTerminal,

--- a/src/shared/list-files-response.ts
+++ b/src/shared/list-files-response.ts
@@ -16,7 +16,10 @@
  *   limit (200) is not echoed; explicit selectors / filters are.
  */
 
-import type { ListFilesResult, RepoFileEntry } from "../services/index.js";
+import type {
+  ListFilesResult,
+  RepoFileEntry,
+} from "../services/code-navigation-service.js";
 import { colorize, dim } from "./colors.js";
 import {
   buildTargetResolutionNotes,

--- a/src/shared/list-package-docs-request.ts
+++ b/src/shared/list-package-docs-request.ts
@@ -1,4 +1,4 @@
-import type { ListPackageDocsParams } from "../services/index.js";
+import type { ListPackageDocsParams } from "../services/package-intelligence-service.js";
 import {
   InvalidPackageSpecError,
   UnsupportedRegistryError,

--- a/src/shared/list-package-docs-response.ts
+++ b/src/shared/list-package-docs-response.ts
@@ -1,5 +1,5 @@
-import type { PackageDocsList } from "../services/index.js";
-import { MalformedPackageIntelligenceResponseError } from "../services/index.js";
+import type { PackageDocsList } from "../services/package-intelligence-service.js";
+import { MalformedPackageIntelligenceResponseError } from "../services/package-intelligence-service.js";
 import { colorize, dim } from "./colors.js";
 import { lowerDocSourceKind } from "./docs-follow-up.js";
 import { toIsoDate } from "./format-date.js";

--- a/src/shared/package-changelog-request.ts
+++ b/src/shared/package-changelog-request.ts
@@ -23,7 +23,7 @@
  *   defaults.
  */
 
-import type { PackageChangelogParams } from "../services/index.js";
+import type { PackageChangelogParams } from "../services/package-intelligence-service.js";
 import {
   InvalidPackageSpecError,
   UnsupportedRegistryError,

--- a/src/shared/package-changelog-response.test.ts
+++ b/src/shared/package-changelog-response.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import type { ChangelogReport } from "../services/index.js";
+import type { ChangelogReport } from "../services/package-intelligence-service.js";
 import type { ExplicitFilterField } from "./package-changelog-request.js";
 import {
   buildPackageChangelogSuccessPayload,

--- a/src/shared/package-changelog-response.ts
+++ b/src/shared/package-changelog-response.ts
@@ -39,7 +39,7 @@
  *   later. TODO(backend) marker in the service types.
  */
 
-import type { ChangelogReport } from "../services/index.js";
+import type { ChangelogReport } from "../services/package-intelligence-service.js";
 import { colorize, dim, highlight } from "./colors.js";
 import type { ExplicitFilterField } from "./package-changelog-request.js";
 

--- a/src/shared/package-dependencies-request.ts
+++ b/src/shared/package-dependencies-request.ts
@@ -20,7 +20,7 @@
  * - Enforce `maxDepth` bounds (1–10).
  */
 
-import type { PackageDependenciesParams } from "../services/index.js";
+import type { PackageDependenciesParams } from "../services/package-intelligence-service.js";
 import {
   InvalidPackageSpecError,
   UnsupportedRegistryError,

--- a/src/shared/package-dependencies-response.test.ts
+++ b/src/shared/package-dependencies-response.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import type { DependencyReport } from "../services/index.js";
+import type { DependencyReport } from "../services/package-intelligence-service.js";
 import {
   cratesFeatureDependencyReport,
   defaultDependencyReport,

--- a/src/shared/package-dependencies-response.ts
+++ b/src/shared/package-dependencies-response.ts
@@ -48,7 +48,7 @@ import type {
   DependencyGroup,
   DependencyReport,
   EnvironmentMarker,
-} from "../services/index.js";
+} from "../services/package-intelligence-service.js";
 import { colorize, dim } from "./colors.js";
 import type {
   DependencyLifecycle,

--- a/src/shared/package-summary-request.ts
+++ b/src/shared/package-summary-request.ts
@@ -15,7 +15,7 @@
  * `{ params }` — no `defaulted` array.
  */
 
-import type { PackageSummaryParams } from "../services/index.js";
+import type { PackageSummaryParams } from "../services/package-intelligence-service.js";
 import {
   InvalidPackageSpecError,
   UnsupportedRegistryError,

--- a/src/shared/package-summary-response.test.ts
+++ b/src/shared/package-summary-response.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import type { PackageSummary } from "../services/index.js";
+import type { PackageSummary } from "../services/package-intelligence-service.js";
 import { defaultPackageSummary } from "../services/test-helpers.js";
 import {
   buildPackageSummarySuccessPayload,

--- a/src/shared/package-summary-response.ts
+++ b/src/shared/package-summary-response.ts
@@ -20,7 +20,7 @@ import type {
   PackageSecurityOverview,
   PackageSummary,
   VulnerabilityOverview,
-} from "../services/index.js";
+} from "../services/package-intelligence-service.js";
 import { colorize, dim, highlight } from "./colors.js";
 import { toIsoDate, toRelativeDate } from "./format-date.js";
 import { formatCompactNumber } from "./format-number.js";

--- a/src/shared/package-upgrade-review-request.ts
+++ b/src/shared/package-upgrade-review-request.ts
@@ -1,4 +1,4 @@
-import type { PackageUpgradeDependencyProbeParams } from "../services/index.js";
+import type { PackageUpgradeDependencyProbeParams } from "../services/package-intelligence-service.js";
 import {
   InvalidPackageSpecError,
   UnsupportedRegistryError,

--- a/src/shared/package-upgrade-review-response.test.ts
+++ b/src/shared/package-upgrade-review-response.test.ts
@@ -5,7 +5,7 @@ import type {
   PackageIntelligenceService,
   TransitiveVulnerabilitySummary,
   VulnerabilityReport,
-} from "../services/index.js";
+} from "../services/package-intelligence-service.js";
 import {
   createMockPackageIntelligenceService,
   defaultPackageSummary,

--- a/src/shared/package-upgrade-review-response.ts
+++ b/src/shared/package-upgrade-review-response.ts
@@ -8,7 +8,7 @@ import type {
   TransitiveVulnerabilitySummary,
   VulnerabilityDetail,
   VulnerabilityReport,
-} from "../services/index.js";
+} from "../services/package-intelligence-service.js";
 import { colorize, highlight } from "./colors.js";
 import { mapPackageIntelligenceError } from "./package-intelligence-error-map.js";
 import {

--- a/src/shared/package-vulnerabilities-request.ts
+++ b/src/shared/package-vulnerabilities-request.ts
@@ -30,7 +30,7 @@
  *   ad hoc normalization rules here.
  */
 
-import type { PackageVulnerabilitiesParams } from "../services/index.js";
+import type { PackageVulnerabilitiesParams } from "../services/package-intelligence-service.js";
 import {
   InvalidPackageSpecError,
   UnsupportedRegistryError,

--- a/src/shared/package-vulnerabilities-response.test.ts
+++ b/src/shared/package-vulnerabilities-response.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import type { VulnerabilityReport } from "../services/index.js";
+import type { VulnerabilityReport } from "../services/package-intelligence-service.js";
 import { defaultVulnerabilityReport } from "../services/test-helpers.js";
 import {
   buildPackageVulnerabilitiesSuccessPayload,

--- a/src/shared/package-vulnerabilities-response.ts
+++ b/src/shared/package-vulnerabilities-response.ts
@@ -42,7 +42,7 @@
 import type {
   VulnerabilityDetail,
   VulnerabilityReport,
-} from "../services/index.js";
+} from "../services/package-intelligence-service.js";
 import { colorize, dim } from "./colors.js";
 import { toIsoDate } from "./format-date.js";
 import type { PackageVulnerabilitiesFilterEcho } from "./package-vulnerabilities-request.js";

--- a/src/shared/read-file-request.test.ts
+++ b/src/shared/read-file-request.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import type { CodeNavigationTarget } from "../services/index.js";
+import type { CodeNavigationTarget } from "../services/code-navigation-service.js";
 import { buildReadFileParams } from "./read-file-request.js";
 
 const target: CodeNavigationTarget = {

--- a/src/shared/read-file-request.ts
+++ b/src/shared/read-file-request.ts
@@ -7,7 +7,7 @@
 import type {
   CodeNavigationTarget,
   ReadFileParams,
-} from "../services/index.js";
+} from "../services/code-navigation-service.js";
 import { DEFAULT_WAIT_TIMEOUT_MS } from "./code-navigation-defaults.js";
 import { InvalidPackageSpecError } from "./package-spec.js";
 

--- a/src/shared/read-file-response.test.ts
+++ b/src/shared/read-file-response.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import type { ReadFileResult } from "../services/index.js";
+import type { ReadFileResult } from "../services/code-navigation-service.js";
 import {
   buildReadFileSuccessPayload,
   formatReadFileTerminal,

--- a/src/shared/read-file-response.ts
+++ b/src/shared/read-file-response.ts
@@ -8,7 +8,7 @@
  * checking a null content field.
  */
 
-import type { ReadFileResult } from "../services/index.js";
+import type { ReadFileResult } from "../services/code-navigation-service.js";
 import { colorize, dim } from "./colors.js";
 import {
   buildTargetResolutionNotes,

--- a/src/shared/read-package-doc-request.ts
+++ b/src/shared/read-package-doc-request.ts
@@ -1,4 +1,4 @@
-import type { ReadPackageDocParams } from "../services/index.js";
+import type { ReadPackageDocParams } from "../services/package-intelligence-service.js";
 import { InvalidPackageSpecError } from "./package-spec.js";
 
 export interface ReadPackageDocRequestInput {

--- a/src/shared/read-package-doc-response.ts
+++ b/src/shared/read-package-doc-response.ts
@@ -1,5 +1,5 @@
-import type { PackageDocResult } from "../services/index.js";
-import { MalformedPackageIntelligenceResponseError } from "../services/index.js";
+import type { PackageDocResult } from "../services/package-intelligence-service.js";
+import { MalformedPackageIntelligenceResponseError } from "../services/package-intelligence-service.js";
 import { colorize } from "./colors.js";
 import { lowerDocSourceKind } from "./docs-follow-up.js";
 import { toIsoDate } from "./format-date.js";

--- a/src/shared/target-resolution.ts
+++ b/src/shared/target-resolution.ts
@@ -1,4 +1,4 @@
-import type { TargetResolution } from "../services/index.js";
+import type { TargetResolution } from "../services/code-navigation-service.js";
 
 export interface LeanTargetResolutionIdentity {
   kind?: string;

--- a/src/shared/unified-search-request.ts
+++ b/src/shared/unified-search-request.ts
@@ -6,7 +6,7 @@ import type {
   UnifiedSearchFilters,
   UnifiedSearchParams,
   UnifiedSearchSource,
-} from "../services/index.js";
+} from "../services/code-navigation-service.js";
 import { DEFAULT_WAIT_TIMEOUT_MS } from "./code-navigation-defaults.js";
 import { InvalidArgumentError } from "./package-spec.js";
 

--- a/src/shared/unified-search-response.ts
+++ b/src/shared/unified-search-response.ts
@@ -5,8 +5,8 @@ import type {
   UnifiedSearchParams,
   UnifiedSearchProgress,
   UnifiedSearchSourceStatus,
-} from "../services/index.js";
-import { MalformedCodeNavigationResponseError } from "../services/index.js";
+} from "../services/code-navigation-service.js";
+import { MalformedCodeNavigationResponseError } from "../services/code-navigation-service.js";
 import { DEFAULT_WAIT_TIMEOUT_MS } from "./code-navigation-defaults.js";
 import { mapCodeNavigationError } from "./code-navigation-error-map.js";
 import { buildSearchHitFollowUpCommand } from "./follow-up-command-text.js";

--- a/src/shared/unified-search-target.ts
+++ b/src/shared/unified-search-target.ts
@@ -1,4 +1,4 @@
-import type { CodeNavigationTarget } from "../services/index.js";
+import type { CodeNavigationTarget } from "../services/code-navigation-service.js";
 import { toCodeNavigationRegistry } from "./code-navigation.js";
 import { InvalidArgumentError, parsePackageSpec } from "./package-spec.js";
 

--- a/src/tools/code-navigation-shared.ts
+++ b/src/tools/code-navigation-shared.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { CodeNavigationTarget } from "../services/index.js";
+import type { CodeNavigationTarget } from "../services/code-navigation-service.js";
 import {
   type CodeNavigationRegistryArg,
   toCodeNavigationRegistry,

--- a/src/tools/grep-repo-parity.test.ts
+++ b/src/tools/grep-repo-parity.test.ts
@@ -7,7 +7,7 @@ import {
   CodeNavigationIndexingError,
   CodeNavigationTargetNotFoundError,
   type GrepRepoResult,
-} from "../services/index.js";
+} from "../services/code-navigation-service.js";
 import {
   createMockCodeNavigationService,
   defaultGrepRepoResult,

--- a/src/tools/grep-repo.test.ts
+++ b/src/tools/grep-repo.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, mock } from "bun:test";
 import {
   CodeNavigationIndexingError,
   CodeNavigationTargetNotFoundError,
-} from "../services/index.js";
+} from "../services/code-navigation-service.js";
 import {
   createMockCodeNavigationService,
   defaultGrepRepoResult,

--- a/src/tools/grep-repo.ts
+++ b/src/tools/grep-repo.ts
@@ -18,7 +18,7 @@ import {
 } from "./code-navigation-shared.js";
 import { CODE_GREP_GUARDRAIL } from "./guardrails.js";
 import { mcpMappedErrorResult } from "./shared.js";
-import { errorResult, type ToolDefinition, textResult } from "./types.js";
+import { type ToolDefinition, textResult } from "./types.js";
 
 export interface GrepRepoArgs {
   target: CodeTargetArg;

--- a/src/tools/grep-repo.ts
+++ b/src/tools/grep-repo.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { CodeNavigationService } from "../services/index.js";
+import type { CodeNavigationService } from "../services/code-navigation-service.js";
 import { mapCodeNavigationError } from "../shared/code-navigation-error-map.js";
 import {
   buildGrepRepoParams,

--- a/src/tools/list-files-parity.test.ts
+++ b/src/tools/list-files-parity.test.ts
@@ -14,7 +14,7 @@ import {
   CodeNavigationIndexingError,
   CodeNavigationTargetNotFoundError,
   type ListFilesResult,
-} from "../services/index.js";
+} from "../services/code-navigation-service.js";
 import {
   createMockCodeNavigationService,
   defaultListFilesResult,

--- a/src/tools/list-files.test.ts
+++ b/src/tools/list-files.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, mock } from "bun:test";
 import {
   CodeNavigationIndexingError,
   CodeNavigationTargetNotFoundError,
-} from "../services/index.js";
+} from "../services/code-navigation-service.js";
 import {
   createMockCodeNavigationService,
   defaultListFilesResult,

--- a/src/tools/list-files.ts
+++ b/src/tools/list-files.ts
@@ -12,7 +12,7 @@ import {
   resolveCodeTarget,
 } from "./code-navigation-shared.js";
 import { mcpMappedErrorResult } from "./shared.js";
-import { errorResult, type ToolDefinition, textResult } from "./types.js";
+import { type ToolDefinition, textResult } from "./types.js";
 
 export interface ListFilesArgs {
   target: CodeTargetArg;

--- a/src/tools/list-files.ts
+++ b/src/tools/list-files.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { CodeNavigationService } from "../services/index.js";
+import type { CodeNavigationService } from "../services/code-navigation-service.js";
 import { knownFileIntentList } from "../shared/code-navigation.js";
 import { mapCodeNavigationError } from "../shared/code-navigation-error-map.js";
 import { buildListFilesParams } from "../shared/list-files-request.js";

--- a/src/tools/list-package-docs-parity.test.ts
+++ b/src/tools/list-package-docs-parity.test.ts
@@ -3,7 +3,7 @@ import {
   type DocsListCommandDependencies,
   docsListAction,
 } from "../commands/docs/list.js";
-import { PackageIntelligenceTargetNotFoundError } from "../services/index.js";
+import { PackageIntelligenceTargetNotFoundError } from "../services/package-intelligence-service.js";
 import {
   createMockPackageIntelligenceService,
   defaultPackageDocsList,

--- a/src/tools/list-package-docs.test.ts
+++ b/src/tools/list-package-docs.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, mock } from "bun:test";
 import {
   type PackageDocsList,
   PackageIntelligenceTargetNotFoundError,
-} from "../services/index.js";
+} from "../services/package-intelligence-service.js";
 import { createMockPackageIntelligenceService } from "../services/test-helpers.js";
 import { createListPackageDocsTool } from "./list-package-docs.js";
 

--- a/src/tools/list-package-docs.ts
+++ b/src/tools/list-package-docs.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { PackageIntelligenceService } from "../services/index.js";
+import type { PackageIntelligenceService } from "../services/package-intelligence-service.js";
 import { buildListPackageDocsParams } from "../shared/list-package-docs-request.js";
 import { buildListPackageDocsSuccessPayload } from "../shared/list-package-docs-response.js";
 import { renderListPackageDocsText } from "../shared/list-package-docs-text.js";

--- a/src/tools/list-package-docs.ts
+++ b/src/tools/list-package-docs.ts
@@ -7,7 +7,7 @@ import { mapPackageIntelligenceError } from "../shared/package-intelligence-erro
 import { PKGSEER_REGISTRY_LIST } from "../shared/pkgseer-registry.js";
 import { DOCS_GUARDRAIL } from "./guardrails.js";
 import { mcpMappedErrorResult } from "./shared.js";
-import { errorResult, type ToolDefinition, textResult } from "./types.js";
+import { type ToolDefinition, textResult } from "./types.js";
 
 export interface ListPackageDocsArgs {
   registry: string;

--- a/src/tools/package-changelog-parity.test.ts
+++ b/src/tools/package-changelog-parity.test.ts
@@ -25,7 +25,7 @@ import {
   PackageIntelligenceChangelogSourceNotFoundError,
   PackageIntelligenceTargetNotFoundError,
   PackageIntelligenceVersionNotFoundError,
-} from "../services/index.js";
+} from "../services/package-intelligence-service.js";
 import {
   createMockPackageIntelligenceService,
   defaultChangelogReport,

--- a/src/tools/package-changelog.test.ts
+++ b/src/tools/package-changelog.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, mock } from "bun:test";
 import {
   PackageIntelligenceChangelogSourceNotFoundError,
   PackageIntelligenceTargetNotFoundError,
-} from "../services/index.js";
+} from "../services/package-intelligence-service.js";
 import {
   createMockPackageIntelligenceService,
   defaultChangelogReport,

--- a/src/tools/package-changelog.ts
+++ b/src/tools/package-changelog.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { PackageIntelligenceService } from "../services/index.js";
+import type { PackageIntelligenceService } from "../services/package-intelligence-service.js";
 import { InvalidPackageSpecError } from "../shared/index.js";
 import { buildPackageChangelogParams } from "../shared/package-changelog-request.js";
 import {

--- a/src/tools/package-dependencies-parity.test.ts
+++ b/src/tools/package-dependencies-parity.test.ts
@@ -19,12 +19,12 @@ import {
   type PkgDepsCommandDependencies,
   pkgDepsAction,
 } from "../commands/pkg/deps.js";
-import type { DependencyReport } from "../services/index.js";
+import type { DependencyReport } from "../services/package-intelligence-service.js";
 import {
   PackageIntelligenceBackendError,
   PackageIntelligenceTargetNotFoundError,
   PackageIntelligenceVersionNotFoundError,
-} from "../services/index.js";
+} from "../services/package-intelligence-service.js";
 import {
   cratesFeatureDependencyReport,
   createMockPackageIntelligenceService,

--- a/src/tools/package-dependencies.test.ts
+++ b/src/tools/package-dependencies.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, mock } from "bun:test";
-import type { DependencyReport } from "../services/index.js";
-import { PackageIntelligenceTargetNotFoundError } from "../services/index.js";
+import type { DependencyReport } from "../services/package-intelligence-service.js";
+import { PackageIntelligenceTargetNotFoundError } from "../services/package-intelligence-service.js";
 import {
   createMockPackageIntelligenceService,
   defaultDependencyReport,

--- a/src/tools/package-dependencies.ts
+++ b/src/tools/package-dependencies.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { PackageIntelligenceService } from "../services/index.js";
+import type { PackageIntelligenceService } from "../services/package-intelligence-service.js";
 import {
   buildPackageDependenciesParams,
   SUPPORTED_DEPS_REGISTRIES_LIST,

--- a/src/tools/package-summary-parity.test.ts
+++ b/src/tools/package-summary-parity.test.ts
@@ -27,7 +27,7 @@ import {
 import {
   PackageIntelligenceBackendError,
   PackageIntelligenceTargetNotFoundError,
-} from "../services/index.js";
+} from "../services/package-intelligence-service.js";
 import { createMockPackageIntelligenceService } from "../services/test-helpers.js";
 import { createPackageSummaryTool } from "./package-summary.js";
 import { isProcessExitSentinel } from "./parity-test-helpers.js";

--- a/src/tools/package-summary.test.ts
+++ b/src/tools/package-summary.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, mock } from "bun:test";
-import { PackageIntelligenceTargetNotFoundError } from "../services/index.js";
+import { PackageIntelligenceTargetNotFoundError } from "../services/package-intelligence-service.js";
 import {
   createMockPackageIntelligenceService,
   defaultPackageSummary,

--- a/src/tools/package-summary.ts
+++ b/src/tools/package-summary.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { PackageIntelligenceService } from "../services/index.js";
+import type { PackageIntelligenceService } from "../services/package-intelligence-service.js";
 import { mapPackageIntelligenceError } from "../shared/package-intelligence-error-map.js";
 import { buildPackageSummaryParams } from "../shared/package-summary-request.js";
 import {

--- a/src/tools/package-upgrade-review-parity.test.ts
+++ b/src/tools/package-upgrade-review-parity.test.ts
@@ -10,7 +10,7 @@ import {
   type PkgUpgradeReviewCommandDependencies,
   pkgUpgradeReviewAction,
 } from "../commands/pkg/upgrade-review.js";
-import type { PackageIntelligenceService } from "../services/index.js";
+import type { PackageIntelligenceService } from "../services/package-intelligence-service.js";
 import { createMockPackageIntelligenceService } from "../services/test-helpers.js";
 import { createPackageUpgradeReviewTool } from "./package-upgrade-review.js";
 import { isProcessExitSentinel } from "./parity-test-helpers.js";

--- a/src/tools/package-upgrade-review.test.ts
+++ b/src/tools/package-upgrade-review.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, mock } from "bun:test";
 import type {
   DependencyReport,
   VulnerabilityReport,
-} from "../services/index.js";
+} from "../services/package-intelligence-service.js";
 import { createMockPackageIntelligenceService } from "../services/test-helpers.js";
 import { createPackageUpgradeReviewTool } from "./package-upgrade-review.js";
 

--- a/src/tools/package-upgrade-review.ts
+++ b/src/tools/package-upgrade-review.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { PackageIntelligenceService } from "../services/index.js";
+import type { PackageIntelligenceService } from "../services/package-intelligence-service.js";
 import {
   buildPackageUpgradeReview,
   buildPackageUpgradeReviewRequest,

--- a/src/tools/package-vulnerabilities-parity.test.ts
+++ b/src/tools/package-vulnerabilities-parity.test.ts
@@ -23,12 +23,12 @@ import {
   type PkgVulnsCommandDependencies,
   pkgVulnsAction,
 } from "../commands/pkg/vulns.js";
-import type { VulnerabilityReport } from "../services/index.js";
+import type { VulnerabilityReport } from "../services/package-intelligence-service.js";
 import {
   PackageIntelligenceBackendError,
   PackageIntelligenceTargetNotFoundError,
   PackageIntelligenceVersionNotFoundError,
-} from "../services/index.js";
+} from "../services/package-intelligence-service.js";
 import {
   createMockPackageIntelligenceService,
   defaultVulnerabilityReport,

--- a/src/tools/package-vulnerabilities.test.ts
+++ b/src/tools/package-vulnerabilities.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, mock } from "bun:test";
-import { PackageIntelligenceTargetNotFoundError } from "../services/index.js";
+import { PackageIntelligenceTargetNotFoundError } from "../services/package-intelligence-service.js";
 import {
   createMockPackageIntelligenceService,
   defaultVulnerabilityReport,

--- a/src/tools/package-vulnerabilities.ts
+++ b/src/tools/package-vulnerabilities.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { PackageIntelligenceService } from "../services/index.js";
+import type { PackageIntelligenceService } from "../services/package-intelligence-service.js";
 import { mapPackageIntelligenceError } from "../shared/package-intelligence-error-map.js";
 import { buildPackageVulnerabilitiesParams } from "../shared/package-vulnerabilities-request.js";
 import {

--- a/src/tools/read-file-parity.test.ts
+++ b/src/tools/read-file-parity.test.ts
@@ -12,7 +12,7 @@ import {
   CodeNavigationFileNotFoundError,
   CodeNavigationIndexingError,
   type ReadFileResult,
-} from "../services/index.js";
+} from "../services/code-navigation-service.js";
 import {
   createMockCodeNavigationService,
   defaultReadFileResult,

--- a/src/tools/read-file.test.ts
+++ b/src/tools/read-file.test.ts
@@ -3,7 +3,7 @@ import {
   CodeNavigationFileNotFoundError,
   CodeNavigationIndexingError,
   CodeNavigationTargetNotFoundError,
-} from "../services/index.js";
+} from "../services/code-navigation-service.js";
 import {
   createMockCodeNavigationService,
   defaultReadFileResult,

--- a/src/tools/read-file.ts
+++ b/src/tools/read-file.ts
@@ -16,7 +16,7 @@ import {
 } from "./code-navigation-shared.js";
 import { CODE_READ_GUARDRAIL } from "./guardrails.js";
 import { mcpMappedErrorResult } from "./shared.js";
-import { errorResult, type ToolDefinition, textResult } from "./types.js";
+import { type ToolDefinition, textResult } from "./types.js";
 
 /**
  * Maximum line span the MCP `code_read` tool will return in one call.

--- a/src/tools/read-file.ts
+++ b/src/tools/read-file.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { CodeNavigationService } from "../services/index.js";
+import type { CodeNavigationService } from "../services/code-navigation-service.js";
 import { mapCodeNavigationError } from "../shared/code-navigation-error-map.js";
 import { toPkgseerRegistryLowercase } from "../shared/pkgseer-registry.js";
 import { withReadFileRecovery } from "../shared/read-file-error.js";

--- a/src/tools/read-package-doc-parity.test.ts
+++ b/src/tools/read-package-doc-parity.test.ts
@@ -3,7 +3,7 @@ import {
   type DocsReadCommandDependencies,
   docsReadAction,
 } from "../commands/docs/read.js";
-import { PackageIntelligenceTargetNotFoundError } from "../services/index.js";
+import { PackageIntelligenceTargetNotFoundError } from "../services/package-intelligence-service.js";
 import { createMockPackageIntelligenceService } from "../services/test-helpers.js";
 import { isProcessExitSentinel } from "./parity-test-helpers.js";
 import { createReadPackageDocTool } from "./read-package-doc.js";

--- a/src/tools/read-package-doc.test.ts
+++ b/src/tools/read-package-doc.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, mock } from "bun:test";
-import { PackageIntelligenceTargetNotFoundError } from "../services/index.js";
+import { PackageIntelligenceTargetNotFoundError } from "../services/package-intelligence-service.js";
 import { createMockPackageIntelligenceService } from "../services/test-helpers.js";
 import { createReadPackageDocTool } from "./read-package-doc.js";
 

--- a/src/tools/read-package-doc.ts
+++ b/src/tools/read-package-doc.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { PackageIntelligenceService } from "../services/index.js";
+import type { PackageIntelligenceService } from "../services/package-intelligence-service.js";
 import { mapPackageIntelligenceError } from "../shared/package-intelligence-error-map.js";
 import { buildReadPackageDocParams } from "../shared/read-package-doc-request.js";
 import { buildReadPackageDocSuccessPayload } from "../shared/read-package-doc-response.js";

--- a/src/tools/read-package-doc.ts
+++ b/src/tools/read-package-doc.ts
@@ -6,7 +6,7 @@ import { buildReadPackageDocSuccessPayload } from "../shared/read-package-doc-re
 import { renderReadPackageDocText } from "../shared/read-package-doc-text.js";
 import { DOCS_GUARDRAIL } from "./guardrails.js";
 import { mcpMappedErrorResult } from "./shared.js";
-import { errorResult, type ToolDefinition, textResult } from "./types.js";
+import { type ToolDefinition, textResult } from "./types.js";
 
 export interface ReadPackageDocArgs {
   page_id: string;

--- a/src/tools/search-status.ts
+++ b/src/tools/search-status.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { CodeNavigationService } from "../services/index.js";
+import type { CodeNavigationService } from "../services/code-navigation-service.js";
 import {
   buildUnifiedSearchErrorPayload,
   buildUnifiedSearchStatusPayload,

--- a/src/tools/search.test.ts
+++ b/src/tools/search.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, mock } from "bun:test";
 import type {
   UnifiedSearchOutcome,
   UnifiedSearchParams,
-} from "../services/index.js";
+} from "../services/code-navigation-service.js";
 import {
   createMockCodeNavigationService,
   defaultUnifiedSearchOutcome,

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import type {
   CodeNavigationService,
   CodeNavigationTarget,
-} from "../services/index.js";
+} from "../services/code-navigation-service.js";
 import {
   type CodeNavigationRegistryArg,
   toCodeNavigationRegistry,

--- a/src/tools/tool-services.ts
+++ b/src/tools/tool-services.ts
@@ -1,8 +1,6 @@
-import type {
-  CodeNavigationService,
-  GitHitsService,
-  PackageIntelligenceService,
-} from "../services/index.js";
+import type { CodeNavigationService } from "../services/code-navigation-service.js";
+import type { GitHitsService } from "../services/githits-service.js";
+import type { PackageIntelligenceService } from "../services/package-intelligence-service.js";
 
 /**
  * Services required to construct the MCP tool surface.


### PR DESCRIPTION
## Summary
- Replace internal imports from services/index.js with defining service module imports across tools, shared code, CLI commands, container wiring, and tests.
- Add a Biome noRestrictedImports rule to prevent services/index.js imports from returning while keeping the barrel available.
- Remove unused tool imports surfaced by the stricter lint pass.

## Verification
- Code reviewer: no findings.
- bun run lint
- bun test
- bun run typecheck
- bun run format:check
- git diff --check
- bun run build

## Notes
- Untracked docs/plans/ remains local and is not part of this PR.