### PR TITLE
chore: release 0.4.15

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "GitHits plugins for Claude Code - code examples from global open source",
-    "version": "0.4.14"
+    "version": "0.4.15"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "description": "Code examples from global open source for developers and AI assistants",
   "author": {
     "name": "GitHits"

--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "description": "Code examples from global open source for developers and AI assistants",
   "author": {
     "name": "GitHits"

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "description": "Code examples from global open source for developers and AI assistants.",
   "mcpServers": {
     "githits": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "githits",
   "description": "CLI companion for GitHits - code examples from global open source for developers and AI assistants",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "type": "module",
   "workspaces": [
     "packages/*"

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "description": "Code examples from global open source for developers and AI assistants",
   "author": {
     "name": "GitHits"


### PR DESCRIPTION
## Summary

Patch release **0.4.15**. Bumps the version across all six release manifests (`package.json`, `.plugin/plugin.json`, `.claude-plugin/plugin.json`, `plugins/claude/.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `gemini-extension.json`).

## Changes since v0.4.14

- **fix: scope automatic auth clears to the active storage backend** (#169) — Automatic refresh-failure cleanup and login's client re-registration cleanup now clear only the active storage backend class, never the inactive one. A stale credential in an inactive backend (e.g. a leftover keychain token) could previously wipe the good credential in the mode the user actually runs, surfacing as a recurring logout. Explicit `logout` still clears every backend.

## Documentation

`docs/implementation/auth.md` was updated in the same fix commit and accurately reflects the active-backend-scoped clear behavior, including the new "Logged out after running in a different storage mode" troubleshooting entry. No public `skills/` updates needed — the change is auth-storage-internal with no CLI/MCP surface change.

## Verification

- `bun test src/plugin-version-consistency.test.ts` — pass
- `bun run build` — clean

Merging to main triggers the Release workflow, which auto-creates the `v0.4.15` tag and publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)