### PR TITLE
Skip MCP publish dry-run for published versions

### DIFF
--- a/scripts/validate-public-packages.ts
+++ b/scripts/validate-public-packages.ts
@@ -84,12 +84,26 @@ async function main(): Promise<void> {
     }
 
     if (runMcpPublishDryRun) {
-      await runCommand(
-        "npm",
-        ["publish", "--dry-run", "--access", "public"],
-        join(root, "packages", "mcp"),
-        "mcp npm publish dry-run",
+      const mcpPackageJson = await readPackageJson(
+        join(root, "packages", "mcp", "package.json"),
       );
+      const mcpVersion = mcpPackageJson.version;
+      if (typeof mcpVersion !== "string") {
+        throw new Error("packages/mcp/package.json must have a string version");
+      }
+
+      if (await packageVersionExists("@githits/mcp", mcpVersion)) {
+        console.log(
+          `Skipping MCP npm publish dry-run because @githits/mcp@${mcpVersion} is already published`,
+        );
+      } else {
+        await runCommand(
+          "npm",
+          ["publish", "--dry-run", "--access", "public"],
+          join(root, "packages", "mcp"),
+          "mcp npm publish dry-run",
+        );
+      }
     }
 
     console.log("Public package validation passed");
@@ -133,6 +147,21 @@ async function assertPublicManifestBoundaries(): Promise<void> {
 
 async function readPackageJson(path: string): Promise<Record<string, unknown>> {
   return JSON.parse(await readFile(path, "utf8")) as Record<string, unknown>;
+}
+
+async function packageVersionExists(
+  packageName: string,
+  version: string,
+): Promise<boolean> {
+  const process = Bun.spawn(
+    ["npm", "view", `${packageName}@${version}`, "version"],
+    {
+      cwd: root,
+      stderr: "ignore",
+      stdout: "ignore",
+    },
+  );
+  return (await process.exited) === 0;
 }
 
 function assertNoDependency(


### PR DESCRIPTION
## Summary
- let package validation skip npm publish --dry-run when @githits/mcp at the current version is already published
- keeps dry-run validation useful after the one-time bootstrap publish
- still runs npm publish --dry-run for unpublished versions

## Validation
- bun run validate:packages:mcp-publish
- bun run typecheck
- bun test src/package-release-boundaries.test.ts
- bun run format:check
- bun run lint