### PR TITLE
fix: retry auth lock owner write races

### DIFF
--- a/src/services/locked-auth-storage.ts
+++ b/src/services/locked-auth-storage.ts
@@ -169,7 +169,13 @@ export class LockedAuthStorage implements AuthStorage, AuthStorageLockProvider {
           await this.writeOwner(processStartedAt);
         } catch (error) {
           this.currentOwner = null;
-          if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+          const code = (error as NodeJS.ErrnoException).code;
+          if (code === "EEXIST" || code === "ENOENT") {
+            // Another contender may have removed the lock directory between
+            // mkdir() and owner.json creation. Treat it as a lost race.
+            if (Date.now() - startedAt >= this.lockTimeoutMs) {
+              throw this.createLockTimeoutError();
+            }
             await sleep(LOCK_RETRY_MS);
             continue;
           }
@@ -183,13 +189,17 @@ export class LockedAuthStorage implements AuthStorage, AuthStorageLockProvider {
         if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
         await this.reclaimStaleLock();
         if (Date.now() - startedAt >= this.lockTimeoutMs) {
-          throw new AuthStorageLockTimeoutError(
-            `Timed out waiting for GitHits auth storage lock at ${this.lockPath}. If no githits process is running, remove this directory and retry.`,
-          );
+          throw this.createLockTimeoutError();
         }
         await sleep(LOCK_RETRY_MS);
       }
     }
+  }
+
+  private createLockTimeoutError(): AuthStorageLockTimeoutError {
+    return new AuthStorageLockTimeoutError(
+      `Timed out waiting for GitHits auth storage lock at ${this.lockPath}. If no githits process is running, remove this directory and retry.`,
+    );
   }
 
   private async writeOwner(processStartedAt: string | null): Promise<void> {


### PR DESCRIPTION
## Summary
- Retry lock acquisition when writing auth.lock/owner.json loses the directory race with another contender.
- Reuse the existing lock timeout error for both lock-directory contention and owner-write contention.

## Root cause
Concurrent token refresh managers could create auth.lock/ and then fail with ENOENT while writing owner.json if another contender removed the lock directory between mkdir and owner-file creation. That rejected TokenManager.getToken()/forceRefresh() under high concurrency.

## Verification
- Reproduced the flaky failure locally before the fix.
- `for i in {1..20}; do bun test src/services/token-manager.integration.test.ts --filter "makes one endpoint refresh" || exit 1; done`
- `bun test src/services/locked-auth-storage.test.ts src/services/token-manager.test.ts`
- `bun test`
- `bun run build`