### PR TITLE
feat: persist auth-clear breadcrumb surfaced by doctor

### DIFF
--- a/docs/implementation/auth.md
+++ b/docs/implementation/auth.md
@@ -184,7 +184,7 @@ The MCP server starts without a synchronous auth gate. Tool calls resolve tokens
 ## Diagnostics
 
 - **Telemetry (opt-in, local repro only)** — When `GITHITS_TELEMETRY` is enabled, auth spans carry diagnostic attributes: `auth.fingerprint` records the resolved storage `mode`, platform, and which scope-determining env vars are set (booleans only, never values); token/client clear spans carry a `reason` (`terminal_invalid_refresh_token`, `terminal_invalid_client`, `logout`). This flushes to stderr and is invisible to external users running the MCP server, so it only helps when we reproduce locally with the flag on.
-- **Planned: persisted auth-clear breadcrumb (fast-follow)** — The only diagnostic channel that reaches an external user is persisted state surfaced by `githits doctor`. A follow-up should persist the last auth-clear `{ reason, at, mode }` and render it in `doctor`, so reports show *why* a token was cleared (migration, terminal refresh failure, or logout). It must live in its own file (e.g. `auth/diagnostics.json`), not `metadata.json`, because credential clears wipe metadata and a breadcrumb stored there would erase itself. The file is retained across clears and holds no secrets.
+- **Persisted auth-clear breadcrumb (doctor-visible)** — Because the only diagnostic channel that reaches an external user is persisted state surfaced by `githits doctor`, the last auth-clear `{ reason, at }` is persisted to `auth/diagnostics.json` and rendered by `doctor` as `last clear: ...`. When the active token is missing, `doctor` adds a recommendation explaining the cause (refresh-token reuse/expiry, rejected client registration, or explicit logout). Writes happen at the clear sites — `logout` and `TokenManager` terminal refresh failures — and are best-effort, so a diagnostics write can never break the path it observes. The file lives separately from `metadata.json` because credential clears wipe metadata and a breadcrumb stored there would erase itself; it is only ever overwritten by the next event, never cleared, and holds no secrets (a reason enum and timestamp keyed by MCP URL).
 
 ## Key Reference Files
 
@@ -199,6 +199,7 @@ The MCP server starts without a synchronous auth gate. Tool calls resolve tokens
 | `src/services/code-navigation-service.ts` | Package/source service client using the shared refresh helper |
 | `src/services/auth-service.ts` | OAuth operations (DCR, PKCE, token exchange, callback server) |
 | `src/services/auth-storage.ts` | `AuthStorage` interface and file-based implementation |
+| `src/services/auth-diagnostics-storage.ts` | Persisted, retained-across-clears breadcrumb of why auth was last cleared |
 | `src/services/locked-auth-storage.ts` | Cross-process auth-storage lock and conditional write serialization |
 | `src/services/auth-config.ts` | `config.toml` and `GITHITS_AUTH_STORAGE` parsing |
 | `src/services/app-config-paths.ts` | Platform-specific config/auth path resolution |

--- a/src/commands/doctor.test.ts
+++ b/src/commands/doctor.test.ts
@@ -377,6 +377,47 @@ describe("doctor", () => {
     );
   });
 
+  it("surfaces the last-clear breadcrumb and explains a missing token", async () => {
+    const fs = createMockFileSystemService({
+      exists: mock((path: string) =>
+        Promise.resolve(path.endsWith("diagnostics.json")),
+      ),
+      readFile: mock((path: string) => {
+        if (path.endsWith("diagnostics.json")) {
+          return Promise.resolve(
+            JSON.stringify({
+              version: 1,
+              events: {
+                "https://mcp.githits.com": {
+                  reason: "terminal_invalid_refresh_token",
+                  at: "2026-05-27T08:00:00.000Z",
+                },
+              },
+            }),
+          );
+        }
+        return Promise.reject(new Error("File not found"));
+      }),
+    });
+
+    const report = await buildDoctorReport(createDeps({ fs }));
+
+    expect(report.auth.files[0]?.lastClear).toMatchObject({
+      status: "present",
+      value: {
+        reason: "terminal_invalid_refresh_token",
+        at: "2026-05-27T08:00:00.000Z",
+      },
+    });
+    expect(
+      report.recommendations.some(
+        (line) =>
+          line.includes("terminal_invalid_refresh_token") &&
+          line.includes("githits login"),
+      ),
+    ).toBe(true);
+  });
+
   it("reports invalid auth config instead of throwing", async () => {
     const fs = createMockFileSystemService({
       exists: mock((path: string) =>

--- a/src/commands/doctor.test.ts
+++ b/src/commands/doctor.test.ts
@@ -418,6 +418,54 @@ describe("doctor", () => {
     ).toBe(true);
   });
 
+  it("does not throw on a diagnostics file with non-object events", async () => {
+    const fs = createMockFileSystemService({
+      exists: mock((path: string) =>
+        Promise.resolve(path.endsWith("diagnostics.json")),
+      ),
+      readFile: mock((path: string) =>
+        path.endsWith("diagnostics.json")
+          ? Promise.resolve(JSON.stringify({ version: 1, events: null }))
+          : Promise.reject(new Error("File not found")),
+      ),
+    });
+
+    const report = await buildDoctorReport(createDeps({ fs }));
+
+    // events:null fails the file-shape guard, so the file is reported, not crashed.
+    expect(report.auth.files[0]?.lastClear.status).not.toBe("present");
+    expect(
+      report.recommendations.some((line) => line.includes("last clear")),
+    ).toBe(false);
+  });
+
+  it("flags a malformed last-clear event as invalid instead of surfacing it", async () => {
+    const fs = createMockFileSystemService({
+      exists: mock((path: string) =>
+        Promise.resolve(path.endsWith("diagnostics.json")),
+      ),
+      readFile: mock((path: string) =>
+        path.endsWith("diagnostics.json")
+          ? Promise.resolve(
+              JSON.stringify({
+                version: 1,
+                events: {
+                  "https://mcp.githits.com": { reason: "bogus", at: 123 },
+                },
+              }),
+            )
+          : Promise.reject(new Error("File not found")),
+      ),
+    });
+
+    const report = await buildDoctorReport(createDeps({ fs }));
+
+    expect(report.auth.files[0]?.lastClear.status).toBe("invalid");
+    expect(
+      report.recommendations.some((line) => line.includes("last clear")),
+    ).toBe(false);
+  });
+
   it("reports invalid auth config instead of throwing", async () => {
     const fs = createMockFileSystemService({
       exists: mock((path: string) =>

--- a/src/commands/doctor.test.ts
+++ b/src/commands/doctor.test.ts
@@ -439,6 +439,106 @@ describe("doctor", () => {
     ).toBe(false);
   });
 
+  it("suppresses the stale clear recommendation when a newer session exists", async () => {
+    const fs = createMockFileSystemService({
+      exists: mock((path: string) =>
+        Promise.resolve(
+          path.endsWith("diagnostics.json") || path.endsWith("metadata.json"),
+        ),
+      ),
+      readFile: mock((path: string) => {
+        if (path.endsWith("diagnostics.json")) {
+          return Promise.resolve(
+            JSON.stringify({
+              version: 1,
+              events: {
+                "https://mcp.githits.com": {
+                  reason: "terminal_invalid_refresh_token",
+                  at: "2026-05-27T08:00:00.000Z",
+                },
+              },
+            }),
+          );
+        }
+        if (path.endsWith("metadata.json")) {
+          // Session created after the clear — keychain re-login already happened.
+          return Promise.resolve(
+            JSON.stringify({
+              version: 1,
+              sessions: {
+                "https://mcp.githits.com": {
+                  createdAt: "2026-05-27T09:00:00.000Z",
+                  expiresAt: "2026-05-27T13:00:00.000Z",
+                  updatedAt: "2026-05-27T09:00:00.000Z",
+                },
+              },
+            }),
+          );
+        }
+        return Promise.reject(new Error("File not found"));
+      }),
+    });
+
+    const report = await buildDoctorReport(createDeps({ fs }));
+
+    // Breadcrumb still shown, but no stale "run login" recommendation.
+    expect(report.auth.files[0]?.lastClear.status).toBe("present");
+    expect(
+      report.recommendations.some((line) => line.includes("last clear")),
+    ).toBe(false);
+  });
+
+  it("still recommends login when the clear is newer than the session", async () => {
+    const fs = createMockFileSystemService({
+      exists: mock((path: string) =>
+        Promise.resolve(
+          path.endsWith("diagnostics.json") || path.endsWith("metadata.json"),
+        ),
+      ),
+      readFile: mock((path: string) => {
+        if (path.endsWith("diagnostics.json")) {
+          return Promise.resolve(
+            JSON.stringify({
+              version: 1,
+              events: {
+                "https://mcp.githits.com": {
+                  reason: "terminal_invalid_refresh_token",
+                  at: "2026-05-27T10:00:00.000Z",
+                },
+              },
+            }),
+          );
+        }
+        if (path.endsWith("metadata.json")) {
+          // Session predates the clear — credentials were cleared after login.
+          return Promise.resolve(
+            JSON.stringify({
+              version: 1,
+              sessions: {
+                "https://mcp.githits.com": {
+                  createdAt: "2026-05-27T08:00:00.000Z",
+                  expiresAt: "2026-05-27T12:00:00.000Z",
+                  updatedAt: "2026-05-27T08:30:00.000Z",
+                },
+              },
+            }),
+          );
+        }
+        return Promise.reject(new Error("File not found"));
+      }),
+    });
+
+    const report = await buildDoctorReport(createDeps({ fs }));
+
+    expect(
+      report.recommendations.some(
+        (line) =>
+          line.includes("terminal_invalid_refresh_token") &&
+          line.includes("githits login"),
+      ),
+    ).toBe(true);
+  });
+
   it("flags a malformed last-clear event as invalid instead of surfacing it", async () => {
     const fs = createMockFileSystemService({
       exists: mock((path: string) =>

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -19,6 +19,7 @@ import {
   type AuthStorageMode,
   parseAuthStorageMode,
 } from "../services/auth-config.js";
+import { isAuthClearReason } from "../services/auth-diagnostics-storage.js";
 import {
   type ClientRegistration,
   normalizeBaseUrl,
@@ -524,11 +525,22 @@ function metadataProbe(
   return { status: "present", source: "file", value: metadata };
 }
 
-function lastClearProbe(
-  event: StoredDiagnosticsFile["events"][string] | undefined,
-): Probe<{ reason: string; at: string }> {
-  if (!event) return { status: "missing", source: "file" };
-  return { status: "present", source: "file", value: event };
+function lastClearProbe(event: unknown): Probe<{ reason: string; at: string }> {
+  if (event === undefined) return { status: "missing", source: "file" };
+  if (!isRecord(event)) return invalidLastClearProbe();
+  const { reason, at } = event as { reason?: unknown; at?: unknown };
+  if (!isAuthClearReason(reason) || typeof at !== "string" || at.length === 0) {
+    return invalidLastClearProbe();
+  }
+  return { status: "present", source: "file", value: { reason, at } };
+}
+
+function invalidLastClearProbe(): Probe<{ reason: string; at: string }> {
+  return {
+    status: "invalid",
+    source: "file",
+    error: { message: "diagnostics.json has an unrecognized last-clear event" },
+  };
 }
 
 function dependentProbe<T>(file: Probe<unknown>, message: string): Probe<T> {
@@ -904,22 +916,16 @@ function getPathExecutableCandidates(
 }
 
 function isStoredAuthFile(value: unknown): value is StoredAuthFile {
-  return (
-    hasVersionOne(value) && typeof (value as StoredAuthFile).tokens === "object"
-  );
+  return hasVersionOne(value) && isRecord((value as StoredAuthFile).tokens);
 }
 
 function isStoredClientFile(value: unknown): value is StoredClientFile {
-  return (
-    hasVersionOne(value) &&
-    typeof (value as StoredClientFile).clients === "object"
-  );
+  return hasVersionOne(value) && isRecord((value as StoredClientFile).clients);
 }
 
 function isStoredMetadataFile(value: unknown): value is StoredMetadataFile {
   return (
-    hasVersionOne(value) &&
-    typeof (value as StoredMetadataFile).sessions === "object"
+    hasVersionOne(value) && isRecord((value as StoredMetadataFile).sessions)
   );
 }
 
@@ -927,17 +933,17 @@ function isStoredDiagnosticsFile(
   value: unknown,
 ): value is StoredDiagnosticsFile {
   return (
-    hasVersionOne(value) &&
-    typeof (value as StoredDiagnosticsFile).events === "object"
+    hasVersionOne(value) && isRecord((value as StoredDiagnosticsFile).events)
   );
 }
 
 function hasVersionOne(value: unknown): value is { version: 1 } {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    (value as { version?: unknown }).version === 1
-  );
+  return isRecord(value) && (value as { version?: unknown }).version === 1;
+}
+
+/** Plain object check that rejects `null` (which `typeof` reports as object) and arrays. */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 const DOCTOR_DESCRIPTION = `Print redacted diagnostics for GitHits configuration and authentication.

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -581,7 +581,8 @@ function buildRecommendations(report: DoctorReport): string[] {
   if (
     activeAuth?.token.status === "missing" &&
     activeAuth.lastClear.status === "present" &&
-    activeAuth.lastClear.value
+    activeAuth.lastClear.value &&
+    !clearSupersededBySession(activeAuth.lastClear.value, activeAuth.metadata)
   ) {
     recommendations.push(lastClearRecommendation(activeAuth.lastClear.value));
   }
@@ -712,6 +713,32 @@ function lastClearRecommendation(event: {
     default:
       return `Auth was last cleared ${when}. Run \`githits login\` if commands report authentication is required.`;
   }
+}
+
+/**
+ * Whether session metadata indicates a login newer than the recorded clear.
+ *
+ * Keychain-mode tokens are not visible in `auth.json`, so `token.status` is
+ * always "missing" even after a successful re-login. The retained breadcrumb
+ * would otherwise produce a stale "run login" recommendation; a session created
+ * or updated after the clear means the user has already re-authenticated.
+ */
+function clearSupersededBySession(
+  lastClear: { at: string },
+  metadata: Probe<{
+    createdAt: string;
+    expiresAt: string | null;
+    updatedAt: string;
+  }>,
+): boolean {
+  if (metadata.status !== "present" || !metadata.value) return false;
+  const clearMs = Date.parse(lastClear.at);
+  if (Number.isNaN(clearMs)) return false;
+  const sessionTimes = [metadata.value.createdAt, metadata.value.updatedAt]
+    .map((value) => Date.parse(value))
+    .filter((ms) => !Number.isNaN(ms));
+  if (sessionTimes.length === 0) return false;
+  return Math.max(...sessionTimes) > clearMs;
 }
 
 function hasLegacyAuthEvidence(entry: AuthFileProbe): boolean {

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -64,6 +64,7 @@ interface AuthFileProbe {
     expiresAt: string | null;
     updatedAt: string;
   }>;
+  lastClear: Probe<{ reason: string; at: string }>;
 }
 
 export interface DoctorReport {
@@ -153,6 +154,11 @@ interface StoredMetadataFile {
     string,
     { createdAt: string; expiresAt: string | null; updatedAt: string }
   >;
+}
+
+interface StoredDiagnosticsFile {
+  version: 1;
+  events: Record<string, { reason: string; at: string }>;
 }
 
 interface ResolvedAuthConfig {
@@ -422,6 +428,7 @@ async function probeAuthFileDir(
   const authPath = fs.joinPath(dir, "auth.json");
   const clientPath = fs.joinPath(dir, "client.json");
   const metadataPath = fs.joinPath(dir, "metadata.json");
+  const diagnosticsPath = fs.joinPath(dir, "diagnostics.json");
   const normalizedMcpUrl = normalizeBaseUrl(
     env.GITHITS_MCP_URL ?? DEFAULT_MCP_URL,
   );
@@ -439,6 +446,11 @@ async function probeAuthFileDir(
     fs,
     metadataPath,
     isStoredMetadataFile,
+  );
+  const diagnosticsFile = await readJsonFile<StoredDiagnosticsFile>(
+    fs,
+    diagnosticsPath,
+    isStoredDiagnosticsFile,
   );
   const token =
     authFile.status === "present" && authFile.value !== undefined
@@ -462,6 +474,13 @@ async function probeAuthFileDir(
           expiresAt: string | null;
           updatedAt: string;
         }>(metadataFile, "metadata.json could not be read");
+  const lastClear =
+    diagnosticsFile.status === "present" && diagnosticsFile.value !== undefined
+      ? lastClearProbe(diagnosticsFile.value.events[normalizedMcpUrl])
+      : dependentProbe<{ reason: string; at: string }>(
+          diagnosticsFile,
+          "diagnostics.json could not be read",
+        );
 
   return {
     dir,
@@ -472,6 +491,7 @@ async function probeAuthFileDir(
     token,
     client,
     metadata,
+    lastClear,
   };
 }
 
@@ -502,6 +522,13 @@ function metadataProbe(
 ): Probe<{ createdAt: string; expiresAt: string | null; updatedAt: string }> {
   if (!metadata) return { status: "missing", source: "file" };
   return { status: "present", source: "file", value: metadata };
+}
+
+function lastClearProbe(
+  event: StoredDiagnosticsFile["events"][string] | undefined,
+): Probe<{ reason: string; at: string }> {
+  if (!event) return { status: "missing", source: "file" };
+  return { status: "present", source: "file", value: event };
 }
 
 function dependentProbe<T>(file: Probe<unknown>, message: string): Probe<T> {
@@ -537,6 +564,14 @@ function buildRecommendations(report: DoctorReport): string[] {
     recommendations.push(
       "APPDATA is set. Compare `githits doctor --json` between the working and failing environments.",
     );
+  }
+  const activeAuth = report.auth.files[0];
+  if (
+    activeAuth?.token.status === "missing" &&
+    activeAuth.lastClear.status === "present" &&
+    activeAuth.lastClear.value
+  ) {
+    recommendations.push(lastClearRecommendation(activeAuth.lastClear.value));
   }
   if (report.auth.storageMode.value === "file") {
     const active = report.auth.files[0];
@@ -639,6 +674,7 @@ function formatDoctorReport(report: DoctorReport): string {
     lines.push(`    token: ${formatTimedProbe(entry.token)}`);
     lines.push(`    client: ${formatTimedProbe(entry.client)}`);
     lines.push(`    metadata: ${formatTimedProbe(entry.metadata)}`);
+    lines.push(`    last clear: ${formatTimedProbe(entry.lastClear)}`);
   }
   if (report.recommendations.length > 0) {
     lines.push("", "Recommendations:");
@@ -649,6 +685,23 @@ function formatDoctorReport(report: DoctorReport): string {
   return lines.join("\n");
 }
 
+function lastClearRecommendation(event: {
+  reason: string;
+  at: string;
+}): string {
+  const when = `(last clear: ${event.reason} at ${event.at})`;
+  switch (event.reason) {
+    case "terminal_invalid_refresh_token":
+      return `Auth was cleared after refresh-token reuse or expiry ${when}. Run \`githits login\`. If this recurs, another agent or a stale CLI is likely refreshing the same credentials concurrently.`;
+    case "terminal_invalid_client":
+      return `Auth was cleared after the OAuth client registration was rejected ${when}. Run \`githits login\` to re-register.`;
+    case "logout":
+      return `Credentials were removed by \`githits logout\` ${when}. Run \`githits login\` to sign back in.`;
+    default:
+      return `Auth was last cleared ${when}. Run \`githits login\` if commands report authentication is required.`;
+  }
+}
+
 function hasLegacyAuthEvidence(entry: AuthFileProbe): boolean {
   return (
     entry.authFile.status !== "missing" ||
@@ -656,7 +709,8 @@ function hasLegacyAuthEvidence(entry: AuthFileProbe): boolean {
     entry.metadataFile.status !== "missing" ||
     entry.token.status !== "missing" ||
     entry.client.status !== "missing" ||
-    entry.metadata.status !== "missing"
+    entry.metadata.status !== "missing" ||
+    entry.lastClear.status !== "missing"
   );
 }
 
@@ -866,6 +920,15 @@ function isStoredMetadataFile(value: unknown): value is StoredMetadataFile {
   return (
     hasVersionOne(value) &&
     typeof (value as StoredMetadataFile).sessions === "object"
+  );
+}
+
+function isStoredDiagnosticsFile(
+  value: unknown,
+): value is StoredDiagnosticsFile {
+  return (
+    hasVersionOne(value) &&
+    typeof (value as StoredDiagnosticsFile).events === "object"
   );
 }
 

--- a/src/commands/logout.test.ts
+++ b/src/commands/logout.test.ts
@@ -17,6 +17,20 @@ describe("logoutAction", () => {
     consoleSpy.mockRestore();
   });
 
+  it("records a logout diagnostics breadcrumb", async () => {
+    const consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+    const authStorage = createMockAuthStorage();
+    const authDiagnostics = {
+      recordClear: mock(() => Promise.resolve()),
+      load: mock(() => Promise.resolve(null)),
+    };
+
+    await logoutAction({ authStorage, mcpUrl, authDiagnostics });
+
+    expect(authDiagnostics.recordClear).toHaveBeenCalledWith(mcpUrl, "logout");
+    consoleSpy.mockRestore();
+  });
+
   it("clears both tokens and client without checking login state", async () => {
     const consoleSpy = spyOn(console, "log").mockImplementation(() => {});
     const authStorage = createMockAuthStorage();

--- a/src/commands/logout.ts
+++ b/src/commands/logout.ts
@@ -1,11 +1,13 @@
 import { withTelemetrySpan } from "@githits/core-internal";
 import type { Command } from "commander";
 import { createAuthCommandDependencies } from "../container.js";
+import type { AuthDiagnosticsStore } from "../services/auth-diagnostics-storage.js";
 import type { AuthStorage } from "../services/auth-storage.js";
 
 export interface LogoutDependencies {
   authStorage: AuthStorage;
   mcpUrl: string;
+  authDiagnostics?: AuthDiagnosticsStore;
 }
 
 /**
@@ -15,13 +17,14 @@ export interface LogoutDependencies {
  * concurrent MCP servers and login/logout commands cannot observe split state.
  */
 export async function logoutAction(deps: LogoutDependencies): Promise<void> {
-  const { authStorage, mcpUrl } = deps;
+  const { authStorage, mcpUrl, authDiagnostics } = deps;
 
   await withTelemetrySpan(
     "auth.clear",
     () => authStorage.clearAuthSession(mcpUrl),
     { reason: "logout" },
   );
+  await authDiagnostics?.recordClear(mcpUrl, "logout");
 
   console.log("Logged out.");
 }

--- a/src/container.ts
+++ b/src/container.ts
@@ -27,6 +27,10 @@ import {
   type AuthStorageMode,
   loadAuthConfig,
 } from "./services/auth-config.js";
+import {
+  AuthDiagnosticsStorage,
+  type AuthDiagnosticsStore,
+} from "./services/auth-diagnostics-storage.js";
 import { type AuthService, AuthServiceImpl } from "./services/auth-service.js";
 import {
   type AuthSessionMetadata,
@@ -174,6 +178,7 @@ export interface AuthCommandDependencies {
   authService: AuthService;
   browserService: BrowserService;
   fileSystemService: FileSystemService;
+  authDiagnostics: AuthDiagnosticsStore;
   mcpUrl: string;
   apiUrl: string;
   envApiToken: string | undefined;
@@ -187,6 +192,7 @@ export async function createAuthCommandDependencies(): Promise<AuthCommandDepend
       authService: new AuthServiceImpl(),
       browserService: new BrowserServiceImpl(),
       fileSystemService,
+      authDiagnostics: new AuthDiagnosticsStorage(fileSystemService),
       mcpUrl: getMcpUrl(),
       apiUrl: getApiUrl(),
       envApiToken: getEnvApiToken(),
@@ -205,6 +211,7 @@ export async function createAuthStatusDependencies(): Promise<AuthCommandDepende
       authService: new AuthServiceImpl(),
       browserService: new BrowserServiceImpl(),
       fileSystemService,
+      authDiagnostics: new AuthDiagnosticsStorage(fileSystemService),
       mcpUrl: getMcpUrl(),
       apiUrl: getApiUrl(),
       envApiToken,
@@ -331,7 +338,12 @@ export async function createContainer(
 
     // Create token manager for stored auth with auto-refresh
     const authStorage = await createAuthStorage(fileSystemService);
-    const tokenManager = new TokenManager({ authService, authStorage, mcpUrl });
+    const tokenManager = new TokenManager({
+      authService,
+      authStorage,
+      mcpUrl,
+      authDiagnostics: new AuthDiagnosticsStorage(fileSystemService),
+    });
     const apiToken = resolveStoredToken
       ? await withTelemetrySpan("container.token.get", () =>
           tokenManager.getToken(),

--- a/src/services/auth-diagnostics-storage.test.ts
+++ b/src/services/auth-diagnostics-storage.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it, mock } from "bun:test";
+import { AuthDiagnosticsStorage } from "./auth-diagnostics-storage.js";
+import { createMockFileSystemService } from "./test-helpers.js";
+
+describe("AuthDiagnosticsStorage", () => {
+  const BASE_URL = "https://mcp.githits.com";
+
+  it("returns null when the diagnostics file does not exist", async () => {
+    const storage = new AuthDiagnosticsStorage(
+      createMockFileSystemService({
+        exists: mock(() => Promise.resolve(false)),
+      }),
+      "/test/auth",
+    );
+
+    await expect(storage.load(BASE_URL)).resolves.toBeNull();
+  });
+
+  it("records a clear breadcrumb with reason and timestamp", async () => {
+    const fs = createMockFileSystemService({
+      exists: mock(() => Promise.resolve(false)),
+    });
+    const storage = new AuthDiagnosticsStorage(fs, "/test/auth");
+
+    await storage.recordClear(BASE_URL, "terminal_invalid_refresh_token");
+
+    expect(fs.ensureDir).toHaveBeenCalledWith("/test/auth", 0o700);
+    expect(fs.atomicWriteFile).toHaveBeenCalledWith(
+      "/test/auth/diagnostics.json",
+      expect.any(String),
+    );
+    const calls = (fs.atomicWriteFile as ReturnType<typeof mock>).mock.calls;
+    const written = JSON.parse(calls[0]?.[1] as string);
+    expect(written.events[BASE_URL].reason).toBe(
+      "terminal_invalid_refresh_token",
+    );
+    expect(typeof written.events[BASE_URL].at).toBe("string");
+    expect(written.events[BASE_URL].at.length).toBeGreaterThan(0);
+  });
+
+  it("preserves other entries and overwrites the same base URL", async () => {
+    const existing = {
+      version: 1,
+      events: {
+        "https://other.githits.com": {
+          reason: "logout",
+          at: "2026-01-01T00:00:00Z",
+        },
+        [BASE_URL]: {
+          reason: "logout",
+          at: "2026-01-01T00:00:00Z",
+        },
+      },
+    };
+    const fs = createMockFileSystemService({
+      exists: mock(() => Promise.resolve(true)),
+      readFile: mock(() => Promise.resolve(JSON.stringify(existing))),
+    });
+    const storage = new AuthDiagnosticsStorage(fs, "/test/auth");
+
+    await storage.recordClear(BASE_URL, "terminal_invalid_client");
+
+    const calls = (fs.atomicWriteFile as ReturnType<typeof mock>).mock.calls;
+    const written = JSON.parse(calls[0]?.[1] as string);
+    // Same base URL is overwritten with the new reason...
+    expect(written.events[BASE_URL].reason).toBe("terminal_invalid_client");
+    // ...while unrelated entries are retained.
+    expect(written.events["https://other.githits.com"].reason).toBe("logout");
+  });
+
+  it("never deletes the file — retention is the point", async () => {
+    const fs = createMockFileSystemService({
+      exists: mock(() => Promise.resolve(true)),
+      readFile: mock(() =>
+        Promise.resolve(
+          JSON.stringify({
+            version: 1,
+            events: {
+              [BASE_URL]: { reason: "logout", at: "2026-01-01T00:00:00Z" },
+            },
+          }),
+        ),
+      ),
+    });
+    const storage = new AuthDiagnosticsStorage(fs, "/test/auth");
+
+    await storage.recordClear(BASE_URL, "logout");
+
+    expect(fs.deleteFile).not.toHaveBeenCalled();
+  });
+
+  it("loads an event with a normalized base URL", async () => {
+    const stored = {
+      version: 1,
+      events: {
+        [BASE_URL]: { reason: "logout", at: "2026-01-01T00:00:00Z" },
+      },
+    };
+    const storage = new AuthDiagnosticsStorage(
+      createMockFileSystemService({
+        exists: mock(() => Promise.resolve(true)),
+        readFile: mock(() => Promise.resolve(JSON.stringify(stored))),
+      }),
+      "/test/auth",
+    );
+
+    await expect(storage.load(`${BASE_URL}/`)).resolves.toEqual({
+      reason: "logout",
+      at: "2026-01-01T00:00:00Z",
+    });
+  });
+
+  it("returns null for an unrecognized reason value", async () => {
+    const stored = {
+      version: 1,
+      events: {
+        [BASE_URL]: { reason: "not-a-real-reason", at: "2026-01-01T00:00:00Z" },
+      },
+    };
+    const storage = new AuthDiagnosticsStorage(
+      createMockFileSystemService({
+        exists: mock(() => Promise.resolve(true)),
+        readFile: mock(() => Promise.resolve(JSON.stringify(stored))),
+      }),
+      "/test/auth",
+    );
+
+    await expect(storage.load(BASE_URL)).resolves.toBeNull();
+  });
+
+  it("swallows write failures so it never breaks the observed clear path", async () => {
+    const storage = new AuthDiagnosticsStorage(
+      createMockFileSystemService({
+        exists: mock(() => Promise.resolve(false)),
+        atomicWriteFile: mock(() => Promise.reject(new Error("disk full"))),
+      }),
+      "/test/auth",
+    );
+
+    await expect(
+      storage.recordClear(BASE_URL, "logout"),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/services/auth-diagnostics-storage.test.ts
+++ b/src/services/auth-diagnostics-storage.test.ts
@@ -128,6 +128,38 @@ describe("AuthDiagnosticsStorage", () => {
     await expect(storage.load(BASE_URL)).resolves.toBeNull();
   });
 
+  it("treats an array events field as malformed and returns null", async () => {
+    const storage = new AuthDiagnosticsStorage(
+      createMockFileSystemService({
+        exists: mock(() => Promise.resolve(true)),
+        readFile: mock(() =>
+          Promise.resolve(JSON.stringify({ version: 1, events: [] })),
+        ),
+      }),
+      "/test/auth",
+    );
+
+    await expect(storage.load(BASE_URL)).resolves.toBeNull();
+  });
+
+  it("self-heals a malformed array file into a valid object on recordClear", async () => {
+    const fs = createMockFileSystemService({
+      exists: mock(() => Promise.resolve(true)),
+      readFile: mock(() =>
+        Promise.resolve(JSON.stringify({ version: 1, events: [] })),
+      ),
+    });
+    const storage = new AuthDiagnosticsStorage(fs, "/test/auth");
+
+    await storage.recordClear(BASE_URL, "logout");
+
+    const calls = (fs.atomicWriteFile as ReturnType<typeof mock>).mock.calls;
+    const written = JSON.parse(calls[0]?.[1] as string);
+    // The breadcrumb is actually persisted, not dropped onto an array property.
+    expect(Array.isArray(written.events)).toBe(false);
+    expect(written.events[BASE_URL].reason).toBe("logout");
+  });
+
   it("swallows write failures so it never breaks the observed clear path", async () => {
     const storage = new AuthDiagnosticsStorage(
       createMockFileSystemService({

--- a/src/services/auth-diagnostics-storage.ts
+++ b/src/services/auth-diagnostics-storage.ts
@@ -1,0 +1,116 @@
+import { getAuthFileStorageDir } from "./app-config-paths.js";
+import { normalizeBaseUrl } from "./auth-storage.js";
+import type { FileSystemService } from "./filesystem-service.js";
+
+/**
+ * Why auth credentials were last cleared. Enumerated so the value carries no
+ * free-form text and is safe to surface in `githits doctor`.
+ */
+export type AuthClearReason =
+  | "logout"
+  | "terminal_invalid_refresh_token"
+  | "terminal_invalid_client";
+
+export interface AuthClearEvent {
+  reason: AuthClearReason;
+  /** ISO timestamp of when the clear happened. */
+  at: string;
+}
+
+export interface AuthDiagnosticsStore {
+  recordClear(baseUrl: string, reason: AuthClearReason): Promise<void>;
+  load(baseUrl: string): Promise<AuthClearEvent | null>;
+}
+
+interface StoredAuthDiagnostics {
+  version: 1;
+  events: Record<string, AuthClearEvent>;
+}
+
+const DIAGNOSTICS_FILE = "diagnostics.json";
+const DIR_MODE = 0o700;
+const CLEAR_REASONS: ReadonlySet<string> = new Set<AuthClearReason>([
+  "logout",
+  "terminal_invalid_refresh_token",
+  "terminal_invalid_client",
+]);
+
+/**
+ * Persists a non-secret breadcrumb describing why auth credentials were last
+ * cleared, so `githits doctor` can explain a missing token in environments
+ * where ephemeral telemetry is not visible (e.g. an MCP server whose stderr is
+ * swallowed by the host harness).
+ *
+ * Deliberately separate from metadata.json: credential clears wipe metadata, so
+ * a breadcrumb stored there would erase itself. This file is only ever
+ * overwritten by the next event, never cleared. It holds no secrets — only a
+ * reason enum and a timestamp.
+ */
+export class AuthDiagnosticsStorage implements AuthDiagnosticsStore {
+  private readonly configDir: string;
+  private readonly diagnosticsPath: string;
+
+  constructor(
+    private readonly fs: FileSystemService,
+    configDir?: string,
+  ) {
+    this.configDir = configDir ?? getAuthFileStorageDir(fs);
+    this.diagnosticsPath = fs.joinPath(this.configDir, DIAGNOSTICS_FILE);
+  }
+
+  /**
+   * Best-effort: a diagnostics write must never break the logout or refresh
+   * path it observes, so all write failures are swallowed.
+   */
+  async recordClear(baseUrl: string, reason: AuthClearReason): Promise<void> {
+    try {
+      const stored = (await this.loadFile()) ?? {
+        version: 1 as const,
+        events: {},
+      };
+      stored.events[normalizeBaseUrl(baseUrl)] = {
+        reason,
+        at: new Date().toISOString(),
+      };
+
+      await this.fs.ensureDir(this.configDir, DIR_MODE);
+      await this.fs.atomicWriteFile(
+        this.diagnosticsPath,
+        JSON.stringify(stored, null, 2),
+      );
+    } catch {
+      // Diagnostic side-channel; never propagate into the observed clear path.
+    }
+  }
+
+  async load(baseUrl: string): Promise<AuthClearEvent | null> {
+    const stored = await this.loadFile();
+    if (!stored) return null;
+    const event = stored.events[normalizeBaseUrl(baseUrl)] ?? null;
+    return isAuthClearEvent(event) ? event : null;
+  }
+
+  private async loadFile(): Promise<StoredAuthDiagnostics | null> {
+    if (!(await this.fs.exists(this.diagnosticsPath))) return null;
+    try {
+      const content = await this.fs.readFile(this.diagnosticsPath);
+      const data = JSON.parse(content);
+      if (data.version !== 1 || !data.events) return null;
+      return data as StoredAuthDiagnostics;
+    } catch {
+      return null;
+    }
+  }
+}
+
+function isAuthClearEvent(
+  value: AuthClearEvent | null,
+): value is AuthClearEvent {
+  if (value === null || typeof value !== "object") return false;
+  return (
+    typeof value.reason === "string" &&
+    CLEAR_REASONS.has(value.reason) &&
+    typeof value.at === "string" &&
+    value.at.length > 0
+  );
+}

--- a/src/services/auth-diagnostics-storage.ts
+++ b/src/services/auth-diagnostics-storage.ts
@@ -94,13 +94,23 @@ export class AuthDiagnosticsStorage implements AuthDiagnosticsStore {
     if (!(await this.fs.exists(this.diagnosticsPath))) return null;
     try {
       const content = await this.fs.readFile(this.diagnosticsPath);
-      const data = JSON.parse(content);
-      if (data.version !== 1 || !data.events) return null;
-      return data as StoredAuthDiagnostics;
+      const data: unknown = JSON.parse(content);
+      // `events` must be a plain object: an array (or null) is truthy but would
+      // silently drop string-keyed writes in JSON.stringify, so reject it and
+      // let the next recordClear rebuild a fresh, self-healed file.
+      if (!isRecord(data) || data.version !== 1 || !isRecord(data.events)) {
+        return null;
+      }
+      return data as unknown as StoredAuthDiagnostics;
     } catch {
       return null;
     }
   }
+}
+
+/** Plain object check that rejects `null` (which `typeof` reports as object) and arrays. */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 /**

--- a/src/services/auth-diagnostics-storage.ts
+++ b/src/services/auth-diagnostics-storage.ts
@@ -103,13 +103,20 @@ export class AuthDiagnosticsStorage implements AuthDiagnosticsStore {
   }
 }
 
+/**
+ * Whether a value is one of the known clear reasons. Exported so consumers that
+ * read the raw file (e.g. `githits doctor`) validate against the same set.
+ */
+export function isAuthClearReason(value: unknown): value is AuthClearReason {
+  return typeof value === "string" && CLEAR_REASONS.has(value);
+}
+
 function isAuthClearEvent(
   value: AuthClearEvent | null,
 ): value is AuthClearEvent {
   if (value === null || typeof value !== "object") return false;
   return (
-    typeof value.reason === "string" &&
-    CLEAR_REASONS.has(value.reason) &&
+    isAuthClearReason(value.reason) &&
     typeof value.at === "string" &&
     value.at.length > 0
   );

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -28,7 +28,10 @@ export type {
   AuthClearReason,
   AuthDiagnosticsStore,
 } from "./auth-diagnostics-storage.js";
-export { AuthDiagnosticsStorage } from "./auth-diagnostics-storage.js";
+export {
+  AuthDiagnosticsStorage,
+  isAuthClearReason,
+} from "./auth-diagnostics-storage.js";
 export type {
   AuthService,
   BuildAuthUrlParams,

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -24,6 +24,12 @@ export {
   parseAuthStorageMode,
 } from "./auth-config.js";
 export type {
+  AuthClearEvent,
+  AuthClearReason,
+  AuthDiagnosticsStore,
+} from "./auth-diagnostics-storage.js";
+export { AuthDiagnosticsStorage } from "./auth-diagnostics-storage.js";
+export type {
   AuthService,
   BuildAuthUrlParams,
   CallbackResult,

--- a/src/services/token-manager.test.ts
+++ b/src/services/token-manager.test.ts
@@ -182,16 +182,25 @@ describe("TokenManager", () => {
     overrides: {
       authService?: ReturnType<typeof createMockAuthService>;
       authStorage?: ReturnType<typeof createMockAuthStorage>;
+      authDiagnostics?: {
+        recordClear: ReturnType<typeof mock>;
+        load: ReturnType<typeof mock>;
+      };
     } = {},
   ) {
     const authService = overrides.authService ?? createMockAuthService();
     const authStorage = overrides.authStorage ?? createMockAuthStorage();
+    const authDiagnostics = overrides.authDiagnostics ?? {
+      recordClear: mock(() => Promise.resolve()),
+      load: mock(() => Promise.resolve(null)),
+    };
     const manager = new TokenManager({
       authService,
       authStorage,
       mcpUrl: MCP_URL,
+      authDiagnostics,
     });
-    return { manager, authService, authStorage };
+    return { manager, authService, authStorage, authDiagnostics };
   }
 
   describe("getToken", () => {
@@ -312,6 +321,72 @@ describe("TokenManager", () => {
         tokenData,
       );
       expect(authStorage.clearClient).not.toHaveBeenCalled();
+    });
+
+    it("records a diagnostics breadcrumb when refresh-token reuse clears the token", async () => {
+      const tokenData = createValidTokenData({
+        createdAt: new Date(Date.now() - 58 * 60_000).toISOString(),
+        expiresAt: new Date(Date.now() + 2 * 60_000).toISOString(),
+      });
+      const { manager, authDiagnostics } = createTokenManager({
+        authService: createMockAuthService({
+          refreshAccessToken: mock(() =>
+            Promise.reject(
+              new TokenRefreshError(
+                400,
+                JSON.stringify({
+                  error: "invalid_grant",
+                  error_description: "Invalid Refresh Token: Already Used",
+                }),
+              ),
+            ),
+          ),
+        }),
+        authStorage: createMockAuthStorage({
+          loadTokens: mock(() => Promise.resolve(tokenData)),
+          loadClient: mock(() => Promise.resolve(defaultClientRegistration)),
+        }),
+      });
+
+      await manager.getToken();
+
+      expect(authDiagnostics.recordClear).toHaveBeenCalledWith(
+        MCP_URL,
+        "terminal_invalid_refresh_token",
+      );
+    });
+
+    it("records a diagnostics breadcrumb when an invalid client clears the token", async () => {
+      const tokenData = createValidTokenData({
+        createdAt: new Date(Date.now() - 58 * 60_000).toISOString(),
+        expiresAt: new Date(Date.now() + 2 * 60_000).toISOString(),
+      });
+      const { manager, authDiagnostics } = createTokenManager({
+        authService: createMockAuthService({
+          refreshAccessToken: mock(() =>
+            Promise.reject(
+              new TokenRefreshError(
+                400,
+                JSON.stringify({
+                  error: "invalid_client",
+                  error_description: "OAuth client not found",
+                }),
+              ),
+            ),
+          ),
+        }),
+        authStorage: createMockAuthStorage({
+          loadTokens: mock(() => Promise.resolve(tokenData)),
+          loadClient: mock(() => Promise.resolve(defaultClientRegistration)),
+        }),
+      });
+
+      await manager.getToken();
+
+      expect(authDiagnostics.recordClear).toHaveBeenCalledWith(
+        MCP_URL,
+        "terminal_invalid_client",
+      );
     });
 
     it("clears client registration when proactive refresh reports invalid client", async () => {

--- a/src/services/token-manager.ts
+++ b/src/services/token-manager.ts
@@ -1,5 +1,6 @@
 import type { TokenProvider } from "@githits/core-internal";
 import { withTelemetrySpan } from "@githits/core-internal";
+import type { AuthDiagnosticsStore } from "./auth-diagnostics-storage.js";
 import {
   type AuthService,
   classifyTerminalRefreshError,
@@ -25,6 +26,11 @@ export interface TokenManagerDeps {
   authService: AuthService;
   authStorage: LockingAuthStorage;
   mcpUrl: string;
+  /**
+   * Optional diagnostics breadcrumb store. When present, terminal refresh
+   * failures that clear the token record why, so `doctor` can explain it later.
+   */
+  authDiagnostics?: AuthDiagnosticsStore;
 }
 
 interface RefreshResult {
@@ -88,6 +94,7 @@ export class TokenManager implements TokenProvider {
   private readonly authService: AuthService;
   private readonly authStorage: LockingAuthStorage;
   private readonly mcpUrl: string;
+  private readonly authDiagnostics?: AuthDiagnosticsStore;
   private cachedToken: TokenData | null = null;
   private softRefreshPromise: Promise<RefreshResult> | null = null;
   private forceRefreshPromise: Promise<RefreshResult> | null = null;
@@ -96,6 +103,7 @@ export class TokenManager implements TokenProvider {
     this.authService = deps.authService;
     this.authStorage = deps.authStorage;
     this.mcpUrl = deps.mcpUrl;
+    this.authDiagnostics = deps.authDiagnostics;
   }
 
   async getToken(): Promise<string | undefined> {
@@ -388,6 +396,8 @@ export class TokenManager implements TokenProvider {
         { reason: "terminal_invalid_client" },
       ).catch(() => undefined);
     }
+
+    await this.authDiagnostics?.recordClear(this.mcpUrl, `terminal_${reason}`);
 
     this.cachedToken = null;
     return refreshResult(undefined, false, true);


### PR DESCRIPTION
## Summary

Fast-follow to #165. Adds the only auth diagnostic that reaches an external user: persisted state surfaced by `githits doctor`. Opt-in stderr telemetry is invisible to users running the MCP server, so a missing token previously had no explanation in a support report.

## What it does

- **`AuthDiagnosticsStorage`** persists the last auth-clear `{ reason, at }` to `auth/diagnostics.json`, keyed by MCP URL. Writes are best-effort (failures swallowed) so a diagnostics write can never break the path it observes.
- **Write sites:** `logout` (`logout`) and `TokenManager` terminal refresh failures (`terminal_invalid_refresh_token`, `terminal_invalid_client`), wired through the container.
- **`doctor`** renders `last clear: ...` and, when the active token is missing, adds a cause-specific recommendation (refresh-token reuse/expiry, rejected client registration, or explicit logout).

## Design constraints

- The breadcrumb lives **separately from `metadata.json`** because credential clears wipe metadata — a breadcrumb stored there would erase itself. It is only ever overwritten by the next event, never cleared.
- Holds **no secrets** — a reason enum and an ISO timestamp, keyed by MCP URL.
- Keyed per MCP URL: a user on a non-default `GITHITS_MCP_URL` records/reads under that key (so does `doctor`).

## Testing

- `bun test` — full suite green (new: diagnostics storage unit tests, token-manager breadcrumb-on-terminal-clear, logout breadcrumb, doctor surfacing + recommendation)
- `bun run typecheck` — clean
- `bun run smoke:cli` / `bun run smoke:mcp` — both pass
- Verified live: with a populated `diagnostics.json` and a missing token, `doctor` renders `last clear: present (reason=terminal_invalid_refresh_token, ...)` and emits the matching recommendation.

## Follow-on note

This makes future lockout reports self-explaining, but does not retroactively help the original reporter until they hit another clear under the instrumented build. Combined with #164/#165, the next `doctor` from an affected user should finally show *why* their token went missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)