### PR TITLE
refactor: remove internal shared barrel imports

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -27,6 +27,10 @@
               {
                 "group": ["**/services/index.js"],
                 "message": "Import from the defining service module instead of the services barrel."
+              },
+              {
+                "group": ["**/shared/index.js"],
+                "message": "Import from the defining shared module instead of the shared barrel."
               }
             ]
           }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -32,14 +32,14 @@ import {
 import { FileSystemServiceImpl } from "./services/filesystem-service.js";
 import { NpmRegistryUpdateCheckService } from "./services/update-check-service.js";
 import { colorizeBrand, shouldUseColors } from "./shared/colors.js";
+import { createRootCliPreAction } from "./shared/root-cli-pre-action.js";
 import {
-  createRootCliPreAction,
   endTelemetrySpan,
   flushTelemetry,
   isTelemetryEnabled,
   startTelemetrySpan,
   withTelemetrySpan,
-} from "./shared/index.js";
+} from "./shared/telemetry.js";
 
 const program = new Command();
 const argv = process.argv.slice(2);

--- a/src/commands/code/code-nav-cli-helpers.ts
+++ b/src/commands/code/code-nav-cli-helpers.ts
@@ -19,8 +19,8 @@ import {
 import {
   InvalidPackageSpecError,
   parsePackageSpec,
-  toPkgseerRegistry,
-} from "../../shared/index.js";
+} from "../../shared/package-spec.js";
+import { toPkgseerRegistry } from "../../shared/pkgseer-registry.js";
 import {
   buildCliMappedErrorPayload,
   formatMappedErrorForTerminal,

--- a/src/commands/code/files.ts
+++ b/src/commands/code/files.ts
@@ -7,12 +7,6 @@ import {
 } from "../../shared/code-navigation-defaults.js";
 import { shouldUseColors } from "../../shared/colors.js";
 import {
-  InvalidPackageSpecError,
-  requireAuth,
-  SPINNER_MESSAGES,
-  startSpinner,
-} from "../../shared/index.js";
-import {
   buildListFilesParams,
   type ListFilesRequestBuildResult,
   type ListFilesRequestInput,
@@ -21,11 +15,15 @@ import {
   buildListFilesSuccessPayload,
   formatListFilesTerminal,
 } from "../../shared/list-files-response.js";
+import { InvalidPackageSpecError } from "../../shared/package-spec.js";
 import {
   PKGSEER_REGISTRY_ARGS,
   PKGSEER_REGISTRY_LIST,
   toPkgseerRegistryLowercase,
 } from "../../shared/pkgseer-registry.js";
+import { requireAuth } from "../../shared/require-auth.js";
+import { startSpinner } from "../../shared/spinner.js";
+import { SPINNER_MESSAGES } from "../../shared/spinner-messages.js";
 import {
   formatIndexingError,
   handleCodeNavCommandError,

--- a/src/commands/code/grep.ts
+++ b/src/commands/code/grep.ts
@@ -7,18 +7,20 @@ import {
 import { shouldUseColors } from "../../shared/colors.js";
 import {
   buildGrepRepoParams,
-  buildGrepRepoSuccessPayload,
-  formatGrepRepoTerminal,
   GREP_REPO_PATTERN_NOTE,
   GREP_REPO_SYMBOL_FIELDS_NOTE,
   type GrepRepoRequestBuildResult,
   type GrepRepoRequestInput,
-  InvalidPackageSpecError,
-  requireAuth,
-  SPINNER_MESSAGES,
-  startSpinner,
-} from "../../shared/index.js";
+} from "../../shared/grep-repo-request.js";
+import {
+  buildGrepRepoSuccessPayload,
+  formatGrepRepoTerminal,
+} from "../../shared/grep-repo-response.js";
+import { InvalidPackageSpecError } from "../../shared/package-spec.js";
 import { toPkgseerRegistryLowercase } from "../../shared/pkgseer-registry.js";
+import { requireAuth } from "../../shared/require-auth.js";
+import { startSpinner } from "../../shared/spinner.js";
+import { SPINNER_MESSAGES } from "../../shared/spinner-messages.js";
 import {
   formatFileErrorWithFilesHint,
   handleCodeNavCommandError,

--- a/src/commands/code/read.ts
+++ b/src/commands/code/read.ts
@@ -6,12 +6,7 @@ import {
   MAX_WAIT_TIMEOUT_MS,
 } from "../../shared/code-navigation-defaults.js";
 import { shouldUseColors } from "../../shared/colors.js";
-import {
-  InvalidPackageSpecError,
-  requireAuth,
-  SPINNER_MESSAGES,
-  startSpinner,
-} from "../../shared/index.js";
+import { InvalidPackageSpecError } from "../../shared/package-spec.js";
 import { toPkgseerRegistryLowercase } from "../../shared/pkgseer-registry.js";
 import { withReadFileRecovery } from "../../shared/read-file-error.js";
 import { buildReadFileParams } from "../../shared/read-file-request.js";
@@ -19,6 +14,9 @@ import {
   buildReadFileSuccessPayload,
   formatReadFileTerminal,
 } from "../../shared/read-file-response.js";
+import { requireAuth } from "../../shared/require-auth.js";
+import { startSpinner } from "../../shared/spinner.js";
+import { SPINNER_MESSAGES } from "../../shared/spinner-messages.js";
 import {
   formatFileErrorWithFilesHint,
   handleCodeNavCommandError,

--- a/src/commands/docs/list.ts
+++ b/src/commands/docs/list.ts
@@ -2,17 +2,19 @@ import type { Command } from "commander";
 import { createContainer } from "../../container.js";
 import type { PackageIntelligenceService } from "../../services/package-intelligence-service.js";
 import { shouldUseColors } from "../../shared/colors.js";
+import { buildListPackageDocsParams } from "../../shared/list-package-docs-request.js";
 import {
-  buildListPackageDocsParams,
   buildListPackageDocsSuccessPayload,
   formatListPackageDocsTerminal,
+} from "../../shared/list-package-docs-response.js";
+import { mapPackageIntelligenceError } from "../../shared/package-intelligence-error-map.js";
+import {
   InvalidPackageSpecError,
-  mapPackageIntelligenceError,
   parsePackageSpec,
-  requireAuth,
-  SPINNER_MESSAGES,
-  startSpinner,
-} from "../../shared/index.js";
+} from "../../shared/package-spec.js";
+import { requireAuth } from "../../shared/require-auth.js";
+import { startSpinner } from "../../shared/spinner.js";
+import { SPINNER_MESSAGES } from "../../shared/spinner-messages.js";
 import {
   buildCliMappedErrorPayload,
   formatMappedErrorForTerminal,

--- a/src/commands/docs/read.ts
+++ b/src/commands/docs/read.ts
@@ -1,18 +1,18 @@
 import type { Command } from "commander";
 import { createContainer } from "../../container.js";
 import type { PackageIntelligenceService } from "../../services/package-intelligence-service.js";
+import { shouldUseColors } from "../../shared/colors.js";
+import { mapPackageIntelligenceError } from "../../shared/package-intelligence-error-map.js";
+import { InvalidPackageSpecError } from "../../shared/package-spec.js";
+import { parseLinesOption } from "../../shared/parse-lines-option.js";
+import { buildReadPackageDocParams } from "../../shared/read-package-doc-request.js";
 import {
-  buildReadPackageDocParams,
   buildReadPackageDocSuccessPayload,
   formatReadPackageDocTerminal,
-  InvalidPackageSpecError,
-  mapPackageIntelligenceError,
-  parseLinesOption,
-  requireAuth,
-  SPINNER_MESSAGES,
-  shouldUseColors,
-  startSpinner,
-} from "../../shared/index.js";
+} from "../../shared/read-package-doc-response.js";
+import { requireAuth } from "../../shared/require-auth.js";
+import { startSpinner } from "../../shared/spinner.js";
+import { SPINNER_MESSAGES } from "../../shared/spinner-messages.js";
 import {
   buildCliMappedErrorPayload,
   formatMappedErrorForTerminal,

--- a/src/commands/pkg/changelog.ts
+++ b/src/commands/pkg/changelog.ts
@@ -2,22 +2,24 @@ import type { Command } from "commander";
 import { createContainer } from "../../container.js";
 import type { PackageIntelligenceService } from "../../services/package-intelligence-service.js";
 import { shouldUseColors } from "../../shared/colors.js";
-import {
-  InvalidPackageSpecError,
-  type MappedError,
-  mapPackageIntelligenceError,
-  parsePackageSpec,
-  requireAuth,
-} from "../../shared/index.js";
 import { buildPackageChangelogParams } from "../../shared/package-changelog-request.js";
 import {
   buildPackageChangelogSuccessPayload,
   formatPackageChangelogTerminal,
 } from "../../shared/package-changelog-response.js";
 import {
+  type MappedError,
+  mapPackageIntelligenceError,
+} from "../../shared/package-intelligence-error-map.js";
+import {
+  InvalidPackageSpecError,
+  parsePackageSpec,
+} from "../../shared/package-spec.js";
+import {
   PKGSEER_REGISTRY_LIST,
   toPkgseerRegistryLowercase,
 } from "../../shared/pkgseer-registry.js";
+import { requireAuth } from "../../shared/require-auth.js";
 import {
   buildCliMappedErrorPayload,
   formatMappedErrorForTerminal,

--- a/src/commands/pkg/deps.ts
+++ b/src/commands/pkg/deps.ts
@@ -3,13 +3,6 @@ import { createContainer } from "../../container.js";
 import type { PackageIntelligenceService } from "../../services/package-intelligence-service.js";
 import { shouldUseColors } from "../../shared/colors.js";
 import {
-  InvalidPackageSpecError,
-  type MappedError,
-  mapPackageIntelligenceError,
-  parsePackageSpec,
-  requireAuth,
-} from "../../shared/index.js";
-import {
   buildPackageDependenciesParams,
   SUPPORTED_DEPS_REGISTRIES_LIST,
 } from "../../shared/package-dependencies-request.js";
@@ -17,6 +10,15 @@ import {
   buildPackageDependenciesSuccessPayload,
   formatPackageDependenciesTerminal,
 } from "../../shared/package-dependencies-response.js";
+import {
+  type MappedError,
+  mapPackageIntelligenceError,
+} from "../../shared/package-intelligence-error-map.js";
+import {
+  InvalidPackageSpecError,
+  parsePackageSpec,
+} from "../../shared/package-spec.js";
+import { requireAuth } from "../../shared/require-auth.js";
 import {
   buildCliMappedErrorPayload,
   formatMappedErrorForTerminal,

--- a/src/commands/pkg/info.ts
+++ b/src/commands/pkg/info.ts
@@ -2,18 +2,18 @@ import type { Command } from "commander";
 import { createContainer } from "../../container.js";
 import type { PackageIntelligenceService } from "../../services/package-intelligence-service.js";
 import { shouldUseColors } from "../../shared/colors.js";
+import { mapPackageIntelligenceError } from "../../shared/package-intelligence-error-map.js";
 import {
   InvalidPackageSpecError,
-  mapPackageIntelligenceError,
   parsePackageSpec,
-  requireAuth,
-} from "../../shared/index.js";
+} from "../../shared/package-spec.js";
 import { buildPackageSummaryParams } from "../../shared/package-summary-request.js";
 import {
   buildPackageSummarySuccessPayload,
   formatPackageSummaryTerminal,
 } from "../../shared/package-summary-response.js";
 import { PKGSEER_REGISTRY_LIST } from "../../shared/pkgseer-registry.js";
+import { requireAuth } from "../../shared/require-auth.js";
 import {
   buildCliMappedErrorPayload,
   formatMappedErrorForTerminal,

--- a/src/commands/pkg/upgrade-review.test.ts
+++ b/src/commands/pkg/upgrade-review.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { InvalidPackageSpecError } from "../../shared/index.js";
+import { InvalidPackageSpecError } from "../../shared/package-spec.js";
 import { parseUpgradeReviewPackageOption } from "./upgrade-review.js";
 
 describe("parseUpgradeReviewPackageOption", () => {

--- a/src/commands/pkg/upgrade-review.ts
+++ b/src/commands/pkg/upgrade-review.ts
@@ -2,15 +2,17 @@ import type { Command } from "commander";
 import { createContainer } from "../../container.js";
 import type { PackageIntelligenceService } from "../../services/package-intelligence-service.js";
 import { shouldUseColors } from "../../shared/colors.js";
+import { mapPackageIntelligenceError } from "../../shared/package-intelligence-error-map.js";
+import {
+  InvalidPackageSpecError,
+  parsePackageSpec,
+} from "../../shared/package-spec.js";
+import { buildPackageUpgradeReviewRequest } from "../../shared/package-upgrade-review-request.js";
 import {
   buildPackageUpgradeReview,
-  buildPackageUpgradeReviewRequest,
   formatPackageUpgradeReviewTerminal,
-  InvalidPackageSpecError,
-  mapPackageIntelligenceError,
-  parsePackageSpec,
-  requireAuth,
-} from "../../shared/index.js";
+} from "../../shared/package-upgrade-review-response.js";
+import { requireAuth } from "../../shared/require-auth.js";
 import {
   buildCliMappedErrorPayload,
   formatMappedErrorForTerminal,

--- a/src/commands/pkg/vulns.ts
+++ b/src/commands/pkg/vulns.ts
@@ -3,17 +3,19 @@ import { createContainer } from "../../container.js";
 import type { PackageIntelligenceService } from "../../services/package-intelligence-service.js";
 import { shouldUseColors } from "../../shared/colors.js";
 import {
-  InvalidPackageSpecError,
   type MappedError,
   mapPackageIntelligenceError,
+} from "../../shared/package-intelligence-error-map.js";
+import {
+  InvalidPackageSpecError,
   parsePackageSpec,
-  requireAuth,
-} from "../../shared/index.js";
+} from "../../shared/package-spec.js";
 import { buildPackageVulnerabilitiesParams } from "../../shared/package-vulnerabilities-request.js";
 import {
   buildPackageVulnerabilitiesSuccessPayload,
   formatPackageVulnerabilitiesTerminal,
 } from "../../shared/package-vulnerabilities-response.js";
+import { requireAuth } from "../../shared/require-auth.js";
 import {
   buildCliMappedErrorPayload,
   formatMappedErrorForTerminal,

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -4,30 +4,34 @@ import type {
   UnifiedSearchSource,
 } from "../services/code-navigation-service.js";
 import { getCodeNavigationUrl } from "../services/config.js";
+import { parseIntCliOption } from "../shared/cli-options.js";
 import {
-  buildUnifiedSearchErrorPayload,
-  buildUnifiedSearchParams,
-  buildUnifiedSearchStatusPayload,
-  buildUnifiedSearchSuccessPayload,
+  knownSymbolCategoryList,
+  knownSymbolKindList,
+  toFileIntent,
+  toSymbolCategory,
+  toSymbolKind,
+} from "../shared/code-navigation.js";
+import {
   dim,
   highlight,
   highlightMatch,
   highlightRanges,
-  InvalidArgumentError,
-  knownSymbolCategoryList,
-  knownSymbolKindList,
-  parseIntCliOption,
-  parseUnifiedSearchTargetSpec,
-  requireAuth,
-  SPINNER_MESSAGES,
   shouldUseColors,
-  startSpinner,
-  toFileIntent,
-  toSymbolCategory,
-  toSymbolKind,
+} from "../shared/colors.js";
+import { InvalidArgumentError } from "../shared/package-spec.js";
+import { requireAuth } from "../shared/require-auth.js";
+import { startSpinner } from "../shared/spinner.js";
+import { SPINNER_MESSAGES } from "../shared/spinner-messages.js";
+import { buildUnifiedSearchParams } from "../shared/unified-search-request.js";
+import {
+  buildUnifiedSearchErrorPayload,
+  buildUnifiedSearchStatusPayload,
+  buildUnifiedSearchSuccessPayload,
   type UnifiedSearchStatusIncompletePayload,
   type UnifiedSearchStatusResultPayload,
-} from "../shared/index.js";
+} from "../shared/unified-search-response.js";
+import { parseUnifiedSearchTargetSpec } from "../shared/unified-search-target.js";
 import { formatMappedErrorForTerminal } from "./format-mapped-error.js";
 
 export interface SearchCommandOptions {

--- a/src/tools/grep-repo.ts
+++ b/src/tools/grep-repo.ts
@@ -3,13 +3,13 @@ import type { CodeNavigationService } from "../services/code-navigation-service.
 import { mapCodeNavigationError } from "../shared/code-navigation-error-map.js";
 import {
   buildGrepRepoParams,
-  buildGrepRepoSuccessPayload,
   GREP_REPO_PATTERN_NOTE,
   GREP_REPO_SYMBOL_FIELDS,
   GREP_REPO_SYMBOL_FIELDS_NOTE,
   type GrepRepoSymbolField,
-  renderGrepRepoText,
-} from "../shared/index.js";
+} from "../shared/grep-repo-request.js";
+import { buildGrepRepoSuccessPayload } from "../shared/grep-repo-response.js";
+import { renderGrepRepoText } from "../shared/grep-repo-text.js";
 import { toPkgseerRegistryLowercase } from "../shared/pkgseer-registry.js";
 import {
   type CodeTargetArg,

--- a/src/tools/package-changelog.ts
+++ b/src/tools/package-changelog.ts
@@ -1,12 +1,12 @@
 import { z } from "zod";
 import type { PackageIntelligenceService } from "../services/package-intelligence-service.js";
-import { InvalidPackageSpecError } from "../shared/index.js";
 import { buildPackageChangelogParams } from "../shared/package-changelog-request.js";
 import {
   buildPackageChangelogSuccessPayload,
   formatPackageChangelogTerminal,
 } from "../shared/package-changelog-response.js";
 import { mapPackageIntelligenceError } from "../shared/package-intelligence-error-map.js";
+import { InvalidPackageSpecError } from "../shared/package-spec.js";
 import {
   PKGSEER_REGISTRY_LIST,
   toPkgseerRegistryLowercase,

--- a/src/tools/package-upgrade-review.ts
+++ b/src/tools/package-upgrade-review.ts
@@ -1,11 +1,11 @@
 import { z } from "zod";
 import type { PackageIntelligenceService } from "../services/package-intelligence-service.js";
+import { mapPackageIntelligenceError } from "../shared/package-intelligence-error-map.js";
+import { buildPackageUpgradeReviewRequest } from "../shared/package-upgrade-review-request.js";
 import {
   buildPackageUpgradeReview,
-  buildPackageUpgradeReviewRequest,
   formatPackageUpgradeReviewTerminal,
-  mapPackageIntelligenceError,
-} from "../shared/index.js";
+} from "../shared/package-upgrade-review-response.js";
 import { PKGSEER_REGISTRY_LIST } from "../shared/pkgseer-registry.js";
 import { mcpMappedErrorResult } from "./shared.js";
 import { type ToolDefinition, textResult } from "./types.js";

--- a/src/tools/search-status.ts
+++ b/src/tools/search-status.ts
@@ -3,8 +3,8 @@ import type { CodeNavigationService } from "../services/code-navigation-service.
 import {
   buildUnifiedSearchErrorPayload,
   buildUnifiedSearchStatusPayload,
-  renderUnifiedSearchStatusText,
-} from "../shared/index.js";
+} from "../shared/unified-search-response.js";
+import { renderUnifiedSearchStatusText } from "../shared/unified-search-status-text.js";
 import { addLocalMcpAuthAction } from "./shared.js";
 import { errorResult, type ToolDefinition, textResult } from "./types.js";
 

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -6,19 +6,21 @@ import type {
 import {
   type CodeNavigationRegistryArg,
   toCodeNavigationRegistry,
-} from "../shared/code-navigation.js";
-import { mapCodeNavigationError } from "../shared/code-navigation-error-map.js";
-import {
-  buildUnifiedSearchErrorPayload,
-  buildUnifiedSearchParams,
-  buildUnifiedSearchSuccessPayload,
-  renderUnifiedSearchError,
-  renderUnifiedSearchSuccess,
   toFileIntent,
   toSymbolCategory,
   toSymbolKind,
-} from "../shared/index.js";
+} from "../shared/code-navigation.js";
+import { mapCodeNavigationError } from "../shared/code-navigation-error-map.js";
+import { buildUnifiedSearchParams } from "../shared/unified-search-request.js";
+import {
+  buildUnifiedSearchErrorPayload,
+  buildUnifiedSearchSuccessPayload,
+} from "../shared/unified-search-response.js";
 import { parseUnifiedSearchTargetSpec } from "../shared/unified-search-target.js";
+import {
+  renderUnifiedSearchError,
+  renderUnifiedSearchSuccess,
+} from "../shared/unified-search-text.js";
 import {
   type CodeTargetArg,
   structuredCodeTargetSchema,


### PR DESCRIPTION
## Summary
- Replace internal imports from shared/index.js with imports from defining shared modules.
- Add a Biome noRestrictedImports rule to prevent shared/index.js imports from returning while keeping the barrel available.
- Leave command/tool registration barrels untouched for now.

## Verification
- Code reviewer: no findings.
- bunx biome check biome.json src
- bun run lint
- bun test
- bun run typecheck
- bun run format:check
- git diff --check
- bun run build

## Notes
- Untracked docs/plans/ remains local and is not part of this PR.