### PR TITLE
feat: add MCP tool execution hook

### DIFF
--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -7,6 +7,7 @@ export type {
   McpRequestContext,
   McpServerMetadata,
   McpToolDescriptor,
+  McpToolExecutionHook,
   McpToolServicesProvider,
 } from "./mcp/server.js";
 export {

--- a/packages/mcp/src/mcp/server.ts
+++ b/packages/mcp/src/mcp/server.ts
@@ -45,12 +45,19 @@ export type McpToolServicesProvider<TExtra = unknown> =
       context: McpRequestContext<TExtra>,
     ) => McpToolServices | Promise<McpToolServices>);
 
+/** Wraps one public MCP tool call without receiving arguments or auth data. */
+export type McpToolExecutionHook = (
+  toolName: string,
+  runHandler: () => Promise<ToolResult>,
+) => ToolResult | Promise<ToolResult>;
+
 export interface CreateMcpServerOptions<TExtra = unknown> {
   metadata: McpServerMetadata;
   services: McpToolServicesProvider<TExtra>;
   authAction?: McpAuthAction;
   instructions?: string;
   instructionOptions?: Parameters<typeof buildMcpInstructions>[0];
+  traceTool?: McpToolExecutionHook;
 }
 
 export interface McpToolDescriptor<TSchema extends ZodRawShape = ZodRawShape> {
@@ -128,6 +135,7 @@ export function registerMcpTools<TExtra = unknown>(
   options: {
     authAction?: McpAuthAction;
     services: McpToolServicesProvider<TExtra>;
+    traceTool?: McpToolExecutionHook;
   },
 ): void {
   for (const createTool of TOOL_FACTORIES) {
@@ -139,8 +147,8 @@ export function registerMcpTools<TExtra = unknown>(
         inputSchema: descriptor.schema,
         annotations: descriptor.annotations,
       },
-      async (args, extra) =>
-        withMcpErrorOptions({ authAction: options.authAction }, async () => {
+      async (args, extra) => {
+        const runHandler = async () => {
           const services = await withErrorHandling("resolve MCP services", () =>
             resolveMcpToolServices(options.services, {
               extra: extra as TExtra | undefined,
@@ -148,7 +156,15 @@ export function registerMcpTools<TExtra = unknown>(
           );
           if (isToolResult(services)) return services;
           return createTool(services).handler(args, extra);
-        }),
+        };
+        return withMcpErrorOptions(
+          { authAction: options.authAction },
+          async () =>
+            options.traceTool
+              ? await options.traceTool(descriptor.name, runHandler)
+              : runHandler(),
+        );
+      },
     );
   }
 }
@@ -167,6 +183,7 @@ export function createMcpServer<TExtra = unknown>(
   registerMcpTools(server, {
     authAction: options.authAction,
     services: options.services,
+    traceTool: options.traceTool,
   });
 
   return server;

--- a/src/commands/mcp.test.ts
+++ b/src/commands/mcp.test.ts
@@ -3,6 +3,7 @@ import { AuthenticationError } from "@githits/core-internal";
 import {
   createMcpServer,
   getMcpToolDescriptors,
+  type McpToolExecutionHook,
   type McpToolServices,
   registerMcpTools,
 } from "@githits/mcp";
@@ -127,6 +128,81 @@ describe("createMcpServer", () => {
 
     expect(result.content[0]?.text).toBe("provider result");
     expect(provider).toHaveBeenCalledWith({ extra });
+  });
+
+  it("runs a configured tool execution hook once around a simple public tool handler", async () => {
+    const server = new McpServer(TEST_MCP_SERVER_METADATA);
+    const events: string[] = [];
+    const search = mock(() => Promise.resolve("hooked result"));
+    const traceTool: McpToolExecutionHook = mock(
+      async (toolName, runHandler) => {
+        events.push(`start:${toolName}`);
+        const result = await runHandler();
+        events.push(`end:${toolName}`);
+        return result;
+      },
+    );
+
+    registerMcpTools(server, {
+      services: createTestServices({
+        githitsService: createMockGitHitsService({ search }),
+      }),
+      traceTool,
+    });
+
+    const result = await registeredTool(server, "get_example").handler(
+      { query: "hello" },
+      undefined as unknown as RequestHandlerExtra<
+        ServerRequest,
+        ServerNotification
+      >,
+    );
+
+    expect(result.content[0]?.text).toBe("hooked result");
+    expect(traceTool).toHaveBeenCalledTimes(1);
+    expect(traceTool).toHaveBeenCalledWith("get_example", expect.any(Function));
+    expect(events).toEqual(["start:get_example", "end:get_example"]);
+  });
+
+  it("runs one tool execution hook around pkg_upgrade_review despite composed downstream probes", async () => {
+    const services = createTestServices();
+    const traceTool: McpToolExecutionHook = mock(
+      async (toolName, runHandler) => {
+        expect(toolName).toBe("pkg_upgrade_review");
+        return runHandler();
+      },
+    );
+    const server = createMcpServer({
+      services,
+      metadata: TEST_MCP_SERVER_METADATA,
+      traceTool,
+    });
+
+    const result = await registeredTool(server, "pkg_upgrade_review").handler(
+      {
+        registry: "npm",
+        package_name: "express",
+        current_version: "4.18.1",
+        target_version: "4.18.2",
+        format: "json",
+      },
+      undefined as unknown as RequestHandlerExtra<
+        ServerRequest,
+        ServerNotification
+      >,
+    );
+
+    expect(result.isError).toBeUndefined();
+    expect(traceTool).toHaveBeenCalledTimes(1);
+    expect(
+      services.packageIntelligenceService.packageSummary,
+    ).toHaveBeenCalledTimes(1);
+    expect(
+      services.packageIntelligenceService.packageVulnerabilities,
+    ).toHaveBeenCalledTimes(2);
+    expect(
+      services.packageIntelligenceService.packageUpgradeDependencyProbe,
+    ).toHaveBeenCalledTimes(2);
   });
 
   it("function providers receive undefined extra deterministically", async () => {


### PR DESCRIPTION
## Summary

- Add optional `traceTool` hook to wrap one full public MCP tool handler call.
- Export `McpToolExecutionHook` from `@githits/mcp`.
- Add tests for one simple tool and composed `pkg_upgrade_review` execution.

## Verification

- `bun test src/commands/mcp.test.ts src/mcp-public-surface.test.ts`
- `bun run format:check`
- `bun run typecheck`
- `bun run build`
- `bun run validate:packages`
- `bun run smoke:mcp`