### PR TITLE
fix: map missing git refs separately

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -34,6 +34,9 @@
     "packages/core-internal": {
       "name": "@githits/core-internal",
       "version": "0.4.11",
+      "dependencies": {
+        "zod": "^4.4.3",
+      },
     },
     "packages/mcp": {
       "name": "@githits/mcp",

--- a/src/commands/code/code-nav-cli-helpers.ts
+++ b/src/commands/code/code-nav-cli-helpers.ts
@@ -146,6 +146,9 @@ export function formatFileErrorWithFilesHint(mapped: MappedError): string {
   ) {
     return `${mapped.message}\n  Use \`code files\` to list available paths.`;
   }
+  if (mapped.code === "REF_NOT_FOUND") {
+    return `${mapped.message}\n  Check that the repository URL and git ref exist and are publicly accessible.`;
+  }
   if (looksLikeMissingNavpackMessage(mapped.message)) {
     return [
       "Source index for this target is temporarily unavailable.",

--- a/src/commands/code/read.test.ts
+++ b/src/commands/code/read.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, mock, spyOn } from "bun:test";
 import {
+  CodeNavigationBackendError,
   CodeNavigationFileNotFoundError,
   CodeNavigationIndexingError,
   CodeNavigationTargetNotFoundError,
@@ -392,6 +393,44 @@ describe("pkgReadAction", () => {
     const output = errorSpy.mock.calls[0]?.[0] as string;
     expect(output).toContain("File not found");
     expect(output).toContain("code files");
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it("routes REF_NOT_FOUND with a repo/ref hint instead of path narrowing", async () => {
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+    const service = createMockCodeNavigationService({
+      readFile: mock(() =>
+        Promise.reject(
+          new CodeNavigationBackendError(
+            "Git ref not found: HEAD for repository https://github.com/acme/missing.",
+            undefined,
+            "REF_NOT_FOUND",
+            false,
+          ),
+        ),
+      ),
+    });
+
+    try {
+      await pkgReadAction(
+        "README.md",
+        undefined,
+        { repoUrl: "https://github.com/acme/missing" },
+        createDeps({ codeNavigationService: service }),
+      );
+    } catch {
+      /* expected */
+    }
+
+    const output = errorSpy.mock.calls[0]?.[0] as string;
+    expect(output).toContain("Git ref not found: HEAD");
+    expect(output).toContain("repository URL and git ref");
+    expect(output).not.toContain("Narrow the target");
+    expect(output).not.toContain("code files");
     errorSpy.mockRestore();
     exitSpy.mockRestore();
   });

--- a/src/shared/code-navigation-error-map.test.ts
+++ b/src/shared/code-navigation-error-map.test.ts
@@ -224,6 +224,22 @@ describe("mapCodeNavigationError", () => {
     });
   });
 
+  it("classifies CodeNavigationBackendError with REF_NOT_FOUND as REF_NOT_FOUND", () => {
+    const err = new CodeNavigationBackendError(
+      "Git ref not found: HEAD for repository https://github.com/acme/missing.",
+      undefined,
+      "REF_NOT_FOUND",
+    );
+
+    expect(mapCodeNavigationError(err)).toEqual({
+      code: "REF_NOT_FOUND",
+      message:
+        "Git ref not found: HEAD for repository https://github.com/acme/missing.",
+      retryable: false,
+      details: { graphqlCode: "REF_NOT_FOUND" },
+    });
+  });
+
   it("classifies CodeNavigationBackendError with UPSTREAM_ERROR as BACKEND_ERROR (retryable default)", () => {
     const err = new CodeNavigationBackendError(
       "Upstream failed",

--- a/src/shared/code-navigation-error-map.ts
+++ b/src/shared/code-navigation-error-map.ts
@@ -25,6 +25,7 @@ import { AuthRequiredError } from "./require-auth.js";
 export type MappedErrorCode =
   | "NOT_FOUND"
   | "FILE_NOT_FOUND"
+  | "REF_NOT_FOUND"
   | "VERSION_NOT_FOUND"
   | "INDEXING"
   | "UNRESOLVABLE"
@@ -259,9 +260,10 @@ export function buildUpdateRequiredError(
 
 /**
  * Dispatch on `CodeNavigationBackendError.graphqlCode` to produce
- * TIMEOUT / RATE_LIMITED / BACKEND_ERROR with the correct retryable
- * default. When the backend provided its own `retryable` hint on the
- * original extensions block, it takes precedence over the default.
+ * specific user-facing codes when available, otherwise BACKEND_ERROR
+ * with the correct retryable default. When the backend provided its own
+ * `retryable` hint on the original extensions block, it takes precedence
+ * over the default.
  */
 function classifyBackendError(error: CodeNavigationBackendError): MappedError {
   const details: MappedErrorDetails = {};
@@ -282,6 +284,8 @@ function classifyBackendError(error: CodeNavigationBackendError): MappedError {
       return build("TIMEOUT", true);
     case "RATE_LIMITED":
       return build("RATE_LIMITED", true);
+    case "REF_NOT_FOUND":
+      return build("REF_NOT_FOUND", false);
     case "UPSTREAM_ERROR":
       return build("BACKEND_ERROR", true);
     default:


### PR DESCRIPTION
## Summary
- classify backend REF_NOT_FOUND responses as a dedicated non-retryable code
- show repo/ref-specific CLI guidance instead of path narrowing or code files hints
- sync bun.lock for the existing core-internal zod dependency

## Tests
- bun test src/shared/code-navigation-error-map.test.ts
- bun test src/commands/code/read.test.ts
- bun run build
- bun test