### PR TITLE
fix: improve init CLI status rows

### DIFF
--- a/src/commands/init/init.test.ts
+++ b/src/commands/init/init.test.ts
@@ -1814,6 +1814,70 @@ describe("initAction", () => {
     });
   });
 
+  it("shows checked CLI detail when a composite setup also writes config", async () => {
+    const enoent = Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    const configFiles: Record<string, string> = {};
+    const fs = createFsWithDetection([], {});
+    fs.readFile = mock((path: string) => {
+      if (path in configFiles) {
+        return Promise.resolve(configFiles[path]!);
+      }
+      return Promise.reject(enoent);
+    });
+    fs.atomicWriteFile = mock((path: string, content: string) => {
+      configFiles[path] = content;
+      return Promise.resolve();
+    });
+    const execService = createMockExecService({
+      exec: mock((cmd: string, args: string[]) => {
+        const key = `${cmd} ${args.join(" ")}`;
+        if (key === `${lookupCommandFor()} pi`) {
+          return Promise.resolve({
+            exitCode: 0,
+            stdout: "/usr/bin/pi\n",
+            stderr: "",
+          });
+        }
+        if (key === "pi list") {
+          return Promise.resolve({
+            exitCode: 0,
+            stdout: "pi-mcp-adapter\n",
+            stderr: "",
+          });
+        }
+        return Promise.resolve({ exitCode: 1, stdout: "", stderr: "" });
+      }),
+    });
+
+    await initAction(
+      { installAgents: "pi" },
+      {
+        fileSystemService: fs,
+        promptService: createMockPromptService(),
+        execService,
+        createLoginDeps: createAlreadyAuthLoginDeps(),
+      },
+    );
+
+    const logCalls = getLogOutput();
+    expect(
+      logCalls.some(
+        (msg) =>
+          msg.includes("Pi") &&
+          msg.includes("unchanged") &&
+          msg.includes("checked via pi list"),
+      ),
+    ).toBe(true);
+    expect(
+      logCalls.some(
+        (msg) =>
+          msg.includes("Pi") &&
+          msg.includes("created") &&
+          msg.includes("~/.pi/agent/mcp.json"),
+      ),
+    ).toBe(true);
+  });
+
   it("sets up Pi using npm global bin fallback when pi is not on PATH", async () => {
     const enoent = Object.assign(new Error("ENOENT"), { code: "ENOENT" });
     const configFiles: Record<string, string> = {};
@@ -2043,6 +2107,229 @@ describe("initAction", () => {
     // Includes Pi fallback global-bin probes when pi is not on PATH.
     expect(execService.exec).toHaveBeenCalledTimes(14);
     expect(execService.exec).toHaveBeenCalledWith("claude", expect.any(Array));
+  });
+
+  it("renders already configured CLI agents with check command details", async () => {
+    const lookupCmd = lookupCommandFor();
+    const fs = createFsWithDetection([]);
+    const execService = createMockExecService({
+      exec: mock((cmd: string, args: string[]) => {
+        const key = `${cmd} ${args.join(" ")}`;
+        if (key === `${lookupCmd} claude` || key === `${lookupCmd} codex`) {
+          return Promise.resolve({
+            exitCode: 0,
+            stdout: `/usr/bin/${args[0]}\n`,
+            stderr: "",
+          });
+        }
+        if (key === "claude plugin list") {
+          return Promise.resolve({
+            exitCode: 0,
+            stdout: "githits@githits-plugins\n",
+            stderr: "",
+          });
+        }
+        if (key === "codex mcp list") {
+          return Promise.resolve({
+            exitCode: 0,
+            stdout: "githits\n",
+            stderr: "",
+          });
+        }
+        return Promise.resolve({ exitCode: 1, stdout: "", stderr: "" });
+      }),
+    });
+
+    await initAction(
+      { installAgents: "claude-code,codex-cli" },
+      {
+        fileSystemService: fs,
+        promptService: createMockPromptService(),
+        execService,
+        createLoginDeps: createAlreadyAuthLoginDeps(),
+      },
+    );
+
+    const claudeRow = getLogOutput().find((msg) => msg.includes("Claude Code"));
+    const codexRow = getLogOutput().find((msg) => msg.includes("Codex CLI"));
+    expect(claudeRow).toBeDefined();
+    expect(codexRow).toBeDefined();
+    expect(claudeRow ?? "").toContain("unchanged");
+    expect(claudeRow ?? "").toContain("checked via claude plugin list");
+    expect(codexRow ?? "").toContain("unchanged");
+    expect(codexRow ?? "").toContain("checked via codex mcp list");
+    expect(claudeRow ?? "").not.toContain("plugin install");
+    expect(codexRow ?? "").not.toContain("mcp add");
+    expect(execService.exec).not.toHaveBeenCalledWith("claude", [
+      "plugin",
+      "marketplace",
+      "add",
+      "githits-com/githits-cli",
+    ]);
+    expect(execService.exec).not.toHaveBeenCalledWith("claude", [
+      "plugin",
+      "install",
+      "githits@githits-plugins",
+    ]);
+    expect(execService.exec).not.toHaveBeenCalledWith("codex", [
+      "mcp",
+      "add",
+      "githits",
+      "--",
+      "npx",
+      "-y",
+      "githits@latest",
+      "mcp",
+      "start",
+    ]);
+  });
+
+  it("renders only Claude Code commands that actually ran", async () => {
+    const lookupCmd = lookupCommandFor();
+    const fs = createFsWithDetection([]);
+    let pluginListCalls = 0;
+    const execService = createMockExecService({
+      exec: mock((cmd: string, args: string[]) => {
+        const key = `${cmd} ${args.join(" ")}`;
+        if (key === `${lookupCmd} claude`) {
+          return Promise.resolve({
+            exitCode: 0,
+            stdout: "/usr/bin/claude\n",
+            stderr: "",
+          });
+        }
+        if (key === "claude plugin list") {
+          pluginListCalls += 1;
+          return Promise.resolve({
+            exitCode: 0,
+            stdout:
+              pluginListCalls === 1
+                ? "other-plugin\n"
+                : "githits@githits-plugins\n",
+            stderr: "",
+          });
+        }
+        if (
+          key === "claude plugin marketplace add githits-com/githits-cli" ||
+          key === "claude plugin install githits@githits-plugins"
+        ) {
+          return Promise.resolve({ exitCode: 0, stdout: "", stderr: "" });
+        }
+        return Promise.resolve({ exitCode: 1, stdout: "", stderr: "" });
+      }),
+    });
+
+    await initAction(
+      { installAgents: "claude-code" },
+      {
+        fileSystemService: fs,
+        promptService: createMockPromptService(),
+        execService,
+        createLoginDeps: createAlreadyAuthLoginDeps(),
+      },
+    );
+
+    expect(execService.exec).toHaveBeenCalledWith("claude", [
+      "plugin",
+      "marketplace",
+      "add",
+      "githits-com/githits-cli",
+    ]);
+    expect(execService.exec).toHaveBeenCalledWith("claude", [
+      "plugin",
+      "install",
+      "githits@githits-plugins",
+    ]);
+    const claudeRows = getLogOutput().filter(
+      (msg) => msg.includes("Claude Code") && msg.includes("claude plugin"),
+    );
+    expect(claudeRows).toHaveLength(1);
+    const claudeRow = claudeRows[0]!;
+    expect(claudeRow).toContain(
+      "claude plugin marketplace add githits-com/githits-cli",
+    );
+    const installRow = getLogOutput().find((msg) =>
+      msg.includes("claude plugin install githits@githits-plugins"),
+    );
+    expect(installRow).toBeDefined();
+    expect(installRow?.trim()).toBe(
+      "claude plugin install githits@githits-plugins",
+    );
+    expect(installRow?.indexOf("claude plugin install")).toBe(
+      claudeRow.indexOf("claude plugin marketplace"),
+    );
+  });
+
+  it("does not render checked-via detail when a later CLI command runs", async () => {
+    const lookupCmd = lookupCommandFor();
+    const fs = createFsWithDetection([]);
+    let pluginListCalls = 0;
+    const execService = createMockExecService({
+      exec: mock((cmd: string, args: string[]) => {
+        const key = `${cmd} ${args.join(" ")}`;
+        if (key === `${lookupCmd} claude`) {
+          return Promise.resolve({
+            exitCode: 0,
+            stdout: "/usr/bin/claude\n",
+            stderr: "",
+          });
+        }
+        if (key === "claude plugin list") {
+          pluginListCalls += 1;
+          return Promise.resolve({
+            exitCode: 0,
+            stdout:
+              pluginListCalls === 1
+                ? "other-plugin\n"
+                : "githits@githits-plugins\n",
+            stderr: "",
+          });
+        }
+        if (key === "claude plugin marketplace add githits-com/githits-cli") {
+          return Promise.resolve({
+            exitCode: 0,
+            stdout: "Marketplace already added\n",
+            stderr: "",
+          });
+        }
+        if (key === "claude plugin install githits@githits-plugins") {
+          return Promise.resolve({
+            exitCode: 0,
+            stdout: "Installed\n",
+            stderr: "",
+          });
+        }
+        return Promise.resolve({ exitCode: 1, stdout: "", stderr: "" });
+      }),
+    });
+
+    await initAction(
+      { installAgents: "claude-code" },
+      {
+        fileSystemService: fs,
+        promptService: createMockPromptService(),
+        execService,
+        createLoginDeps: createAlreadyAuthLoginDeps(),
+      },
+    );
+
+    const logCalls = getLogOutput();
+    expect(
+      logCalls.some((msg) => msg.includes("checked via claude plugin list")),
+    ).toBe(false);
+    expect(
+      logCalls.some((msg) =>
+        msg.includes("claude plugin marketplace add githits-com/githits-cli"),
+      ),
+    ).toBe(false);
+    expect(
+      logCalls.some(
+        (msg) =>
+          msg.includes("Claude Code") &&
+          msg.includes("ran") &&
+          msg.includes("claude plugin install githits@githits-plugins"),
+      ),
+    ).toBe(true);
   });
 
   it("uses one checkbox prompt for multiple unconfigured agents", async () => {
@@ -4531,6 +4818,81 @@ describe("initUninstallAction", () => {
     ).toBe(false);
   });
 
+  it("renders multi-step Claude uninstall commands as continuation rows", async () => {
+    const lookupCmd = lookupCommandFor();
+    const fs = createFsWithDetection([]);
+    let pluginInstalled = true;
+    const execService = createMockExecService({
+      exec: mock((cmd: string, args: string[]) => {
+        const key = `${cmd} ${args.join(" ")}`;
+        if (key === `${lookupCmd} claude`) {
+          return Promise.resolve({
+            exitCode: 0,
+            stdout: "/usr/bin/claude\n",
+            stderr: "",
+          });
+        }
+        if (key === "claude plugin list") {
+          return Promise.resolve({
+            exitCode: 0,
+            stdout: pluginInstalled ? "githits@githits-plugins\n" : "",
+            stderr: "",
+          });
+        }
+        if (key === "claude plugin uninstall githits") {
+          pluginInstalled = false;
+          return Promise.resolve({
+            exitCode: 0,
+            stdout: "Removed\n",
+            stderr: "",
+          });
+        }
+        if (key === "claude plugin marketplace remove githits-plugins") {
+          return Promise.resolve({
+            exitCode: 0,
+            stdout: "Removed\n",
+            stderr: "",
+          });
+        }
+        return Promise.resolve({ exitCode: 1, stdout: "", stderr: "" });
+      }),
+    });
+
+    await initUninstallAction(
+      { yes: true },
+      {
+        fileSystemService: fs,
+        promptService: createMockPromptService(),
+        execService,
+      },
+    );
+
+    expect(execService.exec).toHaveBeenCalledWith("claude", [
+      "plugin",
+      "uninstall",
+      "githits",
+    ]);
+    expect(execService.exec).toHaveBeenCalledWith("claude", [
+      "plugin",
+      "marketplace",
+      "remove",
+      "githits-plugins",
+    ]);
+    const uninstallRow = getLogOutput().find(
+      (msg) =>
+        msg.includes("Claude Code") && msg.includes("claude plugin uninstall"),
+    );
+    const marketplaceRow = getLogOutput().find((msg) =>
+      msg.includes("claude plugin marketplace remove githits-plugins"),
+    );
+    expect(uninstallRow).toBeDefined();
+    expect(marketplaceRow).toBeDefined();
+    expect(marketplaceRow).not.toContain("Claude Code");
+    expect(marketplaceRow?.indexOf("claude plugin marketplace")).toBe(
+      uninstallRow?.indexOf("claude plugin uninstall"),
+    );
+  });
+
   it("reports CLI probe failures as inspection failures without prompting", async () => {
     const lookupCmd = lookupCommandFor();
     const fs = createFsWithDetection([]);
@@ -4867,6 +5229,14 @@ describe("initUninstallAction", () => {
     );
 
     const logCalls = getLogOutput();
+    expect(
+      logCalls.some(
+        (msg) =>
+          msg.includes("Codex CLI") &&
+          msg.includes("unchanged") &&
+          msg.includes("checked via codex mcp list"),
+      ),
+    ).toBe(true);
     expect(
       logCalls.some((msg) =>
         msg.includes(

--- a/src/commands/init/init.ts
+++ b/src/commands/init/init.ts
@@ -44,6 +44,7 @@ import {
   CHANGE_VERB_WIDTH,
   type ChangeRow,
   describeConfigAsUnchanged,
+  formatCliCommand,
   formatConfigPath,
   renderChangeRows,
   type SetupChange,
@@ -224,6 +225,21 @@ function getResolvedSetupConfig(
     agent.resolvedSetupConfig ??
     agent.getSetupConfig(fileSystemService, agent.resolvedSetupContext)
   );
+}
+
+function getCliCheckDetail(config: SetupConfig): string | undefined {
+  if (config.method === "cli" && config.checkCommand) {
+    return `checked via ${formatCliCommand(config.checkCommand)}`;
+  }
+  if (config.method === "composite") {
+    const checkStep = config.steps.find(
+      (step) => step.method === "cli" && step.checkCommand,
+    );
+    return checkStep?.method === "cli" && checkStep.checkCommand
+      ? `checked via ${formatCliCommand(checkStep.checkCommand)}`
+      : undefined;
+  }
+  return undefined;
 }
 
 function getLegacyProjectSetupStatePath(
@@ -2117,13 +2133,77 @@ function uninstallChangeToRow(
   return { tone: "ok", label: name, verb: change.change, detail };
 }
 
-/** Build display rows for one agent's uninstall outcome (+ a failure row). */
+function visibleChangeRows<T extends SetupChange | UninstallChange>(
+  name: string,
+  changes: T[] | undefined,
+  fileSystemService: FileSystemService,
+  unchangedCommandDetail: string | undefined,
+  toRow: (
+    name: string,
+    change: T,
+    fileSystemService: FileSystemService,
+  ) => ChangeRow,
+): ChangeRow[] {
+  const allChanges = changes ?? [];
+  const visibleChanges = allChanges.filter(
+    (change) => change.kind !== "command" || change.change === "ran",
+  );
+  const hiddenCommandChanges = allChanges.filter(
+    (change) => change.kind === "command" && change.change === "unchanged",
+  );
+  const hasVisibleCommandChange = visibleChanges.some(
+    (change) => change.kind === "command",
+  );
+  const rows: ChangeRow[] = [];
+
+  if (
+    hiddenCommandChanges.length > 0 &&
+    !hasVisibleCommandChange &&
+    unchangedCommandDetail
+  ) {
+    rows.push({
+      tone: "ok",
+      label: name,
+      verb: "unchanged",
+      detail: unchangedCommandDetail,
+    });
+  } else if (visibleChanges.length === 0 && hiddenCommandChanges.length > 0) {
+    rows.push({ tone: "ok", label: name, verb: "unchanged", detail: "" });
+  }
+
+  let commandRows = 0;
+  for (const change of visibleChanges) {
+    if (change.kind === "command") {
+      rows.push(
+        commandRows === 0
+          ? toRow(name, change, fileSystemService)
+          : { tone: "ok", label: "", verb: "", detail: change.command },
+      );
+      commandRows += 1;
+    } else {
+      rows.push(toRow(name, change, fileSystemService));
+    }
+  }
+
+  return rows;
+}
+
+/**
+ * Build display rows for one agent's uninstall outcome. Config-file changes
+ * show their paths; CLI command rows show only commands that actually ran, or
+ * the read-only check command when every CLI command was already unnecessary.
+ */
 function uninstallOutcomeRows(
   outcome: AgentUninstallOutcome,
   fileSystemService: FileSystemService,
+  unchangedCommandDetail?: string,
 ): ChangeRow[] {
-  const rows: ChangeRow[] = (outcome.changes ?? []).map((change) =>
-    uninstallChangeToRow(outcome.name, change, fileSystemService),
+  const rows = visibleChangeRows(
+    outcome.name,
+    outcome.changes,
+    fileSystemService,
+    unchangedCommandDetail,
+    uninstallChangeToRow,
   );
   if (outcome.status === "failed") {
     rows.push({
@@ -2149,9 +2229,10 @@ function printUninstallOutcome(
   fileSystemService: FileSystemService,
   useColors: boolean,
   labelWidth: number,
+  unchangedCommandDetail?: string,
 ): void {
   const lines = renderChangeRows(
-    uninstallOutcomeRows(outcome, fileSystemService),
+    uninstallOutcomeRows(outcome, fileSystemService, unchangedCommandDetail),
     { useColors, labelWidth, verbWidth: CHANGE_VERB_WIDTH },
   );
   for (const line of lines) {
@@ -2236,7 +2317,13 @@ async function uninstallSelectedAgents(
       changes: result.changes,
     };
     outcomes.push(outcome);
-    printUninstallOutcome(outcome, fileSystemService, useColors, labelWidth);
+    printUninstallOutcome(
+      outcome,
+      fileSystemService,
+      useColors,
+      labelWidth,
+      getCliCheckDetail(setupConfig),
+    );
   }
 
   return outcomes;
@@ -2471,17 +2558,22 @@ function changeToRow(
 }
 
 /**
- * Build the display rows for one agent's install outcome: one row per change
- * (paths written / commands run), plus a trailing error row when the outcome
- * failed — keeping the written path/command visible even on verification
- * failure.
+ * Build display rows for one agent's install outcome. Config-file changes show
+ * their paths; CLI command rows show only commands that actually ran, or the
+ * read-only check command when every CLI command was already unnecessary. A
+ * failed outcome keeps visible changes plus a trailing error row.
  */
 function agentOutcomeRows(
   outcome: AgentOutcome,
   fileSystemService: FileSystemService,
+  unchangedCommandDetail?: string,
 ): ChangeRow[] {
-  const rows: ChangeRow[] = (outcome.changes ?? []).map((change) =>
-    changeToRow(outcome.name, change, fileSystemService),
+  const rows = visibleChangeRows(
+    outcome.name,
+    outcome.changes,
+    fileSystemService,
+    unchangedCommandDetail,
+    changeToRow,
   );
   if (outcome.status === "failed") {
     rows.push({
@@ -2545,10 +2637,13 @@ async function installSelectedAgents(
     (width, agent) => Math.max(width, agent.name.length),
     0,
   );
-  const printRows = (outcome: AgentOutcome): void => {
+  const printRows = (
+    outcome: AgentOutcome,
+    unchangedCommandDetail?: string,
+  ): void => {
     if (!printResults) return;
     const lines = renderChangeRows(
-      agentOutcomeRows(outcome, fileSystemService),
+      agentOutcomeRows(outcome, fileSystemService, unchangedCommandDetail),
       {
         useColors,
         labelWidth,
@@ -2562,19 +2657,19 @@ async function installSelectedAgents(
 
   for (const agent of agents) {
     if (alreadyConfiguredIds.has(agent.id)) {
+      const config = getResolvedSetupConfig(agent, fileSystemService);
       const outcome: AgentOutcome = {
         id: agent.id,
         name: agent.name,
         status: "already_configured",
-        changes: describeConfigAsUnchanged(
-          getResolvedSetupConfig(agent, fileSystemService),
-        ),
+        changes: describeConfigAsUnchanged(config),
       };
       outcomes.push(outcome);
-      printRows(outcome);
+      printRows(outcome, getCliCheckDetail(config));
       continue;
     }
 
+    const config = getResolvedSetupConfig(agent, fileSystemService);
     const finishTask = printResults ? installTasks.start(agent.name) : () => {};
     let result: SetupResult;
     try {
@@ -2596,7 +2691,7 @@ async function installSelectedAgents(
       changes: result.changes,
     };
     outcomes.push(outcome);
-    printRows(outcome);
+    printRows(outcome, getCliCheckDetail(config));
   }
 
   return outcomes;

--- a/src/commands/init/setup-format.test.ts
+++ b/src/commands/init/setup-format.test.ts
@@ -201,6 +201,29 @@ describe("renderChangeRows", () => {
     expect(lines[2]).toContain("✗");
   });
 
+  it("aligns continuation rows to the detail column", () => {
+    const continuationRows: ChangeRow[] = [
+      rows[0]!,
+      {
+        tone: "ok",
+        label: "",
+        verb: "",
+        detail: "claude plugin install y",
+      },
+    ];
+    const widths = changeRowColumnWidths(rows);
+    const lines = renderChangeRows(continuationRows, {
+      useColors: false,
+      labelWidth: widths.labelWidth,
+      verbWidth: widths.verbWidth,
+    });
+
+    expect(lines[1]!.trim()).toBe("claude plugin install y");
+    expect(lines[1]!.indexOf("claude plugin install y")).toBe(
+      lines[0]!.indexOf("claude plugin install x"),
+    );
+  });
+
   it("produces equal visible column widths regardless of color", () => {
     const opts = { labelWidth: 11, verbWidth: CHANGE_VERB_WIDTH };
     const plain = renderChangeRows(rows, { ...opts, useColors: false });

--- a/src/commands/init/setup-format.ts
+++ b/src/commands/init/setup-format.ts
@@ -101,6 +101,10 @@ export function renderChangeRows(
 ): string[] {
   const { useColors, labelWidth, verbWidth } = options;
   return rows.map((row) => {
+    if (row.label === "" && row.verb === "") {
+      const detailOffset = 10 + labelWidth + verbWidth;
+      return `${" ".repeat(detailOffset)}${row.detail}`.trimEnd();
+    }
     const { glyph, color } = TONE_GLYPH[row.tone];
     const coloredGlyph = colorize(glyph, color, useColors);
     const label = row.label.padEnd(labelWidth);


### PR DESCRIPTION
## Summary
- show read-only CLI probes for unchanged init rows, e.g. `checked via claude plugin list`
- show install/uninstall commands only when they actually ran
- align multi-command continuation rows to the detail column for install and uninstall
- preserve config-file path details and composite rows such as Pi CLI check plus config writes

## Review
- code-reviewer flagged composite CLI checks being hidden beside config-file rows; fixed with a composite regression test
- code-reviewer flagged mixed unchanged+ran CLI steps showing misleading `checked via`; fixed with a mixed Claude regression test

## Tests
- `bun test src/commands/init/setup-format.test.ts src/commands/init/init.test.ts`
- `bun run build`