### PR TITLE
chore: release 0.4.14

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "GitHits plugins for Claude Code - code examples from global open source",
-    "version": "0.4.13"
+    "version": "0.4.14"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "description": "Code examples from global open source for developers and AI assistants",
   "author": {
     "name": "GitHits"

--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "description": "Code examples from global open source for developers and AI assistants",
   "author": {
     "name": "GitHits"

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "description": "Code examples from global open source for developers and AI assistants.",
   "mcpServers": {
     "githits": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "githits",
   "description": "CLI companion for GitHits - code examples from global open source for developers and AI assistants",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "type": "module",
   "workspaces": [
     "packages/*"

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "description": "Code examples from global open source for developers and AI assistants",
   "author": {
     "name": "GitHits"


### PR DESCRIPTION
## Summary

Patch release bump to **0.4.14** across all package and plugin manifests, with the branch brought up to `main` to include the latest auth/doctor fixes.

### Version bump (0.4.13 → 0.4.14)
- `package.json`
- `.plugin/plugin.json`
- `.claude-plugin/plugin.json`
- `plugins/claude/.claude-plugin/plugin.json`
- `.claude-plugin/marketplace.json`
- `gemini-extension.json`

### Included since v0.4.13 (already merged to main)
- **Auth-clear breadcrumb**: persist last auth-clear `{reason, at}` and surface it in `githits doctor` (#166, #168)
- Retry auth lock owner write races
- Harden `doctor` against malformed auth JSON / array events
- Suppress stale clear recommendation after keychain re-login
- Auth-clear attribution + startup auth fingerprint telemetry; isolate auth storage classes
- Prevent auth refresh token reuse races
- Windows path launcher handling + CI test matrix
- Map missing git refs separately (`REF_NOT_FOUND` hint)

## Verification
- `plugin-version-consistency.test.ts` passes (all six manifests aligned)
- `bun run build` succeeds
- Coverage check on changed surface: `auth-diagnostics-storage.ts` 100%, `token-manager.ts` 100% lines, `doctor.ts` ~83% lines, `REF_NOT_FOUND` hint covered via `read.test.ts`. No meaningful gaps — remaining uncovered lines are commander registration glue and `doctor` formatting branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)