### PR TITLE
fix: simplify auth command output

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -397,8 +397,8 @@ describe("root CLI preAction", () => {
     const errorSpy = spyOn(console, "error").mockImplementation(() => {});
     const createContainer = mock(() => Promise.resolve(createLoginDeps()));
     const loginFlow = mock(() => {
-      console.error("Opening browser...");
-      console.error("Waiting for authentication...\n");
+      console.error("Opening browser for GitHits sign-in...");
+      console.error("Waiting for sign-in to finish...\n");
       return Promise.resolve({
         status: "success" as const,
         message: "Logged in successfully.",
@@ -422,8 +422,8 @@ describe("root CLI preAction", () => {
       JSON.stringify({ ok: true }),
     ]);
     expect(errorSpy.mock.calls.map((call) => call[0])).toEqual([
-      "Opening browser...",
-      "Waiting for authentication...\n",
+      "Opening browser for GitHits sign-in...",
+      "Waiting for sign-in to finish...\n",
       "Authentication complete. Running example search...",
     ]);
     logSpy.mockRestore();

--- a/src/commands/login.test.ts
+++ b/src/commands/login.test.ts
@@ -34,6 +34,13 @@ describe("loginAction", () => {
       expect.any(Object),
       expect.any(Object),
     );
+    const output = consoleSpy.mock.calls
+      .map((call) => String(call[0]))
+      .join("\n");
+    expect(output).toContain("Logged in successfully.");
+    expect(output).toContain("You're ready to use GitHits.");
+    expect(output).not.toContain("Token expires");
+    expect(output).not.toContain("Environment:");
 
     consoleSpy.mockRestore();
   });
@@ -65,6 +72,12 @@ describe("loginAction", () => {
       expect.any(Object),
       expect.any(Object),
     );
+    const output = consoleSpy.mock.calls
+      .map((call) => String(call[0]))
+      .join("\n");
+    expect(output).toContain("Already logged in.");
+    expect(output).toContain("You're ready to use GitHits.");
+    expect(output).not.toContain("Environment:");
     consoleSpy.mockRestore();
   });
 
@@ -445,8 +458,8 @@ describe("loginFlow", () => {
     );
 
     expect(result.status).toBe("success");
-    expect(writes).toContain("Discovering OAuth endpoints...");
-    expect(writes).toContain("Opening browser...");
+    expect(writes).toContain("Opening browser for GitHits sign-in...");
+    expect(writes).toContain("Waiting for sign-in to finish...\n");
     expect(consoleSpy).not.toHaveBeenCalled();
     consoleSpy.mockRestore();
   });

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -112,9 +112,9 @@ export async function loginFlow(
     if (!isExpired) {
       return { status: "already_authenticated", message: "Already logged in." };
     }
-    output.write("Token expired. Starting new login...\n");
+    output.write("Starting sign-in...\n");
   } else if (existing && options.force) {
-    output.write("Re-authenticating (--force flag)...\n");
+    output.write("Signing in again...\n");
   }
 
   // If tokens were cleared (expired+refreshFailed or never existed) but a stale
@@ -127,7 +127,6 @@ export async function loginFlow(
   if (persistenceError) return persistenceError;
 
   // Step 1: Discover OAuth endpoints
-  output.write("Discovering OAuth endpoints...");
   const metadata = await authService.discoverEndpoints(mcpUrl);
 
   // Step 2: Load or register client via DCR
@@ -144,7 +143,6 @@ export async function loginFlow(
       redirectUri = `http://127.0.0.1:${options.port}/callback`;
       if (redirectUri !== client.redirectUri) {
         // Port changed - need to re-register
-        output.write("Registering CLI client with new port...");
         const registration = await authService.registerClient({
           registrationEndpoint: metadata.registrationEndpoint,
           redirectUri,
@@ -167,7 +165,6 @@ export async function loginFlow(
   } else {
     port = options.port ?? randomPort();
     redirectUri = `http://127.0.0.1:${port}/callback`;
-    output.write("Registering CLI client...");
     const registration = await authService.registerClient({
       registrationEndpoint: metadata.registrationEndpoint,
       redirectUri,
@@ -209,7 +206,7 @@ export async function loginFlow(
     output.write("Open this URL in your browser:\n");
     output.write(`  ${authUrl}\n`);
   } else {
-    output.write("Opening browser...");
+    output.write("Opening browser for GitHits sign-in...");
     try {
       await browserService.open(authUrl);
     } catch (error) {
@@ -220,7 +217,7 @@ export async function loginFlow(
     }
   }
 
-  output.write("Waiting for authentication...\n");
+  output.write("Waiting for sign-in to finish...\n");
 
   // Wait for callback with timeout
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
@@ -298,11 +295,9 @@ export async function loginFlow(
     createdAt: new Date().toISOString(),
   });
 
-  // Success message
-  const hours = Math.round(tokenResponse.expiresIn / 3600);
   return {
     status: "success",
-    message: `Logged in successfully. Token expires in ${hours} hour${hours !== 1 ? "s" : ""}.`,
+    message: "Logged in successfully.",
   };
 }
 
@@ -318,8 +313,7 @@ export async function loginAction(
 
   if (result.status === "already_authenticated") {
     console.log("Already logged in.\n");
-    console.log(`  Environment: ${deps.mcpUrl}\n`);
-    console.log("To re-authenticate, use `githits login --force`.");
+    console.log("You're ready to use GitHits.");
     return;
   }
 
@@ -329,11 +323,8 @@ export async function loginAction(
     process.exit(1);
   }
 
-  // success
-  console.log("Logged in successfully.\n");
-  console.log(`  Environment: ${deps.mcpUrl}`);
-  console.log(result.message.replace("Logged in successfully. ", "  "));
-  console.log("\nYou're ready to use githits with your AI assistant.");
+  console.log(`${result.message}\n`);
+  console.log("You're ready to use GitHits.");
 }
 
 function printLoginRecoveryHint(message: string): void {

--- a/src/commands/logout.test.ts
+++ b/src/commands/logout.test.ts
@@ -28,6 +28,7 @@ describe("logoutAction", () => {
     expect(authStorage.loadTokens).not.toHaveBeenCalled();
     const output = consoleSpy.mock.calls.map((c) => c[0]).join("\n");
     expect(output).toContain("Logged out");
+    expect(output).not.toContain("Environment:");
     consoleSpy.mockRestore();
   });
 

--- a/src/commands/logout.ts
+++ b/src/commands/logout.ts
@@ -18,8 +18,7 @@ export async function logoutAction(deps: LogoutDependencies): Promise<void> {
 
   await authStorage.clearAuthSession(mcpUrl);
 
-  console.log("Logged out.\n");
-  console.log(`  Environment: ${mcpUrl}`);
+  console.log("Logged out.");
 }
 
 const LOGOUT_DESCRIPTION = `Remove stored credentials.

--- a/src/shared/auto-login.test.ts
+++ b/src/shared/auto-login.test.ts
@@ -272,7 +272,7 @@ describe("maybeAutoLoginBeforeCommand", () => {
     const login = mock(() =>
       Promise.resolve({
         status: "success" as const,
-        message: "Logged in successfully. Token expires in 1 hour.",
+        message: "Logged in successfully.",
       }),
     );
 
@@ -288,7 +288,7 @@ describe("maybeAutoLoginBeforeCommand", () => {
 
     expect(result).toEqual({
       status: "authenticated",
-      message: "Logged in successfully. Token expires in 1 hour.",
+      message: "Logged in successfully.",
     });
     expect(login).toHaveBeenCalledWith({}, container);
   });


### PR DESCRIPTION
## Summary
- simplify login success and already-authenticated output to avoid token lifetime and environment details
- remove implementation-oriented login progress messages
- remove environment detail from logout output
- add regression assertions for concise auth command output

## Tests
- bun test src/commands/login.test.ts src/commands/logout.test.ts src/shared/auto-login.test.ts src/cli.test.ts
- bun test
- bun run build

## Follow-up
- Runner-aware command examples are intentionally out of scope for this PR. We should spike whether npx/npm exec/bunx/pnpm dlx/global install invocation can be detected reliably before adding command CTAs back to auth output.