### PR TITLE
fix: reduce package GraphQL overfetching

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@ Philosophy: "Create architecture that is performant and easy to test"
 - Prefer public helper modules to lots of private methods
 - Use dependency injection for external services (REST client, etc.)
 - For MCP/agent-facing tools, avoid coupled optional flags and default-true booleans. Design schemas for real agent calls, including empty strings, empty arrays, and explicit `false` values.
+- For GraphQL/API-backed tools, treat minimal data fetching as part of the tool contract. Before adding or changing selected fields, compare the query against every consumer (text, verbose, JSON, MCP, CLI, and internal callers), use conditional fields or separate queries for mode-specific data, and add tests that assert the wire variables/selections for compact and detailed modes.
 
 See `docs/guidelines/ARCHITECTURAL_GUIDELINES.md` for detailed planning checklist and design principles.
 
@@ -39,6 +40,7 @@ Philosophy: "If it is not tested, it is likely broken"
 - Use `bun run smoke:mcp` and `bun run smoke:cli` when changing MCP tools, CLI commands, shared formatters, auth/error envelopes, or MCP/CLI parity behavior. These are live smoke suites, not the normal unit suite; they must pass unauthenticated by validating auth handling, and provide deeper coverage when authenticated.
 - Use `bun run agent:e2e` when changing MCP instructions, tool descriptions, or agent-facing tool behavior. This is a human/agent-driven qualitative eval, not a deterministic CI gate. Pick targeted workloads from `eval/agentic/README.md`; run both Claude and Codex for broad instruction changes when practical. Inspect `tool-calls.json` and `final.json` for actual tool use, `toolIssues`, `instructionIssues`, and usefulness, not just harness pass/fail.
 - Maintain smoke coverage when adding or changing user-facing tools/commands. Prefer structural UX assertions over brittle snapshots, and keep MCP `format: "json"` and CLI `--json` behavior aligned.
+- When changing GraphQL/API selections, add regression tests for over-fetch controls (for example `@include` variables, body omission, field lists, or query builders) and live-smoke the affected CLI/MCP surfaces when authenticated access is available.
 - Keep tests async and isolated
 - Mock services at the interface level using factory functions
 - Use mock factories from `test-helpers.ts` (e.g., `createMockGitHitsService()`, `createMockAuthService()`)

--- a/docs/guidelines/ARCHITECTURAL_GUIDELINES.md
+++ b/docs/guidelines/ARCHITECTURAL_GUIDELINES.md
@@ -60,6 +60,17 @@ Design MCP schemas for how real agents call tools, not for ideal hand-written JS
 - Put validation and normalization in shared request builders used by MCP and CLI parity paths, then test the normalized service parameters. Raw Zod errors should not be the primary agent-facing failure mode.
 - Validate changes with real agent evals when changing tool signatures, descriptions, or defaults. Inspect `tool-calls.json` and reported tool/instruction issues, not just harness success.
 
+### 6. GraphQL/API Data Fetching
+
+Treat selected fields and REST/API payload breadth as part of the public tool contract. A correct tool is not just one that formats the right output; it also avoids fetching data that the selected mode cannot use.
+
+- Start from the output surfaces and work backward: compact text, verbose text, CLI `--json`, MCP `format: "json"`, smoke/parity helpers, and internal callers may need different data.
+- Prefer conditional GraphQL fields (`@include` / `@skip`) for small mode switches such as body omission. Prefer separate query documents when plain and detailed modes have substantially different shapes.
+- Name GraphQL directive variables by the field selection they control, not like resolver arguments. For example, `includeVerboseFields` is clearer than `includeDetails`.
+- Do not keep selected fields only for future exploration. If a field is not surfaced, validated, or used by a caller today, remove it until there is a typed consumer.
+- Preserve UX-critical text hints when trimming data. If text output uses a field only to explain hidden data, that still counts as used data and must be covered by tests.
+- Add tests that assert the wire contract for every mode-sensitive selection: variables, directives, omitted fields, and caller params. Mocked formatter tests are not enough because mocks can return fields the live query no longer fetches.
+
 ## Pure Function Helpers & Layering
 
 ### Conversion Modules
@@ -158,5 +169,11 @@ When drafting a plan or proposal, explicitly answer:
 - What docs need updating?
 - Are JSDoc comments added?
 - Is the implementation doc updated?
+
+### 5. Data Fetching
+
+- What fields does each output mode actually consume?
+- Are compact and detailed modes using conditional fields or separate queries where appropriate?
+- Which tests prove unused fields are not fetched and required hidden-hint fields still are?
 
 Checking these boxes before implementation keeps future maintainers from revisiting architectural gaps.

--- a/docs/guidelines/REVIEW_GUIDELINES.md
+++ b/docs/guidelines/REVIEW_GUIDELINES.md
@@ -8,6 +8,7 @@ Checklist for reviewing code changes in githits-cli.
 - [ ] Implementation is easy to understand
 - [ ] Code is in correct modules, no unnecessary duplication
 - [ ] Services are properly abstracted for testing
+- [ ] GraphQL/API-backed changes fetch only fields used by each output mode, with conditional fields or separate queries where needed
 
 ## Code Quality
 
@@ -22,6 +23,7 @@ Checklist for reviewing code changes in githits-cli.
 - [ ] All tests pass (`bun test`)
 - [ ] Tests mock services at interface level
 - [ ] Error paths are tested
+- [ ] GraphQL/API selection changes have tests for compact vs verbose/JSON wire variables, selected fields, and omitted fields
 
 ## Documentation
 

--- a/packages/core-internal/src/services/package-intelligence-service.test.ts
+++ b/packages/core-internal/src/services/package-intelligence-service.test.ts
@@ -205,7 +205,7 @@ describe("PackageIntelligenceServiceImpl", () => {
     ).rejects.toBeInstanceOf(MalformedPackageIntelligenceResponseError);
   });
 
-  it("sends packageSummary query with registry + name vars and latestChangelogs(limit: 3)", async () => {
+  it("sends packageSummary query with registry + name vars and conditional details", async () => {
     let capturedBody: string | undefined;
     const fetchFn = mock((_url: string, init?: RequestInit) => {
       capturedBody = init?.body as string;
@@ -222,11 +222,39 @@ describe("PackageIntelligenceServiceImpl", () => {
     expect(capturedBody).toBeDefined();
     const parsed = JSON.parse(capturedBody ?? "{}");
     expect(parsed.query).toContain("packageSummary(registry: $registry");
-    expect(parsed.query).toContain("latestChangelogs(limit: 3)");
+    expect(parsed.query).toContain(
+      "latestChangelogs(limit: 3) @include(if: $includeVerboseFields)",
+    );
     expect(parsed.query).not.toContain("quickstart");
     expect(parsed.query).not.toContain("installCommand");
     expect(parsed.query).not.toContain("usageExample");
-    expect(parsed.variables).toEqual({ registry: "NPM", name: "express" });
+    expect(parsed.variables).toEqual({
+      registry: "NPM",
+      name: "express",
+      includeVerboseFields: true,
+    });
+  });
+
+  it("can skip verbose packageSummary fields", async () => {
+    let capturedBody: string | undefined;
+    const fetchFn = mock((_url: string, init?: RequestInit) => {
+      capturedBody = init?.body as string;
+      return Promise.resolve(jsonResponse(HAPPY_BODY));
+    });
+    const service = new PackageIntelligenceServiceImpl(
+      ENDPOINT,
+      createMockTokenProvider(),
+      asFetchFn(fetchFn),
+    );
+
+    await service.packageSummary({
+      registry: "NPM",
+      packageName: "express",
+      includeVerboseFields: false,
+    });
+
+    const parsed = JSON.parse(capturedBody ?? "{}");
+    expect(parsed.variables.includeVerboseFields).toBe(false);
   });
 
   it("sends Bearer token and hits the correct URL", async () => {
@@ -1427,6 +1455,47 @@ describe("PackageIntelligenceServiceImpl — packageChangelog", () => {
     ).rejects.toBeInstanceOf(PackageIntelligenceChangelogSourceNotFoundError);
   });
 
+  it("sends includeBodies and omits unused metadata from changelog query", async () => {
+    let capturedBody: string | undefined;
+    const fetchFn = mock((_url: string, init?: RequestInit) => {
+      capturedBody = init?.body as string;
+      return Promise.resolve(
+        jsonResponse({
+          data: {
+            packageChangelog: {
+              package: { name: "express", registry: "NPM" },
+              source: "releases",
+              entries: [
+                {
+                  version: "5.0.0",
+                  normalizedVersion: "5.0.0",
+                  htmlUrl: "https://example.com/release",
+                  publishedAt: "2026-01-01T00:00:00Z",
+                },
+              ],
+            },
+          },
+        }),
+      );
+    });
+    const service = new PackageIntelligenceServiceImpl(
+      ENDPOINT,
+      createMockTokenProvider(),
+      asFetchFn(fetchFn),
+    );
+
+    await service.packageChangelog({
+      registry: "NPM",
+      packageName: "express",
+      includeBodies: false,
+    });
+
+    const parsed = JSON.parse(capturedBody ?? "{}");
+    expect(parsed.query).toContain("body @include(if: $includeBodies)");
+    expect(parsed.query).not.toContain("metadata");
+    expect(parsed.variables.includeBodies).toBe(false);
+  });
+
   it("accepts package version entries without a changelog source", async () => {
     const fetchFn = mock(() =>
       Promise.resolve(
@@ -1442,7 +1511,6 @@ describe("PackageIntelligenceServiceImpl — packageChangelog", () => {
                   body: "React Server Components",
                   htmlUrl: null,
                   publishedAt: "2026-04-08T00:00:00Z",
-                  metadata: null,
                 },
               ],
             },
@@ -1480,7 +1548,6 @@ describe("PackageIntelligenceServiceImpl — packageChangelog", () => {
                   body: null,
                   htmlUrl: null,
                   publishedAt: "2026-04-08T00:00:00Z",
-                  metadata: null,
                 },
               ],
             },
@@ -1581,7 +1648,36 @@ describe("PackageIntelligenceServiceImpl — packageDependencies", () => {
     const parsed = JSON.parse(capturedBody ?? "{}");
     expect(parsed.variables.lifecycle).toEqual(["runtime", "development"]);
     expect(parsed.variables.includeTransitive).toBe(true);
+    expect(parsed.variables.includeTransitiveDetails).toBe(true);
+    expect(parsed.variables.includeDependencyGraph).toBe(true);
+    expect(parsed.variables.includeGroups).toBe(true);
     expect(parsed.variables.maxDepth).toBe(3);
+  });
+
+  it("can skip dependency groups and transitive details while keeping the graph", async () => {
+    let capturedBody: string | undefined;
+    const fetchFn = mock((_url: string, init?: RequestInit) => {
+      capturedBody = init?.body as string;
+      return Promise.resolve(jsonResponse(EXPRESS_BODY));
+    });
+    const service = new PackageIntelligenceServiceImpl(
+      ENDPOINT,
+      createMockTokenProvider(),
+      asFetchFn(fetchFn),
+    );
+    await service.packageDependencies({
+      registry: "NPM",
+      packageName: "express",
+      includeTransitive: true,
+      includeTransitiveDetails: false,
+      includeGroups: false,
+      maxDepth: 1,
+    });
+    const parsed = JSON.parse(capturedBody ?? "{}");
+    expect(parsed.variables.includeTransitive).toBe(true);
+    expect(parsed.variables.includeDependencyGraph).toBe(true);
+    expect(parsed.variables.includeTransitiveDetails).toBe(false);
+    expect(parsed.variables.includeGroups).toBe(false);
   });
 
   it("omits lifecycle when empty array (treated as 'no filter')", async () => {

--- a/packages/core-internal/src/services/package-intelligence-service.ts
+++ b/packages/core-internal/src/services/package-intelligence-service.ts
@@ -43,6 +43,8 @@ import type { TokenProvider } from "./token-provider.js";
 export interface PackageSummaryParams {
   registry: PkgseerRegistry;
   packageName: string;
+  /** Include verbose/json-only fields such as recent advisories and changes. */
+  includeVerboseFields?: boolean;
 }
 
 export interface PackageIdentity {
@@ -158,6 +160,10 @@ export interface PackageDependenciesParams {
   version?: string;
   /** Optional. Backend returns a full transitive graph when true. */
   includeTransitive?: boolean;
+  /** Include transitive aggregate/detail fields beyond the dependency graph. */
+  includeTransitiveDetails?: boolean;
+  /** Include dependency group metadata. */
+  includeGroups?: boolean;
   /**
    * Optional transitive-traversal depth (1–10). Omit for the backend
    * default (full graph) — note the CLI applies a 3-deep guardrail but
@@ -189,14 +195,6 @@ export interface DirectDependency {
   versionConstraint?: string;
   type?: string;
 }
-
-/**
- * Opaque GenericJSON passthrough. The `package_dependencies` tool
- * migrated to typed fields (`dependencyGraph`, `dependencyConflicts`,
- * `circularDependencyCycles`, `environmentMarkers`); this type is
- * retained for the one remaining passthrough — `ChangelogEntryDetail.metadata`.
- */
-export type UntypedGenericJSON = unknown;
 
 /**
  * Node in a typed dependency graph. Mirrors `DependencyGraphNode`.
@@ -454,6 +452,8 @@ export interface PackageChangelogParams {
   toVersion?: string;
   /** Latest-mode cap (1–50). Rejected client-side when `fromVersion` is set. */
   limit?: number;
+  /** Include raw markdown bodies in entries. Defaults to true. */
+  includeBodies?: boolean;
 }
 
 /**
@@ -470,20 +470,13 @@ export interface ChangelogPackageInfo {
   limit?: number;
 }
 
-/**
- * Full changelog entry as observed on the wire. The envelope builder
- * projects this into the lean response shape; `metadata` is dropped
- * from the envelope because its source-specific opaque structure
- * isn't worth the token cost today. Revisit via agent feedback.
- */
+/** Full changelog entry as observed on the wire. */
 export interface ChangelogEntryDetail {
   version?: string;
   normalizedVersion?: string;
   body?: string;
   htmlUrl?: string;
   publishedAt?: string;
-  /** TODO(backend): surface when shape is documented. */
-  metadata?: UntypedGenericJSON;
 }
 
 export interface ChangelogReport {
@@ -775,7 +768,11 @@ const graphQLResponseSchema = z.object({
 });
 
 const PACKAGE_SUMMARY_QUERY = `
-query PackageSummary($registry: Registry!, $name: String!) {
+query PackageSummary(
+  $registry: Registry!
+  $name: String!
+  $includeVerboseFields: Boolean! = true
+) {
   packageSummary(registry: $registry, name: $name) {
     package {
       name
@@ -793,22 +790,22 @@ query PackageSummary($registry: Registry!, $name: String!) {
         forksCount
         openIssuesCount
         archived
-        language
-        topics
-        pushedAt
+        language @include(if: $includeVerboseFields)
+        topics @include(if: $includeVerboseFields)
+        pushedAt @include(if: $includeVerboseFields)
       }
     }
     security {
       vulnerabilityCount
       hasCurrentVulnerabilities
-      recentVulnerabilities {
+      recentVulnerabilities @include(if: $includeVerboseFields) {
         osvId
         summary
         severityScore
         publishedAt
       }
     }
-    latestChangelogs(limit: 3) {
+    latestChangelogs(limit: 3) @include(if: $includeVerboseFields) {
       version
       publishedAt
       body
@@ -1195,6 +1192,9 @@ query PackageDependencies(
   $name: String!
   $version: String
   $includeTransitive: Boolean
+  $includeTransitiveDetails: Boolean! = true
+  $includeDependencyGraph: Boolean! = true
+  $includeGroups: Boolean! = true
   $maxDepth: Int
   $lifecycle: [String!]
 ) {
@@ -1222,10 +1222,10 @@ query PackageDependencies(
         type
       }
       transitive {
-        totalEdges
-        uniquePackagesCount
-        uniqueDependencies
-        dependencyConflicts {
+        totalEdges @include(if: $includeTransitiveDetails)
+        uniquePackagesCount @include(if: $includeTransitiveDetails)
+        uniqueDependencies @include(if: $includeTransitiveDetails)
+        dependencyConflicts @include(if: $includeTransitiveDetails) {
           packageName
           requiredVersions
           conflictingEdges {
@@ -1235,12 +1235,12 @@ query PackageDependencies(
             dependencyType
           }
         }
-        circularDependencyCycles {
+        circularDependencyCycles @include(if: $includeTransitiveDetails) {
           cycleStart
           circularPath
           displayChain
         }
-        dependencyGraph {
+        dependencyGraph @include(if: $includeDependencyGraph) {
           formatVersion
           nodes {
             registry
@@ -1256,7 +1256,7 @@ query PackageDependencies(
         }
       }
     }
-    dependencyGroups {
+    dependencyGroups @include(if: $includeGroups) {
       primaryGroup
       environmentMarkers {
         type
@@ -1502,11 +1502,6 @@ const changelogEntryDetailSchema = z.object({
   body: z.string().nullable().optional(),
   htmlUrl: z.string().nullable().optional(),
   publishedAt: z.string().nullable().optional(),
-  // `metadata` is schema-level GenericJSON and we drop it from the
-  // service-returned shape today (envelope doesn't surface it). We
-  // still request-select it on the wire so live smoke can observe
-  // real shapes for a future typed surface.
-  metadata: z.unknown().nullable().optional(),
 });
 
 const changelogReportResponseSchema = z.object({
@@ -1534,6 +1529,7 @@ query PackageChangelog(
   $fromVersion: String
   $toVersion: String
   $limit: Int
+  $includeBodies: Boolean! = true
 ) {
   packageChangelog(
     registry: $registry
@@ -1556,10 +1552,9 @@ query PackageChangelog(
     entries {
       version
       normalizedVersion
-      body
+      body @include(if: $includeBodies)
       htmlUrl
       publishedAt
-      metadata
     }
   }
 }`;
@@ -1771,6 +1766,7 @@ export class PackageIntelligenceServiceImpl
         variables: {
           registry: params.registry,
           name: params.packageName,
+          includeVerboseFields: params.includeVerboseFields !== false,
         },
         fetchFn: this.fetchFn,
         clientHeaders: this.runtime.clientHeaders,
@@ -2334,6 +2330,9 @@ export class PackageIntelligenceServiceImpl
           name: params.packageName,
           version: params.version,
           includeTransitive: params.includeTransitive,
+          includeTransitiveDetails: params.includeTransitiveDetails !== false,
+          includeDependencyGraph: params.includeTransitive === true,
+          includeGroups: params.includeGroups !== false,
           maxDepth: params.maxDepth,
           lifecycle:
             params.lifecycle && params.lifecycle.length > 0
@@ -2656,6 +2655,7 @@ export class PackageIntelligenceServiceImpl
           fromVersion: params.fromVersion,
           toVersion: params.toVersion,
           limit: params.limit,
+          includeBodies: params.includeBodies !== false,
         },
         fetchFn: this.fetchFn,
         clientHeaders: this.runtime.clientHeaders,
@@ -2724,7 +2724,6 @@ export class PackageIntelligenceServiceImpl
       body: entry.body ?? undefined,
       htmlUrl: entry.htmlUrl ?? undefined,
       publishedAt: entry.publishedAt ?? undefined,
-      metadata: entry.metadata ?? undefined,
     }));
 
     const packageInfo: ChangelogPackageInfo | undefined = data.package

--- a/packages/mcp/src/shared/package-changelog-request.ts
+++ b/packages/mcp/src/shared/package-changelog-request.ts
@@ -58,6 +58,8 @@ export interface PackageChangelogRequestInput {
   toVersion?: string;
   /** Latest-mode entry count cap. */
   limit?: number;
+  /** Include raw markdown bodies in entries. Defaults to true. */
+  includeBodies?: boolean;
 }
 
 /** Fields whose *explicit* presence the envelope echoes under `filter.*`. */
@@ -120,6 +122,7 @@ export function buildPackageChangelogParams(
       fromVersion,
       toVersion,
       limit,
+      includeBodies: input.includeBodies,
     },
     explicitFilterFields: explicit,
   };

--- a/packages/mcp/src/shared/package-dependencies-request.ts
+++ b/packages/mcp/src/shared/package-dependencies-request.ts
@@ -110,6 +110,10 @@ export interface PackageDependenciesRequestInput {
   version?: string;
   /** Optional flag to include transitive graph. */
   includeTransitive?: boolean;
+  /** Optional flag to include transitive aggregate/detail fields. */
+  includeTransitiveDetails?: boolean;
+  /** Optional flag to include dependency group metadata. */
+  includeGroups?: boolean;
   /** Optional traversal depth (1–10). */
   maxDepth?: number;
   /**
@@ -181,6 +185,8 @@ export function buildPackageDependenciesParams(
       packageName: trimmedName,
       version,
       includeTransitive: input.includeTransitive,
+      includeTransitiveDetails: input.includeTransitiveDetails,
+      includeGroups: input.includeGroups,
       maxDepth,
       lifecycle: wireLifecycles.length > 0 ? wireLifecycles : undefined,
     },

--- a/packages/mcp/src/tools/package-changelog.ts
+++ b/packages/mcp/src/tools/package-changelog.ts
@@ -156,6 +156,7 @@ export function createPackageChangelogTool(
           fromVersion: args.from_version,
           toVersion: args.to_version,
           limit: args.limit,
+          includeBodies: args.omit_bodies !== true,
         });
         const report = await service.packageChangelog(params);
         const payload = buildPackageChangelogSuccessPayload(report, {

--- a/packages/mcp/src/tools/package-dependencies.test.ts
+++ b/packages/mcp/src/tools/package-dependencies.test.ts
@@ -101,6 +101,8 @@ describe("createPackageDependenciesTool — happy path", () => {
           version?: string;
           lifecycle?: string[];
           includeTransitive?: boolean;
+          includeTransitiveDetails?: boolean;
+          includeGroups?: boolean;
           maxDepth?: number;
         },
       ]
@@ -110,7 +112,52 @@ describe("createPackageDependenciesTool — happy path", () => {
     expect(calls[0]?.[0]?.version).toBe("5.2.1");
     expect(calls[0]?.[0]?.lifecycle).toEqual(["development"]);
     expect(calls[0]?.[0]?.includeTransitive).toBe(true);
+    expect(calls[0]?.[0]?.includeTransitiveDetails).toBe(true);
+    expect(calls[0]?.[0]?.includeGroups).toBe(true);
     expect(calls[0]?.[0]?.maxDepth).toBe(3);
+  });
+
+  it("fetches groups for default text so hidden group hints can render", async () => {
+    const packageDependencies = mock(() =>
+      Promise.resolve(defaultDependencyReport),
+    );
+    const service = createMockPackageIntelligenceService({
+      packageDependencies,
+    });
+    const tool = createPackageDependenciesTool(service);
+
+    await tool.handler({ registry: "npm", package_name: "express" }, {});
+
+    const calls = packageDependencies.mock.calls as unknown as Array<
+      [
+        {
+          includeTransitiveDetails?: boolean;
+          includeGroups?: boolean;
+        },
+      ]
+    >;
+    expect(calls[0]?.[0]?.includeTransitiveDetails).toBe(false);
+    expect(calls[0]?.[0]?.includeGroups).toBe(true);
+  });
+
+  it("skips groups for default JSON deps mode", async () => {
+    const packageDependencies = mock(() =>
+      Promise.resolve(defaultDependencyReport),
+    );
+    const service = createMockPackageIntelligenceService({
+      packageDependencies,
+    });
+    const tool = createPackageDependenciesTool(service);
+
+    await tool.handler(
+      { registry: "npm", package_name: "express", format: "json" },
+      {},
+    );
+
+    const calls = packageDependencies.mock.calls as unknown as Array<
+      [{ includeGroups?: boolean }]
+    >;
+    expect(calls[0]?.[0]?.includeGroups).toBe(false);
   });
 
   it("emits compact text with runtime block by default", async () => {

--- a/packages/mcp/src/tools/package-dependencies.ts
+++ b/packages/mcp/src/tools/package-dependencies.ts
@@ -112,7 +112,15 @@ export function createPackageDependenciesTool(
           maxDepth: wireMaxDepth,
           lifecycle: args.lifecycle,
         });
-        const report = await service.packageDependencies(params);
+        const showGroups =
+          canonicalLifecycles.length > 0 &&
+          !canonicalLifecycles.every((item) => item === "runtime");
+        const textFormat = isTextFormat(args.format);
+        const report = await service.packageDependencies({
+          ...params,
+          includeTransitiveDetails: includeTransitiveOutput,
+          includeGroups: showGroups || textFormat,
+        });
         const payload = buildPackageDependenciesSuccessPayload(report, {
           requestedVersion: args.version,
           canonicalLifecycles,
@@ -120,7 +128,7 @@ export function createPackageDependenciesTool(
           maxDepth: args.max_depth,
           includeImporters: args.include_importers ?? false,
         });
-        if (isTextFormat(args.format)) {
+        if (textFormat) {
           const textLifecycles =
             canonicalLifecycles.length > 0
               ? canonicalLifecycles
@@ -132,9 +140,7 @@ export function createPackageDependenciesTool(
               canonicalLifecycles: textLifecycles,
               includeTransitive: includeTransitiveOutput,
               maxDepth: args.max_depth,
-              showGroups:
-                canonicalLifecycles.length > 0 &&
-                !canonicalLifecycles.every((item) => item === "runtime"),
+              showGroups,
               hiddenGroupsHint: 'pass lifecycle="all".',
             }).trimEnd(),
           );

--- a/packages/mcp/src/tools/package-summary.ts
+++ b/packages/mcp/src/tools/package-summary.ts
@@ -71,9 +71,13 @@ export function createPackageSummaryTool(
           registry: args.registry,
           packageName: args.package_name,
         });
-        const summary = await service.packageSummary(params);
+        const textFormat = isTextFormat(args.format);
+        const summary = await service.packageSummary({
+          ...params,
+          includeVerboseFields: !textFormat || args.verbose === true,
+        });
         const payload = buildPackageSummarySuccessPayload(summary);
-        if (isTextFormat(args.format)) {
+        if (textFormat) {
           return textResult(
             formatPackageSummaryTerminal(summary, {
               verbose: args.verbose,

--- a/src/commands/pkg/changelog.ts
+++ b/src/commands/pkg/changelog.ts
@@ -85,6 +85,7 @@ export async function pkgChangelogAction(
       fromVersion: options.from,
       toVersion: options.to,
       limit,
+      includeBodies,
     });
 
     const report =

--- a/src/commands/pkg/deps.test.ts
+++ b/src/commands/pkg/deps.test.ts
@@ -105,11 +105,42 @@ describe("pkgDepsAction", () => {
     );
 
     const calls = packageDependencies.mock.calls as unknown as Array<
-      [{ includeTransitive?: boolean; maxDepth?: number }]
+      [
+        {
+          includeTransitive?: boolean;
+          includeTransitiveDetails?: boolean;
+          includeGroups?: boolean;
+          maxDepth?: number;
+        },
+      ]
     >;
     expect(calls[0]?.[0]?.includeTransitive).toBe(true);
+    expect(calls[0]?.[0]?.includeTransitiveDetails).toBe(false);
+    expect(calls[0]?.[0]?.includeGroups).toBe(true);
     expect(calls[0]?.[0]?.maxDepth).toBe(1);
     writeSpy.mockRestore();
+  });
+
+  it("skips groups for default JSON deps mode", async () => {
+    const packageDependencies = mock(() =>
+      Promise.resolve(defaultDependencyReport),
+    );
+    const service = createMockPackageIntelligenceService({
+      packageDependencies,
+    });
+    const logSpy = spyOn(console, "log").mockImplementation(() => {});
+
+    await pkgDepsAction(
+      "npm:express",
+      { json: true },
+      createDeps({ packageIntelligenceService: service }),
+    );
+
+    const calls = packageDependencies.mock.calls as unknown as Array<
+      [{ includeGroups?: boolean }]
+    >;
+    expect(calls[0]?.[0]?.includeGroups).toBe(false);
+    logSpy.mockRestore();
   });
 
   it("sends maxDepth and renders transitive output when --depth N is set", async () => {
@@ -130,9 +161,18 @@ describe("pkgDepsAction", () => {
     );
 
     const calls = packageDependencies.mock.calls as unknown as Array<
-      [{ includeTransitive?: boolean; maxDepth?: number }]
+      [
+        {
+          includeTransitive?: boolean;
+          includeTransitiveDetails?: boolean;
+          includeGroups?: boolean;
+          maxDepth?: number;
+        },
+      ]
     >;
     expect(calls[0]?.[0]?.includeTransitive).toBe(true);
+    expect(calls[0]?.[0]?.includeTransitiveDetails).toBe(true);
+    expect(calls[0]?.[0]?.includeGroups).toBe(true);
     expect(calls[0]?.[0]?.maxDepth).toBe(5);
     writeSpy.mockRestore();
   });

--- a/src/commands/pkg/deps.ts
+++ b/src/commands/pkg/deps.ts
@@ -79,9 +79,14 @@ export async function pkgDepsAction(
       includeTransitive: wireIncludeTransitive,
       maxDepth: wireMaxDepth,
     });
+    const showGroups = canonicalLifecycles.some((entry) => entry !== "runtime");
+    const needsGroupsForTextHint = options.json !== true;
 
-    const report =
-      await deps.packageIntelligenceService.packageDependencies(params);
+    const report = await deps.packageIntelligenceService.packageDependencies({
+      ...params,
+      includeTransitiveDetails: includeTransitiveOutput,
+      includeGroups: showGroups || needsGroupsForTextHint,
+    });
 
     if (options.json) {
       const payload = buildPackageDependenciesSuccessPayload(report, {
@@ -98,8 +103,6 @@ export async function pkgDepsAction(
       console.log(JSON.stringify(payload));
       return;
     }
-
-    const showGroups = canonicalLifecycles.some((entry) => entry !== "runtime");
 
     const output = formatPackageDependenciesTerminal(report, {
       verbose: options.verbose,

--- a/src/commands/pkg/info.ts
+++ b/src/commands/pkg/info.ts
@@ -64,8 +64,10 @@ export async function pkgInfoAction(
       registry: parsed.registry,
       packageName: parsed.name,
     });
-    const summary =
-      await deps.packageIntelligenceService.packageSummary(params);
+    const summary = await deps.packageIntelligenceService.packageSummary({
+      ...params,
+      includeVerboseFields: options.json === true || options.verbose === true,
+    });
 
     if (options.json) {
       const payload = buildPackageSummarySuccessPayload(summary);


### PR DESCRIPTION
## Summary
- add conditional GraphQL field selection for package summary verbose fields, changelog bodies, dependency groups, and transitive dependency detail fields
- keep compact JSON payloads lean while preserving text-mode hidden dependency group hints
- remove unused changelog metadata selection and add regression coverage for query variables and deps text behavior

## Validation
- code-reviewer pass: initial deps hidden-groups regression fixed; second review had no findings
- bun test src/commands/pkg/deps.test.ts packages/mcp/src/tools/package-dependencies.test.ts packages/core-internal/src/services/package-intelligence-service.test.ts
- bun test packages/mcp/src/tools/package-summary.test.ts packages/mcp/src/tools/package-changelog.test.ts src/commands/pkg/info.test.ts src/commands/pkg/changelog.test.ts
- bun run build
- GITHITS_DISABLE_UPDATE_CHECK=1 bun run smoke:cli
- GITHITS_DISABLE_UPDATE_CHECK=1 bun run smoke:mcp
- live bun run dev checks for pkg info, pkg deps, and pkg changelog compact/verbose/json/no-body variants