### PR TITLE
fix: use backend-ranked language search in cli

### DIFF
--- a/packages/core-internal/src/services/githits-service.test.ts
+++ b/packages/core-internal/src/services/githits-service.test.ts
@@ -207,6 +207,41 @@ describe("GitHitsServiceImpl", () => {
     });
   });
 
+  describe("searchLanguages", () => {
+    it("calls backend-ranked language search with query and limit", async () => {
+      const languages = [
+        {
+          id: "2",
+          name: "typescript",
+          display_name: "TypeScript",
+          aliases: ["ts"],
+          search_priority: 10,
+        },
+      ];
+      const fn = mockFetch(() =>
+        Promise.resolve(
+          new Response(JSON.stringify(languages), {
+            headers: { "Content-Type": "application/json" },
+          }),
+        ),
+      );
+
+      const result = await service.searchLanguages("c#", 10);
+
+      expect(result).toEqual(languages);
+      const call = fn.mock.calls[0] as unknown as [string, RequestInit];
+      expect(call[0]).toBe(`${API_URL}/languages?query=c%23&limit=10`);
+    });
+
+    it("throws AuthenticationError on 401", async () => {
+      mockFetch(() => Promise.resolve(new Response("", { status: 401 })));
+
+      await expect(service.searchLanguages("ts")).rejects.toThrow(
+        AuthenticationError,
+      );
+    });
+  });
+
   describe("submitFeedback", () => {
     it("sends correct request with field mapping", async () => {
       const fn = mockFetch(() =>

--- a/packages/core-internal/src/services/githits-service.ts
+++ b/packages/core-internal/src/services/githits-service.ts
@@ -58,6 +58,7 @@ export interface Language {
   name: string;
   display_name: string;
   aliases: string[];
+  search_priority?: number;
 }
 
 /**
@@ -109,6 +110,9 @@ export interface GitHitsService {
   /** Get all supported languages. */
   getLanguages(): Promise<Language[]>;
 
+  /** Search supported languages using backend-ranked matching. */
+  searchLanguages(query: string, limit?: number): Promise<Language[]>;
+
   /** Submit feedback on a result or the current GitHits session. */
   submitFeedback(params: FeedbackParams): Promise<FeedbackResult>;
 }
@@ -154,6 +158,28 @@ export class GitHitsServiceImpl implements GitHitsService {
     return withTelemetrySpan("githits.languages.request", async () => {
       const response = await fetchWithTimeout(
         `${this.apiUrl}/languages`,
+        {
+          headers: this.headers(),
+        },
+        this.fetchOptions(),
+      );
+
+      if (!response.ok) {
+        throw await this.createError(response);
+      }
+
+      return response.json() as Promise<Language[]>;
+    });
+  }
+
+  async searchLanguages(query: string, limit: number = 5): Promise<Language[]> {
+    return withTelemetrySpan("githits.languages.search.request", async () => {
+      const params = new URLSearchParams({
+        query,
+        limit: String(limit),
+      });
+      const response = await fetchWithTimeout(
+        `${this.apiUrl}/languages?${params.toString()}`,
         {
           headers: this.headers(),
         },

--- a/packages/core-internal/src/services/refreshing-githits-service.test.ts
+++ b/packages/core-internal/src/services/refreshing-githits-service.test.ts
@@ -104,6 +104,26 @@ describe("RefreshingGitHitsService", () => {
     });
   });
 
+  describe("searchLanguages", () => {
+    it("delegates to inner service with query and limit", async () => {
+      const innerService = createMockGitHitsService();
+      const tokenProvider = createMockTokenProvider();
+      const factory = mock(() => innerService);
+
+      const service = new RefreshingGitHitsService(
+        API_URL,
+        tokenProvider,
+        factory,
+      );
+
+      const result = await service.searchLanguages("ts", 5);
+
+      expect(result).toHaveLength(1);
+      expect(innerService.searchLanguages).toHaveBeenCalledWith("ts", 5);
+      expect(innerService.getLanguages).not.toHaveBeenCalled();
+    });
+  });
+
   describe("submitFeedback", () => {
     it("delegates to inner service", async () => {
       const innerService = createMockGitHitsService();

--- a/packages/core-internal/src/services/refreshing-githits-service.ts
+++ b/packages/core-internal/src/services/refreshing-githits-service.ts
@@ -37,6 +37,12 @@ export class RefreshingGitHitsService implements GitHitsService {
     return this.withTokenRefresh((service) => service.getLanguages());
   }
 
+  async searchLanguages(query: string, limit?: number): Promise<Language[]> {
+    return this.withTokenRefresh((service) =>
+      service.searchLanguages(query, limit),
+    );
+  }
+
   async submitFeedback(params: FeedbackParams): Promise<FeedbackResult> {
     return this.withTokenRefresh((service) => service.submitFeedback(params));
   }

--- a/packages/core-internal/src/services/test-helpers.ts
+++ b/packages/core-internal/src/services/test-helpers.ts
@@ -31,6 +31,40 @@ export function createMockGitHitsService(
         },
       ]),
     ),
+    searchLanguages: mock((query: string, limit: number = 5) => {
+      const lowerQuery = query.toLowerCase();
+      return Promise.resolve(
+        [
+          {
+            id: "1",
+            name: "javascript",
+            display_name: "JavaScript",
+            aliases: ["js"],
+          },
+          {
+            id: "2",
+            name: "typescript",
+            display_name: "TypeScript",
+            aliases: ["ts"],
+          },
+          {
+            id: "3",
+            name: "python",
+            display_name: "Python",
+            aliases: ["py"],
+          },
+        ]
+          .filter(
+            (language) =>
+              language.name.toLowerCase().includes(lowerQuery) ||
+              language.display_name.toLowerCase().includes(lowerQuery) ||
+              language.aliases.some((alias) =>
+                alias.toLowerCase().includes(lowerQuery),
+              ),
+          )
+          .slice(0, limit),
+      );
+    }),
     submitFeedback: mock(() =>
       Promise.resolve({
         success: true,

--- a/scripts/cli-smoke.ts
+++ b/scripts/cli-smoke.ts
@@ -32,6 +32,7 @@ const DEFAULT_TEXT_LIMIT = 20_000;
 const AUTH_ENV_KEYS = ["GITHITS_API_TOKEN", "GITHITS_TOKEN"] as const;
 const JSON_PARITY_CONCURRENCY = 2;
 const SMOKE_PACKAGE_SPEC = "npm:express@5.2.1";
+const UNAUTHENTICATED_MCP_URL = "https://mcp-smoke-unauth.githits.invalid";
 
 const JSON_PARITY_FIXTURES: JsonParityFixture[] = [
   {
@@ -384,6 +385,9 @@ function isolatedUnauthenticatedEnv(): Record<string, string> {
   env.XDG_CONFIG_HOME = `${dir}/.config`;
   env.APPDATA = `${dir}/AppData/Roaming`;
   env.GITHITS_AUTH_STORAGE = "file";
+  // Auth storage keys credentials by MCP URL. Keep unauth probes away from
+  // real keychain entries even on platforms where HOME does not isolate them.
+  env.GITHITS_MCP_URL = UNAUTHENTICATED_MCP_URL;
   return env;
 }
 

--- a/scripts/mcp-smoke.ts
+++ b/scripts/mcp-smoke.ts
@@ -46,6 +46,7 @@ const EXPECTED_TOOLS = [
 const DEFAULT_TEXT_LIMIT = 12_000;
 const AUTH_ENV_KEYS = ["GITHITS_API_TOKEN", "GITHITS_TOKEN"] as const;
 const SMOKE_PACKAGE_VERSION = "5.2.1";
+const UNAUTHENTICATED_MCP_URL = "https://mcp-smoke-unauth.githits.invalid";
 const SMOKE_PACKAGE_TARGET = {
   registry: "npm",
   package_name: "express",
@@ -178,6 +179,9 @@ function isolatedUnauthenticatedEnv(): Record<string, string> {
   env.XDG_CONFIG_HOME = join(home, ".config");
   env.APPDATA = join(home, "AppData", "Roaming");
   env.GITHITS_AUTH_STORAGE = "file";
+  // Auth storage keys credentials by MCP URL. Keep unauth probes away from
+  // real keychain entries even on platforms where HOME does not isolate them.
+  env.GITHITS_MCP_URL = UNAUTHENTICATED_MCP_URL;
   return env;
 }
 

--- a/src/commands/languages.test.ts
+++ b/src/commands/languages.test.ts
@@ -44,7 +44,7 @@ describe("languagesAction", () => {
     consoleSpy.mockRestore();
   });
 
-  it("filters languages when query provided", async () => {
+  it("uses backend-ranked search when query provided", async () => {
     const consoleSpy = spyOn(console, "log").mockImplementation(() => {});
     const deps = createDeps();
 
@@ -53,6 +53,8 @@ describe("languagesAction", () => {
     const output = consoleSpy.mock.calls.map((c) => c[0]).join("\n");
     expect(output).toContain("python");
     expect(output).not.toContain("javascript");
+    expect(deps.githitsService.searchLanguages).toHaveBeenCalledWith("python");
+    expect(deps.githitsService.getLanguages).not.toHaveBeenCalled();
     consoleSpy.mockRestore();
   });
 
@@ -183,9 +185,20 @@ describe("languagesAction", () => {
     const consoleSpy = spyOn(console, "log").mockImplementation(() => {});
     const deps = createDeps();
 
-    await languagesAction("python", {}, deps);
+    await languagesAction(undefined, {}, deps);
 
     expect(deps.githitsService.getLanguages).toHaveBeenCalledTimes(1);
+    consoleSpy.mockRestore();
+  });
+
+  it("calls searchLanguages exactly once for queries", async () => {
+    const consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+    const deps = createDeps();
+
+    await languagesAction("python", {}, deps);
+
+    expect(deps.githitsService.searchLanguages).toHaveBeenCalledTimes(1);
+    expect(deps.githitsService.getLanguages).not.toHaveBeenCalled();
     consoleSpy.mockRestore();
   });
 });

--- a/src/commands/languages.ts
+++ b/src/commands/languages.ts
@@ -3,10 +3,7 @@ import { AuthenticationError } from "@githits/core-internal";
 import type { Command } from "commander";
 import { createContainer } from "../container.js";
 import { colorize, dim, shouldUseColors } from "../shared/colors.js";
-import {
-  filterLanguages,
-  type LanguageMatch,
-} from "../shared/language-filter.js";
+import type { LanguageMatch } from "../shared/language-filter.js";
 import {
   AuthRequiredError,
   buildAuthRequiredErrorPayload,
@@ -46,23 +43,29 @@ export async function languagesAction(
   }
 
   try {
-    const allLanguages = await deps.githitsService.getLanguages();
-
     const displayList: LanguageMatch[] = query
-      ? filterLanguages(allLanguages, query)
-      : allLanguages.map(({ name, display_name, aliases }) => ({
-          name,
-          display_name,
-          aliases,
-        }));
+      ? await deps.githitsService.searchLanguages(query)
+      : (await deps.githitsService.getLanguages()).map(
+          ({ name, display_name, aliases }) => ({
+            name,
+            display_name,
+            aliases,
+          }),
+        );
+
+    const matches = displayList.map(({ name, display_name, aliases }) => ({
+      name,
+      display_name,
+      aliases,
+    }));
 
     if (options.json) {
-      console.log(JSON.stringify(displayList));
-    } else if (query && displayList.length === 0) {
+      console.log(JSON.stringify(matches));
+    } else if (query && matches.length === 0) {
       console.log(`No languages matching "${query}".`);
     } else {
       const useColors = shouldUseColors();
-      for (const lang of displayList) {
+      for (const lang of matches) {
         console.log(
           `  ${colorize(lang.name, "cyan", useColors)}  ${dim(lang.display_name, useColors)}`,
         );
@@ -93,11 +96,11 @@ export async function languagesAction(
 const LANGUAGES_DESCRIPTION = `List supported programming languages.
 
 Without a query, lists all supported languages.
-With a query, filters to the top 5 matches by name, display name, or alias.
+With a query, searches the top 5 backend-ranked matches by name, display name, or alias.
 
 Examples:
   githits languages              List all languages
-  githits languages python       Filter by name
+  githits languages python       Search by name
   githits languages type --json  JSON output for piping`;
 
 /**
@@ -109,7 +112,7 @@ export function registerLanguagesCommand(program: Command) {
     .command("languages")
     .summary("List supported programming languages")
     .description(LANGUAGES_DESCRIPTION)
-    .argument("[query]", "Filter by name, display name, or alias")
+    .argument("[query]", "Search by name, display name, or alias")
     .option("--json", "Output as JSON for piping")
     .action(async (query: string | undefined, options: LanguagesOptions) => {
       const deps = await createContainer();

--- a/src/services/test-helpers.ts
+++ b/src/services/test-helpers.ts
@@ -279,6 +279,40 @@ export function createMockGitHitsService(
         },
       ]),
     ),
+    searchLanguages: mock((query: string, limit: number = 5) => {
+      const lowerQuery = query.toLowerCase();
+      return Promise.resolve(
+        [
+          {
+            id: "1",
+            name: "javascript",
+            display_name: "JavaScript",
+            aliases: ["js"],
+          },
+          {
+            id: "2",
+            name: "typescript",
+            display_name: "TypeScript",
+            aliases: ["ts"],
+          },
+          {
+            id: "3",
+            name: "python",
+            display_name: "Python",
+            aliases: ["py"],
+          },
+        ]
+          .filter(
+            (language) =>
+              language.name.toLowerCase().includes(lowerQuery) ||
+              language.display_name.toLowerCase().includes(lowerQuery) ||
+              language.aliases.some((alias) =>
+                alias.toLowerCase().includes(lowerQuery),
+              ),
+          )
+          .slice(0, limit),
+      );
+    }),
     submitFeedback: mock(() =>
       Promise.resolve({
         success: true,

--- a/src/tools/search-language-parity.test.ts
+++ b/src/tools/search-language-parity.test.ts
@@ -26,7 +26,7 @@ async function cliJson(): Promise<unknown> {
       { json: true },
       {
         githitsService: createMockGitHitsService({
-          getLanguages: mock(() => Promise.resolve(languages)),
+          searchLanguages: mock(() => Promise.resolve(languages)),
         }),
         hasValidToken: true,
         mcpUrl: "https://mcp.example.com",
@@ -41,7 +41,7 @@ async function cliJson(): Promise<unknown> {
 async function mcpJson(): Promise<unknown> {
   const tool = createSearchLanguageTool(
     createMockGitHitsService({
-      getLanguages: mock(() => Promise.resolve(languages)),
+      searchLanguages: mock(() => Promise.resolve(languages)),
     }),
   );
   const result = await tool.handler({ query: "type", format: "json" }, {});

--- a/src/tools/search-language.test.ts
+++ b/src/tools/search-language.test.ts
@@ -19,7 +19,8 @@ describe("searchLanguageTool", () => {
     expect(result.isError).toBeUndefined();
     expect(getText(result)).toContain("python (Python) aliases: py");
     expect(() => JSON.parse(getText(result))).toThrow();
-    expect(service.getLanguages).toHaveBeenCalled();
+    expect(service.searchLanguages).toHaveBeenCalledWith("python");
+    expect(service.getLanguages).not.toHaveBeenCalled();
   });
 
   it("returns filtered JSON when format=json", async () => {
@@ -35,7 +36,7 @@ describe("searchLanguageTool", () => {
 
   it("returns error result on service failure", async () => {
     const service = createMockGitHitsService({
-      getLanguages: mock(() => Promise.reject(new Error("API error"))),
+      searchLanguages: mock(() => Promise.reject(new Error("API error"))),
     });
     const tool = createSearchLanguageTool(service);
 
@@ -47,7 +48,7 @@ describe("searchLanguageTool", () => {
 
   it("returns recoverable AUTH_REQUIRED envelope on auth failure", async () => {
     const service = createMockGitHitsService({
-      getLanguages: mock(() =>
+      searchLanguages: mock(() =>
         Promise.reject(new AuthenticationError("Authentication required")),
       ),
     });

--- a/src/tools/search-language.ts
+++ b/src/tools/search-language.ts
@@ -1,6 +1,6 @@
-import type { GitHitsService } from "@githits/core-internal";
+import type { GitHitsService, Language } from "@githits/core-internal";
 import { z } from "zod";
-import { filterLanguages } from "../shared/language-filter.js";
+import type { LanguageMatch } from "../shared/language-filter.js";
 import { withErrorHandling } from "./shared.js";
 import { type ToolDefinition, textResult } from "./types.js";
 
@@ -35,8 +35,9 @@ export function createSearchLanguageTool(
     schema,
     handler: async (args) => {
       return withErrorHandling("search languages", async () => {
-        const allLanguages = await service.getLanguages();
-        const result = filterLanguages(allLanguages, args.query);
+        const result = (await service.searchLanguages(args.query)).map(
+          toLanguageMatch,
+        );
         if (isTextFormat(args.format)) {
           return textResult(renderLanguageMatches(result));
         }
@@ -44,6 +45,14 @@ export function createSearchLanguageTool(
       });
     },
   };
+}
+
+function toLanguageMatch({
+  name,
+  display_name,
+  aliases,
+}: Language): LanguageMatch {
+  return { name, display_name, aliases };
 }
 
 function isTextFormat(format: SearchLanguageArgs["format"]): boolean {


### PR DESCRIPTION
## Summary
- route queried `githits languages` calls through backend-ranked `/languages?query=...&limit=5`
- route CLI-hosted MCP `search_language` through the same backend-ranked service method
- isolate unauthenticated smoke probes from real keychain entries by using a dummy MCP URL for smoke-only auth storage keys

## Prod verification
Built `dist/cli.js` and ran it against `https://api.githits.com`:
- `languages ts --json` -> TypeScript first
- `languages type --json` -> TypeScript first
- `languages java --json` -> Java first
- `languages c++ --json` -> C++ first
- `languages c# --json` -> C# first
- `languages js --json` -> JavaScript first
- `languages python --json` -> Python first
- `languages py --json` -> Python first
- CLI-hosted MCP `search_language` produced the same first-result matrix
- `example "typescript debounce function" --lang ts --json` returned a result
- CLI-hosted MCP `get_example` with `language: "ts"` returned a result

## Verification
- `bun test src/services/githits-service.test.ts src/services/refreshing-githits-service.test.ts src/commands/languages.test.ts src/tools/search-language.test.ts src/tools/search-language-parity.test.ts src/shared/language-filter.test.ts`
- `bun run typecheck`
- `bunx biome format <touched files>`
- `bunx biome lint <touched files>`
- `bunx bunup --dts --target node --packages=external --exports`
- `GITHITS_API_URL=https://api.githits.com bun run smoke:cli`
- `GITHITS_API_URL=https://api.githits.com bun run smoke:mcp`

Note: `bun run build` writes the bundle on Windows but exits at the script's trailing Unix-only `chmod`; the equivalent `bunx bunup ...` build command completed successfully.