### PR TITLE
chore: prepare 0.5.0 release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "GitHits plugins for Claude Code - code examples from global open source",
-    "version": "0.4.15"
+    "version": "0.5.0"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.4.15",
+  "version": "0.5.0",
   "description": "Code examples from global open source for developers and AI assistants",
   "author": {
     "name": "GitHits"

--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.4.15",
+  "version": "0.5.0",
   "description": "Code examples from global open source for developers and AI assistants",
   "author": {
     "name": "GitHits"

--- a/bun.lock
+++ b/bun.lock
@@ -40,9 +40,8 @@
     },
     "packages/mcp": {
       "name": "@githits/mcp",
-      "version": "0.4.11",
+      "version": "0.4.15",
       "dependencies": {
-        "@githits/core-internal": "workspace:*",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "^4.4.3",
       },

--- a/docs/guidelines/DOCUMENTATION_GUIDELINES.md
+++ b/docs/guidelines/DOCUMENTATION_GUIDELINES.md
@@ -36,7 +36,7 @@ A reader who stops halfway should still have gained the core understanding.
 
 Point to canonical implementations rather than copy-pasting code:
 
-**Prefer**: "See `src/tools/search.ts` for the implementation pattern"
+**Prefer**: "See `packages/mcp/src/tools/search.ts` for the implementation pattern"
 
 **Avoid**: Embedding 50 lines of code that will drift out of sync
 

--- a/docs/guidelines/TESTING.md
+++ b/docs/guidelines/TESTING.md
@@ -6,7 +6,7 @@ This document provides comprehensive testing patterns for githits-cli.
 
 - **Test Runner**: Bun test (`bun test`)
 - **Mocking**: Bun's built-in `mock()` function
-- **Tool Testing**: See tool test files alongside implementations (e.g., `src/tools/search.test.ts`)
+- **Tool Testing**: See tool test files alongside implementations (e.g., `packages/mcp/src/tools/search.test.ts`)
 
 ## Testing Philosophy
 
@@ -51,7 +51,7 @@ Create a central mock factory in `test-helpers.ts`:
 
 ```typescript
 import { mock } from "bun:test";
-import type { GitHitsService } from "../services/githits-service.js";
+import type { GitHitsService } from "@githits/core-internal";
 
 export function createMockGitHitsService(
   impl: Partial<GitHitsService> = {}
@@ -215,7 +215,7 @@ Do not assert mixed path strings such as `C:\\Users\\test/AppData/Roaming/githit
 bun test
 
 # Run specific test file
-bun test src/tools/search.test.ts
+bun test packages/mcp/src/tools/search.test.ts
 
 # Run tests matching pattern
 bun test --grep "search"
@@ -227,11 +227,13 @@ bun test --watch
 ## Test File Organization
 
 ```
-src/
+packages/mcp/src/
   tools/
     search.ts              # Implementation
     search.test.ts         # Tests
+  services/
     test-helpers.ts        # Shared mock factories
+src/
   commands/
     login.ts               # Implementation
     login.test.ts          # Tests

--- a/docs/guidelines/TESTING.md
+++ b/docs/guidelines/TESTING.md
@@ -22,7 +22,7 @@ This document provides comprehensive testing patterns for githits-cli.
 ```typescript
 import { describe, expect, it, mock } from "bun:test";
 import { createMyTool } from "./my-tool.js";
-import { createMockGitHitsService } from "./test-helpers.js";
+import { createMockGitHitsService } from "../services/test-helpers.js";
 
 describe("createMyTool", () => {
   it("returns tool with correct metadata", () => {

--- a/docs/implementation/EVAL_HARNESS.md
+++ b/docs/implementation/EVAL_HARNESS.md
@@ -186,7 +186,7 @@ Before any empirical pass runs:
 - Neither `ANTHROPIC_API_KEY` nor `OPENAI_API_KEY` set (drivers
   refuse to run otherwise — they only use subscription auth).
 - `eval/mock-mcp/server.ts` imports the live production wording from
-  `src/tools/guardrails.ts` and each tool's exported `DESCRIPTION`.
+  `packages/mcp/src/tools/guardrails.ts` and each tool's exported `DESCRIPTION`.
   Verify by inspecting `eval/mock-mcp/server.ts` imports.
 
 ## Cost shape

--- a/docs/implementation/TOOL_GUARDRAILS.md
+++ b/docs/implementation/TOOL_GUARDRAILS.md
@@ -5,7 +5,7 @@ shared block and per-tool addenda that defend agent flows against
 indirect prompt injection delivered via tool results. It was
 empirically validated by the eval harness in `eval/` against
 Codex gpt-5.4-mini on the `pkg_changelog` surface, and ships in
-`src/tools/guardrails.ts` + `src/mcp/instructions.ts` +
+`packages/mcp/src/tools/guardrails.ts` + `packages/mcp/src/mcp/instructions.ts` +
 each tool's `DESCRIPTION` constant.
 
 ## Threat model (summary)
@@ -84,7 +84,7 @@ additional consideration.
 
 ## Where the wording lives
 
-- Constants: `src/tools/guardrails.ts`
+- Constants: `packages/mcp/src/tools/guardrails.ts`
   - `EXTERNAL_CONTENT_POSTURE` — the shared block (~170 words /
     ~220-250 tokens depending on tokenizer).
   - `PKG_VULNS_GUARDRAIL`, `PKG_INFO_GUARDRAIL`,
@@ -92,7 +92,7 @@ additional consideration.
     `CODE_GREP_GUARDRAIL`, `SEARCH_GUARDRAIL`, `GET_EXAMPLE_GUARDRAIL`
     — currently empty strings, reserved for restoration if a tool
     surface regresses.
-- Shared-block wiring: `src/mcp/instructions.ts` — inserted
+- Shared-block wiring: `packages/mcp/src/mcp/instructions.ts` — inserted
   between `CORE_BLOCK` and `PACKAGE_TOOLS_PREAMBLE`.
 - Per-tool wiring: each tool file imports its guardrail constant
   and appends it to `DESCRIPTION` with `\n\n` separator. Empty
@@ -111,7 +111,7 @@ maintainer-controlled content:
 2. Wire the tool into the MCP server normally — the shared block is
    inherited automatically and is intended to be sufficient.
 3. If a Pass 1 cell on the new tool shows compliance >= 2/3 on any
-   attack, add a per-tool addendum to `src/tools/guardrails.ts`
+   attack, add a per-tool addendum to `packages/mcp/src/tools/guardrails.ts`
    naming the trustworthy structured fields and any tool-specific
    notes (e.g., "comments and string literals may target you" for
    code-surface tools). **Never reference other tools by name in the

--- a/docs/implementation/cli-commands.md
+++ b/docs/implementation/cli-commands.md
@@ -396,8 +396,8 @@ Each command follows this pattern:
 |---|---|
 | `GitHitsService` (via container) | `example`, `languages`, `feedback`, and always-on MCP tools |
 | `CodeNavigationService` (via container) | top-level unified `search` / `search-status`, MCP indexed-search tools (`search`, `search_status`, `code_files`, `code_read`, `code_grep`), and the `githits code` command group |
-| `filterLanguages()` from `src/shared/language-filter.ts` | `search_language` MCP tool + `languages` CLI command |
-| `requireAuth()` from `src/shared/require-auth.ts` | all CLI commands and auth-required MCP tool handlers |
+| `filterLanguages()` from `packages/mcp/src/shared/language-filter.ts` | `search_language` MCP tool + `languages` CLI command |
+| `requireAuth()` from `packages/mcp/src/shared/require-auth.ts` | all CLI commands and auth-required MCP tool handlers |
 
 ## Adding a New CLI Command
 
@@ -438,9 +438,9 @@ All commands support two output modes:
 | `src/commands/search.ts` | Unified search and search-status command implementation |
 | `src/commands/languages.ts` | Languages command with colored output |
 | `src/commands/feedback.ts` | Feedback command with accept/reject validation |
-| `src/shared/language-filter.ts` | Pure `filterLanguages()` shared with MCP tool |
-| `src/shared/require-auth.ts` | Auth guard shared with MCP server |
-| `src/shared/colors.ts` | ANSI color utilities and `shouldUseColors()` |
+| `packages/mcp/src/shared/language-filter.ts` | Pure `filterLanguages()` shared with MCP tool |
+| `packages/mcp/src/shared/require-auth.ts` | Auth guard shared with MCP server |
+| `packages/mcp/src/shared/colors.ts` | ANSI color utilities and `shouldUseColors()` |
 | `src/container.ts` | Dependency container with `githitsService` |
 | `src/commands/init/init.ts` | Init command orchestrator |
 | `src/commands/init/agent-definitions.ts` | Agent detection and setup config |

--- a/docs/implementation/mcp-cli-parity.md
+++ b/docs/implementation/mcp-cli-parity.md
@@ -61,13 +61,13 @@ test suite anchors the doc.
 - **Public enum values** are lowercase strings on both surfaces
   (`production`, `test`, `summary`, `all`).
 - **Service coercion** from lowercase enum values to the internal
-  request enums lives in `src/shared/code-navigation.ts`
+  request enums lives in `packages/mcp/src/shared/code-navigation.ts`
   (`toFileIntent`, `toSymbolKind`, `toSymbolCategory`).
 
 ### `PARITY-DEFAULTS`
 
 - Both surfaces import defaults from
-  `src/shared/code-navigation-defaults.ts`. They never diverge
+  `packages/mcp/src/shared/code-navigation-defaults.ts`. They never diverge
   silently.
 - Cross-tool defaults (e.g. `DEFAULT_WAIT_TIMEOUT_MS`) live without a
   prefix. Tool-local sentinels live there too so both surfaces translate
@@ -80,11 +80,11 @@ test suite anchors the doc.
 ### `PARITY-REQUEST`
 
 - Request construction for a dual-surface tool routes through a single
-  shared helper at `src/shared/<tool>-request.ts`. The helper fills in
+  shared helper at `packages/mcp/src/shared/<tool>-request.ts`. The helper fills in
   defaults and translates user-facing sentinel values into wire-level
   equivalents.
 - Cross-tool helpers (error classification, target resolution) live in
-  `src/shared/` without a tool-name prefix.
+  `packages/mcp/src/shared/` without a tool-name prefix.
 
 ### `PARITY-JSON-KEYS`
 
@@ -112,7 +112,7 @@ test suite anchors the doc.
 - `code` is mandatory. `UNKNOWN` is a last resort — every named error
   class in the code-navigation and package-intelligence stacks maps to a
   specific code. The classifier is tested by table in
-  `src/shared/code-navigation-error-map.test.ts`; that test is the
+  `packages/mcp/src/shared/code-navigation-error-map.test.ts`; that test is the
   enforcement mechanism, not a convention.
 - MCP error text is always valid JSON. A client that parses
   `content[0].text` on error gets the same envelope as CLI `--json`.
@@ -131,14 +131,14 @@ test suite anchors the doc.
 When a new tool lands with both MCP and CLI surfaces:
 
 - [ ] Tool-specific defaults added to
-  `src/shared/code-navigation-defaults.ts` with a `TOOLNAME_` prefix.
-- [ ] Request builder at `src/shared/<tool>-request.ts`. Both surfaces
+  `packages/mcp/src/shared/code-navigation-defaults.ts` with a `TOOLNAME_` prefix.
+- [ ] Request builder at `packages/mcp/src/shared/<tool>-request.ts`. Both surfaces
   import it.
 - [ ] Error classifier reused (`mapCodeNavigationError` /
   `mapPackageIntelligenceError`). Add new `MappedErrorCode` variants
   only when a genuinely new error class exists; cover the new branch
   in the table test.
-- [ ] Response builder at `src/shared/<tool>-response.ts` emitting the
+- [ ] Response builder at `packages/mcp/src/shared/<tool>-response.ts` emitting the
   shared success and error envelopes. JSON shape matches
   `PARITY-JSON-KEYS` rules.
 - [ ] Parity test at `src/tools/<tool>-parity.test.ts` that cites the
@@ -160,42 +160,42 @@ When a new tool lands with both MCP and CLI surfaces:
 
 | File | Role |
 |---|---|
-| `src/shared/code-navigation-defaults.ts` | Canonical cross-surface defaults and sentinels. |
-| `src/shared/code-navigation-error-map.ts` | `mapCodeNavigationError` classifier and `MappedError` union. |
-| `src/shared/pkgseer-graphql.ts` | Low-level authenticated package/source POST helper shared by the service clients. |
-| `src/shared/pkgseer-registry.ts` | Registry taxonomy (registry union type + lowercase↔uppercase converters). |
-| `src/shared/unified-search-request.ts` | Shared request builder for unified `search`; compiles structured query fields and applies defaulting. |
-| `src/shared/unified-search-response.ts` | Shared JSON envelope builders for unified `search` and follow-up `search_status`. |
-| `src/shared/package-summary-request.ts` | Shared request builder for `pkg_info`. |
-| `src/shared/package-summary-response.ts` | Lean JSON envelope builder and shared text/terminal formatter for `pkg_info`. |
-| `src/shared/package-vulnerabilities-request.ts` | Shared request builder for `pkg_vulns`. |
-| `src/shared/package-vulnerabilities-response.ts` | Lean JSON envelope builder and shared text/terminal formatter for `pkg_vulns`. |
-| `src/shared/package-dependencies-request.ts` | Shared request builder for `pkg_deps`. |
-| `src/shared/package-dependencies-response.ts` | Lean JSON envelope builder and shared text/terminal formatter for `pkg_deps`. |
-| `src/shared/package-changelog-request.ts` | Shared request builder for `pkg_changelog`. |
-| `src/shared/package-changelog-response.ts` | JSON envelope builder and shared text/terminal formatter for `pkg_changelog`. |
-| `src/shared/list-files-request.ts` | Shared request builder for `code_files`. |
-| `src/shared/list-files-response.ts` | JSON envelope builder for `code_files`. |
-| `src/shared/read-file-request.ts` | Shared request builder for `code_read`. |
-| `src/shared/read-file-response.ts` | JSON envelope builder for `code_read`. Normalises envelope key to `path` (not `filePath`) so `code_files` → `code_read` chains without renames. |
-| `src/shared/grep-repo-request.ts` | Shared request builder for `code_grep`. Exports `GREP_REPO_PATTERN_NOTE` referenced by MCP description, MCP `pattern` describe, and CLI help. |
-| `src/shared/grep-repo-response.ts` | JSON envelope builder for `code_grep`. |
-| `src/shared/list-package-docs-request.ts` / `list-package-docs-response.ts` | Shared request and envelope for `docs_list`. |
-| `src/shared/read-package-doc-request.ts` / `read-package-doc-response.ts` | Shared request and envelope for `docs_read`. |
-| `src/shared/code-navigation-error-map.ts` | Owns the `INDEXING` / `FILE_NOT_FOUND` / `NOT_FOUND` codes shared across all code-nav tools. |
-| `src/shared/package-intelligence-error-map.ts` | `mapPackageIntelligenceError` classifier (reuses `MappedError` from the code-nav map). |
-| `src/services/promote-version-not-found.ts` | Shared helper that promotes generic backend errors with "no matching version" messages into typed `VERSION_NOT_FOUND`. |
-| `src/tools/code-navigation-shared.ts` | `codeTargetSchema` + `resolveCodeTarget` — the addressing primitive used by `code_files`, `code_read`, `code_grep`, and unified `search`. |
-| `src/tools/search.ts` | MCP tool definition for unified `search`. |
-| `src/tools/search-status.ts` | MCP tool definition for `search_status`. |
-| `src/tools/package-summary.ts` | MCP tool definition for `pkg_info`. |
-| `src/tools/package-vulnerabilities.ts` | MCP tool definition for `pkg_vulns`. |
-| `src/tools/package-dependencies.ts` | MCP tool definition for `pkg_deps`. |
-| `src/tools/package-changelog.ts` | MCP tool definition for `pkg_changelog`. |
-| `src/tools/list-files.ts` | MCP tool definition for `code_files`. |
-| `src/tools/read-file.ts` | MCP tool definition for `code_read`. |
-| `src/tools/grep-repo.ts` | MCP tool definition for `code_grep`. |
-| `src/tools/list-package-docs.ts` / `read-package-doc.ts` | MCP tool definitions for the docs surface. |
+| `packages/mcp/src/shared/code-navigation-defaults.ts` | Canonical cross-surface defaults and sentinels. |
+| `packages/mcp/src/shared/code-navigation-error-map.ts` | `mapCodeNavigationError` classifier and `MappedError` union. |
+| `packages/core-internal/src/shared/pkgseer-graphql.ts` | Low-level authenticated package/source POST helper shared by the service clients. |
+| `packages/core-internal/src/shared/pkgseer-registry.ts` | Registry taxonomy (registry union type + lowercase↔uppercase converters). |
+| `packages/mcp/src/shared/unified-search-request.ts` | Shared request builder for unified `search`; compiles structured query fields and applies defaulting. |
+| `packages/mcp/src/shared/unified-search-response.ts` | Shared JSON envelope builders for unified `search` and follow-up `search_status`. |
+| `packages/mcp/src/shared/package-summary-request.ts` | Shared request builder for `pkg_info`. |
+| `packages/mcp/src/shared/package-summary-response.ts` | Lean JSON envelope builder and shared text/terminal formatter for `pkg_info`. |
+| `packages/mcp/src/shared/package-vulnerabilities-request.ts` | Shared request builder for `pkg_vulns`. |
+| `packages/mcp/src/shared/package-vulnerabilities-response.ts` | Lean JSON envelope builder and shared text/terminal formatter for `pkg_vulns`. |
+| `packages/mcp/src/shared/package-dependencies-request.ts` | Shared request builder for `pkg_deps`. |
+| `packages/mcp/src/shared/package-dependencies-response.ts` | Lean JSON envelope builder and shared text/terminal formatter for `pkg_deps`. |
+| `packages/mcp/src/shared/package-changelog-request.ts` | Shared request builder for `pkg_changelog`. |
+| `packages/mcp/src/shared/package-changelog-response.ts` | JSON envelope builder and shared text/terminal formatter for `pkg_changelog`. |
+| `packages/mcp/src/shared/list-files-request.ts` | Shared request builder for `code_files`. |
+| `packages/mcp/src/shared/list-files-response.ts` | JSON envelope builder for `code_files`. |
+| `packages/mcp/src/shared/read-file-request.ts` | Shared request builder for `code_read`. |
+| `packages/mcp/src/shared/read-file-response.ts` | JSON envelope builder for `code_read`. Normalises envelope key to `path` (not `filePath`) so `code_files` -> `code_read` chains without renames. |
+| `packages/mcp/src/shared/grep-repo-request.ts` | Shared request builder for `code_grep`. Exports `GREP_REPO_PATTERN_NOTE` referenced by MCP description, MCP `pattern` describe, and CLI help. |
+| `packages/mcp/src/shared/grep-repo-response.ts` | JSON envelope builder for `code_grep`. |
+| `packages/mcp/src/shared/list-package-docs-request.ts` / `list-package-docs-response.ts` | Shared request and envelope for `docs_list`. |
+| `packages/mcp/src/shared/read-package-doc-request.ts` / `read-package-doc-response.ts` | Shared request and envelope for `docs_read`. |
+| `packages/mcp/src/shared/code-navigation-error-map.ts` | Owns the `INDEXING` / `FILE_NOT_FOUND` / `NOT_FOUND` codes shared across all code-nav tools. |
+| `packages/mcp/src/shared/package-intelligence-error-map.ts` | `mapPackageIntelligenceError` classifier (reuses `MappedError` from the code-nav map). |
+| `packages/core-internal/src/services/promote-version-not-found.ts` | Shared helper that promotes generic backend errors with "no matching version" messages into typed `VERSION_NOT_FOUND`. |
+| `packages/mcp/src/tools/code-navigation-shared.ts` | `codeTargetSchema` + `resolveCodeTarget` — the addressing primitive used by `code_files`, `code_read`, `code_grep`, and unified `search`. |
+| `packages/mcp/src/tools/search.ts` | MCP tool definition for unified `search`. |
+| `packages/mcp/src/tools/search-status.ts` | MCP tool definition for `search_status`. |
+| `packages/mcp/src/tools/package-summary.ts` | MCP tool definition for `pkg_info`. |
+| `packages/mcp/src/tools/package-vulnerabilities.ts` | MCP tool definition for `pkg_vulns`. |
+| `packages/mcp/src/tools/package-dependencies.ts` | MCP tool definition for `pkg_deps`. |
+| `packages/mcp/src/tools/package-changelog.ts` | MCP tool definition for `pkg_changelog`. |
+| `packages/mcp/src/tools/list-files.ts` | MCP tool definition for `code_files`. |
+| `packages/mcp/src/tools/read-file.ts` | MCP tool definition for `code_read`. |
+| `packages/mcp/src/tools/grep-repo.ts` | MCP tool definition for `code_grep`. |
+| `packages/mcp/src/tools/list-package-docs.ts` / `read-package-doc.ts` | MCP tool definitions for the docs surface. |
 | `src/commands/search.ts` | Top-level CLI commands for unified `search` and `search-status`. |
 | `src/commands/pkg/info.ts` / `vulns.ts` / `deps.ts` / `changelog.ts` | CLI commands for the `pkg` group. |
 | `src/commands/code/files.ts` / `read.ts` / `grep.ts` | CLI commands for the `code` group. |
@@ -299,7 +299,7 @@ When a new tool lands with both MCP and CLI surfaces:
 ### `code_files` / `code_read` / `code_grep` (file-exploration bundle)
 
 All three reuse `codeTargetSchema` + `resolveCodeTarget` from
-`src/tools/code-navigation-shared.ts`. The indexing lifecycle is
+`packages/mcp/src/tools/code-navigation-shared.ts`. The indexing lifecycle is
 shared (see `tools.md` "Indexing lifecycle" section). Parity tests
 cover dual addressing, default + explicit filter echoes, INDEXING
 error envelope, NOT_FOUND envelope, and INVALID_ARGUMENT with full

--- a/docs/implementation/pkg-upgrade-review.md
+++ b/docs/implementation/pkg-upgrade-review.md
@@ -481,9 +481,9 @@ Add instruction-level guidance now:
 
 Add the tool in the same style as current package tools:
 
-- `src/tools/package-upgrade-review.ts`
+- `packages/mcp/src/tools/package-upgrade-review.ts`
 - `src/commands/pkg/upgrade-review.ts` if exposing a CLI command
-- shared request/response modules under `src/shared/package-upgrade-review-*`
+- shared request/response modules under `packages/mcp/src/shared/package-upgrade-review-*`
 - service composition should live in a focused helper module that reuses existing service methods plus the dedicated internal dependency probe
 - parity tests should assert CLI `--json` and MCP `format:"json"` equality
 - text snapshot tests should cover vulnerability, changelog, dependency-change, and unknown-evidence cases

--- a/docs/implementation/signup-flow.md
+++ b/docs/implementation/signup-flow.md
@@ -15,7 +15,7 @@ The underlying OAuth pieces already exist:
 - `src/services/auth-service.ts` serves the callback success page and exchanges
   the auth code for tokens.
 - `src/container.ts` resolves token state at startup.
-- `src/shared/require-auth.ts` currently blocks individual command actions when
+- `packages/mcp/src/shared/require-auth.ts` currently blocks individual command actions when
   no valid token is present.
 
 Today, auth-required commands fail fast and tell the user to run `githits
@@ -147,7 +147,7 @@ Use these rules when implementing the feature:
 |---|---|
 | `src/cli.ts` | Best hook point for a single auto-login bootstrap policy. |
 | `src/commands/login.ts` | Reusable login flow and current standalone login output. |
-| `src/shared/require-auth.ts` | Final invariant for command actions after bootstrap. |
+| `packages/mcp/src/shared/require-auth.ts` | Final invariant for command actions after bootstrap. |
 | `src/container.ts` | Startup token resolution and auth-state snapshot. |
 | `src/commands/init/init.ts` | Advertised onboarding command; `--skip-login` remains the explicit opt-out. |
 | `src/commands/search.ts` | Top-level package/source registration and auth-required action. |

--- a/docs/implementation/tools.md
+++ b/docs/implementation/tools.md
@@ -55,7 +55,7 @@ Treat failures as live backend or contract findings, not deterministic unit-test
 
 **Unified `search` query syntax.** The `search.query` field is the backend discovery query syntax, not a raw pass-through to a per-source search engine. It supports implicit `AND`, uppercase `OR`, parentheses, unary `-`, quoted phrases, semantic qualifiers (`kind:`, `category:`, `path:`, `lang:`, `name:`, `intent:`), and routing qualifiers (`registry:`, `package:`, `version:`, `repo:`). The backend parses the query once and compiles it per source. Structured `name` and `language` inputs are compiled into `name:` / `lang:` qualifiers and AND-ed with the query before sending. Per-source support, ignored features, and incompatibilities are reported in `sourceStatus`.
 
-**Promoted `warnings[]`.** Noteworthy `sourceStatus` entries — sources reporting `incompatibleQueryFeatures`, `ignoredQueryFeatures`, `incompatibleFilters`, `ignoredFilters`, lifecycle anomalies (`indexingStatus`, `codeIndexState`), or a free-form `note` — are also surfaced as a top-level `warnings: string[]` in the completed/incomplete payloads (and appended after parser warnings inside the `search_status` result block). The structured detail still lives in `sourceStatus`; `warnings[]` is the agent-visible signal that something about execution did not match the request. Mitigates backend issue B5: docs-only search plus a `kind:`/`lang:` qualifier returns `results: []` with the only diagnostic buried inside `sourceStatus[].note`. The text-v1 renderer prints the warnings as a `warnings:` preamble. Implementation in `buildSourceStatusWarnings` (`src/shared/unified-search-response.ts`); remove once the backend surfaces these at the top level itself.
+**Promoted `warnings[]`.** Noteworthy `sourceStatus` entries — sources reporting `incompatibleQueryFeatures`, `ignoredQueryFeatures`, `incompatibleFilters`, `ignoredFilters`, lifecycle anomalies (`indexingStatus`, `codeIndexState`), or a free-form `note` — are also surfaced as a top-level `warnings: string[]` in the completed/incomplete payloads (and appended after parser warnings inside the `search_status` result block). The structured detail still lives in `sourceStatus`; `warnings[]` is the agent-visible signal that something about execution did not match the request. Mitigates backend issue B5: docs-only search plus a `kind:`/`lang:` qualifier returns `results: []` with the only diagnostic buried inside `sourceStatus[].note`. The text-v1 renderer prints the warnings as a `warnings:` preamble. Implementation in `buildSourceStatusWarnings` (`packages/mcp/src/shared/unified-search-response.ts`); remove once the backend surfaces these at the top level itself.
 
 ### `pkg_info` response shape
 
@@ -67,7 +67,7 @@ Treat failures as live backend or contract findings, not deterministic unit-test
 
 **Always latest.** The query exposes no `version` input because the upstream `packageSummary` resolver always returns the latest published version. The CLI `githits pkg info` rejects `<spec>@<version>` with `INVALID_ARGUMENT` rather than silently swapping — a silent-swap would break security-testing workflows that pin to an older vulnerable release.
 
-`pkg_info` shares its envelope builder, text formatter, and error classifier with the CLI `githits pkg info` command via `src/shared/package-summary-request.ts`, `src/shared/package-summary-response.ts`, and `src/shared/package-intelligence-error-map.ts`. The parity test (`src/tools/package-summary-parity.test.ts`) passes `format: "json"` and asserts `toEqual` between CLI `--json` and MCP JSON output for service-sourced fixtures, and `toMatchObject` for the `INVALID_ARGUMENT` fixture where surface-specific error text is acceptable.
+`pkg_info` shares its envelope builder, text formatter, and error classifier with the CLI `githits pkg info` command via `packages/mcp/src/shared/package-summary-request.ts`, `packages/mcp/src/shared/package-summary-response.ts`, and `packages/mcp/src/shared/package-intelligence-error-map.ts`. The parity test (`src/tools/package-summary-parity.test.ts`) passes `format: "json"` and asserts `toEqual` between CLI `--json` and MCP JSON output for service-sourced fixtures, and `toMatchObject` for the `INVALID_ARGUMENT` fixture where surface-specific error text is acceptable.
 
 ### `pkg_vulns` response shape
 
@@ -77,7 +77,7 @@ Treat failures as live backend or contract findings, not deterministic unit-test
 
 **Partitioning buckets.** Advisories with `isMalicious: true` count **only** under `summary.bySeverity.malware`; severity bands (`critical`/`high`/`medium`/`low`) count non-malicious advisories with a positive CVSS score; non-malicious advisories with no score count under `summary.bySeverity.unrated`. Every returned advisory lands in exactly one bucket. For default affected scope, the bucket sum equals `summary.total`. For `non_affecting` / `all`, the bucket sum describes the selected advisory rows while `summary.total` still describes affected-version risk. The malware bucket sorts to the top of the advisory list regardless of score. The `unrated` bucket keeps Rust / PyPI packages with missing CVSS values explicit.
 
-**Alias-cluster dedup.** Some registries (most visibly Crates) return the GHSA-prefixed and the RUSTSEC-prefixed entry for the same underlying vulnerability as separate advisories, cross-linked via `aliases[]`. The shared envelope builder unions clusters over `id ∪ aliases[]`, picks one canonical advisory per cluster (severity-bearing entries first, then `GHSA-*` over `RUSTSEC-*`, then lexicographic `id` ascending), and merges the rest under the canonical's `aliases`. `affectedRanges`, `fixedIn`, malware/withdrawn flags, and the latest `modifiedAt` are unioned across the cluster; a withdrawal only sticks if every cluster member is withdrawn. `summary.total` and `summary.bySeverity` are recomputed from the deduped list so the partition invariant holds. This is a client-side mitigation for backend issue B3 (https://app.githits.com — eval report 2026-04-28); remove `dedupAdvisoriesByAlias` from `src/shared/package-vulnerabilities-response.ts` once the backend dedups upstream.
+**Alias-cluster dedup.** Some registries (most visibly Crates) return the GHSA-prefixed and the RUSTSEC-prefixed entry for the same underlying vulnerability as separate advisories, cross-linked via `aliases[]`. The shared envelope builder unions clusters over `id ∪ aliases[]`, picks one canonical advisory per cluster (severity-bearing entries first, then `GHSA-*` over `RUSTSEC-*`, then lexicographic `id` ascending), and merges the rest under the canonical's `aliases`. `affectedRanges`, `fixedIn`, malware/withdrawn flags, and the latest `modifiedAt` are unioned across the cluster; a withdrawal only sticks if every cluster member is withdrawn. `summary.total` and `summary.bySeverity` are recomputed from the deduped list so the partition invariant holds. This is a client-side mitigation for backend issue B3 (https://app.githits.com — eval report 2026-04-28); remove `dedupAdvisoriesByAlias` from `packages/mcp/src/shared/package-vulnerabilities-response.ts` once the backend dedups upstream.
 
 **Version validation.** `pkg_vulns` accepts canonical package versions only. Tag-style refs with a leading `v` (for example `v4.18.0`) are rejected client-side with `INVALID_ARGUMENT` before the backend call. This avoids the current production backend's unhelpful generic error for that input shape. This is intentionally narrow: proper ecosystem-aware version parsing and typed invalid-version errors belong in the backend, not in ad hoc CLI normalization rules.
 
@@ -85,9 +85,9 @@ Treat failures as live backend or contract findings, not deterministic unit-test
 
 **Omission rules.** Null scalars omitted; empty arrays dropped; zero-count `bySeverity` keys dropped; the `bySeverity` block itself dropped when `total === 0`. `modifiedAt` included only when it differs from `publishedAt`. `isMalicious` included only when `true`.
 
-**Registry coverage.** npm, PyPI, Hex, Crates, NuGet, Maven, Packagist, RubyGems, Go, and Swift have vulnerability data. vcpkg and Zig are rejected client-side with a tool-specific message (`pkg vulns only supports npm, pypi, hex, crates, nuget, maven, packagist, rubygems, go, and swift. Got: ${registry}.`) — rejection predicate lives in `src/shared/package-vulnerabilities-request.ts` rather than the shared registry module, since it is a tool-specific capability matrix.
+**Registry coverage.** npm, PyPI, Hex, Crates, NuGet, Maven, Packagist, RubyGems, Go, and Swift have vulnerability data. vcpkg and Zig are rejected client-side with a tool-specific message (`pkg vulns only supports npm, pypi, hex, crates, nuget, maven, packagist, rubygems, go, and swift. Got: ${registry}.`) — rejection predicate lives in `packages/mcp/src/shared/package-vulnerabilities-request.ts` rather than the shared registry module, since it is a tool-specific capability matrix.
 
-`pkg_vulns` shares its envelope builder and text formatter with the CLI `githits pkg vulns` command via `src/shared/package-vulnerabilities-request.ts` and `src/shared/package-vulnerabilities-response.ts`. MCP defaults to compact text and uses `format: "json"` for structured output. The shared text formatter is surface-aware so MCP hints never mention CLI flags. The parity test (`src/tools/package-vulnerabilities-parity.test.ts`) passes `format: "json"`, asserts `toEqual` across the service-sourced success/filter/typed-error fixtures, and uses `toMatchObject` for builder-sourced `INVALID_ARGUMENT` fixtures such as unsupported registries and tag-style `v`-prefixed versions.
+`pkg_vulns` shares its envelope builder and text formatter with the CLI `githits pkg vulns` command via `packages/mcp/src/shared/package-vulnerabilities-request.ts` and `packages/mcp/src/shared/package-vulnerabilities-response.ts`. MCP defaults to compact text and uses `format: "json"` for structured output. The shared text formatter is surface-aware so MCP hints never mention CLI flags. The parity test (`src/tools/package-vulnerabilities-parity.test.ts`) passes `format: "json"`, asserts `toEqual` across the service-sourced success/filter/typed-error fixtures, and uses `toMatchObject` for builder-sourced `INVALID_ARGUMENT` fixtures such as unsupported registries and tag-style `v`-prefixed versions.
 
 ### `pkg_deps` response shape
 
@@ -103,13 +103,13 @@ Treat failures as live backend or contract findings, not deterministic unit-test
 
 **Typed dependency graph projection.** Backend exposes typed `dependencyGraph`, `dependencyConflicts`, `circularDependencyCycles`, and `environmentMarkers`; `pkg_deps` consumes those typed fields and projects them into a lean agent-facing envelope. Deprecated raw fields (`dag`, `conflicts`, `circularDependencies`, `environmentConstraints`) are intentionally not queried. The raw graph is deliberately not exposed by this tool.
 
-**Registry coverage.** npm, PyPI, Hex, Crates, vcpkg, Zig, RubyGems, Go, and Swift support the `packageDependencies` query. NuGet / Maven / Packagist are rejected client-side with a tool-specific message (`pkg deps only supports npm, pypi, hex, crates, vcpkg, zig, rubygems, go, swift. Got: ${registry}.`). Predicate lives in `src/shared/package-dependencies-request.ts`.
+**Registry coverage.** npm, PyPI, Hex, Crates, vcpkg, Zig, RubyGems, Go, and Swift support the `packageDependencies` query. NuGet / Maven / Packagist are rejected client-side with a tool-specific message (`pkg deps only supports npm, pypi, hex, crates, vcpkg, zig, rubygems, go, swift. Got: ${registry}.`). Predicate lives in `packages/mcp/src/shared/package-dependencies-request.ts`.
 
 **Version validation.** Same rule as `pkg_vulns`: tag-style `v`-prefixed inputs are rejected client-side with `INVALID_ARGUMENT` before the backend call.
 
 **MCP schema notes.** Permissive (`registry: z.string()`, `package_name: z.string()`, …) with validation in-handler via `buildPackageDependenciesParams`. Deliberately no `include_groups` input — with the data-first envelope emitting `groups` unconditionally when the backend returns `dependencyGroups`, the flag would be a silently ignored no-op. `max_depth` / CLI `--depth` is optional; when omitted the surface shows direct dependencies only while still fetching depth 1 on the wire to resolve direct dependency versions. Passing `max_depth` requests the transitive block and caps traversal. `include_importers` adds importer provenance; if used without `max_depth`, it also requests transitive output.
 
-`pkg_deps` shares its envelope builder and text formatter with the CLI `githits pkg deps` command via `src/shared/package-dependencies-request.ts` and `src/shared/package-dependencies-response.ts`. MCP defaults to compact text and uses MCP-native hints such as `pass lifecycle="all"`; CLI hints remain CLI-native. The parity test (`src/tools/package-dependencies-parity.test.ts`) passes `format: "json"`, asserts `toEqual` across every service-sourced success / error fixture (runtime, zero-dep, full-view, optional-lifecycle, multi-lifecycle, filter-matched-nothing, Crates-target-cfg dedup round-trip, transitive, versioned match / diff, NOT_FOUND, VERSION_NOT_FOUND, BACKEND_ERROR), and uses `toMatchObject` for builder-sourced `INVALID_ARGUMENT` (unsupported registry, tag-style version, unknown lifecycle).
+`pkg_deps` shares its envelope builder and text formatter with the CLI `githits pkg deps` command via `packages/mcp/src/shared/package-dependencies-request.ts` and `packages/mcp/src/shared/package-dependencies-response.ts`. MCP defaults to compact text and uses MCP-native hints such as `pass lifecycle="all"`; CLI hints remain CLI-native. The parity test (`src/tools/package-dependencies-parity.test.ts`) passes `format: "json"`, asserts `toEqual` across every service-sourced success / error fixture (runtime, zero-dep, full-view, optional-lifecycle, multi-lifecycle, filter-matched-nothing, Crates-target-cfg dedup round-trip, transitive, versioned match / diff, NOT_FOUND, VERSION_NOT_FOUND, BACKEND_ERROR), and uses `toMatchObject` for builder-sourced `INVALID_ARGUMENT` (unsupported registry, tag-style version, unknown lifecycle).
 
 ### `pkg_changelog` response shape
 
@@ -131,11 +131,11 @@ Treat failures as live backend or contract findings, not deterministic unit-test
 
 **Overlap with `pkg_info`.** `pkg_info` already surfaces a short-form `recentChanges` block (from the backend's `latestChangelogs` field on `PackageSummaryResult`). For a quick "what shipped recently" glance embedded in a package overview, use `pkg_info`. For the full range-capable, body-rich, `omit_bodies`-toggleable changelog with `--no-body` timeline mode and repo-URL addressing, use `pkg_changelog`.
 
-`pkg_changelog` shares its envelope builder and text formatter with the CLI `githits pkg changelog` command via `src/shared/package-changelog-request.ts` and `src/shared/package-changelog-response.ts`. MCP defaults to compact text with MCP-native `verbose=true`, `body_lines=<n>`, and `format="json"` hints for full bodies. The parity test (`src/tools/package-changelog-parity.test.ts`) passes `format: "json"`, asserts `toEqual` across every service-sourced success / error fixture (happy latest, range mode, repo-URL addressing, no-source package-version entries, `--no-body` / `omit_bodies: true`, default bodies, empty entries, NOT_FOUND, PackageIntelligenceTargetNotFoundError, VERSION_NOT_FOUND, BACKEND_ERROR), and uses `toMatchObject` for builder-sourced `INVALID_ARGUMENT`.
+`pkg_changelog` shares its envelope builder and text formatter with the CLI `githits pkg changelog` command via `packages/mcp/src/shared/package-changelog-request.ts` and `packages/mcp/src/shared/package-changelog-response.ts`. MCP defaults to compact text with MCP-native `verbose=true`, `body_lines=<n>`, and `format="json"` hints for full bodies. The parity test (`src/tools/package-changelog-parity.test.ts`) passes `format: "json"`, asserts `toEqual` across every service-sourced success / error fixture (happy latest, range mode, repo-URL addressing, no-source package-version entries, `--no-body` / `omit_bodies: true`, default bodies, empty entries, NOT_FOUND, PackageIntelligenceTargetNotFoundError, VERSION_NOT_FOUND, BACKEND_ERROR), and uses `toMatchObject` for builder-sourced `INVALID_ARGUMENT`.
 
 ### `code_files` / `code_read` / `code_grep` response shapes
 
-These three indexed tools share an addressing and lifecycle contract (documented below) and then each projects its own data-first envelope. All three reuse the shipped `codeTargetSchema` + `resolveCodeTarget` from `src/tools/code-navigation-shared.ts` — no parallel addressing module.
+These three indexed tools share an addressing and lifecycle contract (documented below) and then each projects its own data-first envelope. All three reuse the shipped `codeTargetSchema` + `resolveCodeTarget` from `packages/mcp/src/tools/code-navigation-shared.ts` — no parallel addressing module.
 
 **`code_files` envelope**: `{registry?|repoUrl?+gitRef?, total, hasMore, indexedVersion?, resolution?, targetResolution?, files: [{path, name?, language?, fileType?, byteSize?}], hint?, filter?}`. `fileType` values preserve the service vocabulary (`CONFIG`, `SOURCE`, `DOC`, `TEST`). `total` is capped at returned count when `hasMore: true` — the terminal formatter renders `N+ files` in that case to avoid misleading users. `filter` echoes only explicit caller filters (`path`, `pathPrefix`, `globs`, `extensions`, `fileTypes`, `languages`, file-intent filters, booleans, and `limit`); default limit (200) never round-trips.
 
@@ -165,13 +165,13 @@ All three code-navigation tools share the same indexing-retry contract. The stat
 
 `details.availableVersions` and `details.availableRefs` are populated when the backend returned already-indexed artifacts alongside the sentinel. Agents can pick one to retry against immediately without waiting. When `details.targetResolution` is present, it is explanatory provenance only; follow-up commands still use served locators / legacy served fields rather than reconstructing targets from the originally requested identity.
 
-**Retry default**: `DEFAULT_WAIT_TIMEOUT_MS = 20_000` (shared, defined in `src/shared/code-navigation-defaults.ts`). Applied inside each request builder so both CLI and MCP surfaces get the same default by construction. CLI's `--wait <ms>` and MCP's `wait_timeout_ms` override.
+**Retry default**: `DEFAULT_WAIT_TIMEOUT_MS = 20_000` (shared, defined in `packages/mcp/src/shared/code-navigation-defaults.ts`). Applied inside each request builder so both CLI and MCP surfaces get the same default by construction. CLI's `--wait <ms>` and MCP's `wait_timeout_ms` override.
 
 **`FILE_NOT_FOUND` vs `NOT_FOUND`**: `code_read` / `code_grep` can hit "path doesn't resolve" errors when an exact path scope is invalid. The classifier is pre-wired to emit `FILE_NOT_FOUND` when the backend sends `extensions.code: "FILE_NOT_FOUND"`, but today the backend emits generic `NOT_FOUND` for both "package missing" and "path missing". The distinction is filed upstream. CLI terminal output for `code read` / `code grep` emits the hint "Use `code files` to list available paths." on both codes so users have an actionable next step regardless of classification.
 
-**`code_read` span cap (MCP-only)**: real session traces showed agents requesting 300-600 line windows (and occasional unbounded full-file reads) which dominated context cost. The MCP surface caps each `code_read` call at `MCP_READ_MAX_SPAN` (150 lines, defined in `src/tools/read-file.ts`). The cap is enforced *before* the backend call — `deriveBoundedRange` clamps the request, so the service does not transfer bytes that will be discarded.
+**`code_read` span cap (MCP-only)**: real session traces showed agents requesting 300-600 line windows (and occasional unbounded full-file reads) which dominated context cost. The MCP surface caps each `code_read` call at `MCP_READ_MAX_SPAN` (150 lines, defined in `packages/mcp/src/tools/read-file.ts`). The cap is enforced *before* the backend call — `deriveBoundedRange` clamps the request, so the service does not transfer bytes that will be discarded.
 
-The `hint` field is emitted only when the cap *actually truncated* the response — i.e., the returned range comes up short of available content. `shouldEmitCappedHint` (in `src/tools/read-file.ts`) suppresses the hint in three cases the agent doesn't need it: (a) the cap clamp didn't fire (caller's range was already within the cap); (b) the file fits within the cap, so the response is the whole file even though the request was clamped; (c) the returned range reaches end of file. Binary files always skip the hint. When emitted, the hint reads from `payload.startLine` / `endLine` / `totalLines` (the actual returned range, not the pre-clamp request) and includes the original request for the agent to learn from. The CLI command `githits code read` does not apply the cap; humans piping whole files to disk continue to work.
+The `hint` field is emitted only when the cap *actually truncated* the response — i.e., the returned range comes up short of available content. `shouldEmitCappedHint` (in `packages/mcp/src/tools/read-file.ts`) suppresses the hint in three cases the agent doesn't need it: (a) the cap clamp didn't fire (caller's range was already within the cap); (b) the file fits within the cap, so the response is the whole file even though the request was clamped; (c) the returned range reaches end of file. Binary files always skip the hint. When emitted, the hint reads from `payload.startLine` / `endLine` / `totalLines` (the actual returned range, not the pre-clamp request) and includes the original request for the agent to learn from. The CLI command `githits code read` does not apply the cap; humans piping whole files to disk continue to work.
 
 ## Text response format (`format: "text-v1"`)
 
@@ -179,7 +179,7 @@ The `hint` field is emitted only when the cap *actually truncated* the response 
 
 **Why text-v1 default.** A 10-hit `search` JSON envelope runs 5–7 KB after compaction; the same hits in `text-v1` land around 3–4 KB. The savings come from dropped quoting, dropped key repetition, and dropped fields that an agent does not need at the per-call decision point (highlights byte offsets, repeated locator scaffolding). The token budget belongs to the agent's reasoning, not to JSON structure.
 
-**Format stability.** The text format is a public contract, locked with snapshot-style tests (`src/shared/unified-search-text.test.ts`, `src/shared/list-files-text.test.ts`). The `text-v1` version tag exists so we can evolve the format without silently breaking downstream parsers — future incompatible changes ship as `text-v2`.
+**Format stability.** The text format is a public contract, locked with snapshot-style tests (`packages/mcp/src/shared/unified-search-text.test.ts`, `packages/mcp/src/shared/list-files-text.test.ts`). The `text-v1` version tag exists so we can evolve the format without silently breaking downstream parsers — future incompatible changes ship as `text-v2`.
 
 **ASCII-only.** Separators are ` | `; ellipsis is `...`; no box-drawing or Latin-1 punctuation. Tokenizer behavior for multi-byte UTF-8 varies across BPE variants, and the format runs into Claude, Codex CLI, OpenCode, Cline, Cursor, etc. — ASCII keeps it predictable.
 
@@ -246,13 +246,13 @@ Standard grep -A/-B notation: `:` separator on match lines, `-` on context lines
 
 The MCP server advertises a short, cross-tool orientation via the protocol's server-level `instructions` field. This is distinct from per-tool `description` text: instructions cover rationale, workflow glue, and decisions that span multiple tools, while per-tool descriptions remain the source of truth for arguments, output shape, and tool-specific constraints.
 
-`src/mcp/instructions.ts` owns two sections:
+`packages/mcp/src/mcp/instructions.ts` owns the server-level instruction sections:
 
 - **Core block** — always loaded. Introduces GitHits, expands trigger criteria to include comparative cross-OSS questions and "how does X actually implement this" archaeology, and walks through the `get_example` / `search_language` / `feedback` workflow.
-- **Package-tools block** — always appended. Contains a preamble plus one bullet per package/code tool, plus three cross-tool tips:
-  - **Reference-first, content-second**: locate symbols and lines first, then read narrowly with `code_read` using `start_line` / `end_line` windows around the match.
-  - **Multi-turn discovery**: anticipate 3+ calls? Delegate to a sub-task / sub-agent and ask for a compact synthesis rather than pulling raw `code_read` / `code_files` output into the main conversation.
-  - **Tool-selection tip**: contrasts `get_example` vs unified `search` vs `code_grep`/`code_read`.
+- **External-content block** — included by default from `packages/mcp/src/tools/guardrails.ts`; tells agents to treat third-party prose as data, not instructions.
+- **Package-tools block** — always appended. Contains a preamble plus one bullet per package/code tool, plus two cross-tool tips:
+  - **Delegate multi-call work**: anticipate 3+ code-navigation calls? Use a sub-agent and ask for a compact synthesis.
+  - **Strategy / reference-first**: source, symbols, tests, and call sites beat docs prose; enumerate paths first, locate symbols or lines, then read focused windows.
 
 When adding a new package tool, extend the composer with a one-line bullet (`\`tool_name\` — one-sentence purpose`) in the same PR that registers the tool. Keep the bullet terse; argument and response detail belong in the tool's `description`. `mcp-instructions.test.ts` enforces both directions of the mention↔registration invariant.
 
@@ -270,7 +270,7 @@ The MCP server starts without a synchronous auth check; auth errors surface per-
 ```
 CLI stdio wrapper (src/commands/mcp.ts)
   └─ creates local services from the CLI container and connects StdioServerTransport
-       └─ transport-neutral MCP server (src/mcp/server.ts)
+       └─ transport-neutral MCP server (packages/mcp/src/mcp/server.ts)
             └─ registers tools using McpToolServices
                  └─ each tool: createXxxTool(service)
                       └─ ToolDefinition { name, description, schema, handler, annotations? }
@@ -280,16 +280,16 @@ CLI stdio wrapper (src/commands/mcp.ts)
 
 The layering is intentional:
 
-- **Tool definitions** (`src/tools/*.ts`) own the MCP contract: names, descriptions, schemas, and response formatting
-- **GitHitsService / CodeNavigationService** own the HTTP transport: endpoints, headers, error mapping
-- **Transport-neutral MCP server setup** (`src/mcp/server.ts`) owns MCP SDK tool registration from `McpToolServices`
+- **Tool definitions** (`packages/mcp/src/tools/*.ts`) own the MCP contract: names, descriptions, schemas, and response formatting
+- **GitHitsService / CodeNavigationService / PackageIntelligenceService** own the HTTP transport contracts and live in `packages/core-internal`
+- **Transport-neutral MCP server setup** (`packages/mcp/src/mcp/server.ts`) owns MCP SDK tool registration from `McpToolServices`
 - **CLI MCP command** (`src/commands/mcp.ts`) owns local stdio startup: creates services from the CLI container, sets request-header mode, connects `StdioServerTransport`, and prints TTY setup instructions
 
 This separation means tool logic can be tested without HTTP calls, and service logic can be tested without MCP SDK dependencies.
 
 ## Tool Definition Pattern
 
-Each tool follows the same structure. See `src/tools/search.ts` for the canonical example:
+Each tool follows the same structure. See `packages/mcp/src/tools/search.ts` for the canonical example:
 
 1. Define an `Args` interface for the handler input
 2. Define a `schema` object with Zod validators (these become the MCP tool's input schema)
@@ -303,12 +303,12 @@ Each tool follows the same structure. See `src/tools/search.ts` for the canonica
 
 When the backend adds a new tool, follow this checklist:
 
-1. **Create tool file** — `src/tools/new-tool.ts` with `Args` interface, `schema`, `DESCRIPTION`, and `createNewTool(service)` factory
-2. **Add service method** — Add the method to `GitHitsService` interface and `GitHitsServiceImpl` in `src/services/githits-service.ts`
-3. **Export from tools barrel** — Add `export { createNewTool } from "./new-tool.js"` to `src/tools/index.ts`
-4. **Register in MCP server** — In `src/mcp/server.ts`, import the factory and add it to `getMcpToolDefinitions()`
-5. **Add tests** — Create `src/tools/new-tool.test.ts` with metadata, service call, success, and error path tests
-6. **Update mock service** — Add the new method to `createMockGitHitsService()` in `src/services/test-helpers.ts`
+1. **Create tool file** — `packages/mcp/src/tools/new-tool.ts` with `Args` interface, `schema`, `DESCRIPTION`, and `createNewTool(service)` factory
+2. **Add service method** — Add the method to the relevant service interface and implementation in `packages/core-internal/src/services/`
+3. **Export from tools barrel** — Add `export { createNewTool } from "./new-tool.js"` to `packages/mcp/src/tools/index.ts`
+4. **Register in MCP server** — In `packages/mcp/src/mcp/server.ts`, import the factory and add it to `getMcpToolDefinitions()`
+5. **Add tests** — Create `packages/mcp/src/tools/new-tool.test.ts` with metadata, service call, success, and error path tests
+6. **Update mock service** — Add the new method to the mock factories in `packages/mcp/src/services/test-helpers.ts`
 7. **Add CLI command** — Create a corresponding CLI command in `src/commands/` (see `docs/implementation/cli-commands.md`)
 
 ## Behavioral Differences from Backend
@@ -321,13 +321,13 @@ While the contract (names, params, descriptions) is identical, some implementati
 | `get_example` response | Backend builds markdown from structured `McpSearchResponse` | CLI receives pre-formatted markdown from REST `/search` endpoint |
 | unified `search` response | Backend returns structured indexed-search hits and follow-up refs | CLI and MCP share JSON envelope builders over the code-navigation service result |
 | `feedback` response | Backend returns different messages for accepted/rejected | CLI hard-codes "Feedback submitted successfully" on success; the REST API response body is not used for the message |
-| Error handling | Catches specific exception types, logs to PostHog | Uses `withErrorHandling()` wrapper for consistent `ToolResult` errors |
+| Error handling | Catches specific exception types, logs to PostHog | Uses shared mapped-error helpers for consistent `ToolResult` errors |
 
 These differences exist because the CLI hits the REST API (which does its own formatting) rather than calling internal backend services directly.
 
 ## Testing Tools
 
-Each tool has a co-located test file (for example `src/tools/get-example.test.ts`, `src/tools/search.test.ts`, `src/tools/search-status.test.ts`). Tests use `createMockGitHitsService()` or `createMockCodeNavigationService()` from `src/services/test-helpers.ts` to mock the service layer.
+Each tool has a co-located test file (for example `packages/mcp/src/tools/get-example.test.ts`, `packages/mcp/src/tools/search.test.ts`, `packages/mcp/src/tools/search-status.test.ts`). Tests use mock factories from `packages/mcp/src/services/test-helpers.ts` to mock the service layer.
 
 Test categories for each tool:
 - **Metadata** — tool name and description are correct
@@ -341,20 +341,20 @@ See `docs/guidelines/TESTING.md` for the full testing pattern.
 
 | File | What it demonstrates |
 |---|---|
-| `src/tools/get-example.ts` | Example-search MCP tool definition |
-| `src/tools/search.ts` | Unified indexed-search MCP tool definition |
-| `src/tools/search-status.ts` | Follow-up MCP tool for incomplete unified searches |
-| `src/tools/search-language.ts` | Tool with client-side filtering logic |
-| `src/tools/feedback.ts` | Simplest tool (direct service delegation) |
-| `src/tools/types.ts` | `ToolDefinition` interface, `textResult`/`errorResult` helpers |
-| `src/tools/shared.ts` | `withErrorHandling()` wrapper |
-| `src/services/test-helpers.ts` | `createMockGitHitsService()` and `createMockCodeNavigationService()` factories |
-| `src/mcp/server.ts` | Transport-neutral MCP server construction and tool registration |
-| `src/mcp/instructions.ts` | Server-level MCP instructions advertised to clients |
+| `packages/mcp/src/tools/get-example.ts` | Example-search MCP tool definition |
+| `packages/mcp/src/tools/search.ts` | Unified indexed-search MCP tool definition |
+| `packages/mcp/src/tools/search-status.ts` | Follow-up MCP tool for incomplete unified searches |
+| `packages/mcp/src/tools/search-language.ts` | Tool with client-side filtering logic |
+| `packages/mcp/src/tools/feedback.ts` | Simplest tool (direct service delegation) |
+| `packages/mcp/src/tools/types.ts` | `ToolDefinition` interface, `textResult`/`errorResult` helpers |
+| `packages/mcp/src/tools/shared.ts` | Shared MCP error/action helpers |
+| `packages/mcp/src/services/test-helpers.ts` | Mock service factories |
+| `packages/mcp/src/mcp/server.ts` | Transport-neutral MCP server construction and tool registration |
+| `packages/mcp/src/mcp/instructions.ts` | Server-level MCP instructions advertised to clients |
 | `src/commands/mcp.ts` | CLI stdio startup, request-header mode setup, and TTY setup instructions |
-| `src/services/githits-service.ts` | REST API client for example search, languages, and feedback |
-| `src/services/code-navigation-service.ts` | Package/source service client for unified `search`, `search_status`, `code_files`, `code_read`, and `code_grep` |
-| `src/shared/language-filter.ts` | Pure `filterLanguages()` function shared between MCP tool and CLI |
+| `packages/core-internal/src/services/githits-service.ts` | REST API client for example search, languages, and feedback |
+| `packages/core-internal/src/services/code-navigation-service.ts` | Package/source service client for unified `search`, `search_status`, `code_files`, `code_read`, and `code_grep` |
+| `packages/mcp/src/shared/language-filter.ts` | Pure `filterLanguages()` function shared between MCP tool and CLI |
 
 ## Related Documentation
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.4.15",
+  "version": "0.5.0",
   "description": "Code examples from global open source for developers and AI assistants.",
   "mcpServers": {
     "githits": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "githits",
   "description": "CLI companion for GitHits - code examples from global open source for developers and AI assistants",
-  "version": "0.4.15",
+  "version": "0.5.0",
   "type": "module",
   "workspaces": [
     "packages/*"

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.4.15",
+  "version": "0.5.0",
   "description": "Code examples from global open source for developers and AI assistants",
   "author": {
     "name": "GitHits"


### PR DESCRIPTION
## Summary
- bump root githits and assistant/plugin manifests to 0.5.0
- update implementation docs and tool-instruction references for the packages/mcp workspace layout
- keep @githits/mcp at 0.4.15 because no MCP-package user-facing changes landed after mcp-v0.4.15

## User-visible changelog
- githits init now reports per-tool config changes more clearly, including created, updated, unchanged, and command rows
- githits init uninstall has unified install/uninstall result reporting and clearer project/user uninstall rows
- package/source targets now require explicit package registries, e.g. npm:express instead of ambiguous package names
- public MCP package boundary is documented: @githits/mcp, @githits/mcp/client, and release separation from root githits
- release/package validation is hardened for public artifacts and recoverable MCP publishing

## Verification
- bun test
- bun run build
- bun run validate:packages
- bun run smoke:cli
- bun run smoke:mcp
- git diff --check