### PR TITLE
fix: handle Windows path launchers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,6 @@ jobs:
   test:
     name: Test / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.os == 'windows-latest' }}
     strategy:
       fail-fast: false
       matrix:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@ Philosophy: "If it is not tested, it is likely broken"
 - Use mock factories from `test-helpers.ts` (e.g., `createMockGitHitsService()`, `createMockAuthService()`)
 - Test behavior, not implementation - focus on inputs and outputs
 - Test only one layer at a time - mock dependencies
+- When tests simulate another platform, simulate that platform's path semantics too. Use `path.win32` for Windows paths and avoid mixed literals like `C:\\Users\\me/app`; mixed separators can make tests pass while real Windows logic is broken.
 
 **Test Structure:**
 

--- a/docs/guidelines/TESTING.md
+++ b/docs/guidelines/TESTING.md
@@ -189,6 +189,25 @@ expect(result.content[0]?.text).toContain("expected");
 expect(result.content[0].text).toContain("expected");
 ```
 
+### 5. Match Simulated Platform Paths
+
+When a test changes `process.platform`, environment variables, or fixtures to simulate another OS, the file-system mock must use that OS's path semantics too.
+
+```typescript
+import { win32 } from "node:path";
+
+const fs = createMockFileSystemService({
+  getHomeDir: mock(() => "C:\\Users\\test"),
+  joinPath: mock((...segments: string[]) => win32.join(...segments)),
+});
+
+expect(configPath).toBe(
+  win32.join("C:\\Users\\test", "AppData", "Roaming", "githits"),
+);
+```
+
+Do not assert mixed path strings such as `C:\\Users\\test/AppData/Roaming/githits`. Those fixtures are neither real POSIX nor real Windows paths, and they can hide Windows-only bugs. Prefer computed expectations via `node:path` (`win32` for Windows, default `join` or POSIX-style mocks for POSIX-only tests).
+
 ## Running Tests
 
 ```bash

--- a/eval/drivers/claude-cli.ts
+++ b/eval/drivers/claude-cli.ts
@@ -26,7 +26,7 @@
 
 import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { delimiter, join } from "node:path";
 import { isCommandAvailable, runProcess } from "../run-process.js";
 import type { AgentDriver, DriverResponse, SendOptions } from "./types.js";
 
@@ -110,7 +110,7 @@ export function createClaudeCliDriver(
         );
         envOverrides = {
           EVAL_MCP_STATE_FILE: sendOpts.skills.stateFilePath,
-          PATH: `${sendOpts.skills.binDir}${process.env.PATH ? `:${process.env.PATH}` : ""}`,
+          PATH: `${sendOpts.skills.binDir}${process.env.PATH ? `${delimiter}${process.env.PATH}` : ""}`,
           ...(sendOpts.skills.extraEnv ?? {}),
         };
         cwd = sendOpts.skills.workspaceDir;

--- a/eval/drivers/codex-cli.ts
+++ b/eval/drivers/codex-cli.ts
@@ -36,6 +36,7 @@
  * continues so the partial signal is still usable.
  */
 
+import { delimiter } from "node:path";
 import { isCommandAvailable, runProcess } from "../run-process.js";
 import type { AgentDriver, DriverResponse, SendOptions } from "./types.js";
 
@@ -118,7 +119,7 @@ export function createCodexCliDriver(
         env: sendOpts?.skills
           ? {
               EVAL_MCP_STATE_FILE: sendOpts.skills.stateFilePath,
-              PATH: `${sendOpts.skills.binDir}${process.env.PATH ? `:${process.env.PATH}` : ""}`,
+              PATH: `${sendOpts.skills.binDir}${process.env.PATH ? `${delimiter}${process.env.PATH}` : ""}`,
               ...(sendOpts.skills.extraEnv ?? {}),
             }
           : undefined,

--- a/eval/run-process.test.ts
+++ b/eval/run-process.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "bun:test";
+import { isCommandAvailable, type RunProcessOptions } from "./run-process.js";
+
+describe("isCommandAvailable", () => {
+  it("uses which on POSIX platforms", async () => {
+    const calls: RunProcessOptions[] = [];
+
+    const available = await isCommandAvailable("codex", {
+      platform: "linux",
+      run: async (opts) => {
+        calls.push(opts);
+        return { exitCode: 0, stdout: "/usr/bin/codex\n", stderr: "" };
+      },
+    });
+
+    expect(available).toBe(true);
+    expect(calls).toEqual([{ cmd: ["which", "codex"], timeoutMs: 2000 }]);
+  });
+
+  it("uses where on Windows", async () => {
+    const calls: RunProcessOptions[] = [];
+
+    const available = await isCommandAvailable("codex", {
+      platform: "win32",
+      run: async (opts) => {
+        calls.push(opts);
+        return {
+          exitCode: 0,
+          stdout: "C:\\Users\\test\\bin\\codex.cmd\r\n",
+          stderr: "",
+        };
+      },
+    });
+
+    expect(available).toBe(true);
+    expect(calls).toEqual([{ cmd: ["where", "codex"], timeoutMs: 2000 }]);
+  });
+
+  it("returns false when the lookup command fails", async () => {
+    const available = await isCommandAvailable("missing", {
+      platform: "win32",
+      run: async () => ({ exitCode: 1, stdout: "", stderr: "" }),
+    });
+
+    expect(available).toBe(false);
+  });
+});

--- a/eval/run-process.ts
+++ b/eval/run-process.ts
@@ -61,7 +61,18 @@ export async function runProcess(
   }
 }
 
-export async function isCommandAvailable(cmd: string): Promise<boolean> {
-  const result = await runProcess({ cmd: ["which", cmd], timeoutMs: 2000 });
+export async function isCommandAvailable(
+  cmd: string,
+  opts: {
+    platform?: NodeJS.Platform;
+    run?: typeof runProcess;
+  } = {},
+): Promise<boolean> {
+  const lookupCommand =
+    (opts.platform ?? process.platform) === "win32" ? "where" : "which";
+  const result = await (opts.run ?? runProcess)({
+    cmd: [lookupCommand, cmd],
+    timeoutMs: 2000,
+  });
   return result.exitCode === 0;
 }

--- a/eval/security-eval.test.ts
+++ b/eval/security-eval.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { basename, join, resolve } from "node:path";
 import { detectFixtureTool, formatFixtureOutput } from "./mock-cli/githits.js";
 import { writeState } from "./mock-mcp/state.js";
 import { prepareSkillsFixtureWorkspace } from "./skills-workspace.js";
@@ -79,9 +79,14 @@ describe("security eval skills surface", () => {
     expect(
       existsSync(join(workspaceDir, "skills", "githits-package", "SKILL.md")),
     ).toBe(true);
-    expect(readFileSync(prepared.shimPath, "utf8")).toContain(
-      "eval/mock-cli/githits.ts",
+    const shimContent = readFileSync(prepared.shimPath, "utf8").replaceAll(
+      "\\",
+      "/",
     );
+    expect(shimContent).toContain("eval/mock-cli/githits.ts");
+    if (process.platform === "win32") {
+      expect(basename(prepared.shimPath)).toBe("githits.cmd");
+    }
   });
 
   it("mock CLI reads the shared eval state file", async () => {

--- a/eval/skills-workspace.ts
+++ b/eval/skills-workspace.ts
@@ -29,6 +29,27 @@ function shQuote(value: string): string {
   return `'${value.replaceAll("'", `'\\''`)}'`;
 }
 
+function writeGitHitsShim(binDir: string, mockCliScriptPath: string): string {
+  const isWindows = process.platform === "win32";
+  const shimPath = join(binDir, isWindows ? "githits.cmd" : "githits");
+  if (isWindows) {
+    writeFileSync(
+      shimPath,
+      `@echo off\r\nbun run "${mockCliScriptPath}" %*\r\n`,
+      "utf8",
+    );
+    return shimPath;
+  }
+
+  writeFileSync(
+    shimPath,
+    `#!/bin/sh\nexec bun run ${shQuote(mockCliScriptPath)} "$@"\n`,
+    "utf8",
+  );
+  chmodSync(shimPath, 0o755);
+  return shimPath;
+}
+
 export function prepareSkillsFixtureWorkspace(
   options: PrepareSkillsFixtureWorkspaceOptions,
 ): SkillsFixtureWorkspace {
@@ -53,13 +74,7 @@ export function prepareSkillsFixtureWorkspace(
 
   const binDir = join(options.workspaceDir, ".eval-bin");
   mkdirSync(binDir, { recursive: true });
-  const shimPath = join(binDir, "githits");
-  writeFileSync(
-    shimPath,
-    `#!/bin/sh\nexec bun run ${shQuote(options.mockCliScriptPath)} "$@"\n`,
-    "utf8",
-  );
-  chmodSync(shimPath, 0o755);
+  const shimPath = writeGitHitsShim(binDir, options.mockCliScriptPath);
 
   return {
     workspaceDir: options.workspaceDir,

--- a/scripts/agent-eval-report.ts
+++ b/scripts/agent-eval-report.ts
@@ -146,7 +146,7 @@ function isSafeWorkloadId(value: string): boolean {
 }
 
 function relativeArtifact(runDir: string, path: string): string {
-  return relative(runDir, path) || basename(path);
+  return (relative(runDir, path) || basename(path)).replaceAll("\\", "/");
 }
 
 export function isContainedRelativePath(relativePath: string): boolean {

--- a/scripts/agent-eval.test.ts
+++ b/scripts/agent-eval.test.ts
@@ -9,7 +9,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { basename, join } from "node:path";
+import { basename, join, resolve } from "node:path";
 import {
   buildClaudeCommand,
   buildCodexCommand,
@@ -492,6 +492,7 @@ describe("agent eval harness", () => {
   });
 
   it("parses repeatable workloads and dry-run options", () => {
+    const repoRoot = join(tmpdir(), "githits-cli");
     const options = parseArgs(
       [
         "--agent",
@@ -510,7 +511,7 @@ describe("agent eval harness", () => {
         "12",
         "--dry-run",
       ],
-      "/repo/githits-cli",
+      repoRoot,
     );
 
     expect(options.agent).toBe("opencode");
@@ -521,7 +522,7 @@ describe("agent eval harness", () => {
     expect(options.timeoutSeconds).toBe(12);
     expect(options.dryRun).toBe(true);
     expect(options.workloads).toEqual([
-      "/repo/githits-cli/eval/agentic/workloads/express-router.md",
+      resolve(repoRoot, "eval/agentic/workloads/express-router.md"),
     ]);
   });
 

--- a/scripts/agent-eval.ts
+++ b/scripts/agent-eval.ts
@@ -9,7 +9,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, isAbsolute, join, resolve } from "node:path";
+import { delimiter, dirname, isAbsolute, join, resolve } from "node:path";
 import {
   assertUniqueWorkloadIds,
   buildRunReportFromMetadata,
@@ -416,7 +416,16 @@ function writeGitHitsShim(
   binDir: string,
 ): string {
   mkdirSync(binDir, { recursive: true });
-  const shimPath = join(binDir, "githits");
+  const isWindows = process.platform === "win32";
+  const shimPath = join(binDir, isWindows ? "githits.cmd" : "githits");
+  if (isWindows) {
+    const command =
+      options.server === "local"
+        ? `bun run --cwd "${options.repoRoot}" dev %*`
+        : `npx -y "${options.publishedPackage}" %*`;
+    writeFileSync(shimPath, `@echo off\r\n${command}\r\n`);
+    return shimPath;
+  }
   const command =
     options.server === "local"
       ? `exec bun run --cwd ${shQuote(options.repoRoot)} dev "$@"`
@@ -1170,7 +1179,7 @@ async function runWorkload(
   );
   const workloadEnv = { ...env };
   if (skillInstallation) {
-    workloadEnv.PATH = `${dirname(skillInstallation.cliShim)}${workloadEnv.PATH ? `:${workloadEnv.PATH}` : ""}`;
+    workloadEnv.PATH = `${dirname(skillInstallation.cliShim)}${workloadEnv.PATH ? `${delimiter}${workloadEnv.PATH}` : ""}`;
   }
   const metadataBase = {
     id,

--- a/scripts/agent-session.ts
+++ b/scripts/agent-session.ts
@@ -1,6 +1,6 @@
 import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import { delimiter, dirname, join, resolve } from "node:path";
 import {
   type AgentName,
   buildCodexConfigArgs,
@@ -260,7 +260,7 @@ export async function runAgentSession(
   const prepared = prepareAgentSession(options);
   const env = buildEvalEnv(process.env);
   if (prepared.skillInstallation) {
-    env.PATH = `${dirname(prepared.skillInstallation.cliShim)}${env.PATH ? `:${env.PATH}` : ""}`;
+    env.PATH = `${dirname(prepared.skillInstallation.cliShim)}${env.PATH ? `${delimiter}${env.PATH}` : ""}`;
   }
 
   console.log(`Workspace: ${options.workspaceDir}`);

--- a/src/commands/doctor.test.ts
+++ b/src/commands/doctor.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, mock, spyOn } from "bun:test";
+import { win32 } from "node:path";
 import { createMockFileSystemService } from "../services/test-helpers.js";
 import {
   buildDoctorReport,
@@ -196,21 +197,27 @@ describe("doctor", () => {
   });
 
   it("uses Windows PATH delimiters when resolving githits", async () => {
+    const githitsCmd = win32.join("C:\\b", "githits.cmd");
     const fs = createMockFileSystemService({
-      exists: mock((path: string) => Promise.resolve(path === "C:\\b/githits")),
+      joinPath: mock((...segments: string[]) => win32.join(...segments)),
+      exists: mock((path: string) => Promise.resolve(path === githitsCmd)),
     });
 
     const report = await buildDoctorReport(
       createDeps({
         fs,
         platform: "win32",
-        env: { USERPROFILE: "C:\\Users\\test", PATH: "C:\\a;C:\\b" },
+        env: {
+          USERPROFILE: "C:\\Users\\test",
+          PATH: "C:\\a;C:\\b",
+          PATHEXT: ".CMD;.EXE",
+        },
       }),
     );
 
     expect(report.runtime.pathGithits).toEqual({
       status: "present",
-      value: "C:\\b/githits",
+      value: githitsCmd,
       source: "env",
     });
   });

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -810,16 +810,35 @@ async function resolvePathExecutable(
   const pathDelimiter = deps.platform === "win32" ? ";" : ":";
   for (const dir of pathValue.split(pathDelimiter)) {
     if (!dir) continue;
-    const candidate = deps.fs.joinPath(dir, name);
-    try {
-      if (await deps.fs.exists(candidate)) {
-        return { status: "present", value: candidate, source: "env" };
+    for (const candidate of getPathExecutableCandidates(name, dir, deps)) {
+      try {
+        if (await deps.fs.exists(candidate)) {
+          return { status: "present", value: candidate, source: "env" };
+        }
+      } catch (error) {
+        return toErrorProbe(error, "env", "error");
       }
-    } catch (error) {
-      return toErrorProbe(error, "env", "error");
     }
   }
   return { status: "missing", source: "env" };
+}
+
+function getPathExecutableCandidates(
+  name: string,
+  dir: string,
+  deps: DoctorDependencies,
+): string[] {
+  if (deps.platform !== "win32") return [deps.fs.joinPath(dir, name)];
+
+  const names = new Set([name]);
+  for (const ext of (deps.env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD")
+    .split(";")
+    .map((ext) => ext.trim())
+    .filter((ext) => ext.length > 0)) {
+    names.add(`${name}${ext}`);
+    names.add(`${name}${ext.toLowerCase()}`);
+  }
+  return Array.from(names, (candidate) => deps.fs.joinPath(dir, candidate));
 }
 
 function isStoredAuthFile(value: unknown): value is StoredAuthFile {

--- a/src/commands/init/agent-definitions.test.ts
+++ b/src/commands/init/agent-definitions.test.ts
@@ -4,6 +4,8 @@ import type { ExecResult } from "../../services/exec-service.js";
 import {
   createMockExecService,
   createMockFileSystemService,
+  createPlatformMockFileSystemService,
+  withTestPlatform,
 } from "../../services/test-helpers.js";
 import {
   type AgentDefinition,
@@ -16,11 +18,7 @@ import {
 function createWindowsFileSystemService(
   impl: Parameters<typeof createMockFileSystemService>[0] = {},
 ) {
-  return createMockFileSystemService({
-    getHomeDir: mock(() => "C:\\Users\\test"),
-    joinPath: mock((...segments: string[]) => win32.join(...segments)),
-    ...impl,
-  });
+  return createPlatformMockFileSystemService("win32", impl);
 }
 
 describe("agentDefinitions", () => {
@@ -1001,26 +999,28 @@ describe("getSetupConfig", () => {
     }
   });
 
-  it("opencode returns config-file setup with mcp serversKey and array command", () => {
-    const fs = createMockFileSystemService({
-      getHomeDir: mock(() => "/home/test"),
-      joinPath: mock((...segments: string[]) => segments.join("/")),
-    });
-    const agent = agentDefinitions.find((a) => a.id === "opencode")!;
-    const config = agent.getSetupConfig(fs);
-    expect(config.method).toBe("config-file");
-    if (config.method === "config-file") {
-      expect(config.configPath).toBe(
-        "/home/test/.config/opencode/opencode.json",
-      );
-      expect(config.serversKey).toBe("mcp");
-      expect(config.serverName).toBe("GitHits");
-      expect(config.serverConfig).toEqual({
-        type: "local",
-        command: ["npx", "-y", "githits@latest", "mcp", "start"],
-        enabled: true,
+  it("opencode returns config-file setup with mcp serversKey and array command", async () => {
+    await withTestPlatform("linux", () => {
+      const fs = createMockFileSystemService({
+        getHomeDir: mock(() => "/home/test"),
+        joinPath: mock((...segments: string[]) => segments.join("/")),
       });
-    }
+      const agent = agentDefinitions.find((a) => a.id === "opencode")!;
+      const config = agent.getSetupConfig(fs);
+      expect(config.method).toBe("config-file");
+      if (config.method === "config-file") {
+        expect(config.configPath).toBe(
+          "/home/test/.config/opencode/opencode.json",
+        );
+        expect(config.serversKey).toBe("mcp");
+        expect(config.serverName).toBe("GitHits");
+        expect(config.serverConfig).toEqual({
+          type: "local",
+          command: ["npx", "-y", "githits@latest", "mcp", "start"],
+          enabled: true,
+        });
+      }
+    });
   });
 
   it("opencode uses APPDATA on win32 for config path", () => {
@@ -1224,9 +1224,7 @@ describe("scanAgents", () => {
     execResults?: Record<string, ExecResult | Error>;
     pathPlatform?: "posix" | "win32";
   }) {
-    const isWin32 =
-      opts.pathPlatform === "win32" ||
-      (opts.pathPlatform === undefined && process.platform === "win32");
+    const isWin32 = opts.pathPlatform === "win32";
     const fs = createMockFileSystemService({
       getHomeDir: mock(() => (isWin32 ? "C:\\Users\\test" : "/home/test")),
       joinPath: mock((...segments: string[]) =>
@@ -1640,32 +1638,34 @@ describe("scanAgents", () => {
   });
 
   it("detects pi from npm global bin when not on PATH", async () => {
-    const lookupCmd = lookupCommandFor();
-    const { fs, execService } = createScanMocks({
-      detectedDirs: [],
-      existingFiles: ["/npm-global/bin/pi"],
-      execResults: {
-        [`${lookupCmd} pi`]: { exitCode: 1, stdout: "", stderr: "" },
-        "npm prefix -g": {
-          exitCode: 0,
-          stdout: "/npm-global\n",
-          stderr: "",
+    await withTestPlatform("linux", async () => {
+      const lookupCmd = lookupCommandFor();
+      const { fs, execService } = createScanMocks({
+        detectedDirs: [],
+        existingFiles: ["/npm-global/bin/pi"],
+        execResults: {
+          [`${lookupCmd} pi`]: { exitCode: 1, stdout: "", stderr: "" },
+          "npm prefix -g": {
+            exitCode: 0,
+            stdout: "/npm-global\n",
+            stderr: "",
+          },
         },
-      },
-    });
-    const result = await scanAgents(agentDefinitions, fs, execService);
-    const piAgent = result.needsSetup.find((a) => a.id === "pi");
-    expect(piAgent).toBeDefined();
-    const config = piAgent?.resolvedSetupConfig;
-    expect(config?.method).toBe("composite");
-    if (config?.method === "composite") {
-      const installStep = config.steps[0]!;
-      expect(installStep.method).toBe("cli");
-      if (installStep.method === "cli") {
-        expect(installStep.commands[0]!.command).toBe("/npm-global/bin/pi");
-        expect(installStep.checkCommand?.command).toBe("/npm-global/bin/pi");
+      });
+      const result = await scanAgents(agentDefinitions, fs, execService);
+      const piAgent = result.needsSetup.find((a) => a.id === "pi");
+      expect(piAgent).toBeDefined();
+      const config = piAgent?.resolvedSetupConfig;
+      expect(config?.method).toBe("composite");
+      if (config?.method === "composite") {
+        const installStep = config.steps[0]!;
+        expect(installStep.method).toBe("cli");
+        if (installStep.method === "cli") {
+          expect(installStep.commands[0]!.command).toBe("/npm-global/bin/pi");
+          expect(installStep.checkCommand?.command).toBe("/npm-global/bin/pi");
+        }
       }
-    }
+    });
   });
 
   it("passes timeout option to Pi global bin probes", async () => {
@@ -1871,7 +1871,7 @@ describe("scanAgents", () => {
     const { fs, execService } = createScanMocks({
       detectedDirs: [],
       configFiles: {
-        ["/home/test/.pi/agent/mcp.json"]: JSON.stringify({
+        "/home/test/.pi/agent/mcp.json": JSON.stringify({
           mcpServers: {
             GitHits: {
               command: "npx",
@@ -2383,6 +2383,10 @@ describe("scanAgents", () => {
     };
 
     describe(`comprehensive all-agents scenarios (${platform})`, () => {
+      const pathPlatform = platform === "win32" ? "win32" : "posix";
+      const createScenarioScanMocks = (
+        scenarioOpts: Parameters<typeof createScanMocks>[0],
+      ) => createScanMocks({ ...scenarioOpts, pathPlatform });
       const originalPlatform = process.platform;
       beforeAll(() => {
         Object.defineProperty(process, "platform", {
@@ -2400,7 +2404,7 @@ describe("scanAgents", () => {
       });
 
       it("all agents configured", async () => {
-        const { fs, execService } = createScanMocks({
+        const { fs, execService } = createScenarioScanMocks({
           detectedDirs: allDetectDirs,
           configFiles: allConfiguredFiles,
           execResults: allCliConfigured,
@@ -2437,7 +2441,7 @@ describe("scanAgents", () => {
           }),
           [joinPath(homeDir, ".hermes", "config.yaml")]: "mcp_servers: {}\n",
         };
-        const { fs, execService } = createScanMocks({
+        const { fs, execService } = createScenarioScanMocks({
           detectedDirs: allDetectDirs,
           configFiles: unconfiguredFiles,
           execResults: {
@@ -2480,7 +2484,9 @@ describe("scanAgents", () => {
       });
 
       it("no agents detected", async () => {
-        const { fs, execService } = createScanMocks({ detectedDirs: [] });
+        const { fs, execService } = createScenarioScanMocks({
+          detectedDirs: [],
+        });
         const result = await scanAgents(agentDefinitions, fs, execService);
         expect(result.alreadyConfigured).toHaveLength(0);
         expect(result.needsSetup).toHaveLength(0);
@@ -2488,7 +2494,7 @@ describe("scanAgents", () => {
       });
 
       it("mixed: 3 configured, 4 unconfigured, 5 not detected", async () => {
-        const { fs, execService } = createScanMocks({
+        const { fs, execService } = createScenarioScanMocks({
           detectedDirs: [
             // Configured: cursor, claude-desktop, claude-code
             joinPath(homeDir, ".cursor"),
@@ -2568,7 +2574,7 @@ describe("scanAgents", () => {
         const enoent = Object.assign(new Error("spawn ENOENT"), {
           code: "ENOENT",
         });
-        const { fs, execService } = createScanMocks({
+        const { fs, execService } = createScenarioScanMocks({
           detectedDirs: [],
           execResults: {
             [`${whichCmd} claude`]: {
@@ -2604,7 +2610,7 @@ describe("scanAgents", () => {
         const enoent = Object.assign(new Error("spawn ENOENT"), {
           code: "ENOENT",
         });
-        const { fs, execService } = createScanMocks({
+        const { fs, execService } = createScenarioScanMocks({
           detectedDirs: [joinPath(homeDir, ".gemini", "extensions", "githits")],
           existingFiles: [
             joinPath(
@@ -2634,7 +2640,7 @@ describe("scanAgents", () => {
       });
 
       it("gemini config probe reports not installed as needsSetup", async () => {
-        const { fs, execService } = createScanMocks({
+        const { fs, execService } = createScenarioScanMocks({
           detectedDirs: [],
           execResults: {
             [`${whichCmd} gemini`]: {
@@ -2654,10 +2660,16 @@ describe("scanAgents", () => {
       });
 
       it("gemini does not use filesystem fallback when probe explicitly reports not installed", async () => {
-        const { fs, execService } = createScanMocks({
-          detectedDirs: ["/home/test/.gemini/extensions/githits"],
+        const { fs, execService } = createScenarioScanMocks({
+          detectedDirs: [joinPath(homeDir, ".gemini", "extensions", "githits")],
           existingFiles: [
-            "/home/test/.gemini/extensions/githits/gemini-extension.json",
+            joinPath(
+              homeDir,
+              ".gemini",
+              "extensions",
+              "githits",
+              "gemini-extension.json",
+            ),
           ],
           execResults: {
             [`${whichCmd} gemini`]: {

--- a/src/commands/init/agent-definitions.test.ts
+++ b/src/commands/init/agent-definitions.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, beforeAll, describe, expect, it, mock } from "bun:test";
+import { win32 } from "node:path";
 import type { ExecResult } from "../../services/exec-service.js";
 import {
   createMockExecService,
@@ -11,6 +12,16 @@ import {
   detectAgents,
   scanAgents,
 } from "./agent-definitions.js";
+
+function createWindowsFileSystemService(
+  impl: Parameters<typeof createMockFileSystemService>[0] = {},
+) {
+  return createMockFileSystemService({
+    getHomeDir: mock(() => "C:\\Users\\test"),
+    joinPath: mock((...segments: string[]) => win32.join(...segments)),
+    ...impl,
+  });
+}
 
 describe("agentDefinitions", () => {
   it("defines 12 agents", () => {
@@ -213,17 +224,20 @@ describe("detection configuration", () => {
     });
     process.env.APPDATA = "C:\\Users\\test\\AppData\\Roaming";
     try {
-      const fs = createMockFileSystemService({
-        getHomeDir: mock(() => "C:\\Users\\test"),
-        joinPath: mock((...segments: string[]) => segments.join("/")),
-      });
+      const fs = createWindowsFileSystemService();
       const agent = agentDefinitions.find((a) => a.id === "opencode")!;
       const paths = agent.detectPaths?.(fs);
       expect(paths).toEqual([
-        "C:\\Users\\test\\AppData\\Roaming/ai.opencode.desktop",
-        "C:\\Users\\test\\AppData\\Roaming/ai.opencode.desktop.beta",
-        "C:\\Users\\test\\AppData\\Roaming/ai.opencode.desktop.dev",
-        "C:\\Users\\test\\AppData\\Roaming/opencode",
+        win32.join("C:\\Users\\test\\AppData\\Roaming", "ai.opencode.desktop"),
+        win32.join(
+          "C:\\Users\\test\\AppData\\Roaming",
+          "ai.opencode.desktop.beta",
+        ),
+        win32.join(
+          "C:\\Users\\test\\AppData\\Roaming",
+          "ai.opencode.desktop.dev",
+        ),
+        win32.join("C:\\Users\\test\\AppData\\Roaming", "opencode"),
       ]);
     } finally {
       Object.defineProperty(process, "platform", {
@@ -247,18 +261,15 @@ describe("detection configuration", () => {
     });
     process.env.LOCALAPPDATA = "C:\\Users\\test\\AppData\\Local";
     try {
-      const fs = createMockFileSystemService({
-        getHomeDir: mock(() => "C:\\Users\\test"),
-        joinPath: mock((...segments: string[]) => segments.join("/")),
-      });
+      const fs = createWindowsFileSystemService();
       const agent = agentDefinitions.find((a) => a.id === "claude-desktop")!;
       const paths = agent.detectPaths?.(fs);
       expect(paths).toBeDefined();
       if (!paths) throw new Error("expected claude-desktop paths");
       expect(paths).toHaveLength(3);
       expect(paths[0]).toContain("Roaming");
-      expect(paths[1]).toContain("Local/Claude");
-      expect(paths[2]).toContain("Local/Programs/Claude");
+      expect(paths[1]).toContain(win32.join("Local", "Claude"));
+      expect(paths[2]).toContain(win32.join("Local", "Programs", "Claude"));
     } finally {
       Object.defineProperty(process, "platform", {
         value: originalPlatform,
@@ -307,17 +318,18 @@ describe("detection configuration", () => {
     process.env.APPDATA = "C:\\Users\\test\\AppData\\Roaming";
     delete process.env.LOCALAPPDATA;
     try {
-      const fs = createMockFileSystemService({
-        getHomeDir: mock(() => "C:\\Users\\test"),
-        joinPath: mock((...segments: string[]) => segments.join("/")),
-      });
+      const fs = createWindowsFileSystemService();
       const agent = agentDefinitions.find((a) => a.id === "claude-desktop")!;
       const paths = agent.detectPaths?.(fs);
       expect(paths).toBeDefined();
       if (!paths) throw new Error("expected claude-desktop paths");
       expect(paths).toHaveLength(3);
-      expect(paths[1]).toBe("C:\\Users\\test/AppData/Local/Claude");
-      expect(paths[2]).toBe("C:\\Users\\test/AppData/Local/Programs/Claude");
+      expect(paths[1]).toBe(
+        win32.join("C:\\Users\\test", "AppData", "Local", "Claude"),
+      );
+      expect(paths[2]).toBe(
+        win32.join("C:\\Users\\test", "AppData", "Local", "Programs", "Claude"),
+      );
     } finally {
       Object.defineProperty(process, "platform", {
         value: originalPlatform,
@@ -656,15 +668,16 @@ describe("getSetupConfig", () => {
     });
     process.env.APPDATA = "C:\\Users\\test\\AppData\\Roaming";
     try {
-      const fs = createMockFileSystemService({
-        getHomeDir: mock(() => "C:\\Users\\test"),
-        joinPath: mock((...segments: string[]) => segments.join("/")),
-      });
+      const fs = createWindowsFileSystemService();
       const agent = agentDefinitions.find((a) => a.id === "claude-desktop")!;
       const config = agent.getSetupConfig(fs);
       if (config.method === "config-file") {
         expect(config.configPath).toBe(
-          "C:\\Users\\test\\AppData\\Roaming/Claude/claude_desktop_config.json",
+          win32.join(
+            "C:\\Users\\test\\AppData\\Roaming",
+            "Claude",
+            "claude_desktop_config.json",
+          ),
         );
       }
     } finally {
@@ -689,15 +702,18 @@ describe("getSetupConfig", () => {
     });
     delete process.env.APPDATA;
     try {
-      const fs = createMockFileSystemService({
-        getHomeDir: mock(() => "C:\\Users\\test"),
-        joinPath: mock((...segments: string[]) => segments.join("/")),
-      });
+      const fs = createWindowsFileSystemService();
       const agent = agentDefinitions.find((a) => a.id === "claude-desktop")!;
       const config = agent.getSetupConfig(fs);
       if (config.method === "config-file") {
         expect(config.configPath).toBe(
-          "C:\\Users\\test/AppData/Roaming/Claude/claude_desktop_config.json",
+          win32.join(
+            "C:\\Users\\test",
+            "AppData",
+            "Roaming",
+            "Claude",
+            "claude_desktop_config.json",
+          ),
         );
       }
     } finally {
@@ -1016,16 +1032,17 @@ describe("getSetupConfig", () => {
     });
     process.env.APPDATA = "C:\\Users\\test\\AppData\\Roaming";
     try {
-      const fs = createMockFileSystemService({
-        getHomeDir: mock(() => "C:\\Users\\test"),
-        joinPath: mock((...segments: string[]) => segments.join("/")),
-      });
+      const fs = createWindowsFileSystemService();
       const agent = agentDefinitions.find((a) => a.id === "opencode")!;
       const config = agent.getSetupConfig(fs);
       expect(config.method).toBe("config-file");
       if (config.method === "config-file") {
         expect(config.configPath).toBe(
-          "C:\\Users\\test\\AppData\\Roaming/opencode/opencode.json",
+          win32.join(
+            "C:\\Users\\test\\AppData\\Roaming",
+            "opencode",
+            "opencode.json",
+          ),
         );
       }
     } finally {
@@ -1205,10 +1222,16 @@ describe("scanAgents", () => {
     configFiles?: Record<string, string>;
     existingFiles?: string[];
     execResults?: Record<string, ExecResult | Error>;
+    pathPlatform?: "posix" | "win32";
   }) {
+    const isWin32 =
+      opts.pathPlatform === "win32" ||
+      (opts.pathPlatform === undefined && process.platform === "win32");
     const fs = createMockFileSystemService({
-      getHomeDir: mock(() => "/home/test"),
-      joinPath: mock((...segments: string[]) => segments.join("/")),
+      getHomeDir: mock(() => (isWin32 ? "C:\\Users\\test" : "/home/test")),
+      joinPath: mock((...segments: string[]) =>
+        isWin32 ? win32.join(...segments) : segments.join("/"),
+      ),
       isDirectory: mock(async (path: string) =>
         (opts.detectedDirs ?? []).includes(path),
       ),
@@ -1766,9 +1789,11 @@ describe("scanAgents", () => {
       configurable: true,
     });
     try {
+      const piCmd = win32.join("C:\\npm", "pi.cmd");
       const { fs, execService } = createScanMocks({
+        pathPlatform: "win32",
         detectedDirs: [],
-        existingFiles: ["C:\\npm/pi.cmd"],
+        existingFiles: [piCmd],
         execResults: {
           "where pi": { exitCode: 1, stdout: "", stderr: "" },
           "npm prefix -g": {
@@ -1789,7 +1814,7 @@ describe("scanAgents", () => {
       if (installStep.method !== "cli") {
         throw new Error("expected pi cli setup step");
       }
-      expect(installStep.commands[0]!.command).toBe("C:\\npm/pi.cmd");
+      expect(installStep.commands[0]!.command).toBe(piCmd);
     } finally {
       Object.defineProperty(process, "platform", {
         value: originalPlatform,
@@ -1805,8 +1830,13 @@ describe("scanAgents", () => {
       configurable: true,
     });
     try {
+      const piCmd = win32.join(
+        "C:\\Users\\Jane Doe\\AppData\\Roaming\\npm",
+        "pi.cmd",
+      );
       const { fs, execService } = createScanMocks({
-        existingFiles: ["C:\\Users\\Jane Doe\\AppData\\Roaming\\npm/pi.cmd"],
+        pathPlatform: "win32",
+        existingFiles: [piCmd],
         execResults: {
           "where pi": { exitCode: 1, stdout: "", stderr: "" },
           "npm prefix -g": {
@@ -1827,9 +1857,7 @@ describe("scanAgents", () => {
       if (installStep.method !== "cli") {
         throw new Error("expected pi cli setup step");
       }
-      expect(installStep.commands[0]!.command).toBe(
-        "C:\\Users\\Jane Doe\\AppData\\Roaming\\npm/pi.cmd",
-      );
+      expect(installStep.commands[0]!.command).toBe(piCmd);
     } finally {
       Object.defineProperty(process, "platform", {
         value: originalPlatform,
@@ -1843,7 +1871,7 @@ describe("scanAgents", () => {
     const { fs, execService } = createScanMocks({
       detectedDirs: [],
       configFiles: {
-        "/home/test/.pi/agent/mcp.json": JSON.stringify({
+        ["/home/test/.pi/agent/mcp.json"]: JSON.stringify({
           mcpServers: {
             GitHits: {
               command: "npx",
@@ -1852,14 +1880,15 @@ describe("scanAgents", () => {
             },
           },
         }),
-        "C:\\Users\\test\\.pi/agent/mcp.json": JSON.stringify({
-          mcpServers: {
-            GitHits: {
-              command: "npx",
-              args: ["-y", "githits@latest", "mcp", "start"],
+        [win32.join("C:\\Users\\test", ".pi", "agent", "mcp.json")]:
+          JSON.stringify({
+            mcpServers: {
+              GitHits: {
+                command: "npx",
+                args: ["-y", "githits@latest", "mcp", "start"],
+              },
             },
-          },
-        }),
+          }),
       },
       execResults: {
         [`${lookupCmd} pi`]: {
@@ -2029,8 +2058,13 @@ describe("scanAgents", () => {
     });
     process.env.APPDATA = "C:\\Users\\test\\AppData\\Roaming";
     try {
+      const opencodeDesktopDir = win32.join(
+        "C:\\Users\\test\\AppData\\Roaming",
+        "ai.opencode.desktop",
+      );
       const { fs, execService } = createScanMocks({
-        detectedDirs: ["C:\\Users\\test\\AppData\\Roaming/ai.opencode.desktop"],
+        pathPlatform: "win32",
+        detectedDirs: [opencodeDesktopDir],
       });
       const result = await scanAgents(agentDefinitions, fs, execService);
       expect(result.notDetected.some((a) => a.id === "opencode")).toBe(false);
@@ -2176,22 +2210,26 @@ describe("scanAgents", () => {
     envTeardown?: () => void;
   }) {
     const { platform, appDataPrefix } = opts;
+    const isWin32 = platform === "win32";
+    const homeDir = isWin32 ? "C:\\Users\\test" : "/home/test";
+    const joinPath = (...segments: string[]) =>
+      isWin32 ? win32.join(...segments) : segments.join("/");
 
     // Platform-independent detect dirs for path-detected agents
     const homeDirs = [
-      "/home/test/.cursor",
-      "/home/test/.codeium/windsurf",
-      "/home/test/.cline",
-      "/home/test/.gemini/antigravity",
-      "/home/test/.hermes",
+      joinPath(homeDir, ".cursor"),
+      joinPath(homeDir, ".codeium", "windsurf"),
+      joinPath(homeDir, ".cline"),
+      joinPath(homeDir, ".gemini", "antigravity"),
+      joinPath(homeDir, ".hermes"),
     ];
     // Platform-dependent detect dirs
-    const vscodePath = `${appDataPrefix}/Code`;
-    const claudeDesktopPath = `${appDataPrefix}/Claude`;
+    const vscodePath = joinPath(appDataPrefix, "Code");
+    const claudeDesktopPath = joinPath(appDataPrefix, "Claude");
     const opencodePath =
       platform === "win32"
-        ? `${appDataPrefix}/opencode`
-        : "/home/test/.config/opencode";
+        ? joinPath(appDataPrefix, "opencode")
+        : joinPath(homeDir, ".config", "opencode");
     const allDetectDirs = [
       ...homeDirs,
       vscodePath,
@@ -2201,7 +2239,7 @@ describe("scanAgents", () => {
 
     // Config files for all config-file agents with GitHits configured
     const allConfiguredFiles: Record<string, string> = {
-      "/home/test/.cursor/mcp.json": JSON.stringify({
+      [joinPath(homeDir, ".cursor", "mcp.json")]: JSON.stringify({
         mcpServers: {
           GitHits: {
             command: "npx",
@@ -2209,16 +2247,17 @@ describe("scanAgents", () => {
           },
         },
       }),
-      "/home/test/.codeium/windsurf/mcp_config.json": JSON.stringify({
-        mcpServers: {
-          GitHits: {
-            command: "npx",
-            args: ["-y", "githits@latest", "mcp", "start"],
-            lifecycle: "eager",
+      [joinPath(homeDir, ".codeium", "windsurf", "mcp_config.json")]:
+        JSON.stringify({
+          mcpServers: {
+            GitHits: {
+              command: "npx",
+              args: ["-y", "githits@latest", "mcp", "start"],
+              lifecycle: "eager",
+            },
           },
-        },
-      }),
-      [`${vscodePath}/User/mcp.json`]: JSON.stringify({
+        }),
+      [joinPath(vscodePath, "User", "mcp.json")]: JSON.stringify({
         servers: {
           GitHits: {
             type: "stdio",
@@ -2227,17 +2266,13 @@ describe("scanAgents", () => {
           },
         },
       }),
-      "/home/test/.cline/data/settings/cline_mcp_settings.json": JSON.stringify(
-        {
-          mcpServers: {
-            GitHits: {
-              command: "npx",
-              args: ["-y", "githits@latest", "mcp", "start"],
-            },
-          },
-        },
-      ),
-      [`${claudeDesktopPath}/claude_desktop_config.json`]: JSON.stringify({
+      [joinPath(
+        homeDir,
+        ".cline",
+        "data",
+        "settings",
+        "cline_mcp_settings.json",
+      )]: JSON.stringify({
         mcpServers: {
           GitHits: {
             command: "npx",
@@ -2245,7 +2280,16 @@ describe("scanAgents", () => {
           },
         },
       }),
-      "C:\\Users\\test\\.pi/agent/mcp.json": JSON.stringify({
+      [joinPath(claudeDesktopPath, "claude_desktop_config.json")]:
+        JSON.stringify({
+          mcpServers: {
+            GitHits: {
+              command: "npx",
+              args: ["-y", "githits@latest", "mcp", "start"],
+            },
+          },
+        }),
+      [joinPath(homeDir, ".pi", "agent", "mcp.json")]: JSON.stringify({
         mcpServers: {
           GitHits: {
             command: "npx",
@@ -2254,15 +2298,16 @@ describe("scanAgents", () => {
           },
         },
       }),
-      "/home/test/.gemini/antigravity/mcp_config.json": JSON.stringify({
-        mcpServers: {
-          GitHits: {
-            command: "npx",
-            args: ["-y", "githits@latest", "mcp", "start"],
+      [joinPath(homeDir, ".gemini", "antigravity", "mcp_config.json")]:
+        JSON.stringify({
+          mcpServers: {
+            GitHits: {
+              command: "npx",
+              args: ["-y", "githits@latest", "mcp", "start"],
+            },
           },
-        },
-      }),
-      [`${opencodePath}/opencode.json`]: JSON.stringify({
+        }),
+      [joinPath(opencodePath, "opencode.json")]: JSON.stringify({
         mcp: {
           GitHits: {
             type: "local",
@@ -2271,22 +2316,13 @@ describe("scanAgents", () => {
           },
         },
       }),
-      "/home/test/.hermes/config.yaml": [
+      [joinPath(homeDir, ".hermes", "config.yaml")]: [
         "mcp_servers:",
         "  GitHits:",
         '    command: "npx"',
         '    args: ["-y", "githits@latest", "mcp", "start"]',
         "",
       ].join("\n"),
-      "/home/test/.pi/agent/mcp.json": JSON.stringify({
-        mcpServers: {
-          GitHits: {
-            command: "npx",
-            args: ["-y", "githits@latest", "mcp", "start"],
-            lifecycle: "eager",
-          },
-        },
-      }),
     };
 
     // Binary detection command varies by platform
@@ -2377,23 +2413,29 @@ describe("scanAgents", () => {
 
       it("all agents detected but none configured", async () => {
         const unconfiguredFiles: Record<string, string> = {
-          "/home/test/.cursor/mcp.json": JSON.stringify({ mcpServers: {} }),
-          "/home/test/.codeium/windsurf/mcp_config.json": JSON.stringify({
+          [joinPath(homeDir, ".cursor", "mcp.json")]: JSON.stringify({
             mcpServers: {},
           }),
-          [`${vscodePath}/User/mcp.json`]: JSON.stringify({ servers: {} }),
-          "/home/test/.cline/data/settings/cline_mcp_settings.json":
+          [joinPath(homeDir, ".codeium", "windsurf", "mcp_config.json")]:
             JSON.stringify({ mcpServers: {} }),
-          [`${claudeDesktopPath}/claude_desktop_config.json`]: JSON.stringify({
-            mcpServers: {},
+          [joinPath(vscodePath, "User", "mcp.json")]: JSON.stringify({
+            servers: {},
           }),
-          "/home/test/.gemini/antigravity/mcp_config.json": JSON.stringify({
-            mcpServers: {},
-          }),
-          [`${opencodePath}/opencode.json`]: JSON.stringify({
+          [joinPath(
+            homeDir,
+            ".cline",
+            "data",
+            "settings",
+            "cline_mcp_settings.json",
+          )]: JSON.stringify({ mcpServers: {} }),
+          [joinPath(claudeDesktopPath, "claude_desktop_config.json")]:
+            JSON.stringify({ mcpServers: {} }),
+          [joinPath(homeDir, ".gemini", "antigravity", "mcp_config.json")]:
+            JSON.stringify({ mcpServers: {} }),
+          [joinPath(opencodePath, "opencode.json")]: JSON.stringify({
             mcp: {},
           }),
-          "/home/test/.hermes/config.yaml": "mcp_servers: {}\n",
+          [joinPath(homeDir, ".hermes", "config.yaml")]: "mcp_servers: {}\n",
         };
         const { fs, execService } = createScanMocks({
           detectedDirs: allDetectDirs,
@@ -2449,16 +2491,16 @@ describe("scanAgents", () => {
         const { fs, execService } = createScanMocks({
           detectedDirs: [
             // Configured: cursor, claude-desktop, claude-code
-            "/home/test/.cursor",
+            joinPath(homeDir, ".cursor"),
             claudeDesktopPath,
             // Unconfigured: windsurf, vscode
-            "/home/test/.codeium/windsurf",
+            joinPath(homeDir, ".codeium", "windsurf"),
             vscodePath,
             // CLI tools are detected via binary checks below
             // Not detected: cline, pi, gemini-cli, google-antigravity, hermes-agent
           ],
           configFiles: {
-            "/home/test/.cursor/mcp.json": JSON.stringify({
+            [joinPath(homeDir, ".cursor", "mcp.json")]: JSON.stringify({
               mcpServers: {
                 GitHits: {
                   command: "npx",
@@ -2466,16 +2508,15 @@ describe("scanAgents", () => {
                 },
               },
             }),
-            [`${claudeDesktopPath}/claude_desktop_config.json`]: JSON.stringify(
-              {
+            [joinPath(claudeDesktopPath, "claude_desktop_config.json")]:
+              JSON.stringify({
                 mcpServers: {
                   GitHits: {
                     command: "npx",
                     args: ["-y", "githits@latest", "mcp", "start"],
                   },
                 },
-              },
-            ),
+              }),
           },
           execResults: {
             [`${whichCmd} claude`]: {
@@ -2564,9 +2605,15 @@ describe("scanAgents", () => {
           code: "ENOENT",
         });
         const { fs, execService } = createScanMocks({
-          detectedDirs: ["/home/test/.gemini/extensions/githits"],
+          detectedDirs: [joinPath(homeDir, ".gemini", "extensions", "githits")],
           existingFiles: [
-            "/home/test/.gemini/extensions/githits/gemini-extension.json",
+            joinPath(
+              homeDir,
+              ".gemini",
+              "extensions",
+              "githits",
+              "gemini-extension.json",
+            ),
           ],
           execResults: {
             [`${whichCmd} gemini`]: {
@@ -2646,7 +2693,7 @@ describe("scanAgents", () => {
     appDataPrefix: "/home/test/.config",
   });
 
-  // Windows: %APPDATA%/<app> (mock joinPath still uses /)
+  // Windows: %APPDATA%\<app>
   let originalAppdata: string | undefined;
   defineComprehensiveTests({
     platform: "win32",

--- a/src/commands/init/init.test.ts
+++ b/src/commands/init/init.test.ts
@@ -7,6 +7,9 @@ import {
   mock,
   spyOn,
 } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { ExitPromptError } from "@inquirer/core";
 import { Command } from "commander";
 import type {
@@ -33,10 +36,16 @@ import {
 let logSpy: ReturnType<typeof spyOn>;
 let errorSpy: ReturnType<typeof spyOn>;
 let originalExitCode: string | number | null | undefined;
+let originalPlatform: NodeJS.Platform;
 
 beforeEach(() => {
   originalExitCode = process.exitCode;
   process.exitCode = 0;
+  originalPlatform = process.platform;
+  Object.defineProperty(process, "platform", {
+    configurable: true,
+    value: "linux",
+  });
   logSpy = spyOn(console, "log").mockImplementation(() => {});
   errorSpy = spyOn(console, "error").mockImplementation(() => {});
 });
@@ -45,6 +54,10 @@ afterEach(() => {
   logSpy.mockRestore();
   errorSpy.mockRestore();
   process.exitCode = originalExitCode;
+  Object.defineProperty(process, "platform", {
+    configurable: true,
+    value: originalPlatform,
+  });
 });
 
 /** Create mock login deps that report already authenticated */
@@ -4685,7 +4698,8 @@ describe("registerInitCommand", () => {
     program.exitOverride();
     registerInitCommand(program);
     const originalCwd = process.cwd();
-    process.chdir("/tmp");
+    const tempCwd = mkdtempSync(join(tmpdir(), "githits-init-test-"));
+    process.chdir(tempCwd);
     try {
       await program.parseAsync(["node", "githits", ...args], { from: "node" });
     } finally {

--- a/src/container.test.ts
+++ b/src/container.test.ts
@@ -42,7 +42,9 @@ describe("container auth dependencies", () => {
       await withAuthStorageEnv("file", async () => {
         const deps = await createAuthCommandDependencies();
         expect(deps.envApiToken).toBe("ghi-test");
-        expect(deps.authStorage.getStorageLocation()).toContain("githits/auth");
+        expect(
+          deps.authStorage.getStorageLocation().split(/[\\/]/).slice(-2),
+        ).toEqual(["githits", "auth"]);
       });
     });
   });

--- a/src/services/app-config-paths.test.ts
+++ b/src/services/app-config-paths.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { win32 } from "node:path";
 import {
   getAppConfigDir,
   getAuthConfigPath,
@@ -90,8 +91,11 @@ describe("app config paths", () => {
     process.env.APPDATA = "C:\\Users\\test\\AppData\\Roaming";
     try {
       withPlatform("win32", () => {
-        expect(getAppConfigDir(createMockFileSystemService())).toBe(
-          "C:\\Users\\test\\AppData\\Roaming/githits",
+        const fs = createMockFileSystemService({
+          joinPath: (...segments: string[]) => win32.join(...segments),
+        });
+        expect(getAppConfigDir(fs)).toBe(
+          win32.join("C:\\Users\\test\\AppData\\Roaming", "githits"),
         );
       });
     } finally {

--- a/src/services/app-config-paths.test.ts
+++ b/src/services/app-config-paths.test.ts
@@ -8,34 +8,17 @@ import {
   getLegacyMacAuthConfigPath,
   getLegacyMacAuthFileStorageDir,
 } from "./app-config-paths.js";
-import { createMockFileSystemService } from "./test-helpers.js";
-
-function withPlatform<T>(platform: NodeJS.Platform, fn: () => T): T {
-  const originalPlatform = process.platform;
-  Object.defineProperty(process, "platform", { value: platform });
-  try {
-    return fn();
-  } finally {
-    Object.defineProperty(process, "platform", { value: originalPlatform });
-  }
-}
-
-function withEnvVar<T>(key: string, value: string | undefined, fn: () => T): T {
-  const original = process.env[key];
-  if (value === undefined) delete process.env[key];
-  else process.env[key] = value;
-  try {
-    return fn();
-  } finally {
-    if (original === undefined) delete process.env[key];
-    else process.env[key] = original;
-  }
-}
+import {
+  createMockFileSystemService,
+  createPlatformMockFileSystemService,
+  withTestEnvVar,
+  withTestPlatform,
+} from "./test-helpers.js";
 
 describe("app config paths", () => {
-  it("uses XDG_CONFIG_HOME on linux", () => {
-    withEnvVar("XDG_CONFIG_HOME", "/xdg/config", () => {
-      withPlatform("linux", () => {
+  it("uses XDG_CONFIG_HOME on linux", async () => {
+    await withTestEnvVar("XDG_CONFIG_HOME", "/xdg/config", async () => {
+      await withTestPlatform("linux", () => {
         const fs = createMockFileSystemService();
         expect(getAppConfigDir(fs)).toBe("/xdg/config/githits");
         expect(getAuthConfigPath(fs)).toBe("/xdg/config/githits/config.toml");
@@ -44,9 +27,9 @@ describe("app config paths", () => {
     });
   });
 
-  it("falls back to ~/.config on linux", () => {
-    withEnvVar("XDG_CONFIG_HOME", undefined, () => {
-      withPlatform("linux", () => {
+  it("falls back to ~/.config on linux", async () => {
+    await withTestEnvVar("XDG_CONFIG_HOME", undefined, async () => {
+      await withTestPlatform("linux", () => {
         expect(getAppConfigDir(createMockFileSystemService())).toBe(
           "/home/test/.config/githits",
         );
@@ -54,9 +37,9 @@ describe("app config paths", () => {
     });
   });
 
-  it("uses ~/.config on macOS", () => {
-    withEnvVar("XDG_CONFIG_HOME", undefined, () => {
-      withPlatform("darwin", () => {
+  it("uses ~/.config on macOS", async () => {
+    await withTestEnvVar("XDG_CONFIG_HOME", undefined, async () => {
+      await withTestPlatform("darwin", () => {
         expect(getAppConfigDir(createMockFileSystemService())).toBe(
           "/home/test/.config/githits",
         );
@@ -64,9 +47,9 @@ describe("app config paths", () => {
     });
   });
 
-  it("uses XDG_CONFIG_HOME on macOS when set", () => {
-    withEnvVar("XDG_CONFIG_HOME", "/xdg/config", () => {
-      withPlatform("darwin", () => {
+  it("uses XDG_CONFIG_HOME on macOS when set", async () => {
+    await withTestEnvVar("XDG_CONFIG_HOME", "/xdg/config", async () => {
+      await withTestPlatform("darwin", () => {
         expect(getAppConfigDir(createMockFileSystemService())).toBe(
           "/xdg/config/githits",
         );
@@ -74,8 +57,8 @@ describe("app config paths", () => {
     });
   });
 
-  it("keeps legacy macOS Application Support paths for migration", () => {
-    withPlatform("darwin", () => {
+  it("keeps legacy macOS Application Support paths for migration", async () => {
+    await withTestPlatform("darwin", () => {
       const fs = createMockFileSystemService();
       expect(getLegacyMacAuthConfigPath(fs)).toBe(
         "/home/test/Library/Application Support/githits/config.toml",
@@ -86,22 +69,19 @@ describe("app config paths", () => {
     });
   });
 
-  it("uses APPDATA on Windows", () => {
-    const original = process.env.APPDATA;
-    process.env.APPDATA = "C:\\Users\\test\\AppData\\Roaming";
-    try {
-      withPlatform("win32", () => {
-        const fs = createMockFileSystemService({
-          joinPath: (...segments: string[]) => win32.join(...segments),
+  it("uses APPDATA on Windows", async () => {
+    await withTestEnvVar(
+      "APPDATA",
+      "C:\\Users\\test\\AppData\\Roaming",
+      async () => {
+        await withTestPlatform("win32", () => {
+          const fs = createPlatformMockFileSystemService("win32");
+          expect(getAppConfigDir(fs)).toBe(
+            win32.join("C:\\Users\\test\\AppData\\Roaming", "githits"),
+          );
         });
-        expect(getAppConfigDir(fs)).toBe(
-          win32.join("C:\\Users\\test\\AppData\\Roaming", "githits"),
-        );
-      });
-    } finally {
-      if (original === undefined) delete process.env.APPDATA;
-      else process.env.APPDATA = original;
-    }
+      },
+    );
   });
 
   it("keeps legacy auth storage under ~/.githits", () => {

--- a/src/services/exec-service.ts
+++ b/src/services/exec-service.ts
@@ -149,13 +149,14 @@ export class ExecServiceImpl implements ExecService {
         fn();
       };
 
-      if (options.timeoutMs !== undefined) {
+      const timeoutMs = options.timeoutMs;
+      if (timeoutMs !== undefined) {
         timeout = setTimeout(() => {
           settle(() => {
             child.kill("SIGTERM");
-            reject(new ExecTimeoutError(command, args, options.timeoutMs!));
+            reject(new ExecTimeoutError(command, args, timeoutMs));
           });
-        }, options.timeoutMs);
+        }, timeoutMs);
       }
 
       child.stdout.on("data", (chunk: Buffer) => stdoutChunks.push(chunk));

--- a/src/services/test-helpers.ts
+++ b/src/services/test-helpers.ts
@@ -1,4 +1,5 @@
 import { mock } from "bun:test";
+import { posix, win32 } from "node:path";
 import type {
   ChangelogReport,
   CodeNavigationService,
@@ -231,6 +232,64 @@ export function createMockFileSystemService(
     atomicWriteFile: mock(() => Promise.resolve()),
     ...impl,
   };
+}
+
+export function createPlatformMockFileSystemService(
+  platform: NodeJS.Platform,
+  impl: Partial<FileSystemService> = {},
+): FileSystemService {
+  const pathApi = platform === "win32" ? win32 : posix;
+  const homeDir = platform === "win32" ? "C:\\Users\\test" : "/home/test";
+  const cwd = platform === "win32" ? "C:\\current\\dir" : "/current/dir";
+
+  return createMockFileSystemService({
+    getHomeDir: mock(() => homeDir),
+    joinPath: mock((...segments: string[]) => pathApi.join(...segments)),
+    getCwd: mock(() => cwd),
+    getDirname: mock((path: string) => pathApi.dirname(path)),
+    ...impl,
+  });
+}
+
+export async function withTestPlatform<T>(
+  platform: NodeJS.Platform,
+  fn: () => T | Promise<T>,
+): Promise<T> {
+  const originalPlatform = process.platform;
+  Object.defineProperty(process, "platform", {
+    configurable: true,
+    value: platform,
+  });
+  try {
+    return await fn();
+  } finally {
+    Object.defineProperty(process, "platform", {
+      configurable: true,
+      value: originalPlatform,
+    });
+  }
+}
+
+export async function withTestEnvVar<T>(
+  key: string,
+  value: string | undefined,
+  fn: () => T | Promise<T>,
+): Promise<T> {
+  const original = process.env[key];
+  if (value === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
+  try {
+    return await fn();
+  } finally {
+    if (original === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = original;
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fix doctor PATH lookup on Windows to check PATHEXT launchers such as githits.cmd
- Replace mixed Windows/POSIX path expectations in Windows-simulated tests with path.win32 semantics
- Add agent/testing guidance to prevent mixed-separator fixtures in future platform-simulated tests

Fixes #160.

## Review
- Code reviewer comments: no findings.

## Tests
- bun test
- bun run typecheck
- bun run format:check