### PR TITLE
fix: isolate auth storage classes and add auth diagnostics

### DIFF
--- a/docs/implementation/auth.md
+++ b/docs/implementation/auth.md
@@ -181,6 +181,11 @@ The MCP server starts without a synchronous auth gate. Tool calls resolve tokens
 - **System keychain unavailable** — In default keychain mode, OAuth login/refresh fails rather than writing plaintext credentials. Use `GITHITS_API_TOKEN`, fix/unlock the keychain, or explicitly configure `auth.storage = "file"` if plaintext local storage is acceptable.
 - **Windows "password encoded as UTF-16 is longer than platform limit"** — The Windows Credential Manager limits credential blobs to 2560 bytes (`CRED_MAX_CREDENTIAL_BLOB_SIZE`). Since passwords are stored as UTF-16 (2 bytes per char), the effective limit is 1280 characters. The `ChunkingKeyringService` decorator handles this automatically by splitting large values across multiple entries. If this error occurs on an older CLI version, upgrade to get chunked storage support.
 
+## Diagnostics
+
+- **Telemetry (opt-in, local repro only)** — When `GITHITS_TELEMETRY` is enabled, auth spans carry diagnostic attributes: `auth.fingerprint` records the resolved storage `mode`, platform, and which scope-determining env vars are set (booleans only, never values); token/client clear spans carry a `reason` (`terminal_invalid_refresh_token`, `terminal_invalid_client`, `logout`). This flushes to stderr and is invisible to external users running the MCP server, so it only helps when we reproduce locally with the flag on.
+- **Planned: persisted auth-clear breadcrumb (fast-follow)** — The only diagnostic channel that reaches an external user is persisted state surfaced by `githits doctor`. A follow-up should persist the last auth-clear `{ reason, at, mode }` and render it in `doctor`, so reports show *why* a token was cleared (migration, terminal refresh failure, or logout). It must live in its own file (e.g. `auth/diagnostics.json`), not `metadata.json`, because credential clears wipe metadata and a breadcrumb stored there would erase itself. The file is retained across clears and holds no secrets.
+
 ## Key Reference Files
 
 | File | What it demonstrates |

--- a/docs/implementation/auth.md
+++ b/docs/implementation/auth.md
@@ -114,21 +114,21 @@ The legacy `~/.githits/auth.json` and `~/.githits/client.json` path is still rea
 
 ### Migration
 
-On first use after upgrading, `MigratingAuthStorage` transparently migrates credentials according to the configured storage mode:
+`MigratingAuthStorage` only performs same-storage-class migration. Switching `auth.storage` between `keychain` and `file` intentionally does not move credentials; run `githits login` after changing modes.
 
 Keychain mode:
 
 1. Check keychain — if found, return it
-2. Check new file path, then legacy `~/.githits` — if found, write to keychain, delete the migrated plaintext entry, return it
-3. Both empty — return null
+2. Do not inspect plaintext file storage or legacy plaintext paths
+3. Keychain empty or unavailable — return null
 
 File mode:
 
 1. Check new file path — if found, return it
 2. Check legacy `~/.githits` — if found, write to new file path, delete legacy entry, return it
-3. Check keychain only as a last-resort migration source, then warn before exporting encrypted credentials to plaintext
+3. Do not inspect or export keychain credentials
 
-The configured target write must succeed before the source entry is deleted. Tokens and client registrations migrate independently. If both plaintext paths contain entries, the newer timestamp wins; ambiguous ties prefer the new file path and leave the other entry intact with a warning.
+The file-mode legacy target write must succeed before the legacy source entry is deleted. Tokens and client registrations migrate independently. If both plaintext paths contain entries, the newer timestamp wins; ambiguous ties prefer the new file path and leave the other entry intact with a warning.
 
 ### Architecture
 
@@ -202,7 +202,7 @@ The MCP server starts without a synchronous auth gate. Tool calls resolve tokens
 | `src/services/keyring-service.ts` | `KeyringService` interface wrapping `@napi-rs/keyring` |
 | `src/services/chunking-keyring-service.ts` | `KeyringService` decorator for chunked storage (Windows 2560-char limit) |
 | `src/services/keychain-auth-storage.ts` | `AuthStorage` implementation backed by system keychain |
-| `src/services/migrating-auth-storage.ts` | Mode-aware migration across keychain, config file storage, and legacy file storage |
+| `src/services/migrating-auth-storage.ts` | Active-mode auth storage plus legacy plaintext-to-plaintext migration |
 | `src/services/filesystem-service.ts` | File system abstraction for testable storage |
 | `src/auth/pkce.ts` | PKCE cryptographic primitives |
 | `src/services/config.ts` | URL and API token configuration |

--- a/src/commands/doctor.test.ts
+++ b/src/commands/doctor.test.ts
@@ -327,6 +327,56 @@ describe("doctor", () => {
     expect(writes.atomicWriteFile).not.toHaveBeenCalled();
   });
 
+  it("recommends login when file mode has metadata but no token", async () => {
+    const fs = createMockFileSystemService({
+      exists: mock((path: string) =>
+        Promise.resolve(
+          path.endsWith("config.toml") ||
+            path.endsWith("client.json") ||
+            path.endsWith("metadata.json"),
+        ),
+      ),
+      readFile: mock((path: string) => {
+        if (path.endsWith("config.toml")) {
+          return Promise.resolve('[auth]\nstorage = "file"\n');
+        }
+        if (path.endsWith("client.json")) {
+          return Promise.resolve(
+            JSON.stringify({
+              version: 1,
+              clients: {
+                "https://mcp.githits.com": {
+                  clientId: "secret-client-id",
+                  clientSecret: "secret-client-secret",
+                  redirectUri: "http://127.0.0.1:8080/callback",
+                  registeredAt: "2026-05-20T09:00:00.000Z",
+                },
+              },
+            }),
+          );
+        }
+        return Promise.resolve(
+          JSON.stringify({
+            version: 1,
+            sessions: {
+              "https://mcp.githits.com": {
+                createdAt: "2026-05-27T10:00:00.000Z",
+                expiresAt: "2026-05-27T14:00:00.000Z",
+                updatedAt: "2026-05-27T10:05:00.000Z",
+              },
+            },
+          }),
+        );
+      }),
+    });
+
+    const report = await buildDoctorReport(createDeps({ fs }));
+
+    expect(report.recommendations).toContain(
+      "File auth token is missing but client/session metadata remains. Run `githits login` in this environment.",
+    );
+  });
+
   it("reports invalid auth config instead of throwing", async () => {
     const fs = createMockFileSystemService({
       exists: mock((path: string) =>

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -541,9 +541,17 @@ function buildRecommendations(report: DoctorReport): string[] {
   if (report.auth.storageMode.value === "file") {
     const active = report.auth.files[0];
     const activeMissing = active?.token.status === "missing";
+    const staleSessionEvidence =
+      active?.client.status === "present" ||
+      active?.metadata.status === "present";
     const legacyPresent = report.auth.files
       .slice(1)
       .some((entry) => entry.token.status === "present");
+    if (activeMissing && staleSessionEvidence) {
+      recommendations.push(
+        "File auth token is missing but client/session metadata remains. Run `githits login` in this environment.",
+      );
+    }
     if (activeMissing && legacyPresent) {
       recommendations.push(
         "The active file auth location has no token, but a legacy auth location has one.",

--- a/src/commands/logout.ts
+++ b/src/commands/logout.ts
@@ -1,3 +1,4 @@
+import { withTelemetrySpan } from "@githits/core-internal";
 import type { Command } from "commander";
 import { createAuthCommandDependencies } from "../container.js";
 import type { AuthStorage } from "../services/auth-storage.js";
@@ -16,7 +17,11 @@ export interface LogoutDependencies {
 export async function logoutAction(deps: LogoutDependencies): Promise<void> {
   const { authStorage, mcpUrl } = deps;
 
-  await authStorage.clearAuthSession(mcpUrl);
+  await withTelemetrySpan(
+    "auth.clear",
+    () => authStorage.clearAuthSession(mcpUrl),
+    { reason: "logout" },
+  );
 
   console.log("Logged out.");
 }

--- a/src/container.test.ts
+++ b/src/container.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, it, mock } from "bun:test";
 import {
+  flushTelemetry,
+  resetTelemetryCollectorForTests,
+} from "@githits/core-internal";
+import {
   createAuthCommandDependencies,
   createAuthStatusDependencies,
   createContainer,
+  recordAuthFingerprint,
 } from "./container.js";
 import { AuthConfigError } from "./services/auth-config.js";
 
@@ -106,6 +111,33 @@ describe("createContainer", () => {
       } finally {
         globalThis.fetch = originalFetch;
       }
+    });
+  });
+
+  describe("recordAuthFingerprint", () => {
+    it("records mode and env presence as booleans, never raw values", () => {
+      const writes: string[] = [];
+      resetTelemetryCollectorForTests({
+        env: { GITHITS_TELEMETRY: "1" },
+        now: () => 0,
+        write: (text) => writes.push(text),
+      });
+
+      recordAuthFingerprint("file", {
+        HOME: "/home/secret-user",
+        XDG_CONFIG_HOME: "/home/secret-user/.config",
+      } as NodeJS.ProcessEnv);
+      flushTelemetry(0);
+
+      const report = writes.join("");
+      expect(report).toContain("auth.fingerprint");
+      expect(report).toContain("mode=file");
+      expect(report).toContain("homeSet=true");
+      expect(report).toContain("xdgConfigHomeSet=true");
+      expect(report).toContain("appDataSet=false");
+      // Privacy: env values must never reach telemetry output.
+      expect(report).not.toContain("secret-user");
+      resetTelemetryCollectorForTests({ env: {} });
     });
   });
 });

--- a/src/container.ts
+++ b/src/container.ts
@@ -3,6 +3,7 @@ import {
   type CodeNavigationService,
   CodeNavigationServiceImpl,
   createClientHeaderBuilder,
+  endTelemetrySpan,
   type GitHitsService,
   GitHitsServiceImpl,
   getApiUrl,
@@ -12,6 +13,7 @@ import {
   type PackageIntelligenceService,
   PackageIntelligenceServiceImpl,
   RefreshingGitHitsService,
+  startTelemetrySpan,
   type TokenProvider,
   withTelemetrySpan,
 } from "@githits/core-internal";
@@ -65,12 +67,36 @@ async function createAuthStorage(
 ): Promise<LockingAuthStorage> {
   return withTelemetrySpan("container.create-auth-storage", async () => {
     const authConfig = await loadAuthConfig(fileSystemService);
+    recordAuthFingerprint(authConfig.storage);
     return createAuthStorageForMode(
       fileSystemService,
       authConfig.storage,
       authConfig.configPath,
     );
   });
+}
+
+/**
+ * Emit a one-shot telemetry fingerprint of the resolved auth configuration so
+ * lockout reports can be segmented by storage mode and config-scope divergence.
+ *
+ * Records only the storage mode, platform, and which scope-determining env vars
+ * are set — never their values, paths, usernames, or credentials. Does not probe
+ * the keychain, so it cannot trigger an OS unlock prompt on startup.
+ */
+export function recordAuthFingerprint(
+  mode: AuthStorageMode,
+  env: NodeJS.ProcessEnv = process.env,
+): void {
+  const handle = startTelemetrySpan("auth.fingerprint", {
+    mode,
+    platform: process.platform,
+    homeSet: Boolean(env.HOME),
+    xdgConfigHomeSet: Boolean(env.XDG_CONFIG_HOME),
+    appDataSet: Boolean(env.APPDATA),
+    userProfileSet: Boolean(env.USERPROFILE),
+  });
+  endTelemetrySpan(handle);
 }
 
 function createAuthStorageForMode(

--- a/src/services/migrating-auth-storage.test.ts
+++ b/src/services/migrating-auth-storage.test.ts
@@ -70,7 +70,7 @@ describe("MigratingAuthStorage", () => {
     expect(metadata.clear).toHaveBeenCalledWith(BASE_URL);
   });
 
-  it("keychain mode migrates new file tokens into keychain", async () => {
+  it("keychain mode ignores file tokens instead of migrating across storage modes", async () => {
     const token = createValidTokenData();
     const primary = createMockAuthStorage();
     const file = createMockAuthStorage({
@@ -79,13 +79,45 @@ describe("MigratingAuthStorage", () => {
     const legacy = createMockAuthStorage();
     const storage = new MigratingAuthStorage(primary, file, legacy, "keychain");
 
-    await expect(storage.loadTokens(BASE_URL)).resolves.toEqual(token);
-    expect(primary.saveTokens).toHaveBeenCalledWith(BASE_URL, token);
-    expect(file.clearTokens).toHaveBeenCalledWith(BASE_URL);
-    expect(legacy.clearTokens).toHaveBeenCalledWith(BASE_URL);
+    await expect(storage.loadTokens(BASE_URL)).resolves.toBeNull();
+    expect(file.loadTokens).not.toHaveBeenCalled();
+    expect(primary.saveTokens).not.toHaveBeenCalled();
+    expect(file.clearTokens).not.toHaveBeenCalled();
+    expect(legacy.clearTokens).not.toHaveBeenCalled();
   });
 
-  it("keychain mode migrates legacy tokens into keychain", async () => {
+  it("keychain mode does not touch file metadata when file tokens exist", async () => {
+    const token = createValidTokenData();
+    const primary = createMockAuthStorage();
+    const file = createMockAuthStorage({
+      loadTokens: mock(() => Promise.resolve(token)),
+    });
+    const legacy = createMockAuthStorage();
+    const metadata = {
+      load: mock(() => Promise.resolve(null)),
+      saveFromTokens: mock(() => Promise.resolve()),
+      clear: mock(() => Promise.resolve()),
+    };
+    const storage = new MigratingAuthStorage(
+      primary,
+      file,
+      legacy,
+      "keychain",
+      "test-config.toml",
+      () => {},
+      metadata,
+    );
+
+    await expect(storage.loadTokens(BASE_URL)).resolves.toBeNull();
+
+    expect(file.loadTokens).not.toHaveBeenCalled();
+    expect(primary.saveTokens).not.toHaveBeenCalled();
+    expect(file.clearTokens).not.toHaveBeenCalled();
+    expect(metadata.clear).not.toHaveBeenCalled();
+    expect(metadata.saveFromTokens).not.toHaveBeenCalled();
+  });
+
+  it("keychain mode ignores legacy plaintext tokens instead of migrating across storage modes", async () => {
     const token = createValidTokenData();
     const primary = createMockAuthStorage();
     const file = createMockAuthStorage();
@@ -94,15 +126,16 @@ describe("MigratingAuthStorage", () => {
     });
     const storage = new MigratingAuthStorage(primary, file, legacy, "keychain");
 
-    await expect(storage.loadTokens(BASE_URL)).resolves.toEqual(token);
-    expect(primary.saveTokens).toHaveBeenCalledWith(BASE_URL, token);
-    expect(legacy.clearTokens).toHaveBeenCalledWith(BASE_URL);
+    await expect(storage.loadTokens(BASE_URL)).resolves.toBeNull();
+    expect(legacy.loadTokens).not.toHaveBeenCalled();
+    expect(primary.saveTokens).not.toHaveBeenCalled();
+    expect(legacy.clearTokens).not.toHaveBeenCalled();
   });
 
-  it("keychain mode keeps plaintext entry if keychain migration write fails", async () => {
+  it("keychain mode returns null when keychain is unavailable instead of falling back to plaintext", async () => {
     const token = createValidTokenData();
     const primary = createMockAuthStorage({
-      saveTokens: mock(() =>
+      loadTokens: mock(() =>
         Promise.reject(new KeychainUnavailableError("keychain locked")),
       ),
     });
@@ -112,7 +145,8 @@ describe("MigratingAuthStorage", () => {
     const legacy = createMockAuthStorage();
     const storage = new MigratingAuthStorage(primary, file, legacy, "keychain");
 
-    await expect(storage.loadTokens(BASE_URL)).resolves.toEqual(token);
+    await expect(storage.loadTokens(BASE_URL)).resolves.toBeNull();
+    expect(file.loadTokens).not.toHaveBeenCalled();
     expect(file.clearTokens).not.toHaveBeenCalled();
   });
 
@@ -223,7 +257,7 @@ describe("MigratingAuthStorage", () => {
     expect(legacy.clearTokens).not.toHaveBeenCalled();
   });
 
-  it("file mode uses keychain only as last-resort migration source", async () => {
+  it("file mode ignores keychain tokens instead of exporting across storage modes", async () => {
     const token = createValidTokenData();
     const primary = createMockAuthStorage({
       loadTokens: mock(() => Promise.resolve(token)),
@@ -240,12 +274,13 @@ describe("MigratingAuthStorage", () => {
       warning,
     );
 
-    await expect(storage.loadTokens(BASE_URL)).resolves.toEqual(token);
-    expect(file.saveTokens).toHaveBeenCalledWith(BASE_URL, token);
-    expect(warning).toHaveBeenCalledWith(expect.stringContaining("exporting"));
+    await expect(storage.loadTokens(BASE_URL)).resolves.toBeNull();
+    expect(primary.loadTokens).not.toHaveBeenCalled();
+    expect(file.saveTokens).not.toHaveBeenCalled();
+    expect(warning).not.toHaveBeenCalled();
   });
 
-  it("chooses newer plaintext token and leaves ambiguous other entry intact", async () => {
+  it("keychain mode does not inspect plaintext candidates", async () => {
     const older = createValidTokenData({ createdAt: "2025-01-01T00:00:00Z" });
     const newer = createValidTokenData({ createdAt: "2025-02-01T00:00:00Z" });
     const primary = createMockAuthStorage();
@@ -257,13 +292,15 @@ describe("MigratingAuthStorage", () => {
     });
     const storage = new MigratingAuthStorage(primary, file, legacy, "keychain");
 
-    await expect(storage.loadTokens(BASE_URL)).resolves.toEqual(newer);
-    expect(primary.saveTokens).toHaveBeenCalledWith(BASE_URL, newer);
-    expect(legacy.clearTokens).toHaveBeenCalledWith(BASE_URL);
-    expect(file.clearTokens).toHaveBeenCalledWith(BASE_URL);
+    await expect(storage.loadTokens(BASE_URL)).resolves.toBeNull();
+    expect(file.loadTokens).not.toHaveBeenCalled();
+    expect(legacy.loadTokens).not.toHaveBeenCalled();
+    expect(primary.saveTokens).not.toHaveBeenCalled();
+    expect(legacy.clearTokens).not.toHaveBeenCalled();
+    expect(file.clearTokens).not.toHaveBeenCalled();
   });
 
-  it("prefers new file path and warns when plaintext timestamps are tied", async () => {
+  it("keychain mode does not warn about ambiguous plaintext entries", async () => {
     const token = createValidTokenData({ createdAt: "2025-01-01T00:00:00Z" });
     const primary = createMockAuthStorage();
     const file = createMockAuthStorage({
@@ -284,10 +321,12 @@ describe("MigratingAuthStorage", () => {
       warning,
     );
 
-    await expect(storage.loadTokens(BASE_URL)).resolves.toEqual(token);
-    expect(file.clearTokens).toHaveBeenCalledWith(BASE_URL);
+    await expect(storage.loadTokens(BASE_URL)).resolves.toBeNull();
+    expect(file.loadTokens).not.toHaveBeenCalled();
+    expect(legacy.loadTokens).not.toHaveBeenCalled();
+    expect(file.clearTokens).not.toHaveBeenCalled();
     expect(legacy.clearTokens).not.toHaveBeenCalled();
-    expect(warning).toHaveBeenCalledWith(expect.stringContaining("ambiguous"));
+    expect(warning).not.toHaveBeenCalled();
   });
 
   it("does not migrate when only legacy stores have ambiguous timestamps", async () => {
@@ -320,7 +359,7 @@ describe("MigratingAuthStorage", () => {
     await expect(storage.loadTokens(BASE_URL)).resolves.toBeNull();
     expect(additionalLegacy.clearTokens).not.toHaveBeenCalled();
     expect(legacy.clearTokens).not.toHaveBeenCalled();
-    expect(warning).toHaveBeenCalledWith(expect.stringContaining("ambiguous"));
+    expect(warning).not.toHaveBeenCalled();
   });
 
   it("clears all legacy stores during logout", async () => {
@@ -343,7 +382,7 @@ describe("MigratingAuthStorage", () => {
     expect(legacy.clearAuthSession).toHaveBeenCalledWith(BASE_URL);
   });
 
-  it("keychain mode clears both plaintext clients after unambiguous migration", async () => {
+  it("keychain mode ignores plaintext clients instead of migrating across storage modes", async () => {
     const older = {
       ...defaultClientRegistration,
       registeredAt: "2025-01-01T00:00:00Z",
@@ -362,10 +401,12 @@ describe("MigratingAuthStorage", () => {
     });
     const storage = new MigratingAuthStorage(primary, file, legacy, "keychain");
 
-    await expect(storage.loadClient(BASE_URL)).resolves.toEqual(newer);
-    expect(primary.saveClient).toHaveBeenCalledWith(BASE_URL, newer);
-    expect(file.clearClient).toHaveBeenCalledWith(BASE_URL);
-    expect(legacy.clearClient).toHaveBeenCalledWith(BASE_URL);
+    await expect(storage.loadClient(BASE_URL)).resolves.toBeNull();
+    expect(file.loadClient).not.toHaveBeenCalled();
+    expect(legacy.loadClient).not.toHaveBeenCalled();
+    expect(primary.saveClient).not.toHaveBeenCalled();
+    expect(file.clearClient).not.toHaveBeenCalled();
+    expect(legacy.clearClient).not.toHaveBeenCalled();
   });
 
   it("migrates clients according to configured mode", async () => {

--- a/src/services/migrating-auth-storage.ts
+++ b/src/services/migrating-auth-storage.ts
@@ -11,8 +11,6 @@ import {
   createFileAuthStorageGuidance,
 } from "./mode-aware-file-auth-storage.js";
 
-type CredentialKind = "tokens" | "client";
-
 interface Candidate<T> {
   data: T;
   source: "file" | "legacy";
@@ -23,10 +21,10 @@ interface Candidate<T> {
 
 /**
  * AuthStorage implementation that coordinates the configured active store with
- * legacy plaintext locations so credentials migrate without silent downgrades.
+ * legacy plaintext locations. Switching between keychain and file storage is
+ * intentionally not migrated; users must run `githits login` in the new mode.
  */
 export class MigratingAuthStorage implements AuthStorage {
-  private warnedFileModeKeychainExport = false;
   private warnedAmbiguousPlaintext = false;
 
   constructor(
@@ -185,26 +183,7 @@ export class MigratingAuthStorage implements AuthStorage {
     } catch (error) {
       if (!(error instanceof KeychainUnavailableError)) throw error;
     }
-
-    const candidate = await this.selectPlaintextTokenCandidate(baseUrl);
-    if (!candidate) return null;
-
-    try {
-      await this.primary.saveTokens(baseUrl, candidate.data);
-    } catch (error) {
-      if (error instanceof KeychainUnavailableError) return candidate.data;
-      throw error;
-    }
-
-    await this.clearMigratedPlaintext(
-      baseUrl,
-      "tokens",
-      candidate.source,
-      candidate.storage,
-      candidate.ambiguous,
-    );
-    await this.saveMetadataBestEffort(baseUrl, candidate.data);
-    return candidate.data;
+    return null;
   }
 
   private async loadTokensFileMode(baseUrl: string): Promise<TokenData | null> {
@@ -220,18 +199,7 @@ export class MigratingAuthStorage implements AuthStorage {
       return candidate.data;
     }
 
-    let primaryTokens: TokenData | null = null;
-    try {
-      primaryTokens = await this.primary.loadTokens(baseUrl);
-    } catch (error) {
-      if (!(error instanceof KeychainUnavailableError)) throw error;
-    }
-    if (!primaryTokens) return null;
-
-    this.warnKeychainExport();
-    await this.file.saveTokens(baseUrl, primaryTokens);
-    await this.saveMetadataBestEffort(baseUrl, primaryTokens);
-    return primaryTokens;
+    return null;
   }
 
   private async loadClientKeychainMode(
@@ -243,25 +211,7 @@ export class MigratingAuthStorage implements AuthStorage {
     } catch (error) {
       if (!(error instanceof KeychainUnavailableError)) throw error;
     }
-
-    const candidate = await this.selectPlaintextClientCandidate(baseUrl);
-    if (!candidate) return null;
-
-    try {
-      await this.primary.saveClient(baseUrl, candidate.data);
-    } catch (error) {
-      if (error instanceof KeychainUnavailableError) return candidate.data;
-      throw error;
-    }
-
-    await this.clearMigratedPlaintext(
-      baseUrl,
-      "client",
-      candidate.source,
-      candidate.storage,
-      candidate.ambiguous,
-    );
-    return candidate.data;
+    return null;
   }
 
   private async loadClientFileMode(
@@ -278,17 +228,7 @@ export class MigratingAuthStorage implements AuthStorage {
       return candidate.data;
     }
 
-    let primaryClient: ClientRegistration | null = null;
-    try {
-      primaryClient = await this.primary.loadClient(baseUrl);
-    } catch (error) {
-      if (!(error instanceof KeychainUnavailableError)) throw error;
-    }
-    if (!primaryClient) return null;
-
-    this.warnKeychainExport();
-    await this.file.saveClient(baseUrl, primaryClient);
-    return primaryClient;
+    return null;
   }
 
   private async selectPlaintextTokenCandidate(
@@ -382,43 +322,8 @@ export class MigratingAuthStorage implements AuthStorage {
     return first.candidate;
   }
 
-  private async clearMigratedPlaintext(
-    baseUrl: string,
-    kind: CredentialKind,
-    source: "file" | "legacy",
-    storage: AuthStorage,
-    ambiguous = false,
-  ): Promise<void> {
-    if (!ambiguous) {
-      await this.clearPlaintextSource(this.file, baseUrl, kind);
-      for (const legacy of this.getLegacyStores()) {
-        await this.clearPlaintextSource(legacy, baseUrl, kind);
-      }
-      return;
-    }
-    if (source === "file") {
-      await this.clearPlaintextSource(this.file, baseUrl, kind);
-      return;
-    }
-    if (source === "legacy") {
-      await this.clearPlaintextSource(storage, baseUrl, kind);
-    }
-  }
-
   private getLegacyStores(): AuthStorage[] {
     return [...this.additionalLegacyStores, this.legacy];
-  }
-
-  private async clearPlaintextSource(
-    storage: AuthStorage,
-    baseUrl: string,
-    kind: CredentialKind,
-  ): Promise<void> {
-    await this.clearBestEffort(() =>
-      kind === "tokens"
-        ? storage.clearTokens(baseUrl)
-        : storage.clearClient(baseUrl),
-    );
   }
 
   private async clearBestEffort(fn: () => Promise<void>): Promise<unknown> {
@@ -443,14 +348,6 @@ export class MigratingAuthStorage implements AuthStorage {
     if (!(error instanceof KeychainUnavailableError)) return error;
     return new AuthStoragePolicyError(
       `System keychain is unavailable. ${createFileAuthStorageGuidance(this.configPath)}`,
-    );
-  }
-
-  private warnKeychainExport(): void {
-    if (this.warnedFileModeKeychainExport) return;
-    this.warnedFileModeKeychainExport = true;
-    this.onWarning(
-      "Warning: auth.storage=file is exporting existing keychain credentials to plaintext file storage.",
     );
   }
 

--- a/src/services/token-manager.ts
+++ b/src/services/token-manager.ts
@@ -370,6 +370,7 @@ export class TokenManager implements TokenProvider {
     const cleared = await withTelemetrySpan(
       "token-manager.clear-terminal-refresh-failure",
       () => this.authStorage.clearTokensIfUnchanged(this.mcpUrl, failedTokens),
+      { reason: `terminal_${reason}` },
     );
     if (!cleared) {
       const latestToken = await withTelemetrySpan(
@@ -381,8 +382,10 @@ export class TokenManager implements TokenProvider {
     }
 
     if (reason === "invalid_client") {
-      await withTelemetrySpan("token-manager.clear-invalid-client", () =>
-        this.authStorage.clearClient(this.mcpUrl),
+      await withTelemetrySpan(
+        "token-manager.clear-invalid-client",
+        () => this.authStorage.clearClient(this.mcpUrl),
+        { reason: "terminal_invalid_client" },
       ).catch(() => undefined);
     }
 


### PR DESCRIPTION
## Summary

Hardens auth against repeated lockouts for users running multiple agents/harnesses, and adds diagnostics to make future lockout reports debuggable. Sits on top of #164 (refresh-token reuse race fix).

## Changes

**Isolate auth storage classes, drop cross-class migration** (`16a5fe7`)
- `MigratingAuthStorage` no longer migrates credentials between keychain and file storage. The previous cross-class migration read the *other* storage class and **deleted the source after copying**, so agents running in different storage modes could steal and delete each other's tokens and client registrations — a credential tug-of-war that produces repeated lockouts.
- Storage classes are now isolated for both read and write. Keychain mode reads only the keychain; file mode reads only plaintext file/legacy locations. Switching `auth.storage` between modes intentionally requires an explicit `githits login`. Legacy plaintext→file migration within file mode is retained.
- `doctor` now recommends `githits login` when file mode has a client or session metadata present but no token, surfacing this recoverable state instead of leaving it unexplained.

**Auth diagnostics telemetry** (`28330e5`)
- Clear attribution: token/client clear spans carry a `reason` (`terminal_invalid_refresh_token`, `terminal_invalid_client`, `logout`) so a vanished credential is attributable rather than silent.
- Startup fingerprint: `auth.fingerprint` span records resolved storage mode, platform, and which scope-determining env vars are set — booleans only, never values/paths/usernames/credentials, and no keychain probe (cannot trigger an OS unlock prompt).

**Docs** (`4a36a98`)
- Document the diagnostics and their limitation (telemetry is stderr-only/opt-in, so invisible to external users running the MCP server).
- Record the planned fast-follow: a persisted auth-clear breadcrumb surfaced by `doctor`, including the constraint that it must not live in `metadata.json` (credential clears wipe metadata).

## Caveat

This and #164 harden two genuine auth defects, but neither cleanly matches the *exact* configuration in the original reporter's `doctor` dump (file mode, single config dir). We do not yet have proof either resolves that specific case — which is why the planned `doctor` breadcrumb (only diagnostic channel that reaches external users) is the intended fast-follow. Avoid marking the report "fixed" until a follow-up `doctor` confirms it.

## Testing

- `bun test` — 2180 pass
- `bun run typecheck` — clean
- `bun run build` — clean

`smoke:cli` / `smoke:mcp` not yet run; recommended before release since `logout` and `container` auth wiring changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)