### PR TITLE
fix: distinguish auth failure sources

### DIFF
--- a/src/commands/auth-json.test.ts
+++ b/src/commands/auth-json.test.ts
@@ -134,9 +134,10 @@ describe("authenticated command JSON auth failures", () => {
       expect(logSpy).not.toHaveBeenCalled();
       const payload = JSON.parse(String(errorSpy.mock.calls[0]?.[0]));
       expect(payload).toEqual({
-        error: "Authentication required.",
+        error: "No local GitHits authentication token found.",
         code: "AUTH_REQUIRED",
         retryable: false,
+        details: { authSource: "local" },
       });
     } finally {
       logSpy.mockRestore();

--- a/src/commands/code/files.test.ts
+++ b/src/commands/code/files.test.ts
@@ -274,7 +274,7 @@ describe("pkgFilesAction", () => {
     }
 
     expect(errorSpy.mock.calls[0]?.[0]).toBe(
-      "Authentication required. Run `githits login` to authenticate.",
+      "Authentication required. Run `githits login` to authenticate or set GITHITS_API_TOKEN.",
     );
     errorSpy.mockRestore();
     exitSpy.mockRestore();
@@ -304,6 +304,7 @@ describe("pkgFilesAction", () => {
       error: "Authentication required.",
       code: "AUTH_REQUIRED",
       retryable: false,
+      details: { authSource: "local" },
     });
     errorSpy.mockRestore();
     exitSpy.mockRestore();

--- a/src/commands/example.test.ts
+++ b/src/commands/example.test.ts
@@ -99,9 +99,10 @@ describe("exampleAction", () => {
 
     const output = errorSpy.mock.calls[0]?.[0] as string;
     expect(JSON.parse(output)).toEqual({
-      error: "Authentication required.",
+      error: "No local GitHits authentication token found.",
       code: "AUTH_REQUIRED",
       retryable: false,
+      details: { authSource: "local" },
     });
     expect(exitSpy).toHaveBeenCalledWith(1);
 
@@ -125,7 +126,7 @@ describe("exampleAction", () => {
     );
 
     expect(errorSpy.mock.calls[0]?.[0]).toBe(
-      "Authentication required. Run `githits login` to authenticate.",
+      "Authentication required. Run `githits login` to authenticate or set GITHITS_API_TOKEN.",
     );
     expect(exitSpy).toHaveBeenCalledWith(1);
     errorSpy.mockRestore();
@@ -151,6 +152,7 @@ describe("exampleAction", () => {
       error: "Authentication required.",
       code: "AUTH_REQUIRED",
       retryable: false,
+      details: { authSource: "local" },
     });
     expect(exitSpy).toHaveBeenCalledWith(1);
     errorSpy.mockRestore();

--- a/src/commands/example.ts
+++ b/src/commands/example.ts
@@ -67,6 +67,7 @@ export async function exampleAction(
         code: "AUTH_REQUIRED" as const,
         message: error.message,
         retryable: false,
+        details: { authSource: error.source },
       };
       if (options.json) {
         console.error(JSON.stringify(buildCliMappedErrorPayload(mapped)));

--- a/src/commands/feedback.test.ts
+++ b/src/commands/feedback.test.ts
@@ -251,6 +251,7 @@ describe("feedbackAction", () => {
       error: "Authentication required.",
       code: "AUTH_REQUIRED",
       retryable: false,
+      details: { authSource: "local" },
     });
     expect(exitSpy).toHaveBeenCalledWith(1);
     errorSpy.mockRestore();
@@ -273,7 +274,7 @@ describe("feedbackAction", () => {
     ).rejects.toThrow("process.exit");
 
     expect(errorSpy.mock.calls[0]?.[0]).toBe(
-      "Authentication required. Run `githits login` to authenticate.",
+      "Authentication required. Run `githits login` to authenticate or set GITHITS_API_TOKEN.",
     );
     expect(exitSpy).toHaveBeenCalledWith(1);
     errorSpy.mockRestore();

--- a/src/commands/feedback.ts
+++ b/src/commands/feedback.ts
@@ -77,6 +77,7 @@ export async function feedbackAction(
         code: "AUTH_REQUIRED" as const,
         message: error.message,
         retryable: false,
+        details: { authSource: error.source },
       };
       if (options.json) {
         console.error(JSON.stringify(buildCliMappedErrorPayload(mapped)));

--- a/src/commands/format-mapped-error.test.ts
+++ b/src/commands/format-mapped-error.test.ts
@@ -15,6 +15,32 @@ describe("formatMappedErrorForTerminal", () => {
     ).toBe("Authentication required. Run `githits login` to authenticate.");
   });
 
+  it("keeps distinct AUTH_REQUIRED messages in terminal output", () => {
+    expect(
+      formatMappedErrorForTerminal({
+        code: "AUTH_REQUIRED",
+        message: "GitHits could not accept the authentication token.",
+        retryable: false,
+        details: { authSource: "server" },
+      }),
+    ).toBe(
+      "GitHits could not accept the authentication token. Re-authenticate with `githits login` or update GITHITS_API_TOKEN if set. If this persists, contact support@githits.com.",
+    );
+  });
+
+  it("mentions API token recovery for local auth failures", () => {
+    expect(
+      formatMappedErrorForTerminal({
+        code: "AUTH_REQUIRED",
+        message: "No local GitHits authentication token found.",
+        retryable: false,
+        details: { authSource: "local" },
+      }),
+    ).toBe(
+      "No local GitHits authentication token found. Run `githits login` to authenticate or set GITHITS_API_TOKEN.",
+    );
+  });
+
   it("leaves CLI JSON auth envelopes neutral", () => {
     expect(
       buildCliMappedErrorPayload({

--- a/src/commands/format-mapped-error.ts
+++ b/src/commands/format-mapped-error.ts
@@ -2,6 +2,10 @@ import type { MappedError } from "../shared/code-navigation-error-map.js";
 
 const CLI_AUTH_ERROR_MESSAGE =
   "Authentication required. Run `githits login` to authenticate.";
+const CLI_LOCAL_AUTH_REMEDIATION =
+  "Run `githits login` to authenticate or set GITHITS_API_TOKEN.";
+const CLI_SERVER_AUTH_REMEDIATION =
+  "Re-authenticate with `githits login` or update GITHITS_API_TOKEN if set. If this persists, contact support@githits.com.";
 
 interface CliErrorPayload {
   error: string;
@@ -12,7 +16,13 @@ interface CliErrorPayload {
 
 export function formatMappedErrorForTerminal(mapped: MappedError): string {
   if (mapped.code === "AUTH_REQUIRED") {
-    return CLI_AUTH_ERROR_MESSAGE;
+    if (
+      mapped.message === "Authentication required." &&
+      mapped.details?.authSource === undefined
+    ) {
+      return CLI_AUTH_ERROR_MESSAGE;
+    }
+    return `${mapped.message} ${authRemediation(mapped)}`;
   }
   if (mapped.code !== "UPDATE_REQUIRED") {
     return mapped.message;
@@ -23,6 +33,12 @@ export function formatMappedErrorForTerminal(mapped: MappedError): string {
       ? detail.updateCommand
       : "npm i -g githits@latest";
   return [mapped.message, "", "Update with:", `  ${updateCommand}`].join("\n");
+}
+
+function authRemediation(mapped: MappedError): string {
+  return mapped.details?.authSource === "server"
+    ? CLI_SERVER_AUTH_REMEDIATION
+    : CLI_LOCAL_AUTH_REMEDIATION;
 }
 
 export function buildCliMappedErrorPayload(

--- a/src/commands/languages.test.ts
+++ b/src/commands/languages.test.ts
@@ -149,6 +149,7 @@ describe("languagesAction", () => {
       error: "Authentication required.",
       code: "AUTH_REQUIRED",
       retryable: false,
+      details: { authSource: "local" },
     });
     expect(exitSpy).toHaveBeenCalledWith(1);
     errorSpy.mockRestore();
@@ -171,7 +172,7 @@ describe("languagesAction", () => {
     );
 
     expect(errorSpy.mock.calls[0]?.[0]).toBe(
-      "Authentication required. Run `githits login` to authenticate.",
+      "Authentication required. Run `githits login` to authenticate or set GITHITS_API_TOKEN.",
     );
     expect(exitSpy).toHaveBeenCalledWith(1);
     errorSpy.mockRestore();

--- a/src/commands/languages.ts
+++ b/src/commands/languages.ts
@@ -74,6 +74,7 @@ export async function languagesAction(
         code: "AUTH_REQUIRED" as const,
         message: error.message,
         retryable: false,
+        details: { authSource: error.source },
       };
       if (options.json) {
         console.error(JSON.stringify(buildCliMappedErrorPayload(mapped)));

--- a/src/commands/pkg/info.test.ts
+++ b/src/commands/pkg/info.test.ts
@@ -187,7 +187,7 @@ describe("pkgInfoAction", () => {
     }
 
     expect(errorSpy.mock.calls[0]?.[0]).toBe(
-      "Authentication required. Run `githits login` to authenticate.",
+      "Authentication required. Run `githits login` to authenticate or set GITHITS_API_TOKEN.",
     );
     errorSpy.mockRestore();
     exitSpy.mockRestore();
@@ -216,6 +216,43 @@ describe("pkgInfoAction", () => {
       error: "Authentication required.",
       code: "AUTH_REQUIRED",
       retryable: false,
+      details: { authSource: "local" },
+    });
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it("preserves server auth rejection source in JSON service auth failures", async () => {
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+    const service = createMockPackageIntelligenceService({
+      packageSummary: mock(() =>
+        Promise.reject(
+          new AuthenticationError(
+            "GitHits could not accept the authentication token.",
+            "server",
+          ),
+        ),
+      ),
+    });
+
+    try {
+      await pkgInfoAction(
+        "npm:express",
+        { json: true },
+        createDeps({ packageIntelligenceService: service }),
+      );
+    } catch {
+      // expected
+    }
+
+    expect(JSON.parse(errorSpy.mock.calls[0]?.[0] as string)).toEqual({
+      error: "GitHits could not accept the authentication token.",
+      code: "AUTH_REQUIRED",
+      retryable: false,
+      details: { authSource: "server" },
     });
     errorSpy.mockRestore();
     exitSpy.mockRestore();

--- a/src/commands/search.test.ts
+++ b/src/commands/search.test.ts
@@ -73,7 +73,7 @@ describe("searchAction", () => {
     ).rejects.toThrow("process.exit");
 
     expect(errorSpy.mock.calls[0]?.[0]).toBe(
-      "Authentication required. Run `githits login` to authenticate.",
+      "Authentication required. Run `githits login` to authenticate or set GITHITS_API_TOKEN.",
     );
     errorSpy.mockRestore();
     exitSpy.mockRestore();
@@ -787,7 +787,7 @@ describe("searchStatusAction", () => {
     ).rejects.toThrow("process.exit");
 
     expect(errorSpy.mock.calls[0]?.[0]).toBe(
-      "Authentication required. Run `githits login` to authenticate.",
+      "Authentication required. Run `githits login` to authenticate or set GITHITS_API_TOKEN.",
     );
     errorSpy.mockRestore();
     exitSpy.mockRestore();

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -379,7 +379,7 @@ function handleSearchError(
 }
 
 function formatSearchErrorTerminal(
-  payload: { error: string; code: string },
+  payload: { error: string; code: string; details?: Record<string, unknown> },
   context: "search" | "status",
 ): string {
   if (payload.code === "AUTH_REQUIRED") {
@@ -387,6 +387,7 @@ function formatSearchErrorTerminal(
       code: "AUTH_REQUIRED",
       message: payload.error,
       retryable: false,
+      details: payload.details,
     });
   }
   if (context === "status" && payload.code === "NOT_FOUND") {

--- a/src/services/code-navigation-service.ts
+++ b/src/services/code-navigation-service.ts
@@ -14,7 +14,10 @@ import {
   isGraphQLSchemaMismatchError,
 } from "./client-update-required-error.js";
 import { executeWithTokenRefresh } from "./execute-with-token-refresh.js";
-import { AuthenticationError } from "./githits-service.js";
+import {
+  AuthenticationError,
+  SERVER_AUTHENTICATION_REJECTED_MESSAGE,
+} from "./githits-service.js";
 import type { TokenProvider } from "./token-manager.js";
 
 /**
@@ -1806,7 +1809,10 @@ export class CodeNavigationServiceImpl implements CodeNavigationService {
     const detail = parseDetail(response.responseBody);
 
     if (status === 401) {
-      return new AuthenticationError();
+      return new AuthenticationError(
+        SERVER_AUTHENTICATION_REJECTED_MESSAGE,
+        "server",
+      );
     }
 
     if (status === 403) {
@@ -1949,7 +1955,10 @@ export class CodeNavigationServiceImpl implements CodeNavigationService {
         return new CodeNavigationFeatureFlagRequiredError(message);
 
       case "UNAUTHORIZED":
-        return new AuthenticationError();
+        return new AuthenticationError(
+          SERVER_AUTHENTICATION_REJECTED_MESSAGE,
+          "server",
+        );
 
       case "FORBIDDEN":
         return new CodeNavigationAccessError(

--- a/src/services/execute-with-token-refresh.ts
+++ b/src/services/execute-with-token-refresh.ts
@@ -1,4 +1,7 @@
-import { AuthenticationError } from "./githits-service.js";
+import {
+  AuthenticationError,
+  LOCAL_AUTHENTICATION_MISSING_MESSAGE,
+} from "./githits-service.js";
 
 export interface ExecuteWithTokenRefreshOptions<T> {
   getToken: () => Promise<string | undefined>;
@@ -16,7 +19,10 @@ export async function executeWithTokenRefresh<T>(
 ): Promise<T> {
   const token = await options.getToken();
   if (!token) {
-    throw new AuthenticationError();
+    throw new AuthenticationError(
+      LOCAL_AUTHENTICATION_MISSING_MESSAGE,
+      "local",
+    );
   }
 
   try {

--- a/src/services/githits-service.test.ts
+++ b/src/services/githits-service.test.ts
@@ -142,7 +142,7 @@ describe("GitHitsServiceImpl", () => {
       ).rejects.toThrow(AuthenticationError);
       await expect(
         service.search({ query: "test", language: "js" }),
-      ).rejects.toThrow("Authentication required");
+      ).rejects.toThrow("GitHits could not accept the authentication token.");
     });
 
     it("throws on 500 with status code", async () => {

--- a/src/services/githits-service.ts
+++ b/src/services/githits-service.ts
@@ -10,15 +10,27 @@ import { withTelemetrySpan } from "../shared/telemetry.js";
  * CLI- or MCP-specific recovery guidance when presenting the error.
  */
 export const AUTHENTICATION_REQUIRED_MESSAGE = "Authentication required.";
+export const LOCAL_AUTHENTICATION_MISSING_MESSAGE =
+  "No local GitHits authentication token found.";
+export const SERVER_AUTHENTICATION_REJECTED_MESSAGE =
+  "GitHits could not accept the authentication token.";
+
+export type AuthenticationErrorSource = "local" | "server";
 
 /**
  * Error thrown when the API returns 401 Unauthorized.
  * Used by RefreshingGitHitsService to detect auth failures and trigger token refresh.
  */
 export class AuthenticationError extends Error {
-  constructor(message: string = AUTHENTICATION_REQUIRED_MESSAGE) {
+  readonly source: AuthenticationErrorSource;
+
+  constructor(
+    message: string = AUTHENTICATION_REQUIRED_MESSAGE,
+    source: AuthenticationErrorSource = "local",
+  ) {
     super(message);
     this.name = "AuthenticationError";
+    this.source = source;
   }
 }
 
@@ -216,7 +228,10 @@ export class GitHitsServiceImpl implements GitHitsService {
 
     switch (status) {
       case 401:
-        return new AuthenticationError();
+        return new AuthenticationError(
+          SERVER_AUTHENTICATION_REJECTED_MESSAGE,
+          "server",
+        );
       case 403:
         return new Error("Access denied.");
       case 404:

--- a/src/services/package-intelligence-service.ts
+++ b/src/services/package-intelligence-service.ts
@@ -33,7 +33,10 @@ import {
   isGraphQLSchemaMismatchError,
 } from "./client-update-required-error.js";
 import { executeWithTokenRefresh } from "./execute-with-token-refresh.js";
-import { AuthenticationError } from "./githits-service.js";
+import {
+  AuthenticationError,
+  SERVER_AUTHENTICATION_REJECTED_MESSAGE,
+} from "./githits-service.js";
 import { promoteGenericVersionNotFound } from "./promote-version-not-found.js";
 import type { TokenProvider } from "./token-manager.js";
 
@@ -1810,7 +1813,10 @@ export class PackageIntelligenceServiceImpl
     const detail = parseDetail(response.responseBody);
 
     if (status === 401) {
-      return new AuthenticationError();
+      return new AuthenticationError(
+        SERVER_AUTHENTICATION_REJECTED_MESSAGE,
+        "server",
+      );
     }
 
     if (status === 403) {
@@ -1910,7 +1916,10 @@ export class PackageIntelligenceServiceImpl
         return new PackageIntelligenceFeatureFlagRequiredError(message);
 
       case "UNAUTHORIZED":
-        return new AuthenticationError();
+        return new AuthenticationError(
+          SERVER_AUTHENTICATION_REJECTED_MESSAGE,
+          "server",
+        );
 
       case "FORBIDDEN":
         return new PackageIntelligenceAccessError(

--- a/src/shared/code-navigation-error-map.test.ts
+++ b/src/shared/code-navigation-error-map.test.ts
@@ -150,6 +150,17 @@ describe("mapCodeNavigationError", () => {
       code: "AUTH_REQUIRED",
       message: "Login required",
       retryable: false,
+      details: { authSource: "local" },
+    });
+  });
+
+  it("preserves server auth rejection source", () => {
+    const err = new AuthenticationError("Token rejected", "server");
+    expect(mapCodeNavigationError(err)).toEqual({
+      code: "AUTH_REQUIRED",
+      message: "Token rejected",
+      retryable: false,
+      details: { authSource: "server" },
     });
   });
 

--- a/src/shared/code-navigation-error-map.ts
+++ b/src/shared/code-navigation-error-map.ts
@@ -19,7 +19,10 @@ import {
   MalformedCodeNavigationResponseError,
   type TargetResolution,
 } from "../services/code-navigation-service.js";
-import { AuthenticationError } from "../services/githits-service.js";
+import {
+  AuthenticationError,
+  type AuthenticationErrorSource,
+} from "../services/githits-service.js";
 import { debugLog } from "./debug-log.js";
 import { AuthRequiredError } from "./require-auth.js";
 
@@ -66,6 +69,8 @@ export interface MappedErrorDetails {
   updateCommand?: string;
   /** Human-readable update reason. */
   reason?: string;
+  /** Whether auth failed before making a request or after backend rejection. */
+  authSource?: AuthenticationErrorSource;
 }
 
 export interface MappedError {
@@ -191,6 +196,10 @@ function classify(error: unknown): MappedError {
       code: "AUTH_REQUIRED",
       message: error.message,
       retryable: false,
+      details: {
+        authSource:
+          error instanceof AuthenticationError ? error.source : "local",
+      },
     };
   }
   if (error instanceof CodeNavigationNetworkError) {

--- a/src/shared/package-intelligence-error-map.test.ts
+++ b/src/shared/package-intelligence-error-map.test.ts
@@ -102,6 +102,20 @@ describe("mapPackageIntelligenceError", () => {
       code: "AUTH_REQUIRED",
       message: "login required",
       retryable: false,
+      details: { authSource: "local" },
+    });
+  });
+
+  it("preserves server auth rejection source", () => {
+    expect(
+      mapPackageIntelligenceError(
+        new AuthenticationError("token rejected", "server"),
+      ),
+    ).toEqual({
+      code: "AUTH_REQUIRED",
+      message: "token rejected",
+      retryable: false,
+      details: { authSource: "server" },
     });
   });
 

--- a/src/shared/package-intelligence-error-map.ts
+++ b/src/shared/package-intelligence-error-map.ts
@@ -115,6 +115,10 @@ function classify(error: unknown): MappedError {
       code: "AUTH_REQUIRED",
       message: error.message,
       retryable: false,
+      details: {
+        authSource:
+          error instanceof AuthenticationError ? error.source : "local",
+      },
     };
   }
   if (error instanceof PackageIntelligenceNetworkError) {

--- a/src/shared/require-auth.test.ts
+++ b/src/shared/require-auth.test.ts
@@ -35,7 +35,9 @@ describe("requireAuth", () => {
         { hasValidToken: false, mcpUrl: "https://mcp.githits.com" },
         "to start MCP server",
       ),
-    ).toThrow("Authentication required to start MCP server.");
+    ).toThrow(
+      "No local GitHits authentication token found to start MCP server.",
+    );
   });
 
   it("formats terminal recovery text", () => {
@@ -67,6 +69,7 @@ describe("requireAuth", () => {
       error: "Authentication required.",
       code: "AUTH_REQUIRED",
       retryable: false,
+      details: { authSource: "local" },
     });
   });
 });

--- a/src/shared/require-auth.ts
+++ b/src/shared/require-auth.ts
@@ -1,3 +1,5 @@
+import { LOCAL_AUTHENTICATION_MISSING_MESSAGE } from "../services/githits-service.js";
+
 /**
  * Error thrown when authentication is required but no valid token is available.
  * Caught at the CLI boundary to trigger process.exit(1).
@@ -16,6 +18,7 @@ export interface AuthRequiredErrorPayload {
   error: string;
   code: "AUTH_REQUIRED";
   retryable: false;
+  details: { authSource: "local" };
 }
 
 /**
@@ -36,7 +39,10 @@ export function requireAuth(
   if (deps.hasValidToken) return;
 
   const suffix = context ? ` ${context}` : "";
-  throw new AuthRequiredError(`Authentication required${suffix}.`, deps.mcpUrl);
+  throw new AuthRequiredError(
+    `${LOCAL_AUTHENTICATION_MISSING_MESSAGE.slice(0, -1)}${suffix}.`,
+    deps.mcpUrl,
+  );
 }
 
 export function buildAuthRequiredErrorPayload(
@@ -46,6 +52,7 @@ export function buildAuthRequiredErrorPayload(
     error: error.message,
     code: "AUTH_REQUIRED",
     retryable: false,
+    details: { authSource: "local" },
   };
 }
 

--- a/src/tools/package-summary.test.ts
+++ b/src/tools/package-summary.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, mock } from "bun:test";
+import { AuthenticationError } from "../services/githits-service.js";
 import { PackageIntelligenceTargetNotFoundError } from "../services/package-intelligence-service.js";
 import {
   createMockPackageIntelligenceService,
@@ -181,5 +182,35 @@ describe("createPackageSummaryTool — service errors", () => {
     expect(result.isError).toBe(true);
     const payload = parseText(result) as { code: string };
     expect(payload.code).toBe("UNKNOWN");
+  });
+
+  it("preserves server auth rejection source in MCP envelope", async () => {
+    const service = createMockPackageIntelligenceService({
+      packageSummary: mock(() =>
+        Promise.reject(
+          new AuthenticationError(
+            "GitHits could not accept the authentication token.",
+            "server",
+          ),
+        ),
+      ),
+    });
+    const tool = createPackageSummaryTool(service);
+    const result = await tool.handler(
+      { registry: "npm", package_name: "express", format: "json" },
+      {},
+    );
+
+    expect(result.isError).toBe(true);
+    expect(parseText(result)).toEqual({
+      error: "GitHits could not accept the authentication token.",
+      code: "AUTH_REQUIRED",
+      retryable: false,
+      details: {
+        authSource: "server",
+        action:
+          "Re-authenticate with `githits login` or update GITHITS_API_TOKEN if set. If this persists, contact support@githits.com.",
+      },
+    });
   });
 });

--- a/src/tools/search-language.test.ts
+++ b/src/tools/search-language.test.ts
@@ -61,7 +61,11 @@ describe("searchLanguageTool", () => {
       error: "Authentication required",
       code: "AUTH_REQUIRED",
       retryable: false,
-      details: { action: "Run `githits login`, then retry this tool call." },
+      details: {
+        action:
+          "Run `githits login`, or set GITHITS_API_TOKEN, then retry this tool call.",
+        authSource: "local",
+      },
     });
   });
 });

--- a/src/tools/search-status.test.ts
+++ b/src/tools/search-status.test.ts
@@ -84,7 +84,11 @@ describe("searchStatusTool", () => {
       error: "Authentication required.",
       code: "AUTH_REQUIRED",
       retryable: false,
-      details: { action: "Run `githits login`, then retry this tool call." },
+      details: {
+        action:
+          "Run `githits login`, or set GITHITS_API_TOKEN, then retry this tool call.",
+        authSource: "local",
+      },
     });
   });
 

--- a/src/tools/shared.ts
+++ b/src/tools/shared.ts
@@ -2,7 +2,10 @@ import { AuthenticationError } from "../services/githits-service.js";
 import type { MappedError } from "../shared/code-navigation-error-map.js";
 import { errorResult, type ToolResult } from "./types.js";
 
-const LOCAL_MCP_AUTH_ACTION = "Run `githits login`, then retry this tool call.";
+const LOCAL_MCP_AUTH_ACTION =
+  "Run `githits login`, or set GITHITS_API_TOKEN, then retry this tool call.";
+const SERVER_MCP_AUTH_ACTION =
+  "Re-authenticate with `githits login` or update GITHITS_API_TOKEN if set. If this persists, contact support@githits.com.";
 
 /**
  * Wraps a tool handler with the shared structured `{error, code,
@@ -44,7 +47,10 @@ export function buildMcpErrorPayload(mapped: MappedError): ToolErrorEnvelope {
     retryable: mapped.retryable ?? false,
     ...(mapped.code === "AUTH_REQUIRED"
       ? {
-          details: { ...(mapped.details ?? {}), action: LOCAL_MCP_AUTH_ACTION },
+          details: {
+            ...(mapped.details ?? {}),
+            action: mcpAuthAction(mapped.details?.authSource),
+          },
         }
       : mapped.details
         ? { details: mapped.details }
@@ -58,7 +64,10 @@ export function addLocalMcpAuthAction<T extends MappableErrorPayload>(
   if (payload.code !== "AUTH_REQUIRED") return payload;
   return {
     ...payload,
-    details: { ...(payload.details ?? {}), action: LOCAL_MCP_AUTH_ACTION },
+    details: {
+      ...(payload.details ?? {}),
+      action: mcpAuthAction(payload.details?.authSource),
+    },
   };
 }
 
@@ -68,7 +77,10 @@ function classify(operation: string, error: unknown): ToolErrorEnvelope {
       error: error.message,
       code: "AUTH_REQUIRED",
       retryable: false,
-      details: { action: LOCAL_MCP_AUTH_ACTION },
+      details: {
+        action: mcpAuthAction(error.source),
+        authSource: error.source,
+      },
     };
   }
   const message = error instanceof Error ? error.message : "Unknown error";
@@ -77,4 +89,10 @@ function classify(operation: string, error: unknown): ToolErrorEnvelope {
     code: "UNKNOWN",
     retryable: false,
   };
+}
+
+function mcpAuthAction(authSource: unknown): string {
+  return authSource === "server"
+    ? SERVER_MCP_AUTH_ACTION
+    : LOCAL_MCP_AUTH_ACTION;
 }


### PR DESCRIPTION
## Summary
- distinguish missing local credentials from backend-rejected auth tokens
- preserve non-secret authSource details in CLI JSON and MCP error envelopes
- update auth remediation for OAuth login, GITHITS_API_TOKEN, and support escalation

## Verification
- bun test
- bun run build

## Review
- code-reviewer final pass: no findings