### PR TITLE
feat: report per-tool config changes in init and unify uninstall UX

### DIFF
--- a/docs/implementation/init-setup-output.md
+++ b/docs/implementation/init-setup-output.md
@@ -1,0 +1,82 @@
+# Init setup/uninstall change reporting
+
+How `init` and `init uninstall` report, per coding tool, what changed during
+configuration. Implements GitHub issue #156 and the uninstall UX unification.
+
+## Goal
+
+Make setup auditable: each tool row shows the config file path with a
+created/updated/unchanged verb, or the command(s) run for CLI-configured tools.
+Install and uninstall share one renderer and read consistently.
+
+## Pieces
+
+- `src/commands/init/setup-format.ts` — pure, IO-free, unit-tested:
+  - `SetupChange` / `UninstallChange` — structured per-target changes. The verb
+    describes the action **actually taken** on the target, so config files and
+    commands read consistently across install/uninstall. Config-file verbs:
+    `created` | `updated` | `unchanged`. Command verbs: `ran` | `unchanged`.
+    Uninstall never deletes a shared config file — it strips the GitHits entry
+    and rewrites the file, so that is an `updated`, not a `removed`. A command
+    is `ran`, never `removed`.
+  - `ChangeRow` + `renderChangeRows` — the shared display unit. Fixed-width
+    columns; padding is applied to raw text **before** color so ANSI codes never
+    corrupt alignment. Column widths are caller-supplied (`CHANGE_VERB_WIDTH` +
+    a label width computed from the known agent list) because rows print
+    incrementally inside a per-agent loop.
+  - `formatConfigPath` — collapses home → `~` and cwd → `./`, choosing the
+    **longest** matching prefix (a repo under home renders `./…`, not `~/…`).
+    Windows-like prefixes match case-insensitively while preserving display
+    casing.
+  - `describeConfigAsUnchanged` — maps a `SetupConfig` to `unchanged` changes
+    without executing, for already-configured tools and pre-skipped composite
+    steps.
+
+- `src/commands/init/setup-handlers.ts` — executors emit the change data:
+  - `executeConfigFileSetup`: `created` when the file was absent, `updated` when
+    it pre-existed (even if empty), `unchanged` when already configured.
+  - `executeCliSetup`: one change per command (`ran` / `unchanged`), so
+    multi-command setups (e.g. Claude Code) report each step.
+  - `executeCompositeSetup`: concatenates executed-step changes with
+    synthesized `unchanged` changes for pre-skipped steps (so Pi shows all
+    sub-steps).
+  - Uninstall executors mirror this: config-file `updated` (entry stripped, file
+    kept) / `unchanged`, one `ran` / `unchanged` change per CLI command,
+    composite concatenation. Partial changes and warnings are preserved when a
+    later step fails.
+
+- `src/commands/init/init.ts` — threads changes onto `AgentOutcome` /
+  `AgentUninstallOutcome` (so they also appear in `--install-agents --json`),
+  renders them via `renderChangeRows`, and preserves changes through
+  verification failure (the written path/command stays visible under a `failed`
+  row). A trailing summary confirms the server: `Configured MCP server "githits"
+  with local command \`npx -y githits@latest mcp start\`` (wording reflects
+  whether anything was actually installed; the command is muted inline so it
+  does not read as something to run).
+
+## Uninstall UX
+
+User uninstall uses the same selection model as install: configured tools are
+pre-checked in a multiselect, the user deselects the ones to keep, and the
+selection itself is the consent — no per-agent or final confirmation (reinstall
+is easy). `--yes` / non-interactive removes from all configured tools. Results
+render with the shared row format — config-file tools show `updated <path>`
+(the entry is stripped, the file kept), CLI tools show `ran <command>`.
+
+`uninstallSelectedAgents` mirrors `installSelectedAgents`. Every uninstall verb
+uses the ok tone (green ✓): for uninstall the desired end state is "GitHits
+absent", which holds whether we just edited a file, ran a command, or found it
+already gone (`unchanged`).
+
+Project uninstall (`init uninstall --project`) is file-based (it dedupes config
+paths across project-supported tools) and uses a single confirmation, not the
+per-agent prompt. It already shows the affected paths and is intentionally left
+on its own rendering path.
+
+## Conventions
+
+- Config-file tools show a path; CLI-configured tools (Claude Code, Codex,
+  Gemini at user scope) show the command — never a fabricated path. In project
+  scope Claude Code and Codex are config-file and do show paths.
+- `format: json` / `--json` carry the structured `changes`; the friendly
+  trailing block is text-only.

--- a/src/commands/init/agent-definitions.ts
+++ b/src/commands/init/agent-definitions.ts
@@ -87,7 +87,8 @@ export type UninstallConfig = UninstallStep | CompositeUninstall;
 export const GITHITS_SERVER_NAME = "GitHits";
 const GITHITS_MCP_COMMAND = "npx";
 const GITHITS_MCP_ARGS = ["-y", "githits@latest", "mcp", "start"] as const;
-const GITHITS_MCP_INVOCATION = [
+/** The canonical GitHits MCP launch invocation, e.g. for setup summaries. */
+export const GITHITS_MCP_INVOCATION = [
   GITHITS_MCP_COMMAND,
   ...GITHITS_MCP_ARGS,
 ] as const;

--- a/src/commands/init/index.ts
+++ b/src/commands/init/index.ts
@@ -26,8 +26,6 @@ export {
   executeCliUninstall,
   executeConfigFileSetup,
   executeConfigFileUninstall,
-  formatSetupPreview,
-  formatUninstallPreview,
   getConfigUninstallCheckStatus,
   hasServerConfigEntry,
   isConfiguredForUninstall,

--- a/src/commands/init/init.test.ts
+++ b/src/commands/init/init.test.ts
@@ -3209,7 +3209,8 @@ describe("initUninstallAction", () => {
       logCalls.some(
         (msg) =>
           msg.includes("GitHits project config") &&
-          msg.includes("removed from /repo/.mcp.json"),
+          msg.includes("updated") &&
+          msg.includes("./.mcp.json"),
       ),
     ).toBe(true);
   });
@@ -3601,6 +3602,14 @@ describe("initUninstallAction", () => {
     expect(
       logCalls.some((msg) =>
         msg.includes("Removed legacy GitHits project setup marker"),
+      ),
+    ).toBe(true);
+    expect(
+      logCalls.some(
+        (msg) =>
+          msg.includes("Legacy project setup marker") &&
+          msg.includes("updated") &&
+          msg.includes("./.githits/init/project-setup.json"),
       ),
     ).toBe(true);
     expect(

--- a/src/commands/init/init.test.ts
+++ b/src/commands/init/init.test.ts
@@ -1591,24 +1591,36 @@ describe("initAction", () => {
     expect(logCalls.some((msg) => msg.includes("already configured"))).toBe(
       true,
     );
+    expect(
+      logCalls.some(
+        (msg) =>
+          msg.includes("Cursor") &&
+          msg.includes("unchanged") &&
+          msg.includes("~/.cursor/mcp.json"),
+      ),
+    ).toBe(true);
     expectReadyNextSteps(logCalls);
   });
 
   it("handles mixed status: configured + unconfigured", async () => {
     // Cursor configured, windsurf not configured
+    const configFiles: Record<string, string> = {
+      "/home/test/.cursor/mcp.json": JSON.stringify({
+        mcpServers: {
+          GitHits: {
+            command: "npx",
+            args: ["-y", "githits@latest", "mcp", "start"],
+          },
+        },
+      }),
+    };
     const fs = createFsWithDetection(
       ["/home/test/.cursor", "/home/test/.codeium/windsurf"],
-      {
-        "/home/test/.cursor/mcp.json": JSON.stringify({
-          mcpServers: {
-            GitHits: {
-              command: "npx",
-              args: ["-y", "githits@latest", "mcp", "start"],
-            },
-          },
-        }),
-      },
+      configFiles,
     );
+    fs.atomicWriteFile = mock(async (path: string, content: string) => {
+      configFiles[path] = content;
+    }) as typeof fs.atomicWriteFile;
     const promptService = createMockPromptService();
 
     await initAction(
@@ -1636,6 +1648,69 @@ describe("initAction", () => {
         (msg) => msg.includes("Windsurf") && msg.includes("needs setup"),
       ),
     ).toBe(true);
+    expect(
+      logCalls.some(
+        (msg) =>
+          msg.includes("Cursor") &&
+          msg.includes("unchanged") &&
+          msg.includes("~/.cursor/mcp.json"),
+      ),
+    ).toBe(true);
+    expect(
+      logCalls.some(
+        (msg) =>
+          msg.includes("Windsurf") &&
+          msg.includes("created") &&
+          msg.includes("~/.codeium/windsurf/mcp_config.json"),
+      ),
+    ).toBe(true);
+  });
+
+  it("shows already-configured rows when no new tools are selected", async () => {
+    const fs = createFsWithDetection(
+      ["/home/test/.cursor", "/home/test/.codeium/windsurf"],
+      {
+        "/home/test/.cursor/mcp.json": JSON.stringify({
+          mcpServers: {
+            GitHits: {
+              command: "npx",
+              args: ["-y", "githits@latest", "mcp", "start"],
+            },
+          },
+        }),
+      },
+    );
+    const promptService = createMockPromptService({
+      checkbox: mock(() => Promise.resolve([])) as PromptService["checkbox"],
+    });
+
+    await initAction(
+      {},
+      {
+        fileSystemService: fs,
+        promptService,
+        execService: createMockExecService(),
+        createLoginDeps: createAlreadyAuthLoginDeps(),
+      },
+    );
+
+    expect(fs.atomicWriteFile).not.toHaveBeenCalled();
+    const logCalls = getLogOutput();
+    expect(logCalls.some((msg) => msg.includes("Setup skipped"))).toBe(true);
+    expect(
+      logCalls.some(
+        (msg) =>
+          msg.includes("Cursor") &&
+          msg.includes("unchanged") &&
+          msg.includes("~/.cursor/mcp.json"),
+      ),
+    ).toBe(true);
+    expect(
+      logCalls.some(
+        (msg) => msg.includes("Windsurf") && msg.includes("created"),
+      ),
+    ).toBe(false);
+    expectReadyNextSteps(logCalls);
   });
 
   it("configures only the agents selected in the checkbox", async () => {
@@ -2056,7 +2131,7 @@ describe("initAction", () => {
     ).toBe(true);
   });
 
-  it("--yes with all agents already configured shows nothing to do", async () => {
+  it("--yes with all agents already configured shows unchanged paths", async () => {
     const fs = createFsWithDetection(["/home/test/.cursor"], {
       "/home/test/.cursor/mcp.json": JSON.stringify({
         mcpServers: {
@@ -2080,6 +2155,17 @@ describe("initAction", () => {
 
     const logCalls = getLogOutput();
     expectReadyNextSteps(logCalls);
+    expect(
+      logCalls.some(
+        (msg) =>
+          msg.includes("Cursor") &&
+          msg.includes("unchanged") &&
+          msg.includes("~/.cursor/mcp.json"),
+      ),
+    ).toBe(true);
+    expect(logCalls.some((msg) => msg.includes("Nothing to install"))).toBe(
+      false,
+    );
     // The MCP server is still confirmed, with already-configured wording.
     expect(
       logCalls.some((msg) =>

--- a/src/commands/init/init.test.ts
+++ b/src/commands/init/init.test.ts
@@ -1224,8 +1224,23 @@ describe("initAction", () => {
     );
 
     expect(fs.atomicWriteFile).not.toHaveBeenCalled();
+    // Already-configured targets render an "unchanged" row pointing at the
+    // existing config file rather than rewriting it.
+    const logCalls = getLogOutput();
     expect(
-      getLogOutput().some((msg) => msg.includes("already configured")),
+      logCalls.some(
+        (msg) =>
+          msg.includes("unchanged") && msg.includes("~/.cursor/mcp.json"),
+      ),
+    ).toBe(true);
+    // Nothing was installed this run, so we must not claim we configured it now.
+    expect(
+      logCalls.some((msg) => msg.includes('Configured MCP server "githits"')),
+    ).toBe(false);
+    expect(
+      logCalls.some((msg) =>
+        msg.includes('MCP server "githits" already configured'),
+      ),
     ).toBe(true);
   });
 
@@ -1279,6 +1294,106 @@ describe("initAction", () => {
     expect(payload.outcomes[0].status).toBe("failed");
     expect(payload.auth.required).toBe(false);
     expect(JSON.stringify(payload)).not.toContain("githits@latest login");
+  });
+
+  it("shows a created row, collapsed path, and the MCP server block", async () => {
+    // A store so the post-setup verification scan sees what was written.
+    const store: Record<string, string> = {};
+    const fs = createFsWithDetection(["/home/test/.cursor"], store);
+    fs.atomicWriteFile = mock(async (path: string, content: string) => {
+      store[path] = content;
+    }) as typeof fs.atomicWriteFile;
+
+    await initAction(
+      { installAgents: "cursor" },
+      {
+        fileSystemService: fs,
+        promptService: createMockPromptService(),
+        execService: createMockExecService(),
+        createLoginDeps: createAlreadyAuthLoginDeps(),
+      },
+    );
+
+    const logCalls = getLogOutput();
+    // Per-client row: verb + home-collapsed path (not the old fixed wording).
+    expect(
+      logCalls.some(
+        (msg) => msg.includes("created") && msg.includes("~/.cursor/mcp.json"),
+      ),
+    ).toBe(true);
+    expect(
+      logCalls.some((msg) => msg.includes("configured and verified")),
+    ).toBe(false);
+    // Trailing MCP server confirmation on the human text path: states that the
+    // server was configured and shows the launch command inline.
+    expect(
+      logCalls.some(
+        (msg) =>
+          msg.includes('Configured MCP server "githits"') &&
+          msg.includes("npx -y githits@latest mcp start"),
+      ),
+    ).toBe(true);
+  });
+
+  it("includes structured changes in --install-agents --json output", async () => {
+    const store: Record<string, string> = {};
+    const fs = createFsWithDetection(["/home/test/.cursor"], store);
+    fs.atomicWriteFile = mock(async (path: string, content: string) => {
+      store[path] = content;
+    }) as typeof fs.atomicWriteFile;
+
+    await initAction(
+      { installAgents: "cursor", json: true },
+      {
+        fileSystemService: fs,
+        promptService: createMockPromptService(),
+        execService: createMockExecService(),
+        createLoginDeps: createAlreadyAuthLoginDeps(),
+      },
+    );
+
+    const payload = JSON.parse(getLogOutput()[0] ?? "{}");
+    expect(payload.outcomes[0].status).toBe("success");
+    expect(payload.outcomes[0].changes).toEqual([
+      {
+        kind: "config-file",
+        path: "/home/test/.cursor/mcp.json",
+        change: "created",
+      },
+    ]);
+    // The friendly MCP block is text-only; it must not leak into JSON.
+    expect(JSON.stringify(payload)).not.toContain("with local command");
+  });
+
+  it("keeps the written path visible when verification fails", async () => {
+    // The write "succeeds" but persists an entry without GitHits, so the
+    // post-setup verification scan fails — the created path must still show.
+    const fs = createFsWithDetection(["/home/test/.cursor"]);
+    fs.atomicWriteFile = mock(async () => {
+      // Intentionally do not persist a usable GitHits entry.
+    }) as typeof fs.atomicWriteFile;
+
+    await initAction(
+      { installAgents: "cursor" },
+      {
+        fileSystemService: fs,
+        promptService: createMockPromptService(),
+        execService: createMockExecService(),
+        createLoginDeps: createAlreadyAuthLoginDeps(),
+      },
+    );
+
+    const logCalls = getLogOutput();
+    expect(process.exitCode).toBe(1);
+    // The created path is still shown, alongside a failed row.
+    expect(logCalls.some((msg) => msg.includes("~/.cursor/mcp.json"))).toBe(
+      true,
+    );
+    expect(logCalls.some((msg) => msg.includes("failed"))).toBe(true);
+    // No success confirmation block when verification failed.
+    expect(logCalls.some((msg) => msg.includes("with local command"))).toBe(
+      false,
+    );
   });
 
   it("rejects unknown staged install IDs before writing", async () => {
@@ -1965,6 +2080,15 @@ describe("initAction", () => {
 
     const logCalls = getLogOutput();
     expectReadyNextSteps(logCalls);
+    // The MCP server is still confirmed, with already-configured wording.
+    expect(
+      logCalls.some((msg) =>
+        msg.includes('MCP server "githits" already configured'),
+      ),
+    ).toBe(true);
+    expect(logCalls.some((msg) => msg.includes("Configured MCP server"))).toBe(
+      false,
+    );
   });
 
   it("treats equivalent local npx @latest configs as already configured", async () => {
@@ -3592,9 +3716,8 @@ describe("initUninstallAction", () => {
         currentConfig = content;
       },
     );
-    const promptService = createMockPromptService({
-      confirm3: mock(() => Promise.resolve("yes" as ConfirmChoice)),
-    });
+    // Default checkbox mock selects all pre-checked (configured) tools.
+    const promptService = createMockPromptService();
 
     await initUninstallAction(
       {},
@@ -3605,8 +3728,9 @@ describe("initUninstallAction", () => {
       },
     );
 
-    expect(promptService.confirm3).toHaveBeenCalledTimes(1);
-    expect(promptService.confirm3).toHaveBeenCalledWith("Proceed?", "no");
+    // The selection checkbox is the consent — no per-agent confirm prompt.
+    expect(promptService.checkbox).toHaveBeenCalledTimes(1);
+    expect(promptService.confirm3).not.toHaveBeenCalled();
     expect(fs.atomicWriteFile).toHaveBeenCalledTimes(1);
     const parsed = JSON.parse(currentConfig);
     expect(parsed.mcpServers.GitHits).toBeUndefined();
@@ -3742,8 +3866,9 @@ describe("initUninstallAction", () => {
         },
       }),
     });
+    // Deselecting everything in the checkbox keeps all tools.
     const promptService = createMockPromptService({
-      confirm3: mock(() => Promise.resolve("no" as ConfirmChoice)),
+      checkbox: mock(() => Promise.resolve([])) as PromptService["checkbox"],
     });
 
     await initUninstallAction(
@@ -3762,7 +3887,7 @@ describe("initUninstallAction", () => {
     );
   });
 
-  it("stops prompting after always response", async () => {
+  it("removes all selected tools without per-agent prompts", async () => {
     let cursorConfig = JSON.stringify({
       mcpServers: {
         GitHits: {
@@ -3793,20 +3918,83 @@ describe("initUninstallAction", () => {
         }
       },
     );
-    const confirm3 = mock(() => Promise.resolve("always" as ConfirmChoice));
+    // Default checkbox selects both pre-checked configured tools.
+    const promptService = createMockPromptService();
 
     await initUninstallAction(
       {},
       {
         fileSystemService: fs,
-        promptService: createMockPromptService({ confirm3 }),
+        promptService,
         execService: createMockExecService(),
       },
     );
 
-    expect(confirm3).toHaveBeenCalledTimes(1);
-    expect(confirm3).toHaveBeenCalledWith("Proceed?", "no");
+    expect(promptService.checkbox).toHaveBeenCalledTimes(1);
+    expect(promptService.confirm3).not.toHaveBeenCalled();
     expect(fs.atomicWriteFile).toHaveBeenCalledTimes(2);
+  });
+
+  it("removes only the tools left selected in the checkbox", async () => {
+    const githits = JSON.stringify({
+      mcpServers: {
+        GitHits: {
+          command: "npx",
+          args: ["-y", "githits@latest", "mcp", "start"],
+        },
+      },
+    });
+    const writes: string[] = [];
+    const fs = createFsWithDetection([
+      "/home/test/.cursor",
+      "/home/test/.codeium/windsurf",
+    ]);
+    (fs.readFile as ReturnType<typeof mock>).mockImplementation(
+      async (path: string) => {
+        if (
+          path === "/home/test/.cursor/mcp.json" ||
+          path === "/home/test/.codeium/windsurf/mcp_config.json"
+        ) {
+          return githits;
+        }
+        throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+      },
+    );
+    (fs.atomicWriteFile as ReturnType<typeof mock>).mockImplementation(
+      async (path: string) => {
+        writes.push(path);
+      },
+    );
+    // Keep Windsurf by leaving only Cursor checked.
+    const promptService = createMockPromptService({
+      checkbox: mock(<T>(_m: string, choices: { value: T }[]) =>
+        Promise.resolve(
+          choices
+            .map((c) => c.value)
+            .filter((v): v is T => (v as { id?: string }).id === "cursor"),
+        ),
+      ) as PromptService["checkbox"],
+    });
+
+    await initUninstallAction(
+      {},
+      {
+        fileSystemService: fs,
+        promptService,
+        execService: createMockExecService(),
+      },
+    );
+
+    expect(writes).toEqual(["/home/test/.cursor/mcp.json"]);
+    const logCalls = getLogOutput();
+    expect(
+      logCalls.some(
+        (msg) =>
+          msg.includes("Cursor") &&
+          msg.includes("updated") &&
+          msg.includes("~/.cursor/mcp.json"),
+      ),
+    ).toBe(true);
   });
 
   it("removes configured CLI agents with verified commands", async () => {
@@ -3927,7 +4115,9 @@ describe("initUninstallAction", () => {
     expect(fs.atomicWriteFile).toHaveBeenCalledTimes(1);
     expect(JSON.parse(piConfig).mcpServers.GitHits).toBeUndefined();
     const logCalls = getLogOutput();
-    expect(logCalls.some((msg) => msg.includes("Pi removed"))).toBe(true);
+    expect(
+      logCalls.some((msg) => msg.includes("Pi") && msg.includes("updated")),
+    ).toBe(true);
   });
 
   it("uses resolved Pi fallback executable for uninstall", async () => {
@@ -4123,7 +4313,9 @@ describe("initUninstallAction", () => {
     expect(fs.atomicWriteFile).toHaveBeenCalledTimes(1);
     expect(JSON.parse(piConfig).mcpServers.GitHits).toBeUndefined();
     const logCalls = getLogOutput();
-    expect(logCalls.some((msg) => msg.includes("Pi removed"))).toBe(true);
+    expect(
+      logCalls.some((msg) => msg.includes("Pi") && msg.includes("updated")),
+    ).toBe(true);
     expect(logCalls.some((msg) => msg.includes("Pi — not detected"))).toBe(
       false,
     );
@@ -4233,9 +4425,11 @@ describe("initUninstallAction", () => {
     );
 
     const logCalls = getLogOutput();
-    expect(logCalls.some((msg) => msg.includes("Claude Code removed"))).toBe(
-      true,
-    );
+    expect(
+      logCalls.some(
+        (msg) => msg.includes("Claude Code") && msg.includes("ran"),
+      ),
+    ).toBe(true);
     expect(logCalls.some((msg) => msg.includes("Warning:"))).toBe(true);
     expect(
       logCalls.some((msg) => msg.includes("Uninstall completed with errors")),
@@ -4466,6 +4660,19 @@ describe("initUninstallAction", () => {
     ).toBe(true);
     expect(logCalls.some((msg) => msg.includes("Warning:"))).toBe(true);
     expect(logCalls.some((msg) => msg.includes("boom"))).toBe(true);
+    // The command that did run stays visible even though verification failed.
+    expect(
+      logCalls.some(
+        (msg) =>
+          msg.includes("ran") &&
+          msg.includes("claude plugin uninstall githits"),
+      ),
+    ).toBe(true);
+    expect(
+      logCalls.some(
+        (msg) => msg.includes("Claude Code") && msg.includes("failed"),
+      ),
+    ).toBe(true);
   });
 
   it("fails verification when CLI agent is not detected after uninstall", async () => {
@@ -4641,7 +4848,7 @@ describe("initUninstallAction", () => {
     expect(logCalls.some((msg) => msg.includes("- Codex CLI:"))).toBe(true);
   });
 
-  it("handles Ctrl+C on confirm prompt gracefully", async () => {
+  it("handles Ctrl+C on the selection prompt gracefully", async () => {
     const fs = createFsWithDetection(["/home/test/.cursor"], {
       "/home/test/.cursor/mcp.json": JSON.stringify({
         mcpServers: {
@@ -4653,9 +4860,9 @@ describe("initUninstallAction", () => {
       }),
     });
     const promptService = createMockPromptService({
-      confirm3: mock(() =>
+      checkbox: mock(() =>
         Promise.reject(new ExitPromptError("User force closed")),
-      ),
+      ) as PromptService["checkbox"],
     });
 
     await initUninstallAction(

--- a/src/commands/init/init.ts
+++ b/src/commands/init/init.ts
@@ -17,7 +17,6 @@ import type { FileSystemService } from "../../services/filesystem-service.js";
 import { FileSystemServiceImpl } from "../../services/filesystem-service.js";
 import type {
   CheckboxChoice,
-  ConfirmChoice,
   PromptService,
   SelectChoice,
 } from "../../services/prompt-service.js";
@@ -32,6 +31,7 @@ import {
   type AgentDefinition,
   agentDefinitions,
   type ConfigFileSetup,
+  GITHITS_MCP_INVOCATION,
   getAgentSetupConfig,
   type InitSetupScope,
   isGeminiExtensionInstalledFromFilesystem,
@@ -41,13 +41,21 @@ import {
   scanAgents,
 } from "./agent-definitions.js";
 import {
+  CHANGE_VERB_WIDTH,
+  type ChangeRow,
+  describeConfigAsUnchanged,
+  formatConfigPath,
+  renderChangeRows,
+  type SetupChange,
+  type UninstallChange,
+} from "./setup-format.js";
+import {
   executeCliSetup,
   executeCliUninstall,
   executeCompositeSetup,
   executeCompositeUninstall,
   executeConfigFileSetup,
   executeConfigFileUninstall,
-  formatUninstallPreview,
   getCliCheckStatus,
   getConfigUninstallCheckStatus,
   type SetupResult,
@@ -98,6 +106,8 @@ interface AgentOutcome {
   name: string;
   status: "success" | "already_configured" | "failed" | "skipped";
   message?: string;
+  /** Paths written / commands run, for display and `--json` auditing. */
+  changes?: SetupChange[];
 }
 
 type StagedAgentStatus =
@@ -117,9 +127,11 @@ interface StagedAgentEntry {
 interface AgentUninstallOutcome {
   id: string;
   name: string;
-  status: "removed" | "not_configured" | "failed" | "skipped";
+  status: "removed" | "not_configured" | "failed";
   message?: string;
   warnings?: string[];
+  /** Paths/commands removed or found already absent, for display. */
+  changes?: UninstallChange[];
 }
 
 type UninstallInspectionResult =
@@ -1428,9 +1440,16 @@ async function runInstallAgentsMode(
     return;
   }
 
+  const installedAny = outcomes.some((outcome) => outcome.status === "success");
   console.log();
   if (failed.length === 0) {
-    console.log("GitHits MCP installation complete.");
+    console.log(
+      installedAny
+        ? "GitHits MCP installation complete."
+        : "GitHits MCP was already configured.",
+    );
+    console.log();
+    printMcpServerSummary(useColors, installedAny);
   } else {
     console.log("GitHits MCP installation completed with errors.");
     for (const outcome of failed) {
@@ -1972,6 +1991,167 @@ function printNonInteractiveUninstallGuidance(useColors: boolean): void {
   console.log();
 }
 
+/** Build the deselect-to-keep checkbox for the uninstall flow. */
+function buildUninstallAgentChoices(
+  scan: UninstallScanResult,
+): CheckboxChoice<AgentDefinition>[] {
+  return [
+    ...scan.configured.map((agent) => ({
+      name: `${agent.name} (configured)`,
+      value: agent,
+      checked: true,
+    })),
+    ...scan.notConfigured.map((agent) => ({
+      name: `${agent.name} (not configured)`,
+      value: agent,
+      disabled: "not configured" as const,
+    })),
+  ];
+}
+
+/**
+ * Map an uninstall change to a display row for the given agent. Both "removed"
+ * and "unchanged" use the ok tone (green ✓): for uninstall the desired end
+ * state is "GitHits absent", which holds in both cases. This matches install,
+ * where "unchanged" is likewise a ✓ rather than a warning.
+ */
+function uninstallChangeToRow(
+  name: string,
+  change: UninstallChange,
+  fileSystemService: FileSystemService,
+): ChangeRow {
+  const detail =
+    change.kind === "config-file"
+      ? formatConfigPath(change.path, fileSystemService)
+      : change.command;
+  return { tone: "ok", label: name, verb: change.change, detail };
+}
+
+/** Build display rows for one agent's uninstall outcome (+ a failure row). */
+function uninstallOutcomeRows(
+  outcome: AgentUninstallOutcome,
+  fileSystemService: FileSystemService,
+): ChangeRow[] {
+  const rows: ChangeRow[] = (outcome.changes ?? []).map((change) =>
+    uninstallChangeToRow(outcome.name, change, fileSystemService),
+  );
+  if (outcome.status === "failed") {
+    rows.push({
+      tone: "error",
+      label: outcome.name,
+      verb: "failed",
+      detail: outcome.message ?? "uninstall failed",
+    });
+  } else if (rows.length === 0) {
+    rows.push({
+      tone: "ok",
+      label: outcome.name,
+      verb: outcome.status === "removed" ? "removed" : "unchanged",
+      detail: "",
+    });
+  }
+  return rows;
+}
+
+/** Render an uninstall outcome's rows and any warnings. */
+function printUninstallOutcome(
+  outcome: AgentUninstallOutcome,
+  fileSystemService: FileSystemService,
+  useColors: boolean,
+  labelWidth: number,
+): void {
+  const lines = renderChangeRows(
+    uninstallOutcomeRows(outcome, fileSystemService),
+    { useColors, labelWidth, verbWidth: CHANGE_VERB_WIDTH },
+  );
+  for (const line of lines) {
+    console.log(line);
+  }
+  for (const warn of outcome.warnings ?? []) {
+    console.log(`    ${warning(`Warning: ${warn}`, useColors)}`);
+  }
+}
+
+/**
+ * Remove GitHits from the selected agents, verifying each removal. Mirrors
+ * installSelectedAgents: no per-agent prompt (the selection is the consent).
+ */
+async function uninstallSelectedAgents(
+  agents: AgentDefinition[],
+  fileSystemService: FileSystemService,
+  execService: ExecService,
+  useColors: boolean,
+  labelWidth: number,
+): Promise<AgentUninstallOutcome[]> {
+  const outcomes: AgentUninstallOutcome[] = [];
+
+  for (const agent of agents) {
+    const setupConfig = getResolvedSetupConfig(agent, fileSystemService);
+    const uninstallConfig =
+      agent.resolvedUninstallConfig ??
+      (setupConfig.method === "config-file"
+        ? setupConfig
+        : agent.getUninstallConfig?.(
+            fileSystemService,
+            agent.resolvedSetupContext,
+          ));
+
+    if (!uninstallConfig) {
+      const outcome: AgentUninstallOutcome = {
+        id: agent.id,
+        name: agent.name,
+        status: "failed",
+        message: `${agent.name} does not have a verified uninstall command.`,
+      };
+      outcomes.push(outcome);
+      printUninstallOutcome(outcome, fileSystemService, useColors, labelWidth);
+      continue;
+    }
+
+    let result =
+      uninstallConfig.method === "cli"
+        ? await executeCliUninstall(uninstallConfig, execService)
+        : uninstallConfig.method === "config-file"
+          ? await executeConfigFileUninstall(uninstallConfig, fileSystemService)
+          : await executeCompositeUninstall(
+              uninstallConfig,
+              fileSystemService,
+              execService,
+            );
+
+    if (result.status === "removed" && !agent.skipUninstallVerification) {
+      const verification = await verifyAgentUnconfigured(
+        agent,
+        fileSystemService,
+        execService,
+      );
+      if (!verification.ok) {
+        result = {
+          status: "failed",
+          message:
+            verification.message ??
+            `${agent.name} verification failed after uninstall.`,
+          warnings: result.warnings,
+          changes: result.changes,
+        };
+      }
+    }
+
+    const outcome: AgentUninstallOutcome = {
+      id: agent.id,
+      name: agent.name,
+      status: result.status,
+      message: result.status === "failed" ? result.message : undefined,
+      warnings: result.warnings,
+      changes: result.changes,
+    };
+    outcomes.push(outcome);
+    printUninstallOutcome(outcome, fileSystemService, useColors, labelWidth);
+  }
+
+  return outcomes;
+}
+
 async function runUserMcpUninstall(
   options: InitUninstallOptions,
   deps: InitDependencies,
@@ -2016,131 +2196,75 @@ async function runUserMcpUninstall(
     return;
   }
 
-  const outcomes: AgentUninstallOutcome[] = [...scan.failed];
-  let alwaysMode = options.yes ?? false;
-
-  for (const agent of scan.configured) {
-    console.log(
-      `  Uninstalling from ${colorize(agent.name, "bold", useColors)}...\n`,
-    );
-
-    const setupConfig = getResolvedSetupConfig(agent, fileSystemService);
-    const uninstallConfig =
-      agent.resolvedUninstallConfig ??
-      (setupConfig.method === "config-file"
-        ? setupConfig
-        : agent.getUninstallConfig?.(
-            fileSystemService,
-            agent.resolvedSetupContext,
-          ));
-
-    if (!uninstallConfig) {
-      outcomes.push({
-        id: agent.id,
-        name: agent.name,
-        status: "failed",
-        message: `${agent.name} does not have a verified uninstall command.`,
-      });
-      console.log(
-        `    ${errorFmt(`${agent.name} does not have a verified uninstall command.`, useColors)}\n`,
+  // Select which configured tools to remove from. The selection is the
+  // consent — no per-agent confirmation. All configured tools are pre-checked;
+  // deselect the ones to keep. --yes removes from all. (initUninstallAction
+  // already routes non-interactive-without-yes to guidance, so reaching the
+  // checkbox below always means an interactive session.)
+  let toRemove: AgentDefinition[];
+  if (options.yes || scan.configured.length === 0) {
+    toRemove = scan.configured;
+    if (scan.configured.length > 0) {
+      printTask(
+        "success",
+        "Selected all configured tools",
+        options.yes ? "--yes" : undefined,
+        useColors,
       );
-      continue;
     }
-
-    const preview = formatUninstallPreview(uninstallConfig);
-    for (const line of preview.split("\n")) {
-      console.log(`    ${line}`);
-    }
-    console.log();
-
-    if (!alwaysMode) {
-      let choice: ConfirmChoice;
-      try {
-        choice = await promptService.confirm3("Proceed?", "no");
-      } catch (err) {
-        if (err instanceof ExitPromptError) {
-          console.log("\n  Uninstall cancelled.\n");
-          return;
-        }
-        throw err;
-      }
-
-      if (choice === "no") {
-        outcomes.push({ id: agent.id, name: agent.name, status: "skipped" });
-        console.log();
-        continue;
-      }
-      if (choice === "always") {
-        alwaysMode = true;
-      }
-    }
-
-    let result =
-      uninstallConfig.method === "cli"
-        ? await executeCliUninstall(uninstallConfig, execService)
-        : uninstallConfig.method === "config-file"
-          ? await executeConfigFileUninstall(uninstallConfig, fileSystemService)
-          : await executeCompositeUninstall(
-              uninstallConfig,
-              fileSystemService,
-              execService,
-            );
-
-    if (result.status === "removed" && !agent.skipUninstallVerification) {
-      const verification = await verifyAgentUnconfigured(
-        agent,
-        fileSystemService,
-        execService,
+  } else {
+    try {
+      toRemove = await promptService.checkbox(
+        "  Select which tools to remove GitHits from:",
+        buildUninstallAgentChoices(scan),
       );
-      if (!verification.ok) {
-        result = {
-          status: "failed",
-          message:
-            verification.message ??
-            `${agent.name} verification failed after uninstall.`,
-          warnings: result.warnings,
-        };
+    } catch (err) {
+      if (err instanceof ExitPromptError) {
+        console.log("\n  Uninstall cancelled. No changes made.\n");
+        return;
       }
-    }
-
-    outcomes.push({
-      id: agent.id,
-      name: agent.name,
-      status: result.status,
-      message: result.status === "failed" ? result.message : undefined,
-      warnings: result.warnings,
-    });
-
-    if (result.status === "removed") {
-      console.log(`    ${success(`${agent.name} removed`, useColors)}\n`);
-      for (const warn of result.warnings ?? []) {
-        console.log(`    ${warning(`Warning: ${warn}`, useColors)}`);
-      }
-    } else if (result.status === "not_configured") {
-      console.log(
-        `    ${warning(`${agent.name} was not configured`, useColors)}\n`,
-      );
-    } else {
-      console.log(`    ${errorFmt(result.message, useColors)}\n`);
-      for (const warn of result.warnings ?? []) {
-        console.log(`    ${warning(`Warning: ${warn}`, useColors)}`);
-      }
+      throw err;
     }
   }
+
+  if (toRemove.length === 0 && scan.failed.length === 0) {
+    printTask("skipped", "Uninstall skipped", "no tools selected", useColors);
+    console.log();
+    return;
+  }
+
+  const labelWidth = toRemove.reduce(
+    (width, agent) => Math.max(width, agent.name.length),
+    0,
+  );
+  if (toRemove.length > 0) {
+    console.log();
+  }
+  // scan.failed (could not inspect config) are already shown in the detection
+  // list above and the failure summary below; they carry into outcomes only
+  // for the counts.
+  const outcomes: AgentUninstallOutcome[] = [
+    ...scan.failed,
+    ...(await uninstallSelectedAgents(
+      toRemove,
+      fileSystemService,
+      execService,
+      useColors,
+      labelWidth,
+    )),
+  ];
+  console.log();
 
   const removed = outcomes.filter((o) => o.status === "removed").length;
   const notConfigured =
     outcomes.filter((o) => o.status === "not_configured").length +
     scan.notConfigured.length;
   const failed = outcomes.filter((o) => o.status === "failed").length;
-  const skipped = outcomes.filter((o) => o.status === "skipped").length;
 
   if (failed > 0) {
     console.log("  Uninstall completed with errors.");
   } else if (removed > 0) {
     console.log("  Done! GitHits MCP configuration was removed.");
-  } else if (skipped > 0) {
-    console.log("  Uninstall skipped.");
   } else if (notConfigured > 0) {
     console.log(
       "  No GitHits MCP configurations were active. Nothing to remove.",
@@ -2154,9 +2278,6 @@ async function runUserMcpUninstall(
     console.log(
       `  ${notConfigured} agent${notConfigured !== 1 ? "s" : ""} not configured.`,
     );
-  }
-  if (skipped > 0) {
-    console.log(`  ${skipped} agent${skipped !== 1 ? "s" : ""} skipped.`);
   }
   if (failed > 0) {
     console.log(
@@ -2228,11 +2349,89 @@ async function executeAgentSetupWithVerification(
             ? "Gemini installation did not complete. Retry, or run: gemini extensions install --consent https://github.com/githits-com/githits-cli"
             : (verification.message ??
               `${agent.name} verification failed after setup.`),
+        // Preserve what was written so the user can still locate/fix it.
+        changes: result.changes,
       };
     }
   }
 
   return result;
+}
+
+/** Map a single setup change to a display row for the given agent. */
+function changeToRow(
+  name: string,
+  change: SetupChange,
+  fileSystemService: FileSystemService,
+): ChangeRow {
+  if (change.kind === "config-file") {
+    return {
+      tone: "ok",
+      label: name,
+      verb: change.change,
+      detail: formatConfigPath(change.path, fileSystemService),
+    };
+  }
+  return {
+    tone: "ok",
+    label: name,
+    verb: change.change,
+    detail: change.command,
+  };
+}
+
+/**
+ * Build the display rows for one agent's install outcome: one row per change
+ * (paths written / commands run), plus a trailing error row when the outcome
+ * failed — keeping the written path/command visible even on verification
+ * failure.
+ */
+function agentOutcomeRows(
+  outcome: AgentOutcome,
+  fileSystemService: FileSystemService,
+): ChangeRow[] {
+  const rows: ChangeRow[] = (outcome.changes ?? []).map((change) =>
+    changeToRow(outcome.name, change, fileSystemService),
+  );
+  if (outcome.status === "failed") {
+    rows.push({
+      tone: "error",
+      label: outcome.name,
+      verb: "failed",
+      detail: outcome.message ?? "verification failed",
+    });
+  } else if (rows.length === 0) {
+    rows.push({
+      tone: "ok",
+      label: outcome.name,
+      verb: "configured",
+      detail: "",
+    });
+  }
+  return rows;
+}
+
+/**
+ * Confirm the MCP server and its launch command. The wording reflects whether
+ * anything was actually installed this run versus already being configured, so
+ * we never claim to have installed when nothing changed. The command is shown
+ * as a muted inline value (the agent runs it, not the user), so it does not
+ * read as something to copy-paste. Callers provide the leading separator; a
+ * trailing blank line separates it from what follows.
+ */
+function printMcpServerSummary(useColors: boolean, installed: boolean): void {
+  const verb = installed
+    ? 'Configured MCP server "githits"'
+    : 'MCP server "githits" already configured';
+  const command = colorize(
+    `\`${GITHITS_MCP_INVOCATION.join(" ")}\``,
+    "dim",
+    useColors,
+  );
+  console.log(
+    `  ${success(`${verb} with local command ${command}`, useColors)}`,
+  );
+  console.log();
 }
 
 async function installSelectedAgents(
@@ -2250,16 +2449,39 @@ async function installSelectedAgents(
   const outcomes: AgentOutcome[] = [];
   const installTasks = createInstallTaskReporter(useColors);
 
+  // Column widths are fixed up front (agent names are known; verbs are a closed
+  // set) so rows align even though they print one agent at a time.
+  const labelWidth = agents.reduce(
+    (width, agent) => Math.max(width, agent.name.length),
+    0,
+  );
+  const printRows = (outcome: AgentOutcome): void => {
+    if (!printResults) return;
+    const lines = renderChangeRows(
+      agentOutcomeRows(outcome, fileSystemService),
+      {
+        useColors,
+        labelWidth,
+        verbWidth: CHANGE_VERB_WIDTH,
+      },
+    );
+    for (const line of lines) {
+      console.log(line);
+    }
+  };
+
   for (const agent of agents) {
     if (alreadyConfiguredIds.has(agent.id)) {
-      outcomes.push({
+      const outcome: AgentOutcome = {
         id: agent.id,
         name: agent.name,
         status: "already_configured",
-      });
-      if (printResults) {
-        printTask("warning", agent.name, "already configured", useColors);
-      }
+        changes: describeConfigAsUnchanged(
+          getResolvedSetupConfig(agent, fileSystemService),
+        ),
+      };
+      outcomes.push(outcome);
+      printRows(outcome);
       continue;
     }
 
@@ -2276,23 +2498,15 @@ async function installSelectedAgents(
       finishTask();
     }
 
-    outcomes.push({
+    const outcome: AgentOutcome = {
       id: agent.id,
       name: agent.name,
       status: result.status,
       message: result.status === "failed" ? result.message : undefined,
-    });
-
-    if (!printResults) {
-      continue;
-    }
-    if (result.status === "success") {
-      printTask("success", agent.name, "configured and verified", useColors);
-    } else if (result.status === "already_configured") {
-      printTask("warning", agent.name, "already configured", useColors);
-    } else {
-      printTask("failed", agent.name, result.message, useColors);
-    }
+      changes: result.changes,
+    };
+    outcomes.push(outcome);
+    printRows(outcome);
   }
 
   return outcomes;
@@ -2646,6 +2860,8 @@ export async function initAction(
       "all detected tools are already configured",
       useColors,
     );
+    console.log();
+    printMcpServerSummary(useColors, false);
     printScopedNextSteps(setupScope, authStatus, useColors);
     console.log();
     return;
@@ -2672,6 +2888,7 @@ export async function initAction(
   if (failed > 0) {
     console.log("  Setup completed with errors.");
   } else if (configured > 0 || alreadyDone > 0) {
+    printMcpServerSummary(useColors, configured > 0);
     printScopedNextSteps(setupScope, authStatus, useColors);
   }
 

--- a/src/commands/init/init.ts
+++ b/src/commands/init/init.ts
@@ -168,6 +168,13 @@ interface ProjectUninstallSummary {
   failed: ProjectUninstallFailure[];
 }
 
+const PROJECT_CONFIG_ROW_LABEL = "GitHits project config";
+const LEGACY_PROJECT_MARKER_ROW_LABEL = "Legacy project setup marker";
+const PROJECT_UNINSTALL_LABEL_WIDTH = Math.max(
+  PROJECT_CONFIG_ROW_LABEL.length,
+  LEGACY_PROJECT_MARKER_ROW_LABEL.length,
+);
+
 type InitIntent = "mcp" | "skills" | "later";
 
 type InitScopeChoice = InitSetupScope;
@@ -1815,6 +1822,28 @@ function printProjectUninstallSummary(summary: ProjectUninstallSummary): void {
   console.log();
 }
 
+function printProjectUninstallRow(
+  label: string,
+  tone: ChangeRow["tone"],
+  verb: string,
+  path: string,
+  fileSystemService: FileSystemService,
+  useColors: boolean,
+  message?: string,
+): void {
+  const detail = message
+    ? `${formatConfigPath(path, fileSystemService)}: ${message}`
+    : formatConfigPath(path, fileSystemService);
+  const lines = renderChangeRows([{ tone, label, verb, detail }], {
+    useColors,
+    labelWidth: PROJECT_UNINSTALL_LABEL_WIDTH,
+    verbWidth: CHANGE_VERB_WIDTH,
+  });
+  for (const line of lines) {
+    console.log(line);
+  }
+}
+
 async function runProjectMcpUninstall(
   options: InitUninstallOptions,
   deps: InitDependencies,
@@ -1855,7 +1884,15 @@ async function runProjectMcpUninstall(
     } => entry.check.status === "failed",
   );
   for (const { setup, check } of failedChecks) {
-    printTask("failed", setup.configPath, check.message, useColors);
+    printProjectUninstallRow(
+      PROJECT_CONFIG_ROW_LABEL,
+      "error",
+      "failed",
+      setup.configPath,
+      fileSystemService,
+      useColors,
+      check.message,
+    );
   }
   const skipped = checks
     .filter((entry) => entry.check.status === "not_configured")
@@ -1958,21 +1995,38 @@ async function runProjectMcpUninstall(
     const result = await executeConfigFileUninstall(setup, fileSystemService);
     if (result.status === "removed") {
       summary.removed.push(setup.configPath);
-      printTask(
-        "success",
-        "GitHits project config",
-        `removed from ${setup.configPath}`,
+      printProjectUninstallRow(
+        PROJECT_CONFIG_ROW_LABEL,
+        "ok",
+        "updated",
+        setup.configPath,
+        fileSystemService,
         useColors,
       );
     } else if (result.status === "not_configured") {
       summary.skipped.push(setup.configPath);
-      printTask("skipped", setup.configPath, "not configured", useColors);
+      printProjectUninstallRow(
+        PROJECT_CONFIG_ROW_LABEL,
+        "ok",
+        "unchanged",
+        setup.configPath,
+        fileSystemService,
+        useColors,
+      );
     } else {
       summary.failed.push({
         path: setup.configPath,
         reason: result.message,
       });
-      printTask("failed", setup.configPath, result.message, useColors);
+      printProjectUninstallRow(
+        PROJECT_CONFIG_ROW_LABEL,
+        "error",
+        "failed",
+        setup.configPath,
+        fileSystemService,
+        useColors,
+        result.message,
+      );
     }
   }
 
@@ -1981,16 +2035,26 @@ async function runProjectMcpUninstall(
       await cleanupLegacyProjectSetupState(fileSystemService);
     for (const path of legacyCleanup.removed) {
       summary.legacyRemoved.push(path);
-      printTask(
-        "success",
-        "Legacy project setup marker",
-        `removed ${path}`,
+      printProjectUninstallRow(
+        LEGACY_PROJECT_MARKER_ROW_LABEL,
+        "ok",
+        "updated",
+        path,
+        fileSystemService,
         useColors,
       );
     }
     for (const failure of legacyCleanup.failed) {
       summary.failed.push(failure);
-      printTask("failed", failure.path, failure.reason, useColors);
+      printProjectUninstallRow(
+        LEGACY_PROJECT_MARKER_ROW_LABEL,
+        "error",
+        "failed",
+        failure.path,
+        fileSystemService,
+        useColors,
+        failure.reason,
+      );
     }
   }
 

--- a/src/commands/init/init.ts
+++ b/src/commands/init/init.ts
@@ -797,6 +797,32 @@ function buildInitAgentChoices(
   ];
 }
 
+function getInstallSummaryAgents(
+  scan: ScanResult,
+  selectedForSetup: AgentDefinition[],
+): AgentDefinition[] {
+  const selectedIds = new Set(selectedForSetup.map((agent) => agent.id));
+  const included = new Map<string, AgentDefinition>();
+
+  for (const agent of scan.alreadyConfigured) {
+    included.set(agent.id, agent);
+  }
+  for (const agent of scan.needsSetup) {
+    if (selectedIds.has(agent.id)) {
+      included.set(agent.id, agent);
+    }
+  }
+
+  const agentOrder = new Map(
+    agentDefinitions.map((agent, index) => [agent.id, index]),
+  );
+  return [...included.values()].sort(
+    (a, b) =>
+      (agentOrder.get(a.id) ?? Number.MAX_SAFE_INTEGER) -
+      (agentOrder.get(b.id) ?? Number.MAX_SAFE_INTEGER),
+  );
+}
+
 function printScanSummary(
   scan: ScanResult,
   useColors: boolean,
@@ -2834,7 +2860,9 @@ export async function initAction(
   if (toSetup.length === 0 && scan.needsSetup.length > 0) {
     printTask("skipped", "Setup skipped", "no tools selected", useColors);
     console.log();
-    return;
+    if (scan.alreadyConfigured.length === 0) {
+      return;
+    }
   }
 
   if (toSetup.length > 0) {
@@ -2853,22 +2881,9 @@ export async function initAction(
   }
 
   printSection(4, "Install and verify", useColors);
-  if (toSetup.length === 0) {
-    printTask(
-      "success",
-      "Nothing to install",
-      "all detected tools are already configured",
-      useColors,
-    );
-    console.log();
-    printMcpServerSummary(useColors, false);
-    printScopedNextSteps(setupScope, authStatus, useColors);
-    console.log();
-    return;
-  }
-
+  const summaryAgents = getInstallSummaryAgents(scan, toSetup);
   const outcomes = await installSelectedAgents(
-    toSetup,
+    summaryAgents,
     scan,
     fileSystemService,
     execService,
@@ -2880,9 +2895,9 @@ export async function initAction(
   console.log();
 
   const configured = outcomes.filter((o) => o.status === "success").length;
-  const alreadyDone =
-    outcomes.filter((o) => o.status === "already_configured").length +
-    scan.alreadyConfigured.length;
+  const alreadyDone = outcomes.filter(
+    (o) => o.status === "already_configured",
+  ).length;
   const failed = outcomes.filter((o) => o.status === "failed").length;
 
   if (failed > 0) {
@@ -2902,9 +2917,9 @@ export async function initAction(
       );
     }
   }
-  if (scan.alreadyConfigured.length > 0) {
+  if (alreadyDone > 0) {
     console.log(
-      `  ${scan.alreadyConfigured.length} tool${scan.alreadyConfigured.length !== 1 ? "s" : ""} already configured.`,
+      `  ${alreadyDone} tool${alreadyDone !== 1 ? "s" : ""} already configured.`,
     );
   }
 

--- a/src/commands/init/setup-format.test.ts
+++ b/src/commands/init/setup-format.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it, mock } from "bun:test";
+import { createMockFileSystemService } from "../../services/test-helpers.js";
+import type {
+  CliSetup,
+  CompositeSetup,
+  ConfigFileSetup,
+} from "./agent-definitions.js";
+import {
+  CHANGE_VERB_WIDTH,
+  type ChangeRow,
+  changeRowColumnWidths,
+  describeConfigAsUnchanged,
+  formatCliCommand,
+  formatConfigPath,
+  renderChangeRows,
+} from "./setup-format.js";
+
+function fsWith(home: string, cwd: string) {
+  return createMockFileSystemService({
+    getHomeDir: mock(() => home),
+    getCwd: mock(() => cwd),
+  });
+}
+
+describe("formatConfigPath", () => {
+  it("collapses the home directory to ~", () => {
+    const fs = fsWith("/home/user", "/elsewhere");
+    expect(formatConfigPath("/home/user/.cursor/mcp.json", fs)).toBe(
+      "~/.cursor/mcp.json",
+    );
+  });
+
+  it("collapses the cwd to .", () => {
+    const fs = fsWith("/home/user", "/work/repo");
+    expect(formatConfigPath("/work/repo/.mcp.json", fs)).toBe("./.mcp.json");
+  });
+
+  it("prefers the longest matching prefix when cwd is under home", () => {
+    const fs = fsWith("/home/user", "/home/user/repo");
+    // Both home and cwd match; cwd is longer, so it wins.
+    expect(formatConfigPath("/home/user/repo/.mcp.json", fs)).toBe(
+      "./.mcp.json",
+    );
+  });
+
+  it("returns the path unchanged when no prefix matches", () => {
+    const fs = fsWith("/home/user", "/work/repo");
+    expect(formatConfigPath("/etc/app/config.json", fs)).toBe(
+      "/etc/app/config.json",
+    );
+  });
+
+  it("does not treat a sibling directory as being under a prefix", () => {
+    const fs = fsWith("/home/user", "/work/repo");
+    // /home/user2 must not collapse against /home/user.
+    expect(formatConfigPath("/home/user2/.cursor/mcp.json", fs)).toBe(
+      "/home/user2/.cursor/mcp.json",
+    );
+  });
+
+  it("collapses Windows-style paths", () => {
+    const fs = fsWith("C:\\Users\\me", "C:\\Users\\me\\repo");
+    expect(
+      formatConfigPath("C:\\Users\\me\\AppData\\Roaming\\Code\\mcp.json", fs),
+    ).toBe("~\\AppData\\Roaming\\Code\\mcp.json");
+    expect(formatConfigPath("C:\\Users\\me\\repo\\.mcp.json", fs)).toBe(
+      ".\\.mcp.json",
+    );
+  });
+
+  it("matches Windows paths case-insensitively while preserving casing", () => {
+    const fs = fsWith("C:\\Users\\Me", "D:\\nope");
+    // Drive/dir casing differs from the prefix but should still collapse, and
+    // the original casing of the remainder is preserved.
+    expect(
+      formatConfigPath("c:\\users\\me\\AppData\\Roaming\\Code\\mcp.json", fs),
+    ).toBe("~\\AppData\\Roaming\\Code\\mcp.json");
+  });
+
+  it("ignores empty home/cwd prefixes", () => {
+    const fs = fsWith("", "");
+    expect(formatConfigPath("/home/user/.cursor/mcp.json", fs)).toBe(
+      "/home/user/.cursor/mcp.json",
+    );
+  });
+});
+
+describe("formatCliCommand", () => {
+  it("joins command and args", () => {
+    expect(
+      formatCliCommand({ command: "claude", args: ["plugin", "install", "x"] }),
+    ).toBe("claude plugin install x");
+  });
+
+  it("returns the bare command when there are no args", () => {
+    expect(formatCliCommand({ command: "claude", args: [] })).toBe("claude");
+  });
+});
+
+describe("describeConfigAsUnchanged", () => {
+  it("maps a config-file setup to one unchanged path change", () => {
+    const config: ConfigFileSetup = {
+      method: "config-file",
+      configPath: "/home/user/.cursor/mcp.json",
+      serversKey: "mcpServers",
+      serverName: "GitHits",
+      serverConfig: {},
+    };
+    expect(describeConfigAsUnchanged(config)).toEqual([
+      {
+        kind: "config-file",
+        path: "/home/user/.cursor/mcp.json",
+        change: "unchanged",
+      },
+    ]);
+  });
+
+  it("maps a CLI setup to one unchanged change per command", () => {
+    const config: CliSetup = {
+      method: "cli",
+      commands: [
+        { command: "claude", args: ["plugin", "marketplace", "add", "x"] },
+        { command: "claude", args: ["plugin", "install", "y"] },
+      ],
+    };
+    expect(describeConfigAsUnchanged(config)).toEqual([
+      {
+        kind: "command",
+        command: "claude plugin marketplace add x",
+        change: "unchanged",
+      },
+      {
+        kind: "command",
+        command: "claude plugin install y",
+        change: "unchanged",
+      },
+    ]);
+  });
+
+  it("recurses into composite steps", () => {
+    const config: CompositeSetup = {
+      method: "composite",
+      steps: [
+        {
+          method: "cli",
+          commands: [{ command: "pi", args: ["install", "x"] }],
+        },
+        {
+          method: "config-file",
+          configPath: "/home/user/.pi/agent/mcp.json",
+          serversKey: "mcpServers",
+          serverName: "GitHits",
+          serverConfig: {},
+        },
+      ],
+    };
+    expect(describeConfigAsUnchanged(config)).toEqual([
+      { kind: "command", command: "pi install x", change: "unchanged" },
+      {
+        kind: "config-file",
+        path: "/home/user/.pi/agent/mcp.json",
+        change: "unchanged",
+      },
+    ]);
+  });
+});
+
+describe("renderChangeRows", () => {
+  const rows: ChangeRow[] = [
+    {
+      tone: "ok",
+      label: "Claude Code",
+      verb: "ran",
+      detail: "claude plugin install x",
+    },
+    {
+      tone: "ok",
+      label: "VS Code",
+      verb: "updated",
+      detail: "~/.config/Code/User/mcp.json",
+    },
+    { tone: "error", label: "Cline", verb: "failed", detail: "boom" },
+  ];
+
+  it("aligns the detail column across rows of differing label/verb lengths", () => {
+    const widths = changeRowColumnWidths(rows);
+    const lines = renderChangeRows(rows, {
+      useColors: false,
+      labelWidth: widths.labelWidth,
+      verbWidth: widths.verbWidth,
+    });
+    // The label column width equals the longest label ("Claude Code" = 11).
+    expect(widths.labelWidth).toBe("Claude Code".length);
+    // Each row's detail begins at the exact same column despite different
+    // label and verb lengths.
+    const detailOffsets = rows.map((row, i) => lines[i]!.indexOf(row.detail));
+    expect(detailOffsets.every((offset) => offset > 0)).toBe(true);
+    expect(new Set(detailOffsets).size).toBe(1);
+    // Glyphs reflect tone.
+    expect(lines[0]).toContain("✓");
+    expect(lines[2]).toContain("✗");
+  });
+
+  it("produces equal visible column widths regardless of color", () => {
+    const opts = { labelWidth: 11, verbWidth: CHANGE_VERB_WIDTH };
+    const plain = renderChangeRows(rows, { ...opts, useColors: false });
+    const colored = renderChangeRows(rows, { ...opts, useColors: true });
+    // Colored output contains ANSI escapes...
+    expect(colored.join("")).toContain("\x1b[");
+    // ...but stripping them yields identical text to the plain render.
+    // biome-ignore lint/suspicious/noControlCharactersInRegex: stripping ANSI.
+    const strip = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, "");
+    expect(colored.map(strip)).toEqual(plain);
+  });
+});

--- a/src/commands/init/setup-format.ts
+++ b/src/commands/init/setup-format.ts
@@ -1,0 +1,207 @@
+/**
+ * Pure formatting helpers for the init setup/uninstall "what changed" output.
+ *
+ * Kept free of IO and `console` so it can be unit-tested directly and reused by
+ * both install and uninstall rendering. The genuinely shared units are the
+ * `SetupChange` data shape, the display row (`ChangeRow`), and
+ * `renderChangeRows`; executors in `setup-handlers.ts` produce `SetupChange`s
+ * that map onto rows at the call site.
+ */
+
+import { colorize, type colors } from "@githits/mcp/internal";
+import type { FileSystemService } from "../../services/filesystem-service.js";
+import type { CliCommand, SetupConfig } from "./agent-definitions.js";
+
+/**
+ * A single structured change produced by a setup operation, for display and
+ * `--json` auditing. Verbs are set correctly by construction at each executor,
+ * so the union never needs to represent e.g. a command that was "created".
+ *
+ * Lives here (not in setup-handlers) because it is a display/serialization
+ * shape consumed by the formatter and the JSON payload, and keeping it here
+ * keeps the module dependency direction one-way (setup-handlers → setup-format).
+ */
+export type SetupChange =
+  | {
+      kind: "config-file";
+      path: string;
+      change: "created" | "updated" | "unchanged";
+    }
+  | { kind: "command"; command: string; change: "ran" | "unchanged" };
+
+/**
+ * The uninstall counterpart of {@link SetupChange}. The verb describes the
+ * action actually taken on the target: editing a shared config file to strip
+ * the GitHits entry is an "updated" (the file is kept, not deleted); running a
+ * removal command is "ran". Either is "unchanged" when GitHits was already
+ * absent. This mirrors install, where commands are "ran" and files are
+ * created/updated.
+ */
+export type UninstallChange =
+  | { kind: "config-file"; path: string; change: "updated" | "unchanged" }
+  | { kind: "command"; command: string; change: "ran" | "unchanged" };
+
+/** A single rendered output row: glyph tone + three aligned columns. */
+export interface ChangeRow {
+  /** Glyph + emphasis: ok (✓), warn (⚠), error (✗). */
+  tone: "ok" | "warn" | "error";
+  /** Left column — usually the agent/client name. */
+  label: string;
+  /** Middle column — status verb (created/updated/unchanged/ran/removed/failed). */
+  verb: string;
+  /** Right column — collapsed config path or the command that ran. */
+  detail: string;
+}
+
+/** Closed vocabulary of status verbs across install + uninstall rendering. */
+export const CHANGE_VERBS = [
+  "created",
+  "updated",
+  "unchanged",
+  "ran",
+  "removed",
+  "failed",
+] as const;
+
+/** Width of the verb column, derived from the closed verb vocabulary. */
+export const CHANGE_VERB_WIDTH = CHANGE_VERBS.reduce(
+  (width, verb) => Math.max(width, verb.length),
+  0,
+);
+
+const TONE_GLYPH: Record<
+  ChangeRow["tone"],
+  { glyph: string; color: keyof typeof colors }
+> = {
+  ok: { glyph: "✓", color: "green" },
+  warn: { glyph: "⚠", color: "yellow" },
+  error: { glyph: "✗", color: "red" },
+};
+
+export interface RenderChangeRowsOptions {
+  useColors: boolean;
+  /** Width of the label column, precomputed across the batch for alignment. */
+  labelWidth: number;
+  /** Width of the verb column, precomputed across the batch for alignment. */
+  verbWidth: number;
+}
+
+/**
+ * Render aligned change rows. Padding is applied to raw text before any color
+ * codes are added, so ANSI escapes never corrupt column widths. The glyph is a
+ * fixed single visible character regardless of color.
+ *
+ * Column widths are caller-supplied (see {@link changeRowColumnWidths}) because
+ * rows are printed incrementally inside a per-agent loop and cannot all be
+ * collected before the first line is emitted.
+ */
+export function renderChangeRows(
+  rows: ChangeRow[],
+  options: RenderChangeRowsOptions,
+): string[] {
+  const { useColors, labelWidth, verbWidth } = options;
+  return rows.map((row) => {
+    const { glyph, color } = TONE_GLYPH[row.tone];
+    const coloredGlyph = colorize(glyph, color, useColors);
+    const label = row.label.padEnd(labelWidth);
+    const verb = colorize(row.verb.padEnd(verbWidth), "dim", useColors);
+    return `    ${coloredGlyph} ${label}  ${verb}  ${row.detail}`.trimEnd();
+  });
+}
+
+/** Compute aligned column widths from a batch of rows. */
+export function changeRowColumnWidths(rows: ChangeRow[]): {
+  labelWidth: number;
+  verbWidth: number;
+} {
+  let labelWidth = 0;
+  let verbWidth = 0;
+  for (const row of rows) {
+    if (row.label.length > labelWidth) labelWidth = row.label.length;
+    if (row.verb.length > verbWidth) verbWidth = row.verb.length;
+  }
+  return { labelWidth, verbWidth };
+}
+
+/**
+ * Collapse a known root prefix (home or cwd) in an absolute config path for
+ * display. Picks the longest matching prefix so a repository checked out under
+ * the home directory still renders as `./…` rather than `~/…`.
+ *
+ * Separator-agnostic (`/` or `\`) so it behaves correctly for Windows paths in
+ * tests and at runtime.
+ */
+export function formatConfigPath(path: string, fs: FileSystemService): string {
+  const candidates: Array<{ prefix: string; replacement: string }> = [
+    { prefix: fs.getCwd(), replacement: "." },
+    { prefix: fs.getHomeDir(), replacement: "~" },
+  ];
+
+  let best: { length: number; collapsed: string } | null = null;
+  for (const { prefix, replacement } of candidates) {
+    const collapsed = collapsePrefix(path, prefix, replacement);
+    if (collapsed === null) continue;
+    if (!best || prefix.length > best.length) {
+      best = { length: prefix.length, collapsed };
+    }
+  }
+  return best ? best.collapsed : path;
+}
+
+/** Whether a path looks like a Windows path (drive letter or backslashes). */
+function isWindowsLikePath(path: string): boolean {
+  return /^[a-zA-Z]:/.test(path) || path.includes("\\");
+}
+
+/**
+ * Replace `prefix` with `replacement` when `path` is `prefix` itself or sits
+ * directly beneath it. Returns null when `path` is not under `prefix`. The
+ * boundary must be a path separator so `/home/user2` is not treated as being
+ * under `/home/user`. Windows paths are matched case-insensitively (the
+ * filesystem is), while preserving the original casing in the output.
+ */
+function collapsePrefix(
+  path: string,
+  prefix: string,
+  replacement: string,
+): string | null {
+  if (!prefix || prefix.length === 0) return null;
+  const caseInsensitive = isWindowsLikePath(prefix);
+  const cmpPath = caseInsensitive ? path.toLowerCase() : path;
+  const cmpPrefix = caseInsensitive ? prefix.toLowerCase() : prefix;
+  if (cmpPath === cmpPrefix) return replacement;
+  if (!cmpPath.startsWith(cmpPrefix)) return null;
+  const boundary = path.charAt(prefix.length);
+  if (boundary !== "/" && boundary !== "\\") return null;
+  return `${replacement}${path.slice(prefix.length)}`;
+}
+
+/** Render a CLI command + args as a copy-pasteable string. */
+export function formatCliCommand(cmd: CliCommand): string {
+  return cmd.args.length > 0
+    ? `${cmd.command} ${cmd.args.join(" ")}`
+    : cmd.command;
+}
+
+/**
+ * Describe a setup config as a list of `unchanged` changes, without executing
+ * anything. Used to render already-configured clients (the install
+ * short-circuit) and pre-skipped composite steps, so they still report their
+ * path/command instead of vanishing from the output.
+ */
+export function describeConfigAsUnchanged(config: SetupConfig): SetupChange[] {
+  switch (config.method) {
+    case "config-file":
+      return [
+        { kind: "config-file", path: config.configPath, change: "unchanged" },
+      ];
+    case "cli":
+      return config.commands.map((cmd) => ({
+        kind: "command" as const,
+        command: formatCliCommand(cmd),
+        change: "unchanged" as const,
+      }));
+    case "composite":
+      return config.steps.flatMap((step) => describeConfigAsUnchanged(step));
+  }
+}

--- a/src/commands/init/setup-handlers.test.ts
+++ b/src/commands/init/setup-handlers.test.ts
@@ -2457,6 +2457,46 @@ describe("executeCompositeSetup", () => {
     ]);
   });
 
+  it("reports already_configured when a false-negative pre-check still changes nothing", async () => {
+    const fs = createMockFileSystemService({
+      readFile: mock(() =>
+        Promise.resolve(
+          JSON.stringify({
+            mcpServers: { GitHits: piConfigSetup.serverConfig },
+          }),
+        ),
+      ),
+    });
+    const execService = createMockExecService({
+      exec: mock((command: string, args: string[]) => {
+        if (command === "pi" && args.join(" ") === "list") {
+          return Promise.resolve({ exitCode: 0, stdout: "", stderr: "" });
+        }
+        return Promise.resolve({
+          exitCode: 1,
+          stdout: "",
+          stderr: "MCP server GitHits already exists\n",
+        });
+      }),
+    });
+
+    const result = await executeCompositeSetup(piSetup, fs, execService);
+    expect(result.status).toBe("already_configured");
+    expect(result.changes).toEqual([
+      {
+        kind: "command",
+        command: "pi install npm:pi-mcp-adapter",
+        change: "unchanged",
+      },
+      {
+        kind: "config-file",
+        path: "/home/test/.pi/agent/mcp.json",
+        change: "unchanged",
+      },
+    ]);
+    expect(fs.atomicWriteFile).not.toHaveBeenCalled();
+  });
+
   it("stops on failed install before writing config", async () => {
     const enoent = Object.assign(new Error("File not found"), {
       code: "ENOENT",

--- a/src/commands/init/setup-handlers.test.ts
+++ b/src/commands/init/setup-handlers.test.ts
@@ -21,8 +21,6 @@ import {
   executeCompositeUninstall,
   executeConfigFileSetup,
   executeConfigFileUninstall,
-  formatSetupPreview,
-  formatUninstallPreview,
   getCliCheckStatus,
   getConfigUninstallCheckStatus,
   hasServerConfigEntry,
@@ -1241,107 +1239,6 @@ args = ["-y", "githits@latest", "mcp", "start"]
   });
 });
 
-// -- formatSetupPreview --
-
-describe("formatSetupPreview", () => {
-  it("formats single-step CLI setup as a command", () => {
-    const setup: CliSetup = {
-      method: "cli",
-      commands: [{ command: "codex", args: ["mcp", "add", "githits"] }],
-    };
-    const preview = formatSetupPreview(setup);
-    expect(preview).toBe("Will run: codex mcp add githits");
-  });
-
-  it("formats multi-step CLI setup as multiple lines", () => {
-    const setup: CliSetup = {
-      method: "cli",
-      commands: [
-        {
-          command: "claude",
-          args: ["plugin", "marketplace", "add", "githits-com/githits-cli"],
-        },
-        {
-          command: "claude",
-          args: ["plugin", "install", "githits@githits-plugins"],
-        },
-      ],
-    };
-    const preview = formatSetupPreview(setup);
-    expect(preview).toContain(
-      "Will run: claude plugin marketplace add githits-com/githits-cli",
-    );
-    expect(preview).toContain(
-      "Will run: claude plugin install githits@githits-plugins",
-    );
-    expect(preview.split("\n")).toHaveLength(2);
-  });
-
-  it("formats config file setup with path and JSON snippet", () => {
-    const setup: ConfigFileSetup = {
-      method: "config-file",
-      configPath: "/home/test/.cursor/mcp.json",
-      serversKey: "mcpServers",
-      serverName: "GitHits",
-      serverConfig: {
-        command: "npx",
-        args: ["-y", "githits@latest", "mcp", "start"],
-      },
-    };
-    const preview = formatSetupPreview(setup);
-    expect(preview).toContain("Will add to /home/test/.cursor/mcp.json:");
-    expect(preview).toContain('"GitHits"');
-    expect(preview).toContain('"command"');
-  });
-
-  it("formats YAML config file setup with YAML snippet", () => {
-    const setup: ConfigFileSetup = {
-      method: "config-file",
-      format: "yaml",
-      configPath: "/home/test/.hermes/config.yaml",
-      serversKey: "mcp_servers",
-      serverName: "GitHits",
-      serverConfig: {
-        command: "npx",
-        args: ["-y", "githits@latest", "mcp", "start"],
-      },
-    };
-    const preview = formatSetupPreview(setup);
-    expect(preview).toContain("Will add to /home/test/.hermes/config.yaml:");
-    expect(preview).toContain("GitHits:");
-    expect(preview).toContain("command: npx");
-  });
-
-  it("formats composite setup with command and config previews", () => {
-    const setup: CompositeSetup = {
-      method: "composite",
-      steps: [
-        {
-          method: "cli",
-          commands: [
-            { command: "pi", args: ["install", "npm:pi-mcp-adapter"] },
-          ],
-        },
-        {
-          method: "config-file",
-          configPath: "/home/test/.pi/agent/mcp.json",
-          serversKey: "mcpServers",
-          serverName: "GitHits",
-          serverConfig: {
-            command: "npx",
-            args: ["-y", "githits@latest", "mcp", "start"],
-          },
-        },
-      ],
-    };
-
-    const preview = formatSetupPreview(setup);
-    expect(preview).toContain("Will run: pi install npm:pi-mcp-adapter");
-    expect(preview).toContain("Will add to /home/test/.pi/agent/mcp.json:");
-    expect(preview).toContain('"GitHits"');
-  });
-});
-
 describe("hasServerConfigEntry", () => {
   it("returns true for legacy and case-variant GitHits entries", () => {
     expect(
@@ -1480,59 +1377,6 @@ describe("getConfigUninstallCheckStatus", () => {
   });
 });
 
-describe("formatUninstallPreview", () => {
-  it("formats CLI uninstall as commands", () => {
-    const preview = formatUninstallPreview({
-      method: "cli",
-      commands: [{ command: "codex", args: ["mcp", "remove", "githits"] }],
-    });
-    expect(preview).toBe("Will run: codex mcp remove githits");
-  });
-
-  it("formats config-file uninstall with path", () => {
-    const preview = formatUninstallPreview({
-      method: "config-file",
-      configPath: "/home/test/.cursor/mcp.json",
-      serversKey: "mcpServers",
-      serverName: "GitHits",
-      serverConfig: {},
-    });
-    expect(preview).toBe(
-      "Will remove GitHits from /home/test/.cursor/mcp.json",
-    );
-  });
-
-  it("formats composite uninstall as ordered step previews", () => {
-    const preview = formatUninstallPreview({
-      method: "composite",
-      steps: [
-        {
-          failureMode: "required",
-          step: {
-            method: "config-file",
-            configPath: "/home/test/.pi/agent/mcp.json",
-            serversKey: "mcpServers",
-            serverName: "GitHits",
-            serverConfig: {},
-          },
-        },
-        {
-          failureMode: "required",
-          step: {
-            method: "cli",
-            commands: [
-              { command: "pi", args: ["remove", "npm:pi-mcp-adapter"] },
-            ],
-          },
-        },
-      ],
-    });
-    expect(preview).toBe(
-      "Will remove GitHits from /home/test/.pi/agent/mcp.json\nWill run: pi remove npm:pi-mcp-adapter",
-    );
-  });
-});
-
 // -- executeCliSetup --
 
 describe("executeCliSetup", () => {
@@ -1579,6 +1423,89 @@ describe("executeCliSetup", () => {
     const result = await executeCliSetup(multiStepSetup, execService);
     expect(result.status).toBe("success");
     expect(execService.exec).toHaveBeenCalledTimes(2);
+  });
+
+  it("emits one ran change per command on success", async () => {
+    const execService = createMockExecService({
+      exec: mock(() =>
+        Promise.resolve({ exitCode: 0, stdout: "OK\n", stderr: "" }),
+      ),
+    });
+    const result = await executeCliSetup(multiStepSetup, execService);
+    expect(result.changes).toEqual([
+      {
+        kind: "command",
+        command: "claude plugin marketplace add githits-com/githits-cli",
+        change: "ran",
+      },
+      {
+        kind: "command",
+        command: "claude plugin install githits@githits-plugins",
+        change: "ran",
+      },
+    ]);
+  });
+
+  it("reports per-command state for a mixed multi-step run", async () => {
+    // First command is already configured, second actually runs.
+    const responses = [
+      { exitCode: 0, stdout: "MCP server GitHits already exists", stderr: "" },
+      { exitCode: 0, stdout: "Installed\n", stderr: "" },
+    ];
+    let call = 0;
+    const execService = createMockExecService({
+      exec: mock(() => Promise.resolve(responses[call++]!)),
+    });
+    const result = await executeCliSetup(multiStepSetup, execService);
+    // A command ran, so the overall result is success, not already_configured.
+    expect(result.status).toBe("success");
+    expect(result.changes).toEqual([
+      {
+        kind: "command",
+        command: "claude plugin marketplace add githits-com/githits-cli",
+        change: "unchanged",
+      },
+      {
+        kind: "command",
+        command: "claude plugin install githits@githits-plugins",
+        change: "ran",
+      },
+    ]);
+  });
+
+  it("is already_configured only when every command was a no-op", async () => {
+    const execService = createMockExecService({
+      exec: mock(() =>
+        Promise.resolve({
+          exitCode: 0,
+          stdout: "MCP server GitHits already exists",
+          stderr: "",
+        }),
+      ),
+    });
+    const result = await executeCliSetup(multiStepSetup, execService);
+    expect(result.status).toBe("already_configured");
+    expect(result.changes?.every((c) => c.change === "unchanged")).toBe(true);
+  });
+
+  it("keeps changes from commands that ran before a later failure", async () => {
+    const responses = [
+      { exitCode: 0, stdout: "Added.\n", stderr: "" },
+      { exitCode: 1, stdout: "", stderr: "Install failed\n" },
+    ];
+    let call = 0;
+    const execService = createMockExecService({
+      exec: mock(() => Promise.resolve(responses[call++]!)),
+    });
+    const result = await executeCliSetup(multiStepSetup, execService);
+    expect(result.status).toBe("failed");
+    expect(result.changes).toEqual([
+      {
+        kind: "command",
+        command: "claude plugin marketplace add githits-com/githits-cli",
+        change: "ran",
+      },
+    ]);
   });
 
   it("returns failed with stderr on non-zero exit", async () => {
@@ -1677,7 +1604,7 @@ describe("executeCliSetup", () => {
     expect(execService.exec).toHaveBeenCalledTimes(1);
   });
 
-  it("returns already_configured when any step reports it", async () => {
+  it("runs every step and reports success when a later step runs", async () => {
     let callCount = 0;
     const execService = createMockExecService({
       exec: mock(() => {
@@ -1697,7 +1624,8 @@ describe("executeCliSetup", () => {
       }),
     });
     const result = await executeCliSetup(multiStepSetup, execService);
-    expect(result.status).toBe("already_configured");
+    // A command ran, so this is success — not already_configured.
+    expect(result.status).toBe("success");
     // Both commands should still run
     expect(execService.exec).toHaveBeenCalledTimes(2);
   });
@@ -1722,6 +1650,34 @@ describe("executeCliUninstall", () => {
       "mcp",
       "remove",
       "githits",
+    ]);
+  });
+
+  it("emits a ran change per command", async () => {
+    const multi: CliUninstall = {
+      method: "cli",
+      commands: [
+        { command: "claude", args: ["plugin", "uninstall", "githits"] },
+        { command: "claude", args: ["plugin", "marketplace", "remove", "x"] },
+      ],
+    };
+    const execService = createMockExecService({
+      exec: mock(() =>
+        Promise.resolve({ exitCode: 0, stdout: "Removed\n", stderr: "" }),
+      ),
+    });
+    const result = await executeCliUninstall(multi, execService);
+    expect(result.changes).toEqual([
+      {
+        kind: "command",
+        command: "claude plugin uninstall githits",
+        change: "ran",
+      },
+      {
+        kind: "command",
+        command: "claude plugin marketplace remove x",
+        change: "ran",
+      },
     ]);
   });
 
@@ -1955,6 +1911,83 @@ describe("executeConfigFileSetup", () => {
     const result = await executeConfigFileSetup(configSetup, fs);
     expect(result.status).toBe("already_configured");
     expect(atomicWrite).not.toHaveBeenCalled();
+  });
+
+  it("reports a created change when the file did not exist", async () => {
+    const enoent = Object.assign(new Error("File not found"), {
+      code: "ENOENT",
+    });
+    const fs = createMockFileSystemService({
+      readFile: mock(() => Promise.reject(enoent)),
+      getDirname: mock(() => "/home/test/.cursor"),
+      ensureDir: mock(() => Promise.resolve()),
+      atomicWriteFile: mock(() => Promise.resolve()),
+    });
+    const result = await executeConfigFileSetup(configSetup, fs);
+    expect(result.changes).toEqual([
+      {
+        kind: "config-file",
+        path: "/home/test/.cursor/mcp.json",
+        change: "created",
+      },
+    ]);
+  });
+
+  it("reports an updated change when the file already existed", async () => {
+    const existing = JSON.stringify({
+      mcpServers: { other: { command: "other" } },
+    });
+    const fs = createMockFileSystemService({
+      readFile: mock(() => Promise.resolve(existing)),
+      getDirname: mock(() => "/home/test/.cursor"),
+      ensureDir: mock(() => Promise.resolve()),
+      atomicWriteFile: mock(() => Promise.resolve()),
+    });
+    const result = await executeConfigFileSetup(configSetup, fs);
+    expect(result.changes).toEqual([
+      {
+        kind: "config-file",
+        path: "/home/test/.cursor/mcp.json",
+        change: "updated",
+      },
+    ]);
+  });
+
+  it("reports an updated change for a pre-existing empty file", async () => {
+    const fs = createMockFileSystemService({
+      readFile: mock(() => Promise.resolve("")),
+      getDirname: mock(() => "/home/test/.cursor"),
+      ensureDir: mock(() => Promise.resolve()),
+      atomicWriteFile: mock(() => Promise.resolve()),
+    });
+    const result = await executeConfigFileSetup(configSetup, fs);
+    // An existing (even empty) file is "updated", only a missing file is "created".
+    expect(result.changes?.[0]).toMatchObject({ change: "updated" });
+  });
+
+  it("reports an unchanged change when already configured", async () => {
+    const existing = JSON.stringify({
+      mcpServers: {
+        GitHits: {
+          command: "npx",
+          args: ["-y", "githits@latest", "mcp", "start"],
+        },
+      },
+    });
+    const fs = createMockFileSystemService({
+      readFile: mock(() => Promise.resolve(existing)),
+      getDirname: mock(() => "/home/test/.cursor"),
+      ensureDir: mock(() => Promise.resolve()),
+      atomicWriteFile: mock(() => Promise.resolve()),
+    });
+    const result = await executeConfigFileSetup(configSetup, fs);
+    expect(result.changes).toEqual([
+      {
+        kind: "config-file",
+        path: "/home/test/.cursor/mcp.json",
+        change: "unchanged",
+      },
+    ]);
   });
 
   it("migrates legacy remote config to local CLI command", async () => {
@@ -2384,6 +2417,46 @@ describe("executeCompositeSetup", () => {
     expect(fs.atomicWriteFile).not.toHaveBeenCalled();
   });
 
+  it("reports both sub-steps even when one was already configured", async () => {
+    // Adapter step runs; config-file step is already configured (skipped) and
+    // must still appear as an unchanged change.
+    const fs = createMockFileSystemService({
+      readFile: mock(() =>
+        Promise.resolve(
+          JSON.stringify({
+            mcpServers: { GitHits: piConfigSetup.serverConfig },
+          }),
+        ),
+      ),
+    });
+    const execService = createMockExecService({
+      exec: mock((command: string, args: string[]) => {
+        if (command === "pi" && args.join(" ") === "list") {
+          return Promise.resolve({ exitCode: 0, stdout: "", stderr: "" });
+        }
+        return Promise.resolve({
+          exitCode: 0,
+          stdout: "installed\n",
+          stderr: "",
+        });
+      }),
+    });
+
+    const result = await executeCompositeSetup(piSetup, fs, execService);
+    expect(result.changes).toEqual([
+      {
+        kind: "command",
+        command: "pi install npm:pi-mcp-adapter",
+        change: "ran",
+      },
+      {
+        kind: "config-file",
+        path: "/home/test/.pi/agent/mcp.json",
+        change: "unchanged",
+      },
+    ]);
+  });
+
   it("stops on failed install before writing config", async () => {
     const enoent = Object.assign(new Error("File not found"), {
       code: "ENOENT",
@@ -2458,6 +2531,41 @@ describe("executeConfigFileUninstall", () => {
     const result = await executeConfigFileUninstall(configSetup, fs);
     expect(result.status).toBe("not_configured");
     expect(fs.atomicWriteFile).not.toHaveBeenCalled();
+  });
+
+  it("reports an updated change with the path (file kept, entry stripped)", async () => {
+    const existing = JSON.stringify({
+      mcpServers: { GitHits: { command: "npx" } },
+    });
+    const fs = createMockFileSystemService({
+      readFile: mock(() => Promise.resolve(existing)),
+      atomicWriteFile: mock(() => Promise.resolve()),
+    });
+    const result = await executeConfigFileUninstall(configSetup, fs);
+    expect(result.changes).toEqual([
+      {
+        kind: "config-file",
+        path: "/home/test/.cursor/mcp.json",
+        change: "updated",
+      },
+    ]);
+  });
+
+  it("reports an unchanged change when the file is missing", async () => {
+    const enoent = Object.assign(new Error("File not found"), {
+      code: "ENOENT",
+    });
+    const fs = createMockFileSystemService({
+      readFile: mock(() => Promise.reject(enoent)),
+    });
+    const result = await executeConfigFileUninstall(configSetup, fs);
+    expect(result.changes).toEqual([
+      {
+        kind: "config-file",
+        path: "/home/test/.cursor/mcp.json",
+        change: "unchanged",
+      },
+    ]);
   });
 
   it("returns failed on malformed JSON without writing", async () => {
@@ -2610,6 +2718,48 @@ describe("executeCompositeUninstall", () => {
     expect(execService.exec).toHaveBeenCalledWith("pi", [
       "remove",
       "npm:pi-mcp-adapter",
+    ]);
+    // The config file is updated (entry stripped); the adapter-removal command
+    // is reported as ran.
+    expect(result.changes).toEqual([
+      {
+        kind: "config-file",
+        path: "/home/test/.pi/agent/mcp.json",
+        change: "updated",
+      },
+      {
+        kind: "command",
+        command: "pi remove npm:pi-mcp-adapter",
+        change: "ran",
+      },
+    ]);
+  });
+
+  it("keeps changes from earlier steps when a required step fails", async () => {
+    const fs = createMockFileSystemService({
+      readFile: mock(() =>
+        Promise.resolve(JSON.stringify({ mcpServers: { GitHits: {} } })),
+      ),
+    });
+    // Config removal succeeds; the required adapter removal command fails.
+    const execService = createMockExecService({
+      exec: mock(() =>
+        Promise.resolve({ exitCode: 1, stdout: "", stderr: "boom\n" }),
+      ),
+    });
+
+    const result = await executeCompositeUninstall(
+      piUninstall,
+      fs,
+      execService,
+    );
+    expect(result.status).toBe("failed");
+    expect(result.changes).toEqual([
+      {
+        kind: "config-file",
+        path: "/home/test/.pi/agent/mcp.json",
+        change: "updated",
+      },
     ]);
   });
 

--- a/src/commands/init/setup-handlers.ts
+++ b/src/commands/init/setup-handlers.ts
@@ -1457,7 +1457,7 @@ export async function executeCompositeSetup(
   fs: FileSystemService,
   execService: ExecService,
 ): Promise<SetupResult> {
-  let executedAny = false;
+  let changedAny = false;
   const changes: SetupChange[] = [];
 
   for (const step of setup.steps) {
@@ -1468,7 +1468,6 @@ export async function executeCompositeSetup(
       continue;
     }
 
-    executedAny = true;
     const result =
       step.method === "cli"
         ? await executeCliSetup(step, execService)
@@ -1477,6 +1476,13 @@ export async function executeCompositeSetup(
     if (result.changes) {
       changes.push(...result.changes);
     }
+    if (
+      result.status === "success" &&
+      (!result.changes ||
+        result.changes.some((change) => change.change !== "unchanged"))
+    ) {
+      changedAny = true;
+    }
     if (result.status === "failed") {
       // Keep prior steps (and any partial changes from the failing step)
       // visible on failure.
@@ -1484,7 +1490,7 @@ export async function executeCompositeSetup(
     }
   }
 
-  if (!executedAny) {
+  if (!changedAny) {
     return {
       status: "already_configured",
       message: "GitHits already configured",

--- a/src/commands/init/setup-handlers.ts
+++ b/src/commands/init/setup-handlers.ts
@@ -24,10 +24,15 @@ import type {
   ConfigFileFormat,
   ConfigFileSetup,
   SetupConfig,
-  UninstallConfig,
   UninstallStep,
 } from "./agent-definitions.js";
 import { traceProbeEnd, traceProbeStart } from "./init-trace.js";
+import {
+  describeConfigAsUnchanged,
+  formatCliCommand,
+  type SetupChange,
+  type UninstallChange,
+} from "./setup-format.js";
 
 /** A read-only command to check if a CLI agent is already configured. */
 export interface CliCheckCommand {
@@ -674,6 +679,12 @@ export interface SetupResult {
   status: "success" | "already_configured" | "failed";
   /** Human-readable message describing the outcome */
   message: string;
+  /**
+   * Per-target changes for display (paths written, commands run). Present on
+   * success/already_configured; carried through verification failure so the
+   * user can still see what was written.
+   */
+  changes?: SetupChange[];
 }
 
 /** Result of executing an uninstall operation */
@@ -683,6 +694,8 @@ export interface UninstallResult {
   message: string;
   /** Non-fatal cleanup or verification warnings. */
   warnings?: string[];
+  /** Per-target changes for display (paths/commands removed or already absent). */
+  changes?: UninstallChange[];
 }
 
 /**
@@ -845,49 +858,6 @@ export function hasServerConfigEntry(
     getMatchingServerKeys(servers as Record<string, unknown>, serverName)
       .length > 0
   );
-}
-
-/**
- * Format a setup config for display to the user before confirmation.
- * Returns human-readable description of what will happen.
- */
-export function formatSetupPreview(config: SetupConfig): string {
-  if (config.method === "composite") {
-    return config.steps.map((step) => formatSetupPreview(step)).join("\n");
-  }
-  if (config.method === "cli") {
-    return config.commands
-      .map((cmd) => `Will run: ${cmd.command} ${cmd.args.join(" ")}`)
-      .join("\n");
-  }
-  const snippet = JSON.stringify(
-    { [config.serverName]: config.serverConfig },
-    null,
-    2,
-  );
-  const formattedSnippet =
-    config.format === "yaml" || config.format === "toml"
-      ? renderConfigObjectForFormat(
-          { [config.serverName]: config.serverConfig },
-          config.format,
-        ).trimEnd()
-      : snippet;
-  return `Will add to ${config.configPath}:\n\n${formattedSnippet}`;
-}
-
-/** Format an uninstall config for display to the user before confirmation. */
-export function formatUninstallPreview(config: UninstallConfig): string {
-  if (config.method === "composite") {
-    return config.steps
-      .map(({ step }) => formatUninstallPreview(step))
-      .join("\n");
-  }
-  if (config.method === "cli") {
-    return config.commands
-      .map((cmd) => `Will run: ${cmd.command} ${cmd.args.join(" ")}`)
-      .join("\n");
-  }
-  return `Will remove ${config.serverName} from ${config.configPath}`;
 }
 
 /**
@@ -1213,33 +1183,45 @@ async function executeCliUninstallCommand(
  *
  * For multi-step setups (e.g., plugin marketplace add + plugin install),
  * commands run sequentially and stop on first failure.
- * If any step reports "already_configured", the overall result is "already_configured".
+ * The overall result is "success" if any command actually ran (made a change),
+ * and "already_configured" only when every command was already configured.
  */
 export async function executeCliSetup(
   setup: CliSetup,
   execService: ExecService,
 ): Promise<SetupResult> {
-  let anyAlreadyConfigured = false;
+  let anyRan = false;
+  // One change per command so multi-step setups (e.g. Claude Code's marketplace
+  // add + plugin install) report each command's individual outcome.
+  const changes: SetupChange[] = [];
 
   for (const cmd of setup.commands) {
     const result = await executeCliCommand(cmd, execService);
 
     if (result.status === "failed") {
-      return result;
+      // Keep the commands that already ran visible on failure.
+      return { ...result, changes };
     }
-    if (result.status === "already_configured") {
-      anyAlreadyConfigured = true;
+    const wasAlreadyConfigured = result.status === "already_configured";
+    if (!wasAlreadyConfigured) {
+      anyRan = true;
     }
+    changes.push({
+      kind: "command",
+      command: formatCliCommand(cmd),
+      change: wasAlreadyConfigured ? "unchanged" : "ran",
+    });
   }
 
-  if (anyAlreadyConfigured) {
+  if (!anyRan) {
     return {
       status: "already_configured",
       message: `GitHits already configured via ${setup.commands[0]?.command}`,
+      changes,
     };
   }
 
-  return { status: "success", message: "Configured successfully" };
+  return { status: "success", message: "Configured successfully", changes };
 }
 
 /** Execute a CLI-based uninstall with one or more sequential commands. */
@@ -1257,6 +1239,7 @@ export async function executeCliUninstall(
   let anyRemoved = false;
   let anyNotConfigured = false;
   const warnings: string[] = [];
+  const changes: UninstallChange[] = [];
 
   for (const cmd of uninstall.commands) {
     const result = await executeCliUninstallCommand(cmd, execService);
@@ -1266,8 +1249,13 @@ export async function executeCliUninstall(
         warnings.push(result.message);
         continue;
       }
-      return result;
+      return { ...result, changes };
     }
+    changes.push({
+      kind: "command",
+      command: formatCliCommand(cmd),
+      change: result.status === "removed" ? "ran" : "unchanged",
+    });
     if (result.status === "removed") {
       anyRemoved = true;
     }
@@ -1285,15 +1273,17 @@ export async function executeCliUninstall(
       status: "removed",
       message: "Removed successfully",
       warnings: warnings.length > 0 ? warnings : undefined,
+      changes,
     };
   }
   if (anyNotConfigured) {
     return {
       status: "not_configured",
       message: `GitHits not configured via ${uninstall.commands[0]?.command}`,
+      changes,
     };
   }
-  return { status: "removed", message: "Removed successfully" };
+  return { status: "removed", message: "Removed successfully", changes };
 }
 
 /** Execute an uninstall made from ordered CLI/config-file cleanup steps. */
@@ -1305,9 +1295,14 @@ export async function executeCompositeUninstall(
   let anyRemoved = false;
   let anyNotConfigured = false;
   const warnings: string[] = [];
+  const changes: UninstallChange[] = [];
 
   for (const { step, failureMode } of uninstall.steps) {
     const result = await executeUninstallStep(step, fs, execService);
+
+    if (result.changes) {
+      changes.push(...result.changes);
+    }
 
     if (result.status === "removed") {
       anyRemoved = true;
@@ -1328,7 +1323,7 @@ export async function executeCompositeUninstall(
       warnings.push(result.message);
       continue;
     }
-    return result;
+    return { ...result, changes };
   }
 
   if (anyRemoved) {
@@ -1336,6 +1331,7 @@ export async function executeCompositeUninstall(
       status: "removed",
       message: "Removed successfully",
       warnings: warnings.length > 0 ? warnings : undefined,
+      changes,
     };
   }
 
@@ -1343,10 +1339,15 @@ export async function executeCompositeUninstall(
     return {
       status: "not_configured",
       message: "GitHits not configured",
+      changes,
     };
   }
 
-  return { status: "not_configured", message: "GitHits not configured" };
+  return {
+    status: "not_configured",
+    message: "GitHits not configured",
+    changes,
+  };
 }
 
 async function executeUninstallStep(
@@ -1374,6 +1375,7 @@ export async function executeConfigFileSetup(
 
     // Read existing content or start fresh
     let existingContent = "";
+    let fileExisted = true;
     try {
       existingContent = await fs.readFile(setup.configPath);
     } catch (err) {
@@ -1388,6 +1390,7 @@ export async function executeConfigFileSetup(
           message: `Cannot read ${setup.configPath}: ${err instanceof Error ? err.message : String(err)}`,
         };
       }
+      fileExisted = false;
     }
 
     // Merge config
@@ -1403,6 +1406,9 @@ export async function executeConfigFileSetup(
       return {
         status: "already_configured",
         message: `GitHits already configured in ${setup.configPath}`,
+        changes: [
+          { kind: "config-file", path: setup.configPath, change: "unchanged" },
+        ],
       };
     }
 
@@ -1413,10 +1419,21 @@ export async function executeConfigFileSetup(
       };
     }
 
-    // Atomic write — result.status is "added" or "updated" here
+    // Atomic write — result.status is "added" or "updated" here. A pre-existing
+    // (even if empty) file counts as "updated"; only a missing file is "created".
     await fs.atomicWriteFile(setup.configPath, result.content);
 
-    return { status: "success", message: "Configured successfully" };
+    return {
+      status: "success",
+      message: "Configured successfully",
+      changes: [
+        {
+          kind: "config-file",
+          path: setup.configPath,
+          change: fileExisted ? "updated" : "created",
+        },
+      ],
+    };
   } catch (err) {
     if (err instanceof Error && "code" in err && err.code === "EACCES") {
       return {
@@ -1441,9 +1458,13 @@ export async function executeCompositeSetup(
   execService: ExecService,
 ): Promise<SetupResult> {
   let executedAny = false;
+  const changes: SetupChange[] = [];
 
   for (const step of setup.steps) {
     if (await isSetupAlreadyConfigured(step, fs, execService)) {
+      // Skipped steps still contribute an "unchanged" row so a partially
+      // configured composite (e.g. Pi) shows all of its sub-steps.
+      changes.push(...describeConfigAsUnchanged(step));
       continue;
     }
 
@@ -1453,8 +1474,13 @@ export async function executeCompositeSetup(
         ? await executeCliSetup(step, execService)
         : await executeConfigFileSetup(step, fs);
 
+    if (result.changes) {
+      changes.push(...result.changes);
+    }
     if (result.status === "failed") {
-      return result;
+      // Keep prior steps (and any partial changes from the failing step)
+      // visible on failure.
+      return { ...result, changes };
     }
   }
 
@@ -1462,10 +1488,11 @@ export async function executeCompositeSetup(
     return {
       status: "already_configured",
       message: "GitHits already configured",
+      changes,
     };
   }
 
-  return { status: "success", message: "Configured successfully" };
+  return { status: "success", message: "Configured successfully", changes };
 }
 
 /** Execute a config-file-based uninstall (read/remove/atomic-write). */
@@ -1482,6 +1509,13 @@ export async function executeConfigFileUninstall(
         return {
           status: "not_configured",
           message: `GitHits not configured in ${setup.configPath}`,
+          changes: [
+            {
+              kind: "config-file",
+              path: setup.configPath,
+              change: "unchanged",
+            },
+          ],
         };
       }
       return {
@@ -1501,6 +1535,9 @@ export async function executeConfigFileUninstall(
       return {
         status: "not_configured",
         message: `GitHits not configured in ${setup.configPath}`,
+        changes: [
+          { kind: "config-file", path: setup.configPath, change: "unchanged" },
+        ],
       };
     }
 
@@ -1511,9 +1548,17 @@ export async function executeConfigFileUninstall(
       };
     }
 
+    // The file is rewritten with the GitHits entry stripped — the file itself
+    // is updated, not deleted.
     await fs.atomicWriteFile(setup.configPath, result.content);
 
-    return { status: "removed", message: "Removed successfully" };
+    return {
+      status: "removed",
+      message: "Removed successfully",
+      changes: [
+        { kind: "config-file", path: setup.configPath, change: "updated" },
+      ],
+    };
   } catch (err) {
     if (err instanceof Error && "code" in err && err.code === "EACCES") {
       return {


### PR DESCRIPTION
Implements #156 and unifies the `init uninstall` experience with `init`.

## Install output

`4. Install and verify` now reports per-tool change rows instead of only fixed success text:

```text
  ✓ Claude Code         ran        claude plugin install githits@githits-plugins
  ✓ VS Code / Copilot   updated    ~/.config/Code/User/mcp.json
  ✓ Claude Desktop      created    ~/.config/Claude/claude_desktop_config.json
  ✓ Cursor              unchanged  ~/.cursor/mcp.json

  ✓ Configured MCP server "githits" with local command `npx -y githits@latest mcp start`
```

- config-file tools report `created`, `updated`, or `unchanged` plus a home/cwd-collapsed path
- CLI tools report one row per command with `ran` or `unchanged`
- composite setups report every sub-step, including already-configured ones
- normal `githits init` now includes already-configured tools in the audit rows, not just staged `--install-agents`
- `--install-agents --json` includes structured `changes`

## Uninstall output

User uninstall now uses the same selection model as install: configured tools are pre-checked, deselect means keep, and `--yes` removes from all configured tools.

Uninstall rows use the same renderer:

```text
  ✓ Cursor        updated    ~/.cursor/mcp.json
  ✓ Claude Code   ran        claude plugin uninstall githits
```

Config-file uninstall is `updated` because the GitHits entry is stripped while the shared config file is kept. CLI uninstall is `ran`; already-absent targets are `unchanged`.

Project uninstall keeps its project-specific planning/summary copy, but its per-path result rows now use the same aligned renderer:

```text
  ✓ GitHits project config       updated    ./.mcp.json
  ✓ Legacy project setup marker  updated    ./.githits/init/project-setup.json
```

## Implementation notes

- Adds `src/commands/init/setup-format.ts` for shared change row formatting, path collapsing, and unchanged-change synthesis.
- Threads structured setup/uninstall changes through executors and init outcomes.
- Preserves partial changes through later failures and verification failures so users can still find what was written or run.
- Keeps project uninstall path-oriented because several tools can share one project config file, but aligns the row layout with the rest of init/uninstall.
- Adds implementation documentation in `docs/implementation/init-setup-output.md`.

## Review follow-up

A code-review pass found that composite setup could report `success` when a false-negative pre-check was followed by all-unchanged child results. Fixed in a follow-up commit by deriving composite `success` from actual non-`unchanged` changes, with regression coverage.

## Verification

Latest local verification:

- `bun test src/commands/init/init.test.ts src/commands/init/setup-format.test.ts src/commands/init/setup-handlers.test.ts` — 292 pass / 0 fail
- `bun run build` — pass
- pre-commit hooks also ran `biome check --write` and `bun run typecheck` successfully

Earlier branch validation before the follow-up commits included full test/lint/build/smoke coverage noted in the original PR description.
