### PR TITLE
Build public artifacts before package validation

### DIFF
--- a/scripts/validate-public-packages.ts
+++ b/scripts/validate-public-packages.ts
@@ -66,6 +66,7 @@ const textDecoder = new TextDecoder();
 async function main(): Promise<void> {
   const tempRoot = await mkdtemp(join(tmpdir(), "githits-public-packages-"));
   try {
+    await buildPublicPackageArtifacts();
     await assertPublicManifestBoundaries();
 
     for (const packageInfo of publicPackages) {
@@ -95,6 +96,16 @@ async function main(): Promise<void> {
   } finally {
     await rm(tempRoot, { recursive: true, force: true });
   }
+}
+
+async function buildPublicPackageArtifacts(): Promise<void> {
+  await runCommand("bun", ["run", "build"], root, "build root package");
+  await runCommand(
+    "bun",
+    ["run", "build"],
+    join(root, "packages", "mcp"),
+    "build mcp package",
+  );
 }
 
 async function assertPublicManifestBoundaries(): Promise<void> {


### PR DESCRIPTION
## Summary
- make public package validation build root and MCP dist artifacts before scanning or packing
- fixes validate:packages:mcp-publish from a clean checkout with no packages/mcp/dist

## Validation
- rm -rf dist packages/mcp/dist && bun run validate:packages:mcp-publish
- bun test src/package-release-boundaries.test.ts
- bun run typecheck
- bun run format:check
- bun run lint