### PR TITLE
feat: add GitHits onboarding skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "GitHits plugins for Claude Code - code examples from global open source",
-    "version": "0.4.12"
+    "version": "0.4.13"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "Code examples from global open source for developers and AI assistants",
   "author": {
     "name": "GitHits"

--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "Code examples from global open source for developers and AI assistants",
   "author": {
     "name": "GitHits"

--- a/docs/implementation/agent-onboarding-skill.md
+++ b/docs/implementation/agent-onboarding-skill.md
@@ -1,0 +1,108 @@
+# Agent Onboarding Skill
+
+## Purpose
+
+The `githits-onboarding` skill lets an agent guide a user from discovery to a usable GitHits setup with the current CLI surface. The skill orchestrates detection, MCP installation, sign-in/signup startup, verification, and recovery guidance.
+
+## Current Flow
+
+GitHits setup is currently split across existing CLI commands:
+
+- `npx -y githits@latest init --detect-agents --json` scans supported coding tools and reports MCP configuration state.
+- `npx -y githits@latest init --install-agents <ids> --json` installs GitHits MCP configuration for selected tools.
+- `npx -y githits@latest login` starts OAuth PKCE sign-in/signup, opens a browser when possible, waits for the local callback, exchanges the authorization code, and stores credentials through the existing auth storage layer.
+- `npx -y githits@latest auth status` reports whether local auth is active, expired, missing, or provided by `GITHITS_API_TOKEN`.
+
+The onboarding skill uses `npx -y githits@latest` for normal onboarding so new users get the latest published CLI behavior. Installed global `githits` binaries may be stale and are only used when the user explicitly asks to test a local, dev, or pinned CLI build. This may be slower or require network access, but the latest published onboarding behavior is the product requirement.
+
+## User Experience Contract
+
+The agent can safely handle:
+
+- Checking auth state.
+- Detecting supported coding tools.
+- Asking which detected tools to configure.
+- Installing MCP configuration for approved tools.
+- Starting login/signup.
+- Verifying auth and MCP configuration.
+- Reporting failures and restart requirements.
+
+The agent must not claim that account creation is fully browserless. Current login uses browser OAuth, so the user may need to approve or create their account in a browser tab. The skill explicitly forbids asking users to paste passwords, OAuth codes, cookies, access tokens, refresh tokens, or API keys into chat.
+
+## Simplified New-User Flow
+
+The onboarding skill is intentionally more opinionated than generic setup diagnostics. When the user asks to start using GitHits, the skill assumes they want to create or connect a GitHits account and configure GitHits unless they explicitly say otherwise.
+
+The preferred setup path is:
+
+1. Ask whether setup should be project-level or user-level.
+2. Detect supported tools with the matching staged command.
+3. Recommend configuring all detected installable tools first.
+4. Offer individual tool selection only as a secondary path for users who want a smaller setup.
+5. Install the approved IDs with the matching staged install command.
+6. Start sign-in/signup as part of onboarding, skipping login only when `auth status` already reports an active session.
+7. Verify auth and tool configuration.
+
+The skill still requires approval before writing MCP config or launching browser OAuth. It should not present "configure none" or "skip login" as normal onboarding choices, because those paths leave a new user without a working GitHits setup.
+
+## Project And User Setup Scope
+
+The current CLI supports both user-level and project-level staged setup.
+
+User-level setup configures detected tools globally for the current user account on the machine:
+
+```bash
+npx -y githits@latest init --detect-agents --json
+npx -y githits@latest init --install-agents <ids> --json
+```
+
+Project-level setup writes project-local MCP files into the current repo:
+
+```bash
+npx -y githits@latest init --project --detect-agents --json
+npx -y githits@latest init --project --install-agents <ids> --json
+```
+
+User-level setup should be offered first and marked recommended for onboarding because it makes GitHits available wherever the user works with the detected agents. Project-level setup remains available for repo-specific or team setup, and the skill must explain that project-local MCP files may be committed. It must not offer tools with `unsupported_project_config` for project-level installation.
+
+Agents should use structured choice UI for both setup scope and tool selection whenever available. The desired scope choices are `My user account (Recommended)` and `This project only`. The desired tool choices are `Configure all detected tools (Recommended)` followed by individual installable tools. Agents should not ask users to type comma-separated tool IDs unless no structured choice mechanism is available.
+
+## Codex Execution Guardrails
+
+Codex has been observed delegating onboarding shell commands to subagents or background tasks. The skill requires inline execution because setup commands need sequential user approval and visible failure handling.
+
+Onboarding commands such as `npx -y githits@latest`, detection, login, and setup should run in the current agent session. The skill intentionally keeps `npx -y githits@latest` inline rather than allowing background package fetches. If official detection fails or appears stuck, agents should stop and report the detection failure instead of inspecting package internals, manually probing tools, killing processes, or inferring install IDs.
+
+## Detection Probe Reliability
+
+Agent detection may call read-only third-party CLI probes such as `which codex`, `codex mcp list`, `claude plugin list`, `gemini extensions config githits`, and Pi package-manager bin lookups. These probes are bounded so one slow or stuck agent CLI cannot prevent `init --detect-agents --json` from returning. Binary lookups use a short timeout, package-manager global-bin probes use a short timeout, and read-only configuration checks use a slightly longer timeout. Timed-out probes are treated as non-fatal probe failures: binary lookup timeouts make that agent not detected, while configuration-check timeouts leave an already-detected agent installable instead of blocking the whole detection response.
+
+Set `GITHITS_INIT_TRACE=1` to diagnose detection hangs. Trace mode writes progress to stderr only and keeps JSON stdout parseable. It reports scan start/end, per-agent probe start/end, elapsed time, exit codes, and probe timeouts without logging environment values or secrets.
+
+## Why Fully In-Agent Signup Is Future Work
+
+The current OAuth flow starts a local callback server and relies on browser authorization. That is appropriate for secure CLI login, but it means an agent cannot complete the entire account creation flow without user approval outside chat.
+
+A future perfect-state flow should add a structured agent-native command, for example:
+
+```bash
+githits onboard --json
+```
+
+or an OAuth Device Authorization implementation. A future command should return machine-readable state for:
+
+- already authenticated
+- waiting for user approval
+- authorized and stored
+- expired or denied
+- storage failure
+
+The backend could create the GitHits account during the authorization step, then the CLI would store tokens using the same auth storage path as `githits login`.
+
+## Testing Strategy
+
+Static tests protect the skill contract by checking that onboarding files exist, required commands are present, and auth safety guardrails remain in place.
+
+Agentic evals exercise whether real agents discover and follow the skill. The onboarding workload asks the agent to set up GitHits without giving command instructions, so command choice should come from the skill itself.
+
+Agentic eval results are qualitative. Review `tool-calls.json`, `final.json`, `report.json`, `toolIssues`, and `instructionIssues` rather than treating a live-agent pass/fail as deterministic CI evidence.

--- a/eval/agentic/README.md
+++ b/eval/agentic/README.md
@@ -166,6 +166,7 @@ use at least one agent for quick iteration.
 
 | Affected Area | Workload |
 |---|---|
+| Agent-driven GitHits onboarding and setup UX | `githits-onboarding.md` |
 | Core global examples, `get_example`, `search_language`, `feedback` | `global-example.md` |
 | Unified `search` / `search_status` behavior | `unified-search-investigation.md`; use `search-source-ergonomics.md` when changing `search` source-selection arguments or minimal-call guidance |
 | Package overview or vulnerability UX, `pkg_info`, `pkg_vulns` | `package-overview-vulnerabilities.md`; use `package-vulnerability-filter.md` for severity/version filtering behavior; use `package-vulnerability-history.md` for historical/non-affecting advisory scope behavior |

--- a/eval/agentic/workloads/githits-onboarding.md
+++ b/eval/agentic/workloads/githits-onboarding.md
@@ -1,0 +1,1 @@
+I want to start using GitHits in this agent. Please set it up as far as you safely can, explain any approval I need to complete, and report what you verified.

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "Code examples from global open source for developers and AI assistants.",
   "mcpServers": {
     "githits": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "githits",
   "description": "CLI companion for GitHits - code examples from global open source for developers and AI assistants",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "type": "module",
   "workspaces": [
     "packages/*"

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "Code examples from global open source for developers and AI assistants",
   "author": {
     "name": "GitHits"

--- a/plugins/claude/skills/onboarding/SKILL.md
+++ b/plugins/claude/skills/onboarding/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: onboarding
+description: >-
+  Set up GitHits from Claude Code: detect supported tools, install GitHits MCP,
+  start sign-in/signup, verify auth, and recover from setup issues.
+metadata:
+  internal: true
+---
+
+Use this skill when the user asks to install, connect, set up, sign up for, or start using GitHits. This is a new-user onboarding skill: assume the user wants to create or connect a GitHits account and configure GitHits unless they explicitly say otherwise.
+
+## Current Boundary
+
+- GitHits sign-in/signup currently uses browser OAuth. You can start and monitor login, but the user may need to approve GitHits in a browser tab.
+- Never ask the user to paste passwords, OAuth codes, cookies, access tokens, refresh tokens, or API keys into chat.
+
+## Execution Mode
+
+- Use `npx -y githits@latest ...` for every normal onboarding command. This guarantees the latest published GitHits CLI behavior for new users.
+- Do not use a globally installed `githits` binary for onboarding unless the user explicitly asks to test a local, dev, or pinned CLI build.
+- If the user explicitly asks for local/dev/pinned testing, preserve the command and environment they provide.
+- Run onboarding commands inline in the current agent session.
+- Do not use subagents, background agents, background terminals, or long-running background tasks for onboarding.
+- Do not delegate `githits`, `npx`, `npm`, `codex`, `claude`, detection, login, or setup commands to subagents or background agents.
+- Do not start `npx -y githits@latest init --detect-agents --json` as a background task. Wait for the result before continuing.
+- Do not run `pkill`, `ps`, process inspection, or package-source inspection as part of normal onboarding.
+- If `npx -y githits@latest ...` fails because of network, DNS, or package-fetch errors, stop and report that GitHits CLI is unavailable.
+- If official detection fails or appears stuck, do not inspect package internals, manually probe tools to infer install IDs, or ask the user to type inferred IDs. Report the detection failure and offer to retry, switch setup scope, or stop.
+
+## Flow
+
+1. Choose setup scope with a structured choice. Do not ask the user to type a freeform response.
+
+Ask: `Where should GitHits be configured?`
+
+Options:
+
+- `My user account (Recommended)` — configures detected tools globally/user-level on this machine so GitHits is available wherever the user works with those agents.
+- `This project only` — writes project-local MCP files into this repo; files may be committed.
+
+2. Detect supported tools and current MCP state for the selected scope.
+
+Project-level detection:
+
+```bash
+npx -y githits@latest init --project --detect-agents --json
+```
+
+User-level detection:
+
+```bash
+npx -y githits@latest init --detect-agents --json
+```
+
+Run detection inline, not in a background terminal. Wait for JSON before continuing.
+
+Do not offer tools with `unsupported_project_config` for project-level setup.
+
+3. If `installableIds` is non-empty, use structured choices for tool selection. Do not ask the user to type comma-separated tool IDs unless no structured choice UI is available.
+
+Present `Configure all detected tools (Recommended)` as the first option, then list individual tools for selective setup. Do not present "configure none" as a normal onboarding choice.
+
+Ask before writing configuration: `I recommend configuring all detected tools so GitHits works wherever you use an agent. Proceed with all, or choose specific tools?`
+
+Do not run `init -y` or `init --yes` unless the user explicitly asks to configure every detected tool.
+
+4. Install only approved IDs using the selected scope.
+
+Project-level install:
+
+```bash
+npx -y githits@latest init --project --install-agents <comma-separated-approved-ids> --json
+```
+
+User-level install:
+
+```bash
+npx -y githits@latest init --install-agents <comma-separated-approved-ids> --json
+```
+
+5. Start GitHits sign-in/signup as part of onboarding. Do not ask whether the user wants to log in; login creates or connects the GitHits account.
+
+Check whether login can be skipped because auth is already active:
+
+```bash
+npx -y githits@latest auth status
+```
+
+If not authenticated or expired, ask before launching browser login, then run:
+
+```bash
+npx -y githits@latest login
+```
+
+Use this only when browser launch fails or the environment is headless:
+
+```bash
+npx -y githits@latest login --no-browser
+```
+
+With `--no-browser`, ask the user to open the printed URL. Do not ask them to paste secrets or OAuth codes back into chat.
+
+6. Verify with the selected scope.
+
+Project-level verification:
+
+```bash
+npx -y githits@latest auth status
+npx -y githits@latest init --project --detect-agents --json
+```
+
+User-level verification:
+
+```bash
+npx -y githits@latest auth status
+npx -y githits@latest init --detect-agents --json
+```
+
+Report configured tools, auth state, failures, and whether the user should open a new Claude Code session so MCP config changes load.

--- a/skills/githits-onboarding/SKILL.md
+++ b/skills/githits-onboarding/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: githits-onboarding
+description: >-
+  Set up GitHits from an agent session: detect supported coding tools, install
+  GitHits MCP configuration, start account sign-in/signup, verify auth, and
+  recover from setup issues. Use when the user asks to install, connect, set up,
+  sign up for, or start using GitHits.
+compatibility: Requires shell access, internet access, and npx. Use a local githits binary only for explicit local/dev/pinned testing.
+---
+
+Use this skill when the user wants to start using GitHits from their agent.
+This is a new-user onboarding skill: assume the user wants to create or connect
+a GitHits account and configure GitHits unless they explicitly say otherwise.
+
+## Current Boundary
+
+- GitHits account sign-in/signup currently uses browser OAuth. You can start and monitor the flow, but the user may need to approve GitHits in a browser tab.
+- Do not promise browserless account creation or that everything happens inside chat.
+- Never ask the user to paste passwords, OAuth codes, cookies, access tokens, refresh tokens, or API keys into chat.
+
+## Command Style
+
+- Use `npx -y githits@latest ...` for every normal onboarding command. This guarantees the latest published GitHits CLI behavior for new users.
+- Do not use a globally installed `githits` binary for onboarding unless the user explicitly asks to test a local, dev, or pinned CLI build.
+- If the user explicitly asks for local/dev/pinned testing, preserve the command and environment they provide.
+- Prefer `--json` for staged `init` commands because agents need stable fields.
+- Do not start `npx -y githits@latest` as a background task. If `npx` fails because of network, DNS, or package-fetch errors, stop and report that GitHits CLI is unavailable.
+
+## Execution Mode
+
+- Run onboarding commands inline in the current agent session.
+- For Codex and other agents with background/subagent capabilities, do not use subagents, background agents, background terminals, or long-running background tasks for onboarding.
+- Do not delegate `githits`, `npx`, `npm`, `codex`, `claude`, detection, login, or setup commands to subagents or background agents.
+- Do not start `npx -y githits@latest init --detect-agents --json` as a background task. Run it directly, wait for the result, and only continue after it returns.
+- Do not run `pkill`, `ps`, process inspection, or package-source inspection as part of normal onboarding. If a command appears stuck, stop and report that official detection did not return.
+- These are short setup probes and must stay visible and sequential so the user can approve side effects and failures are easy to diagnose.
+- If official detection fails or appears stuck, do not inspect package internals, manually probe tools to infer install IDs, or ask the user to type inferred IDs. Report that official GitHits detection failed and offer to retry, switch setup scope, or stop.
+
+## Onboarding Flow
+
+1. Choose setup scope with a structured choice.
+
+Use the agent's structured choice UI when available. Do not ask the user to type a freeform response for setup scope.
+
+Ask: `Where should GitHits be configured?`
+
+Options:
+
+- `My user account (Recommended)` — configures detected tools globally/user-level on this machine. Best for onboarding because GitHits will be available wherever the user works with those agents.
+- `This project only` — writes project-local MCP files into the current repo. Good for repo-specific or team setup. These files may be committed.
+
+2. Detect supported coding tools and GitHits MCP configuration state for the selected scope:
+
+Project-level detection:
+
+```bash
+npx -y githits@latest init --project --detect-agents --json
+```
+
+User-level detection:
+
+```bash
+npx -y githits@latest init --detect-agents --json
+```
+
+Run detection inline, not in a background terminal. Wait for JSON before continuing.
+
+Use the JSON fields to summarize detected tools. `agents[].status` can be `needs_setup`, `already_configured`, `unsupported_project_config`, or `not_detected`. `installableIds` lists detected tools that need setup for the selected scope.
+
+For project-level setup, do not offer tools with `unsupported_project_config`. Explain only if needed: those detected tools do not have verified project-level MCP support.
+
+3. Recommend the simplest tool setup choice with structured options.
+
+If `installableIds` is non-empty, use structured choices when available. Do not ask the user to type comma-separated tool IDs unless the current agent interface has no structured choice mechanism.
+
+Ask: `Which tools should I configure?`
+
+Options:
+
+- `Configure all detected tools (Recommended)` — the recommended default option; use all `installableIds`.
+- One selective setup option per installable detected tool, using the tool display name and ID.
+
+Do not present "configure none" as a normal onboarding choice; if the user does not want any tool configured, pause and clarify whether they want to stop onboarding.
+
+Ask before writing configuration. A good prompt is: `I recommend configuring all detected tools so GitHits works wherever you use an agent. Proceed with all, or choose specific tools?`
+
+Only install user-approved IDs. Do not run `init -y` or `init --yes` unless the user explicitly asks to configure every detected tool.
+
+4. Install GitHits MCP for approved tools using the selected scope.
+
+Project-level install:
+
+```bash
+npx -y githits@latest init --project --install-agents <comma-separated-approved-ids> --json
+```
+
+User-level install:
+
+```bash
+npx -y githits@latest init --install-agents <comma-separated-approved-ids> --json
+```
+
+Treat `success` and `already_configured` outcomes as usable. Report any `failed` outcome with the tool name and message. For project-level setup, remind the user that project-local MCP files may be committed.
+
+5. Start GitHits sign-in/signup during onboarding.
+
+Do not ask whether the user wants to log in. Login creates or connects the GitHits account, so it is part of onboarding. Ask before launching browser OAuth, then run login unless `auth status` already shows an active session.
+
+Check auth state:
+
+```bash
+npx -y githits@latest auth status
+```
+
+Treat `Authenticated.` and `Authenticated via environment variable.` as already signed in and skip launching login. Treat `Not authenticated.` and `Token expired.` as requiring login.
+
+Explain: `I can start GitHits sign-in now. It may open a browser tab where you approve or create your GitHits account. I will not ask you to paste secrets into chat.`
+
+Then run:
+
+```bash
+npx -y githits@latest login
+```
+
+If the browser cannot open automatically, or the session appears to be SSH/container/headless, use:
+
+```bash
+npx -y githits@latest login --no-browser
+```
+
+With `--no-browser`, ask the user to open the printed URL. Do not ask them to paste passwords, tokens, cookies, or OAuth codes back into chat.
+
+6. Verify setup after login and installation.
+
+Project-level verification:
+
+```bash
+npx -y githits@latest auth status
+npx -y githits@latest init --project --detect-agents --json
+```
+
+User-level verification:
+
+```bash
+npx -y githits@latest auth status
+npx -y githits@latest init --detect-agents --json
+```
+
+Confirm auth is active and selected tools are `already_configured` for the selected scope. If MCP configuration changed, tell the user to open a new agent session in the project or user environment so the tool reloads its MCP config.
+
+## Completion Response
+
+Report:
+
+- Which tools were configured or already configured.
+- Whether GitHits auth is active, requires browser approval, or could not be verified.
+- Whether the user needs to restart/open a new agent session.
+- Any failed tool setup with the exact tool name and error message.
+
+## Safety Rules
+
+- Do not collect or display secrets.
+- Do not write secrets into MCP config.
+- Do not ask the user to run commands manually unless you lack shell access.
+- Do not retry broad setup with `init --yes` after a failure; use the staged JSON flow and approved IDs.
+- If auth storage fails, read `references/troubleshooting.md` before suggesting recovery.
+
+Read `references/troubleshooting.md` for recovery paths when setup, login, storage, or verification fails.

--- a/skills/githits-onboarding/references/troubleshooting.md
+++ b/skills/githits-onboarding/references/troubleshooting.md
@@ -1,0 +1,58 @@
+# GitHits Onboarding Troubleshooting
+
+Use these recovery paths only when the main onboarding flow fails or the environment prevents normal setup.
+
+## No Shell Access
+
+If you cannot run shell commands, explain that you cannot complete setup directly from the agent. Provide commands only if the user asks for manual steps.
+
+## npx Unavailable
+
+`npx -y githits@latest` requires Node/npm tooling. If `npx` is unavailable, try an already installed `githits` binary. Otherwise explain that Node/npm or the GitHits CLI is required before agent-driven setup can continue.
+
+## No Supported Tools Detected
+
+`init --detect-agents --json` detects supported coding tools and their GitHits MCP state. If no supported tools are detected, report that GitHits can still be used through the CLI where available, but automatic MCP setup needs a supported agent installed or detectable on this machine.
+
+## Browser Does Not Open
+
+Retry login with:
+
+```bash
+npx -y githits@latest login --no-browser
+```
+
+Ask the user to open the printed URL. Do not ask them to paste passwords, tokens, cookies, or OAuth codes into chat.
+
+## Authentication Timeout
+
+The login link expires after the timeout. Run a fresh login command to create a new link:
+
+```bash
+npx -y githits@latest login
+```
+
+Use `--no-browser` only if browser launch failed or the environment is headless.
+
+## Keychain Or Storage Failure
+
+If the CLI reports it cannot persist OAuth credentials, ask the user to unlock their system keychain and retry login.
+
+For automation or CI, the user can provide `GITHITS_API_TOKEN` in the environment outside chat. Do not ask them to paste the token into chat.
+
+As a last resort, the user can set `GITHITS_AUTH_STORAGE=file`, but warn that file storage is plaintext on disk.
+
+## Install-Agent Failures
+
+For `init --install-agents <ids> --json`, inspect `outcomes`. Report each failed tool by `name` and `message`. Do not retry with `init -y` or `init --yes` unless the user explicitly approves configuring every detected tool.
+
+## Verification Fails
+
+After setup, run:
+
+```bash
+npx -y githits@latest auth status
+npx -y githits@latest init --detect-agents --json
+```
+
+If auth is active but selected tools are not `already_configured`, report the specific mismatch and failed tool state. If tools are configured, tell the user to open a new agent session so MCP config changes are loaded.

--- a/src/commands/init/agent-definitions.test.ts
+++ b/src/commands/init/agent-definitions.test.ts
@@ -403,7 +403,9 @@ describe("detection configuration", () => {
         });
         const agent = agentDefinitions.find((a) => a.id === testCase.id)!;
         expect(await agent.detectBinary!(exec)).toBe(true);
-        expect(exec.exec).toHaveBeenCalledWith("which", [testCase.binary]);
+        expect(exec.exec).toHaveBeenCalledWith("which", [testCase.binary], {
+          timeoutMs: 2_000,
+        });
       }
     } finally {
       Object.defineProperty(process, "platform", {
@@ -430,7 +432,9 @@ describe("detection configuration", () => {
       });
       const agent = agentDefinitions.find((a) => a.id === "claude-code")!;
       expect(await agent.detectBinary!(exec)).toBe(true);
-      expect(exec.exec).toHaveBeenCalledWith("where", ["claude"]);
+      expect(exec.exec).toHaveBeenCalledWith("where", ["claude"], {
+        timeoutMs: 2_000,
+      });
     } finally {
       Object.defineProperty(process, "platform", {
         value: originalPlatform,
@@ -1219,7 +1223,7 @@ describe("scanAgents", () => {
       ),
     });
     const execService = createMockExecService({
-      exec: mock(async (cmd: string, args: string[]) => {
+      exec: mock(async (cmd: string, args: string[], _options?: unknown) => {
         const key = `${cmd} ${args.join(" ")}`;
         if (opts.execResults && key in opts.execResults) {
           const val = opts.execResults[key]!;
@@ -1501,6 +1505,17 @@ describe("scanAgents", () => {
     expect(result.notDetected.some((a) => a.id === "codex-cli")).toBe(false);
   });
 
+  it("passes timeout option to binary lookup probes", async () => {
+    const lookupCmd = lookupCommandFor();
+    const { fs, execService } = createScanMocks({ detectedDirs: [] });
+
+    await scanAgents(agentDefinitions, fs, execService);
+
+    expect(execService.exec).toHaveBeenCalledWith(lookupCmd, ["codex"], {
+      timeoutMs: 2_000,
+    });
+  });
+
   it("detects pi via detectBinary and requires adapter plus Pi-owned config", async () => {
     const lookupCmd = lookupCommandFor();
     const { fs, execService } = createScanMocks({
@@ -1546,6 +1561,30 @@ describe("scanAgents", () => {
       true,
     );
     expect(result.needsSetup.some((a) => a.id === "codex-cli")).toBe(false);
+  });
+
+  it("keeps Codex CLI installable when config check times out", async () => {
+    const lookupCmd = lookupCommandFor();
+    const timeout = new Error("timed out");
+    timeout.name = "ExecTimeoutError";
+    const { fs, execService } = createScanMocks({
+      detectedDirs: [],
+      execResults: {
+        [`${lookupCmd} codex`]: {
+          exitCode: 0,
+          stdout: "/usr/bin/codex\n",
+          stderr: "",
+        },
+        "codex mcp list": timeout,
+      },
+    });
+
+    const result = await scanAgents(agentDefinitions, fs, execService);
+
+    expect(result.needsSetup.some((a) => a.id === "codex-cli")).toBe(true);
+    expect(result.alreadyConfigured.some((a) => a.id === "codex-cli")).toBe(
+      false,
+    );
   });
 
   it("does not categorize Codex CLI as configured for incidental githits text", async () => {
@@ -1604,6 +1643,22 @@ describe("scanAgents", () => {
         expect(installStep.checkCommand?.command).toBe("/npm-global/bin/pi");
       }
     }
+  });
+
+  it("passes timeout option to Pi global bin probes", async () => {
+    const lookupCmd = lookupCommandFor();
+    const { fs, execService } = createScanMocks({
+      detectedDirs: [],
+      execResults: {
+        [`${lookupCmd} pi`]: { exitCode: 1, stdout: "", stderr: "" },
+      },
+    });
+
+    await scanAgents(agentDefinitions, fs, execService);
+
+    expect(execService.exec).toHaveBeenCalledWith("npm", ["prefix", "-g"], {
+      timeoutMs: 3_000,
+    });
   });
 
   it("detects pi from pnpm global bin when npm candidate is missing", async () => {

--- a/src/commands/init/agent-definitions.ts
+++ b/src/commands/init/agent-definitions.ts
@@ -1,5 +1,6 @@
 import type { ExecService } from "../../services/exec-service.js";
 import type { FileSystemService } from "../../services/filesystem-service.js";
+import { traceInit, traceProbeEnd, traceProbeStart } from "./init-trace.js";
 import {
   type CliCheckCommand,
   getCliCheckStatus,
@@ -94,6 +95,8 @@ const CLAUDE_GITHITS_PLUGIN = "githits";
 const CLAUDE_GITHITS_MARKETPLACE = "githits-plugins";
 const CLAUDE_GITHITS_PLUGIN_REF = `${CLAUDE_GITHITS_PLUGIN}@${CLAUDE_GITHITS_MARKETPLACE}`;
 const CLAUDE_GITHITS_MARKETPLACE_SOURCE = "githits-com/githits-cli";
+const BINARY_LOOKUP_TIMEOUT_MS = 2_000;
+const GLOBAL_BIN_PROBE_TIMEOUT_MS = 3_000;
 
 /** How an agent is considered present on the machine. */
 type DetectionMethod = "binary" | "path" | "hybrid";
@@ -325,7 +328,9 @@ async function isExecutableAvailable(
 ): Promise<boolean> {
   try {
     const lookupCommand = process.platform === "win32" ? "where" : "which";
-    const result = await exec.exec(lookupCommand, [executable]);
+    const result = await exec.exec(lookupCommand, [executable], {
+      timeoutMs: BINARY_LOOKUP_TIMEOUT_MS,
+    });
     return result.exitCode === 0;
   } catch {
     return false;
@@ -359,7 +364,9 @@ async function runGlobalBinProbe(
   probe: PiGlobalBinProbe,
 ): Promise<string | null> {
   try {
-    const result = await exec.exec(probe.command, [...probe.args]);
+    const result = await exec.exec(probe.command, [...probe.args], {
+      timeoutMs: GLOBAL_BIN_PROBE_TIMEOUT_MS,
+    });
     if (result.exitCode !== 0) {
       return null;
     }
@@ -961,24 +968,54 @@ async function scanSingleAgent(
   execService: ExecService,
   scope: InitSetupScope,
 ): Promise<AgentScanOutcome> {
+  const scanStartedAt = Date.now();
+  traceInit(`agent:start agent=${agent.id} scope=${scope}`);
   // Check if available using the agent's declared detection contract.
   let detected = false;
   let setupContext: AgentSetupContext | undefined;
 
   if (agent.detectCommand) {
+    const startedAt = Date.now();
     try {
+      traceProbeStart({ agentId: agent.id, phase: "detectCommand" });
       const resolvedCommand = await agent.detectCommand(execService, fs);
+      traceProbeEnd({
+        agentId: agent.id,
+        phase: "detectCommand",
+        startedAt,
+        status: "end",
+      });
       if (resolvedCommand) {
         detected = true;
         setupContext = { command: resolvedCommand.command };
       }
     } catch {
+      traceProbeEnd({
+        agentId: agent.id,
+        phase: "detectCommand",
+        startedAt,
+        status: "error",
+      });
       detected = false;
     }
   } else if (agent.detectionMethod === "binary" && agent.detectBinary) {
+    const startedAt = Date.now();
     try {
+      traceProbeStart({ agentId: agent.id, phase: "binary" });
       detected = await agent.detectBinary(execService);
+      traceProbeEnd({
+        agentId: agent.id,
+        phase: "binary",
+        startedAt,
+        status: "end",
+      });
     } catch {
+      traceProbeEnd({
+        agentId: agent.id,
+        phase: "binary",
+        startedAt,
+        status: "error",
+      });
       detected = false;
     }
   } else if (agent.detectionMethod === "path" && agent.detectPaths) {
@@ -994,9 +1031,23 @@ async function scanSingleAgent(
     let pathDetected = false;
 
     if (agent.detectBinary) {
+      const startedAt = Date.now();
       try {
+        traceProbeStart({ agentId: agent.id, phase: "binary" });
         binaryDetected = await agent.detectBinary(execService);
+        traceProbeEnd({
+          agentId: agent.id,
+          phase: "binary",
+          startedAt,
+          status: "end",
+        });
       } catch {
+        traceProbeEnd({
+          agentId: agent.id,
+          phase: "binary",
+          startedAt,
+          status: "error",
+        });
         binaryDetected = false;
       }
     }
@@ -1015,6 +1066,9 @@ async function scanSingleAgent(
   }
 
   if (!detected) {
+    traceInit(
+      `agent:end agent=${agent.id} status=not_detected elapsedMs=${Date.now() - scanStartedAt}`,
+    );
     return { status: "not_detected", agent };
   }
 
@@ -1041,6 +1095,7 @@ async function scanSingleAgent(
     const checkStatus = await getCliCheckStatus(
       config.checkCommand,
       execService,
+      { agentId: agent.id, phase: "check" },
     );
     let configured = checkStatus === "configured";
     // Only use filesystem fallback when the CLI probe itself failed.
@@ -1048,15 +1103,27 @@ async function scanSingleAgent(
     if (!configured && checkStatus === "probe_failed") {
       configured = await isGeminiExtensionInstalledFromFilesystem(fs);
     }
-    return {
-      status: configured ? "already_configured" : "needs_setup",
-      agent: scannedAgent,
-    };
+    const status = configured ? "already_configured" : "needs_setup";
+    traceInit(
+      `agent:end agent=${agent.id} status=${status} elapsedMs=${Date.now() - scanStartedAt}`,
+    );
+    return { status, agent: scannedAgent };
   }
 
-  if (await isSetupAlreadyConfigured(config, fs, execService)) {
+  if (
+    await isSetupAlreadyConfigured(config, fs, execService, {
+      agentId: agent.id,
+      phase: "check",
+    })
+  ) {
+    traceInit(
+      `agent:end agent=${agent.id} status=already_configured elapsedMs=${Date.now() - scanStartedAt}`,
+    );
     return { status: "already_configured", agent: scannedAgent };
   }
+  traceInit(
+    `agent:end agent=${agent.id} status=needs_setup elapsedMs=${Date.now() - scanStartedAt}`,
+  );
   return { status: "needs_setup", agent: scannedAgent };
 }
 
@@ -1080,6 +1147,10 @@ export async function scanAgents(
     unsupported: [],
   };
   let completed = 0;
+  const startedAt = Date.now();
+  traceInit(
+    `scan:start scope=${options.scope ?? "user"} total=${definitions.length}`,
+  );
 
   const outcomes = await Promise.all(
     definitions.map((agent) =>
@@ -1112,6 +1183,7 @@ export async function scanAgents(
     }
   }
 
+  traceInit(`scan:end elapsedMs=${Date.now() - startedAt}`);
   return result;
 }
 

--- a/src/commands/init/init-trace.ts
+++ b/src/commands/init/init-trace.ts
@@ -1,0 +1,48 @@
+export interface InitTraceProbeInput {
+  agentId: string;
+  phase: string;
+  command?: string;
+  args?: readonly string[];
+}
+
+export interface InitTraceProbeEndInput extends InitTraceProbeInput {
+  startedAt: number;
+  exitCode?: number;
+  status: "end" | "timeout" | "error";
+}
+
+export function isInitTraceEnabled(): boolean {
+  return process.env.GITHITS_INIT_TRACE === "1";
+}
+
+export function formatCommandForDiagnostics(
+  command: string,
+  args: readonly string[] = [],
+): string {
+  return [command, ...args].map((part) => JSON.stringify(part)).join(" ");
+}
+
+export function traceInit(message: string): void {
+  if (!isInitTraceEnabled()) {
+    return;
+  }
+  console.error(`[githits:init] ${message}`);
+}
+
+export function traceProbeStart(input: InitTraceProbeInput): void {
+  const command = input.command
+    ? ` command=${formatCommandForDiagnostics(input.command, input.args)}`
+    : "";
+  traceInit(
+    `probe:start agent=${input.agentId} phase=${input.phase}${command}`,
+  );
+}
+
+export function traceProbeEnd(input: InitTraceProbeEndInput): void {
+  const elapsedMs = Date.now() - input.startedAt;
+  const exitCode =
+    input.exitCode === undefined ? "" : ` exitCode=${input.exitCode}`;
+  traceInit(
+    `probe:${input.status} agent=${input.agentId} phase=${input.phase} elapsedMs=${elapsedMs}${exitCode}`,
+  );
+}

--- a/src/commands/init/init.test.ts
+++ b/src/commands/init/init.test.ts
@@ -376,6 +376,35 @@ describe("initAction", () => {
     );
   });
 
+  it("keeps detect JSON parseable when init trace is enabled", async () => {
+    const originalTrace = process.env.GITHITS_INIT_TRACE;
+    process.env.GITHITS_INIT_TRACE = "1";
+    const fs = createFsWithDetection(["/home/test/.cursor"]);
+    try {
+      await initAction(
+        { detectAgents: true, json: true },
+        {
+          fileSystemService: fs,
+          promptService: createMockPromptService(),
+          execService: createMockExecService(),
+          createLoginDeps: createUnauthLoginDeps(),
+        },
+      );
+    } finally {
+      if (originalTrace === undefined) {
+        delete process.env.GITHITS_INIT_TRACE;
+      } else {
+        process.env.GITHITS_INIT_TRACE = originalTrace;
+      }
+    }
+
+    const payload = JSON.parse(getLogOutput()[0] ?? "{}");
+    expect(payload.mode).toBe("detect-agents");
+    expect(getErrorOutput().some((msg) => msg.includes("[githits:init]"))).toBe(
+      true,
+    );
+  });
+
   it("emits project-scoped JSON for agent detection", async () => {
     const fs = createFsWithDetection(["/home/test/.cursor"]);
     const createLoginDeps = mock(() =>
@@ -1650,9 +1679,11 @@ describe("initAction", () => {
       "install",
       "npm:pi-mcp-adapter",
     ]);
-    expect(execService.exec).toHaveBeenCalledWith("/npm-global/bin/pi", [
-      "list",
-    ]);
+    expect(execService.exec).toHaveBeenCalledWith(
+      "/npm-global/bin/pi",
+      ["list"],
+      { timeoutMs: 5_000 },
+    );
     expect(atomicWriteFile).toHaveBeenCalled();
     const calls = atomicWriteFile.mock.calls;
     const written = String(calls[0]?.[1] ?? "");

--- a/src/commands/init/setup-handlers.test.ts
+++ b/src/commands/init/setup-handlers.test.ts
@@ -494,6 +494,41 @@ describe("getCliCheckStatus", () => {
     });
     expect(await getCliCheckStatus(check, execService)).toBe("probe_failed");
   });
+
+  it("passes timeout option to read-only CLI checks", async () => {
+    const check: CliCheckCommand = {
+      command: "codex",
+      args: ["mcp", "list"],
+      configuredPattern: /^githits\b/im,
+    };
+    const exec = mock(() =>
+      Promise.resolve({ exitCode: 0, stdout: "", stderr: "" }),
+    );
+    const execService = createMockExecService({ exec });
+
+    await getCliCheckStatus(check, execService);
+
+    expect(exec).toHaveBeenCalledWith("codex", ["mcp", "list"], {
+      timeoutMs: 5_000,
+    });
+  });
+
+  it("returns probe_failed when read-only CLI check times out", async () => {
+    const check: CliCheckCommand = {
+      command: "codex",
+      args: ["mcp", "list"],
+      configuredPattern: /^githits\b/im,
+    };
+    const execService = createMockExecService({
+      exec: mock(() => {
+        const error = new Error("timed out");
+        error.name = "ExecTimeoutError";
+        return Promise.reject(error);
+      }),
+    });
+
+    expect(await getCliCheckStatus(check, execService)).toBe("probe_failed");
+  });
 });
 
 // -- mergeServerConfig (pure function) --
@@ -2311,7 +2346,9 @@ describe("executeCompositeSetup", () => {
     const result = await executeCompositeSetup(piSetup, fs, execService);
     expect(result.status).toBe("success");
     expect(execService.exec).toHaveBeenCalledTimes(1);
-    expect(execService.exec).toHaveBeenCalledWith("pi", ["list"]);
+    expect(execService.exec).toHaveBeenCalledWith("pi", ["list"], {
+      timeoutMs: 5_000,
+    });
     expect(fs.atomicWriteFile).toHaveBeenCalledTimes(1);
   });
 

--- a/src/commands/init/setup-handlers.ts
+++ b/src/commands/init/setup-handlers.ts
@@ -27,6 +27,7 @@ import type {
   UninstallConfig,
   UninstallStep,
 } from "./agent-definitions.js";
+import { traceProbeEnd, traceProbeStart } from "./init-trace.js";
 
 /** A read-only command to check if a CLI agent is already configured. */
 export interface CliCheckCommand {
@@ -1000,6 +1001,7 @@ export async function isSetupAlreadyConfigured(
   config: SetupConfig,
   fs: FileSystemService,
   execService: ExecService,
+  trace?: { agentId: string; phase: string },
 ): Promise<boolean> {
   if (config.method === "config-file") {
     return isAlreadyConfigured(config, fs);
@@ -1009,11 +1011,11 @@ export async function isSetupAlreadyConfigured(
     if (!config.checkCommand) {
       return false;
     }
-    return isCliAlreadyConfigured(config.checkCommand, execService);
+    return isCliAlreadyConfigured(config.checkCommand, execService, trace);
   }
 
   for (const step of config.steps) {
-    if (!(await isSetupAlreadyConfigured(step, fs, execService))) {
+    if (!(await isSetupAlreadyConfigured(step, fs, execService, trace))) {
       return false;
     }
   }
@@ -1028,8 +1030,9 @@ export async function isSetupAlreadyConfigured(
 export async function isCliAlreadyConfigured(
   check: CliCheckCommand,
   execService: ExecService,
+  trace?: { agentId: string; phase: string },
 ): Promise<boolean> {
-  return (await getCliCheckStatus(check, execService)) === "configured";
+  return (await getCliCheckStatus(check, execService, trace)) === "configured";
 }
 
 /**
@@ -1039,9 +1042,30 @@ export async function isCliAlreadyConfigured(
 export async function getCliCheckStatus(
   check: CliCheckCommand,
   execService: ExecService,
+  trace?: { agentId: string; phase: string },
 ): Promise<CliCheckStatus> {
+  const startedAt = Date.now();
+  if (trace) {
+    traceProbeStart({
+      agentId: trace.agentId,
+      phase: trace.phase,
+      command: check.command,
+      args: check.args,
+    });
+  }
   try {
-    const result = await execService.exec(check.command, check.args);
+    const result = await execService.exec(check.command, check.args, {
+      timeoutMs: 5_000,
+    });
+    if (trace) {
+      traceProbeEnd({
+        agentId: trace.agentId,
+        phase: trace.phase,
+        startedAt,
+        status: "end",
+        exitCode: result.exitCode,
+      });
+    }
     const combined = `${result.stdout} ${result.stderr}`;
     if (check.notConfiguredPattern?.test(combined)) {
       return "not_configured";
@@ -1058,7 +1082,18 @@ export async function getCliCheckStatus(
       return "configured";
     }
     return "not_configured";
-  } catch {
+  } catch (err) {
+    if (trace) {
+      traceProbeEnd({
+        agentId: trace.agentId,
+        phase: trace.phase,
+        startedAt,
+        status:
+          err instanceof Error && err.name === "ExecTimeoutError"
+            ? "timeout"
+            : "error",
+      });
+    }
     return "probe_failed";
   }
 }

--- a/src/services/exec-service.test.ts
+++ b/src/services/exec-service.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import { ExecServiceImpl, normalizeSpawnCommand } from "./exec-service.js";
+import {
+  ExecServiceImpl,
+  ExecTimeoutError,
+  normalizeSpawnCommand,
+} from "./exec-service.js";
 
 describe("ExecServiceImpl", () => {
   it("executes a command and returns stdout", async () => {
@@ -29,6 +33,26 @@ describe("ExecServiceImpl", () => {
       "process.stderr.write('err-msg')",
     ]);
     expect(result.stderr).toContain("err-msg");
+  });
+
+  it("rejects with timeout error when command exceeds timeout", async () => {
+    const service = new ExecServiceImpl();
+    await expect(
+      service.exec("node", ["-e", "setTimeout(() => {}, 1000)"], {
+        timeoutMs: 50,
+      }),
+    ).rejects.toBeInstanceOf(ExecTimeoutError);
+  });
+
+  it("does not reject after timed-out process later closes", async () => {
+    const service = new ExecServiceImpl();
+    for (let i = 0; i < 3; i += 1) {
+      await expect(
+        service.exec("node", ["-e", "setTimeout(() => {}, 1000)"], {
+          timeoutMs: 20,
+        }),
+      ).rejects.toBeInstanceOf(ExecTimeoutError);
+    }
   });
 
   it("quotes Windows absolute command paths with spaces for shell execution", () => {

--- a/src/services/exec-service.ts
+++ b/src/services/exec-service.ts
@@ -76,13 +76,37 @@ export interface ExecResult {
   stderr: string;
 }
 
+export interface ExecOptions {
+  timeoutMs?: number;
+}
+
+export class ExecTimeoutError extends Error {
+  readonly command: string;
+  readonly args: string[];
+  readonly timeoutMs: number;
+
+  constructor(command: string, args: string[], timeoutMs: number) {
+    super(
+      `Command timed out after ${timeoutMs}ms: ${command} ${args.join(" ")}`,
+    );
+    this.name = "ExecTimeoutError";
+    this.command = command;
+    this.args = args;
+    this.timeoutMs = timeoutMs;
+  }
+}
+
 /**
  * Service interface for executing CLI commands.
  * Abstraction allows for easy testing with mock implementations.
  */
 export interface ExecService {
   /** Execute a command with arguments and return the result */
-  exec(command: string, args: string[]): Promise<ExecResult>;
+  exec(
+    command: string,
+    args: string[],
+    options?: ExecOptions,
+  ): Promise<ExecResult>;
 }
 
 /**
@@ -93,7 +117,11 @@ export interface ExecService {
  * Callers must not pass untrusted input as command or args.
  */
 export class ExecServiceImpl implements ExecService {
-  async exec(command: string, args: string[]): Promise<ExecResult> {
+  async exec(
+    command: string,
+    args: string[],
+    options: ExecOptions = {},
+  ): Promise<ExecResult> {
     return new Promise((resolve, reject) => {
       const spawnCommand = normalizeSpawnCommand(command, args);
       const child = spawn(spawnCommand.command, spawnCommand.args, {
@@ -107,25 +135,49 @@ export class ExecServiceImpl implements ExecService {
 
       const stdoutChunks: Buffer[] = [];
       const stderrChunks: Buffer[] = [];
+      let settled = false;
+      let timeout: ReturnType<typeof setTimeout> | undefined;
+
+      const settle = (fn: () => void): void => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        if (timeout) {
+          clearTimeout(timeout);
+        }
+        fn();
+      };
+
+      if (options.timeoutMs !== undefined) {
+        timeout = setTimeout(() => {
+          settle(() => {
+            child.kill("SIGTERM");
+            reject(new ExecTimeoutError(command, args, options.timeoutMs!));
+          });
+        }, options.timeoutMs);
+      }
 
       child.stdout.on("data", (chunk: Buffer) => stdoutChunks.push(chunk));
       child.stderr.on("data", (chunk: Buffer) => stderrChunks.push(chunk));
 
       child.on("error", (error) => {
-        reject(error);
+        settle(() => reject(error));
       });
 
       child.on("close", (code) => {
-        const exitCode = code ?? 1;
-        const stderr = Buffer.concat(stderrChunks).toString("utf-8");
-        if (isWindowsCommandNotFound(exitCode, stderr)) {
-          reject(createCommandNotFoundError(command));
-          return;
-        }
-        resolve({
-          exitCode,
-          stdout: Buffer.concat(stdoutChunks).toString("utf-8"),
-          stderr,
+        settle(() => {
+          const exitCode = code ?? 1;
+          const stderr = Buffer.concat(stderrChunks).toString("utf-8");
+          if (isWindowsCommandNotFound(exitCode, stderr)) {
+            reject(createCommandNotFoundError(command));
+            return;
+          }
+          resolve({
+            exitCode,
+            stdout: Buffer.concat(stdoutChunks).toString("utf-8"),
+            stderr,
+          });
         });
       });
     });

--- a/src/services/test-helpers.ts
+++ b/src/services/test-helpers.ts
@@ -881,7 +881,7 @@ export function createMockExecService(
   impl: Partial<ExecService> = {},
 ): ExecService {
   return {
-    exec: mock(() =>
+    exec: mock((_command: string, _args: string[], _options?: unknown) =>
       Promise.resolve({ exitCode: 1, stdout: "", stderr: "" } as ExecResult),
     ),
     ...impl,

--- a/src/skills-packaging.test.ts
+++ b/src/skills-packaging.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const root = join(import.meta.dir, "..");
+const onboardingSkillPath = join(
+  root,
+  "skills",
+  "githits-onboarding",
+  "SKILL.md",
+);
+const troubleshootingPath = join(
+  root,
+  "skills",
+  "githits-onboarding",
+  "references",
+  "troubleshooting.md",
+);
+const claudeOnboardingSkillPath = join(
+  root,
+  "plugins",
+  "claude",
+  "skills",
+  "onboarding",
+  "SKILL.md",
+);
+
+async function read(path: string): Promise<string> {
+  return readFile(path, "utf8");
+}
+
+function expectContainsAll(content: string, expected: string[]): void {
+  for (const text of expected) {
+    expect(content).toContain(text);
+  }
+}
+
+describe("agent skills packaging", () => {
+  it("packages a public githits-onboarding skill with setup-focused frontmatter", async () => {
+    const content = await read(onboardingSkillPath);
+
+    expectContainsAll(content, [
+      "name: githits-onboarding",
+      "Set up GitHits from an agent session",
+      "install",
+      "connect",
+      "set up",
+      "sign up",
+      "start using GitHits",
+      "compatibility:",
+    ]);
+  });
+
+  it("documents current onboarding commands without inventing auth JSON", async () => {
+    const content = await read(onboardingSkillPath);
+
+    expectContainsAll(content, [
+      "Use `npx -y githits@latest ...` for every normal onboarding command.",
+      "guarantees the latest published GitHits CLI behavior",
+      "Do not use a globally installed `githits` binary",
+      "local, dev, or pinned CLI build",
+      "npx -y githits@latest auth status",
+      "npx -y githits@latest init --detect-agents --json",
+      "npx -y githits@latest init --project --detect-agents --json",
+      "npx -y githits@latest init --install-agents",
+      "npx -y githits@latest init --project --install-agents",
+      "npx -y githits@latest login",
+      "npx -y githits@latest login --no-browser",
+    ]);
+    expect(content).not.toContain("command -v githits");
+    expect(content).not.toContain("{GITHITS}");
+    expect(content).not.toContain("auth status --json");
+  });
+
+  it("keeps onboarding auth and setup safety guardrails", async () => {
+    const content = await read(onboardingSkillPath);
+
+    expectContainsAll(content, [
+      "browser OAuth",
+      "browser tab",
+      "passwords",
+      "OAuth codes",
+      "cookies",
+      "access tokens",
+      "refresh tokens",
+      "API keys",
+      "Ask before writing configuration",
+      "Ask before launching browser OAuth",
+      "Do not run `init -y` or `init --yes` unless the user explicitly asks",
+    ]);
+  });
+
+  it("frames onboarding as new-user signup with configure-all as the default", async () => {
+    const content = await read(onboardingSkillPath);
+
+    expectContainsAll(content, [
+      "new-user onboarding skill",
+      "Configure all detected tools (Recommended)",
+      "recommended default option",
+      "selective setup option",
+      'Do not present "configure none" as a normal onboarding choice',
+      "Start GitHits sign-in/signup during onboarding",
+      "Do not ask whether the user wants to log in",
+      "Login creates or connects the GitHits account",
+    ]);
+    expect(content).not.toContain(
+      "If auth is required, ask before launching browser login",
+    );
+  });
+
+  it("uses project-vs-user setup scope and structured choices instead of freeform IDs", async () => {
+    const content = await read(onboardingSkillPath);
+
+    expectContainsAll(content, [
+      "structured choice",
+      "Do not ask the user to type",
+      "My user account (Recommended)",
+      "This project only",
+      "project-local MCP",
+      "may be committed",
+      "unsupported_project_config",
+      "Do not ask the user to type comma-separated tool IDs unless the current agent interface has no structured choice mechanism.",
+    ]);
+  });
+
+  it("keeps Codex-style onboarding commands inline and avoids inferred install IDs", async () => {
+    const content = await read(onboardingSkillPath);
+
+    expectContainsAll(content, [
+      "Run onboarding commands inline",
+      "Do not delegate",
+      "do not use subagents",
+      "subagents",
+      "background",
+      "background terminals",
+      "Do not start `npx -y githits@latest init --detect-agents --json` as a background task",
+      "Do not run `pkill`",
+      "Run detection inline",
+      "Wait for JSON",
+      "official detection fails",
+      "do not inspect package internals",
+      "manually probe tools to infer install IDs",
+      "stop and report that GitHits CLI is unavailable",
+    ]);
+  });
+
+  it("includes onboarding troubleshooting for known recovery paths", async () => {
+    const content = await read(troubleshootingPath);
+
+    expectContainsAll(content, [
+      "Authentication Timeout",
+      "keychain",
+      "login --no-browser",
+      "GITHITS_API_TOKEN",
+      "GITHITS_AUTH_STORAGE=file",
+      "plaintext",
+    ]);
+  });
+
+  it("packages Claude marketplace onboarding guidance with matching safety posture", async () => {
+    const content = await read(claudeOnboardingSkillPath);
+
+    expectContainsAll(content, [
+      "name: onboarding",
+      "Use `npx -y githits@latest ...` for every normal onboarding command.",
+      "guarantees the latest published GitHits CLI behavior",
+      "Do not use a globally installed `githits` binary",
+      "local, dev, or pinned CLI build",
+      "npx -y githits@latest init --detect-agents --json",
+      "npx -y githits@latest init --project --detect-agents --json",
+      "npx -y githits@latest init --install-agents",
+      "npx -y githits@latest init --project --install-agents",
+      "npx -y githits@latest auth status",
+      "npx -y githits@latest login",
+      "npx -y githits@latest login --no-browser",
+      "Configure all detected tools",
+      "structured choice",
+      "My user account (Recommended)",
+      "This project only",
+      "sign-in/signup",
+      "Run onboarding commands inline",
+      "Do not delegate",
+      "Do not use subagents",
+      "subagents",
+      "background",
+      "pkill",
+      "official detection fails",
+      "manually probe tools to infer install IDs",
+      "passwords",
+      "OAuth codes",
+      "cookies",
+      "access tokens",
+      "refresh tokens",
+      "API keys",
+    ]);
+    expect(content).not.toContain("command -v githits");
+    expect(content).not.toContain("{GITHITS}");
+  });
+});


### PR DESCRIPTION
## Summary

Adds a GitHits onboarding skill and supporting CLI hardening for agent-driven setup.

This work was prompted by testing the onboarding skill across agents. The skill worked well in OpenCode and Claude Code, but Codex exposed hangs during onboarding. That led to adding bounded timeouts and trace diagnostics around `init` agent detection/config probes.

This PR is intentionally draft because Codex onboarding is still not fully proven end-to-end.

## Current State

The onboarding skill now guides agents through staged, agent-safe setup:

- detect supported tools with `init --detect-agents --json`
- ask before writing config
- install selected tools with `init --install-agents <ids> --json`
- guide auth with `auth status` / `login`
- verify setup after auth

Normal onboarding uses `npx -y githits@latest`. Local/dev/pinned CLI usage is documented only for explicit test scenarios.

## What Worked

OpenCode:

- onboarding skill loaded successfully
- staged flow worked
- GitHits setup completed successfully

Claude Code:

- onboarding skill loaded successfully
- staged flow worked
- GitHits setup completed successfully
- one Claude Code auth error encountered was Claude auth, not GitHits auth

Local CLI testing:

- project detection works
- user-level detection works
- project install works
- user-level install works
- login works against dev endpoints
- verification reports configured tools correctly

Codex detection:

- Codex can run local `init --detect-agents --json`
- adding an explicit `EXITED:$?` marker showed detection exits successfully
- `codex mcp list` works directly and via spawned/piped stdio

## What Changed

CLI changes:

- added bounded exec timeout support
- added `ExecTimeoutError`
- bounded read-only detection/config probes:
  - binary lookups: 2s
  - config checks: 5s
  - Pi global-bin probe: 3s
- added `GITHITS_INIT_TRACE=1` diagnostics for init detection/config checks
- kept JSON stdout parseable by writing trace output to stderr

Skill changes:

- added public `githits-onboarding` skill
- added Claude plugin onboarding skill
- added troubleshooting reference
- documented Codex-specific local/dev testing behavior
- forbids plain interactive `init`, `init -y`, and `init --yes` in agent onboarding
- recommends user-level setup first, with project-level as secondary

Eval/docs changes:

- added onboarding workload for agentic evals
- documented current onboarding skill behavior and known Codex limitations

## What Is Still Failing

Codex still has an unresolved failure during user-level install.

The failing command shape is:

```bash
bun run src/cli.ts init --install-agents codex-cli,pi --json
```

From Codex, this does not return JSON or the explicit `EXITED:$?` marker.

Detection no longer appears to be the blocker. The remaining failure appears to be in setup/install.

## Unknowns

We do not yet know whether the Codex install hang is caused by:

- `codex mcp add ...`
- `pi install npm:pi-mcp-adapter`
- setup verification after one of those commands
- the combination of installing `codex-cli,pi` together

Current tracing only covers detection/config probes. It does not yet trace actual setup command start/end/error, so the exact hanging setup command is not identified.

## Follow-Up Needed

Before marking this ready:

- run Codex install one ID at a time:
- `init --install-agents codex-cli --json`
- `init --install-agents pi --json`
- add setup-command tracing around actual install commands
- consider setup-command timeouts only after identifying the exact hanging command
- if `codex mcp add` is the culprit, evaluate direct Codex TOML writes for user-level setup

## Verification

Completed locally before opening draft:

- `bun test src/services/exec-service.test.ts`
- `bun test src/commands/init/agent-definitions.test.ts src/commands/init/setup-handlers.test.ts src/commands/init/init.test.ts`
- `bun test src/skills-packaging.test.ts`
- `bun run typecheck`
- `git diff --check`
- `bun test`

Live/manual checks completed:

- local project detection against dev endpoints
- local project install for Codex
- local login against dev endpoints
- local user-level detection
- local user-level install
- Codex detection with explicit exit marker
- direct and spawned `codex mcp list`
