### PR TITLE
refactor: scaffold workspace packages

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,8 @@
     "": {
       "name": "githits",
       "dependencies": {
-        "@inquirer/prompts": "^8.4.3",
+        "@inquirer/core": "11.1.10",
+        "@inquirer/prompts": "8.4.3",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@napi-rs/keyring": "^1.3.0",
         "commander": "^14.0.2",
@@ -24,6 +25,23 @@
         "husky": "^9.1.7",
         "lint-staged": "^17.0.4",
         "typescript": "^6.0.3",
+      },
+    },
+    "packages/cli": {
+      "name": "@githits/cli-workspace",
+      "version": "0.4.11",
+    },
+    "packages/core-internal": {
+      "name": "@githits/core-internal",
+      "version": "0.4.11",
+    },
+    "packages/mcp": {
+      "name": "@githits/mcp",
+      "version": "0.4.11",
+      "dependencies": {
+        "@githits/core-internal": "workspace:*",
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "zod": "^4.4.3",
       },
     },
   },
@@ -63,6 +81,12 @@
     "@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
 
     "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.1.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ=="],
+
+    "@githits/cli-workspace": ["@githits/cli-workspace@workspace:packages/cli"],
+
+    "@githits/core-internal": ["@githits/core-internal@workspace:packages/core-internal"],
+
+    "@githits/mcp": ["@githits/mcp@workspace:packages/mcp"],
 
     "@hono/node-server": ["@hono/node-server@1.19.9", "", { "peerDependencies": { "hono": "^4" } }, "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw=="],
 

--- a/docs/implementation/workspace-packages.md
+++ b/docs/implementation/workspace-packages.md
@@ -1,0 +1,42 @@
+# Workspace Packages
+
+The repository now has a Bun workspace scaffold under `packages/*`, while the
+root package remains the publishable `githits` package until the CLI source and
+manifest move is complete.
+
+## Current Scaffold
+
+- `packages/core-internal` is private and source-exported.
+- `packages/mcp` is private for now and source-exported through `./src/index.ts`.
+- `packages/cli` is a private placeholder package; the public `githits` manifest
+  still lives at the repository root.
+- Root TypeScript path aliases exist for workspace development imports:
+  `@githits/core-internal` and `@githits/mcp`.
+
+## Build Lessons
+
+- Do not publish a package that still references `@githits/core-internal`,
+  `core-internal`, source aliases, or `workspace:*` in shipped artifacts.
+- Public package builds that consume private workspace source must bundle private
+  source, not externalize it. The validated direction is `--packages=bundle` plus
+  explicit `--external` entries for real third-party dependencies.
+- Bunup declaration generation cannot mix simple `--dts` with object-form
+  `--dts.resolve`; use object-form flags such as `--dts.entry` when resolving
+  private workspace declarations.
+- Declaration output must resolve every workspace layer that should disappear
+  from public artifacts. For MCP builds this means resolving both `@githits/mcp`
+  and `@githits/core-internal` when validating a consumer-facing bundle.
+- Minify whitespace or otherwise strip generated source-path comments before
+  scanning JS output for private package names, because bundled output can include
+  source path comments such as `packages/core-internal/...`.
+- Validate package-boundary behavior from outside the repo root or without root
+  `tsconfig` path aliases. A root-local entry can pass by resolving aliases and
+  bypassing package manifest wiring.
+
+## Dependency Notes
+
+- `src/commands/init/**` imports `@inquirer/core` directly for
+  `ExitPromptError`, so it is a direct root dependency.
+- Keep `@inquirer/prompts` and `@inquirer/core` pinned to the validated pair
+  (`8.4.3` and `11.1.10` currently) unless prompt abort handling is changed to
+  avoid `instanceof` checks across package copies.

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "description": "CLI companion for GitHits - code examples from global open source for developers and AI assistants",
   "version": "0.4.11",
   "type": "module",
+  "workspaces": [
+    "packages/*"
+  ],
   "files": [
     "dist",
     "LICENSE",
@@ -75,7 +78,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@inquirer/prompts": "^8.4.3",
+    "@inquirer/core": "11.1.10",
+    "@inquirer/prompts": "8.4.3",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@napi-rs/keyring": "^1.3.0",
     "commander": "^14.0.2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@githits/cli-workspace",
+  "version": "0.4.11",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,0 +1,1 @@
+export const cliWorkspacePackageName = "@githits/cli-workspace";

--- a/packages/core-internal/package.json
+++ b/packages/core-internal/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@githits/core-internal",
+  "version": "0.4.11",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  }
+}

--- a/packages/core-internal/src/index.ts
+++ b/packages/core-internal/src/index.ts
@@ -1,0 +1,21 @@
+export interface WorkspaceScaffoldCoreIdentity {
+  packageName: "githits-core";
+  boundary: "core";
+}
+
+export interface WorkspaceScaffoldCorePayload<TValue> {
+  identity: WorkspaceScaffoldCoreIdentity;
+  value: TValue;
+}
+
+export function createWorkspaceScaffoldCorePayload<TValue>(
+  value: TValue,
+): WorkspaceScaffoldCorePayload<TValue> {
+  return {
+    identity: {
+      packageName: "githits-core",
+      boundary: "core",
+    },
+    value,
+  };
+}

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@githits/mcp",
+  "version": "0.4.11",
+  "description": "MCP server APIs for GitHits",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./package.json": "./package.json"
+  },
+  "types": "./src/index.ts",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/githits-com/githits-cli.git"
+  },
+  "bugs": {
+    "url": "https://github.com/githits-com/githits-cli/issues"
+  },
+  "homepage": "https://githits.com",
+  "engines": {
+    "node": "^20.12.0 || >=22.13.0"
+  },
+  "dependencies": {
+    "@githits/core-internal": "workspace:*",
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "zod": "^4.4.3"
+  }
+}

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,0 +1,18 @@
+import {
+  createWorkspaceScaffoldCorePayload,
+  type WorkspaceScaffoldCorePayload,
+} from "@githits/core-internal";
+
+export interface WorkspaceScaffoldMcpEnvelope<TValue> {
+  source: "@githits/mcp";
+  core: WorkspaceScaffoldCorePayload<TValue>;
+}
+
+export function createWorkspaceScaffoldMcpEnvelope<TValue>(
+  value: TValue,
+): WorkspaceScaffoldMcpEnvelope<TValue> {
+  return {
+    source: "@githits/mcp",
+    core: createWorkspaceScaffoldCorePayload(value),
+  };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,10 @@
 
     // Bundler mode
     "moduleResolution": "bundler",
+    "paths": {
+      "@githits/core-internal": ["./packages/core-internal/src/index.ts"],
+      "@githits/mcp": ["./packages/mcp/src/index.ts"]
+    },
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,
     "noEmit": true,


### PR DESCRIPTION
## Summary
- Add Bun workspace scaffolding for future core, MCP, and CLI packages while keeping the root githits package publishable.
- Add private placeholder package manifests and source exports for packages/core-internal, packages/mcp, and packages/cli.
- Add bare package-root TypeScript aliases and document private-source bundling/package-boundary lessons.
- Pin @inquirer/prompts and @inquirer/core to the validated pair to preserve ExitPromptError instanceof behavior.

## Verification
- Code reviewer: no findings.
- bun install --frozen-lockfile
- bun run typecheck
- bun test
- bun run lint
- bun run format:check
- git diff --check
- bun run build
- npm pack --dry-run

## Notes
- No runtime source moved in this PR.
- Root package remains publishable.
- docs/plans/ remains local and is not part of this PR.