### PR TITLE
feat: use aggregate package upgrade review

### DIFF
--- a/docs/implementation/pkg-upgrade-review.md
+++ b/docs/implementation/pkg-upgrade-review.md
@@ -6,25 +6,31 @@ Dependency-upgrade reviews are a distinct agent workflow. Agents should not infe
 
 `pkg_upgrade_review` is the MCP/CLI-facing tool for this workflow. It answers: "What changed between the currently used version and the target version, and what evidence is available or missing?"
 
-This report reflects the backend schema inspected at `/Users/jpl/.superset/worktrees/pkgseer-backend/best-maxilla/priv/graphql/schema.graphql`.
+This report reflects the backend schema inspected at `/Users/jpl/.superset/worktrees/af856079-3997-4271-af85-b1901f8a2119/forest-reference/priv/graphql/schema.graphql`.
 
 ## Current Schema Fit
 
-The existing GraphQL schema already has most primitives needed for a first version:
+The backend now exposes the aggregate query the CLI/MCP tool should call directly:
 
-| Need | Current GraphQL support | Notes |
-|---|---|---|
-| Latest version and package identity | `packageSummary(registry, name)` | Gives `latestVersion`, repository metadata, license, downloads, latest changelogs, and latest-version security overview. It is latest-only. |
-| Version-specific vulnerabilities | `packageVulnerabilities(registry, name, version, minSeverity, includeWithdrawn, deduplicate)` | Good fit for current and target direct-package advisory comparison. `security.advisories(scope: AFFECTED/NON_AFFECTING/ALL)` is the correct field. |
-| Changelog range | `packageChangelog(registry, name, fromVersion, toVersion, limit)` | Good fit. Range mode returns all entries between versions. Package-addressed queries use registry versions as the spine and attach changelog details when available. |
-| Direct and transitive dependencies | `packageDependencies(registry, name, version, includeTransitive, maxDepth, lifecycle)` | Good fit for target dependency graph and can also be run for current version to diff dependency graph client-side. |
-| API/symbol change signals | `versionDiff(registry, packageName, fromVersion, toVersion, includePrivate, kind, category, fileIntent, limit)` | Future enhancement only. It requires code indexing and a new typed CLI service/error surface, so it is out of v1. |
-| Version publish/deprecation metadata | `PackageVersionIdentity.publishedAt`, `deprecated`, `deprecationReason` | Available through version-specific package responses such as `packageVulnerabilities` and `packageDependencies`. `deprecated: null` means metadata unavailable; do not treat it as false. |
-| Engines / runtime requirements | Not exposed | Intentionally out of v1. The backend removed the unstable `runtimeRequirements` API. Report engine-related changelog text signals until a stable schema exists. |
-| Peer dependency compatibility | Partially represented in `dependencyGroups.lifecycle == "peer"` | Good enough to expose peer dependency changes, but not enough to validate against the local project without project dependency context. |
-| Transitive vulnerability summary | `TransitiveDependencySummary.vulnerabilitySummary` | Available as a lazy nested field. Use non-deprecated fields: `affected`, `nonAffecting`, `combined`, `packages[].affectedCount`, `packages[].advisoryOccurrences(scope: AFFECTED)`. |
-| Dependency issues summary | `TransitiveDependencySummary.dependencyIssues` | Available as a lazy nested field. Covers deprecated, outdated, duplicate, and conflict summaries. Rank outdated below vulnerabilities, deprecations, and conflicts in review text. |
-| Yanked/withdrawn package versions | Not exposed | Out of v1. Do not mention yanked status except as unavailable. Advisory `withdrawnAt` is separate vulnerability metadata, not package-version yanking. |
+```graphql
+packageUpgradeReview(
+  packages: [PackageUpgradeReviewPackageInput!]!
+  includeTransitiveSecurity: Boolean
+  minSeverity: Float
+  changelogLimit: Int
+): PackageUpgradeReviewResponse!
+```
+
+The CLI/MCP implementation must not fall back to composing `packageSummary`, `packageVulnerabilities`, `packageChangelog`, or `packageDependencies` calls. If the aggregate query is unavailable, surface the backend protocol error. Release should wait until the backend aggregate support is deployed.
+
+Optional evidence is controlled by GraphQL field selection and local query variables:
+
+- `includeTransitiveSecurity` is sent to the backend root field and also controls the selected `security.transitive` subtree.
+- `include_dependency_issues` / `--dependency-issues` controls the selected `dependencyIssues @include(...)` subtree. It is not a backend root argument.
+- `changelogLimit` caps ordinary changelog entries per package.
+- `min_severity` maps to CVSS thresholds and is omitted for `low`, matching the existing upgrade-review request builder behavior.
+
+Out-of-scope evidence remains unchanged: `versionDiff` and runtime/engine compatibility are future enhancements, and the tool must not infer accept/reject recommendations.
 
 ## Proposed MCP Tool
 
@@ -137,9 +143,27 @@ interface UpgradeSecurity {
 }
 ```
 
-Advisory diffs (`added`, `removed`, `notAddressed`) must reuse the existing vulnerability alias-cluster canonicalization from `package-vulnerabilities-response.ts`. Diff logical advisories over `osvId ∪ aliases[]`, not raw IDs, or GHSA/RUSTSEC duplicates will be misclassified. The legacy aliases (`introduced`, `fixed`, `unchanged`) remain in JSON for compatibility while the text output uses vulnerability-focused labels: `added`, `fixed`, and `still-present`.
+Advisory diffs (`added`, `removed`, `notAddressed`) are now backend-provided. The backend must diff logical advisories over `id ∪ aliases[]`, not raw IDs, or GHSA/RUSTSEC duplicates will be misclassified. The legacy aliases (`introduced`, `fixed`, `unchanged`) remain in JSON for compatibility while the text output uses vulnerability-focused labels: `added`, `fixed`, and `still-present`.
 
-Transitive vulnerability diffs are package/advisory-aware. Use `advisoryOccurrences[].advisory.osvId ∪ aliases[]` for alias-cluster identity when occurrence metadata is available, with `advisoryIds[]` as the fallback. A dependency version change with the same affected advisory remains `stillAffectedPackageDetails`, not a fixed plus introduced pair. A package can appear in both added and still-affected groups if the target keeps one advisory and adds another.
+Transitive vulnerability diffs are backend-provided and package/advisory-aware. A dependency version change with the same affected advisory remains `stillAffectedPackageDetails`, not a fixed plus introduced pair. A package can appear in both added and still-affected groups if the target keeps one advisory and adds another. Detail pages preserve backend `totalCount` / `truncated` metadata so JSON and text output do not present capped samples as complete evidence.
+
+```ts
+interface TransitiveSecuritySummary {
+  currentAffected: number;
+  targetAffected: number;
+  introducedPackages: string[];
+  fixedPackages: string[];
+  introducedPackageDetails: TransitiveVulnerablePackage[];
+  introducedPackageDetailsTotalCount: number;
+  introducedPackageDetailsTruncated: boolean;
+  fixedPackageDetails: TransitiveVulnerablePackage[];
+  fixedPackageDetailsTotalCount: number;
+  fixedPackageDetailsTruncated: boolean;
+  stillAffectedPackageDetails: TransitiveVulnerablePackage[];
+  stillAffectedPackageDetailsTotalCount: number;
+  stillAffectedPackageDetailsTruncated: boolean;
+}
+```
 
 Version vulnerability summaries should include package-version metadata from `PackageVersionIdentity`:
 
@@ -210,7 +234,7 @@ interface UpgradeDependencyChangeGroup {
 }
 ```
 
-Dependency changes are always requested by the upgrade-review dependency probe. Direct dependency set or constraint changes are reported as facts because they alter install behavior even when direct vulnerabilities and changelog checks are clean. Transitive dependency graph changes are rendered for context. The target/current root package node and synthetic nodes are excluded from transitive change rows.
+Dependency changes are backend-provided by the aggregate upgrade-review response. Direct dependency set or constraint changes are reported as facts because they alter install behavior even when direct vulnerabilities and changelog checks are clean. Transitive dependency graph changes are rendered for context. The backend excludes the target/current root package node and synthetic nodes from transitive change rows.
 
 ## Text Shape
 
@@ -264,254 +288,42 @@ The factual evidence includes:
 
 Keyword matching should be lexical and transparent, not hidden model inference. Treat matches only as sampling hints. Start with conservative terms in changelog bodies: `breaking`, `breaks`, `removed`, `drop support`, `migration`, `migrate`, `deprecated`, `renamed`. Avoid broad ecosystem terms such as `node`, `python`, `peer`, `requires`, `config`, or `engine`; real runs showed those produce false positives from CI/config mentions that are not compatibility changes. Handle obvious negations such as `no breaking changes`.
 
-## Client-Side First Implementation
+## Current Implementation
 
-A first implementation does not require a new backend query.
+The CLI/MCP implementation has one active backend path:
 
-For each package review:
+1. `buildPackageUpgradeReviewRequest` validates single-package vs batch mode, normalises registry values to backend enum casing, maps `min_severity` to CVSS thresholds, and keeps `low` unfiltered.
+2. `buildPackageUpgradeReview` calls `PackageIntelligenceService.packageUpgradeReview` exactly once with the full package batch.
+3. `PackageIntelligenceServiceImpl.packageUpgradeReview` posts the aggregate GraphQL query, validates the typed response with Zod, strips `null` fields to the existing JSON omission convention, and reuses standard package-intelligence transport/auth/error handling.
+4. The shared response module normalises backend enum strings to the existing CLI/MCP JSON/text casing (`NPM` -> `npm`, `MAJOR` -> `major`, `HIGH` -> `high`) and preserves the existing terminal formatter shape.
 
-1. Call `packageSummary(registry, name)` for `latestVersion`, repository metadata, and latest-version context. If this fails, continue the review without `latestVersion` and add an `unknowns[]` entry; do not fail the package unless all core calls fail.
-2. Call `packageVulnerabilities(registry, name, version: currentVersion, advisory scope AFFECTED)` and select `package { publishedAt deprecated deprecationReason }`.
-3. Call `packageVulnerabilities(registry, name, version: targetVersion, advisory scope AFFECTED)` and select `package { publishedAt deprecated deprecationReason }`.
-4. Call `packageChangelog(registry, name, fromVersion: currentVersion, toVersion: targetVersion)`.
-5. Call a dedicated upgrade-review dependency probe for current and target. It always selects direct dependencies, peer dependency groups, package-version metadata, the transitive dependency graph needed for dependency-change diffs, and transitive vulnerability summaries unless explicitly disabled. It selects lazy `dependencyIssues` only when `include_dependency_issues` is requested.
-6. Diff current-vs-target dependency changes, peer groups, transitive vulnerability summaries, and dependency-issue summaries. Target-only unresolved issues can be shown as context but must not be reported as upgrade regressions.
+There is deliberately no compatibility fallback to the old client-side fanout. Backend schema mismatch, missing resolver, or deployment skew should surface as the normal package-intelligence backend/protocol error. This prevents the CLI from silently making many backend calls after the aggregate tool exists.
 
-Batching can initially be client-side concurrency with per-package isolation. Cap package-level concurrency at 3 by default because each package review can make several GraphQL calls. One package failure should produce a review item with `unknowns[]` instead of failing the entire batch unless request validation fails.
+## Implementation Notes For CLI/MCP
 
-Version resolution failures should map to an `unknown` review with the structured `VERSION_NOT_FOUND` / `NOT_FOUND` details preserved where available. A missing current or target version is not retryable by the tool unless the backend supplies available versions for an actionable hint.
-
-This is still a better MCP UX because the agent makes one tool call and receives one evidence-shaped result, even if the CLI internally composes multiple backend queries.
-
-## Current Backend Surface
-
-The current schema can support v1. The backend work should be treated as available surface, not future work, with one explicit omission: runtime/engine requirements are not stable and are intentionally not exposed.
-
-### 1. Lazy Transitive Security on Dependency Reports
-
-Use lazy nested fields under `TransitiveDependencySummary`. Do not add `includeTransitiveSecurity` as a GraphQL root argument. Absinthe resolves nested fields only when selected, so field selection is the right cost-control mechanism.
-
-Current schema shape, using non-deprecated fields:
-
-```graphql
-type TransitiveDependencySummary {
-  dependencyGraph: DependencyGraph
-  dependencyConflicts: [DependencyConflict!]!
-  circularDependencyCycles: [CircularDependencyCycle!]
-  vulnerabilitySummary: TransitiveVulnerabilitySummary
-  dependencyIssues: DependencyIssuesSummary
-}
-
-type TransitiveVulnerabilitySummary {
-  affected: VulnerabilityCount!
-  nonAffecting: VulnerabilityCount!
-  combined: VulnerabilityCount!
-  totalPackagesAnalyzed: Int!
-  affectedPackageCount: Int!
-  packages: [TransitiveVulnerablePackage!]!
-  calculatedAt: String
-}
-
-type TransitiveVulnerablePackage {
-  registry: DependencyGraphRegistry!
-  name: String!
-  versions: [String!]!
-  affectedCount: Int!
-  nonAffectingCount: Int!
-  totalCount: Int!
-  maxSeverityScore: Float
-  maxSeverityLabel: String
-  advisoryIds(scope: VulnerabilityScope): [String!]!
-  mostCritical: VulnerabilitySummaryDetail
-  advisoryOccurrences(scope: VulnerabilityScope, minSeverity: Float, limit: Int): [TransitiveDependencyVulnerability!]!
-}
-```
-
-Do not put vulnerability data on every `DependencyGraphNode` in v1. That bloats graph responses and makes common dependency-tree queries more expensive. A summary with package rows fits the upgrade-review and CLI workflows better.
-
-The resolver should be lazy:
-
-- `packageDependencies` continues resolving direct deps and, when `includeTransitive: true`, the DAG.
-- `dependencies.transitive.vulnerabilitySummary` has its own resolver and only executes when selected.
-- The parent transitive map can carry internal non-schema keys such as `:_registry`, `:_package_name`, `:_version`, and `:_dag_data` so nested resolvers do not recompute or reverse-parse the graph.
-- Add explicit GraphQL complexity cost to `vulnerabilitySummary` because it performs chunked package/version lookups and advisory aggregation.
-
-For MCP/CLI wrappers, keep an ergonomic skip flag (`skip_transitive_security` on MCP, `--no-transitive-security` on CLI). The wrapper translates that flag into selecting or omitting `vulnerabilitySummary`; it should not imply a backend root argument.
-
-### 2. Lazy Dependency Issues on Dependency Reports
-
-Use the second lazy nested field for non-vulnerability dependency issue signals:
-
-```graphql
-type DependencyIssuesSummary {
-  totalCount: Int!
-  deprecatedCount: Int!
-  outdatedCount: Int!
-  duplicateCount: Int!
-  conflictCount: Int!
-  deprecatedPackages: [DeprecatedDependency!]!
-  outdatedPackages: [OutdatedDependency!]!
-  duplicatePackages: [DuplicateDependency!]!
-  conflicts: [DependencyIssueConflict!]!
-}
-
-type DeprecatedDependency {
-  registry: DependencyGraphRegistry!
-  name: String!
-  versions: [String!]!
-  reasons: [DependencyDeprecationReason!]!
-}
-
-type DependencyDeprecationReason {
-  version: String!
-  reason: String
-}
-
-type OutdatedDependency {
-  registry: DependencyGraphRegistry!
-  name: String!
-  latestVersion: String
-  severity: DependencyOutdatedSeverity!
-  versions: [OutdatedDependencyVersion!]!
-  repositoryUrl: String
-}
-
-type OutdatedDependencyVersion {
-  version: String!
-  severity: DependencyOutdatedSeverity!
-}
-
-type DuplicateDependency {
-  registry: DependencyGraphRegistry
-  name: String!
-  versions: [String!]!
-}
-
-enum DependencyOutdatedSeverity {
-  PATCH
-  MINOR
-  MAJOR
-  UNKNOWN
-}
-```
-
-The resolver is lazy. Outdated is included in the backend surface, but CLI/MCP text should rank it below vulnerabilities, deprecations, duplicates, and conflicts.
-
-### 3. Future Batch Vulnerability Query
-
-Client-side batching is fine for v1. A backend batch security primitive may still be useful later for non-upgrade workflows, but it is not needed to implement `pkg_upgrade_review` because transitive security is now available under `packageDependencies` and direct current/target checks are two bounded calls per package.
-
-```graphql
-packageVulnerabilityBatch(packages: [PackageVersionInput!]!, minSeverity: Float, includeWithdrawn: Boolean): [VulnerabilityReport!]!
-
-input PackageVersionInput {
-  registry: Registry!
-  name: String!
-  version: String!
-}
-```
-
-This is more generally useful than an upgrade-specific query.
-
-### 4. Version Metadata
-
-Version-level publish/deprecation metadata is available on `PackageVersionIdentity`:
-
-```graphql
-type PackageVersionIdentity {
-  name: String
-  registry: String
-  version: String
-  publishedAt: String
-  deprecated: Boolean
-  deprecationReason: String
-}
-```
-
-Important caveat: `PackageVersionIdentity` is reused by vulnerability reports and dependency reports. Populate these fields only where the resolver already has verified package-version metadata, or resolve lazily. Do not fake defaults. `deprecated: false` should mean verified not deprecated, not unknown.
-
-Engines/runtime requirements are intentionally absent. A separate metadata query remains an option if a stable runtime compatibility API is added later:
-
-```graphql
-packageVersionMetadata(registry: Registry!, name: String!, version: String!): PackageVersionMetadata
-```
-
-### 5. Future Version Diff / Aggregate Query
-
-`versionDiff` is out of v1. It needs a typed service method, request/response schemas, indexing lifecycle handling, and package-intelligence error mapping before it can be safely exposed as an upgrade-review option.
-
-A backend aggregate query is also not required for v1. Consider it only after the client-side composition proves the shape.
-
-```graphql
-packageUpgradeReview(
-  registry: Registry!
-  name: String!
-  currentVersion: String!
-  targetVersion: String!
-  includeTransitiveSecurity: Boolean
-  minSeverity: Float
-): PackageUpgradeReviewResult!
-```
-
-This should remain a backend optimization, not the first design step. The tool contract should be designed at the MCP layer first because that is where the agent UX is clearest. If this query is added later, prefer field selection for optional expensive subtrees inside `PackageUpgradeReviewResult` rather than accumulating root booleans for every optional section.
-
-## Client Implementation Steps
-
-Suggested CLI sequence:
-
-1. Extend service-level `PackageVersionIdentity` types and Zod schemas with optional `publishedAt`, `deprecated`, and `deprecationReason`.
-2. Add a dedicated internal dependency probe for upgrade review instead of overloading the existing `packageDependencies(params)` method used by `pkg_deps`. The existing method intentionally fetches the full DAG for direct-version/importer enrichment; upgrade review needs separate sparse peer-group and transitive-evidence probes to avoid overfetching and regressions.
-3. Add optional dependency query selection for `vulnerabilitySummary` and `dependencyIssues`, controlled by variables and GraphQL `@include` directives.
-4. Add service-level types/Zod schemas for `VulnerabilityCount`, `TransitiveVulnerabilitySummary`, `TransitiveVulnerablePackage`, `TransitiveDependencyVulnerability`, `VulnerabilitySummaryDetail`, `DependencyIssuesSummary`, and issue row types.
-5. Keep these dependency fields optional in normalised results because they are omitted unless selected and unavailable when `includeTransitive` is false.
-6. Implement `packageUpgradeReview` composition in a small package-upgrade-review helper module that depends on existing service methods and the new internal dependency probe. Do not make `PackageIntelligenceService` the workflow orchestrator.
-7. Add the MCP tool and CLI command using shared request/response modules and parity tests.
-8. Update MCP instructions and package tool descriptions after the tool exists.
-
-## Existing Tool Updates
-
-Add instruction-level guidance now:
-
-- Server MCP instructions: "Use `pkg_upgrade_review` when the user asks for evidence about dependency updates, outdated dependency bumps, or lockfile/package updates. Do not infer acceptability from semver alone; patch updates still require changelog and vulnerability checks. The tool reports facts only; the calling agent owns the final assessment."
-- `pkg_changelog`: mention that range mode should be used for every upgrade review, including patches, unless `pkg_upgrade_review` is available.
-- `pkg_vulns`: mention that upgrade reviews must check the target version explicitly, not just latest.
-- `pkg_deps`: mention that `pkg_upgrade_review` is preferred for upgrade evidence; raw transitive vulnerability/issue fields are available through upgrade review rather than ordinary dependency listing unless we also add explicit `pkg_deps` flags.
-
-## Implementation Notes for CLI
-
-Add the tool in the same style as current package tools:
-
-- `packages/mcp/src/tools/package-upgrade-review.ts`
-- `src/commands/pkg/upgrade-review.ts` if exposing a CLI command
-- shared request/response modules under `packages/mcp/src/shared/package-upgrade-review-*`
-- service composition should live in a focused helper module that reuses existing service methods plus the dedicated internal dependency probe
-- parity tests should assert CLI `--json` and MCP `format:"json"` equality
-- text snapshot tests should cover vulnerability, changelog, dependency-change, and unknown-evidence cases
-- unit fixtures should cover deprecated target, missing deprecation metadata (`deprecated: null`), malicious advisory, alias-linked advisory diffing, transitive vulnerability summary, dependency issues, body-less changelog package-version fallback, version-not-found errors, per-package failure isolation in batch mode, and unsupported-security registry path
-- live smoke should cover a package with changelog entries, a package with package-version fallback, and a package with dependency issues when practical
+- `packages/mcp/src/tools/package-upgrade-review.ts` is the MCP entrypoint.
+- `src/commands/pkg/upgrade-review.ts` is the CLI entrypoint.
+- `packages/mcp/src/shared/package-upgrade-review-request.ts` owns validation and backend param construction.
+- `packages/mcp/src/shared/package-upgrade-review-response.ts` owns backend response normalisation and text/JSON formatting.
+- `packages/core-internal/src/services/package-intelligence-service.ts` owns the aggregate GraphQL query and typed service method.
+- Parity tests assert CLI `--json` and MCP `format:"json"` equality for single, batch, backend unknown-evidence, and validation-error paths.
 
 ## Acceptance Criteria
 
 - MCP `pkg_upgrade_review` and CLI `githits pkg upgrade-review` expose equivalent JSON envelopes for single-package and repeatable-package batch input.
-- JSON parity tests cover successful single-package, successful batch, per-package unknown failure, and validation errors.
-- The tool never returns risk levels. It reports direct vulnerability check failures, missing changelog bodies, target deprecation metadata gaps, and introduced advisories as facts or `unknowns[]`.
-- Advisory diffing uses alias-cluster canonicalization and does not double-count alias-linked advisories.
-- Transitive vulnerability and dependency issue data are diffed current-vs-target; target-only evidence is labeled as context.
-- `pkg_deps` existing JSON/text/parity tests continue to pass unchanged, proving the upgrade-review dependency probe did not regress the existing dependency command.
-- Batch execution limits package-level concurrency to 3 by default.
-- Transitive security defaults on and can be disabled with `skip_transitive_security` / `--no-transitive-security`; `include_dependency_issues` selects lazy backend fields only when requested.
-- Text output keeps direct and transitive vulnerability counts aligned when `min_severity` is supplied.
+- The tool calls the aggregate backend `packageUpgradeReview` operation once per request.
+- The tool has no fallback to `packageSummary`, `packageVulnerabilities`, `packageChangelog`, `packageDependencies`, or the old upgrade dependency probe.
+- The tool never returns risk levels. It reports vulnerability, changelog, compatibility, dependency-change, dependency-issue, and unknown evidence as facts.
+- Backend enum casing is normalised to the existing public JSON/text contract.
+- Transitive security defaults on and can be disabled with `skip_transitive_security` / `--no-transitive-security`; `include_dependency_issues` selects the backend `dependencyIssues` subtree only when requested.
+- Release waits until the backend aggregate resolver is deployed to production; smoke suites fail with a backend protocol mismatch before that deployment.
 
 ## Resolved Decisions
 
 - `packages[]` is part of `pkg_upgrade_review` v1 because batch upgrade review is the core agent UX problem.
 - Transitive security evidence defaults on so vulnerability output includes dependency-tree evidence by default.
 - `include_dependency_issues` is a separate flag and defaults to `false`.
-- Direct/transitive dependency-change diffs are always requested and rendered as facts.
+- Direct/transitive dependency-change diffs are backend-provided and rendered as facts.
 - `versionDiff` remains deferred until a dedicated typed service/error surface exists.
 - Text mode shows compact summaries by default. `--verbose` / `verbose: true` adds dependency-change examples, including transitive version changes.
 - Runtime/engine compatibility is not asserted because no stable backend field exists. Lexical changelog signals are reported only as sampled evidence hints unless later verified by schema data.
-
-## Implementation Direction
-
-Build `pkg_upgrade_review` client-side first using current schema primitives. The backend now provides the required direct deprecation metadata and lazy transitive vulnerability/issue summaries. Defer a dedicated `packageUpgradeReview` GraphQL query until real agent traces show the composed shape is stable and worth optimizing.

--- a/packages/core-internal/src/services/package-intelligence-service.test.ts
+++ b/packages/core-internal/src/services/package-intelligence-service.test.ts
@@ -1571,6 +1571,128 @@ describe("PackageIntelligenceServiceImpl — packageChangelog", () => {
   });
 });
 
+describe("PackageIntelligenceServiceImpl — packageUpgradeReview", () => {
+  const ENDPOINT = "https://pkgseer.dev";
+
+  it("sends aggregate upgrade-review variables and maps the typed response", async () => {
+    let capturedBody: string | undefined;
+    const fetchFn = mock((_url: string, init?: RequestInit) => {
+      capturedBody = init?.body as string;
+      return Promise.resolve(
+        jsonResponse({
+          data: {
+            packageUpgradeReview: {
+              summary: {
+                total: 1,
+                withUnknowns: 0,
+                withAddedAdvisories: 1,
+                withBreakingSignals: 0,
+                withDirectDependencyChanges: 0,
+                withTransitiveVulnerabilityAdditions: 0,
+              },
+              reviews: [
+                {
+                  registry: "NPM",
+                  name: "express",
+                  currentVersion: "4.18.0",
+                  targetVersion: "5.0.0",
+                  latestVersion: "5.0.0",
+                  versionDelta: "MAJOR",
+                  security: {
+                    current: null,
+                    target: null,
+                    added: [
+                      {
+                        id: "GHSA-test",
+                        aliases: [],
+                        summary: "Example advisory",
+                        severity: 7.5,
+                        severityLabel: "HIGH",
+                        fixedIn: ["5.0.1"],
+                        isMalicious: false,
+                      },
+                    ],
+                    removed: [],
+                    notAddressed: [],
+                    fixed: [],
+                    introduced: [],
+                    unchanged: [],
+                  },
+                  changelog: {
+                    source: null,
+                    fallback: "PACKAGE_VERSIONS",
+                    entries: [],
+                    sampledEntries: [],
+                    keywordEntries: [],
+                    totalKeywordEntries: 0,
+                    totalEntries: 0,
+                    totalEntriesWithBodies: 0,
+                    truncated: false,
+                    hasReleaseNoteBodies: false,
+                    breakingSignals: [],
+                    migrationSignals: [],
+                  },
+                  compatibility: null,
+                  dependencyChanges: null,
+                  dependencyIssues: null,
+                  unknowns: [],
+                },
+              ],
+            },
+          },
+        }),
+      );
+    });
+    const service = new PackageIntelligenceServiceImpl(
+      ENDPOINT,
+      createMockTokenProvider(),
+      asFetchFn(fetchFn),
+    );
+
+    const result = await service.packageUpgradeReview({
+      packages: [
+        {
+          registry: "NPM",
+          name: "express",
+          currentVersion: "4.18.0",
+          targetVersion: "5.0.0",
+        },
+      ],
+      includeTransitiveSecurity: false,
+      includeDependencyIssues: true,
+      changelogLimit: 20,
+      minSeverity: 7,
+    });
+
+    const parsed = JSON.parse(capturedBody ?? "{}");
+    expect(parsed.query).toContain("packageUpgradeReview(");
+    expect(parsed.query).toContain("dependencyIssues @include");
+    expect(parsed.query).not.toContain("duplicateIds");
+    expect(parsed.query).not.toContain("matchedAffectedVersionRanges");
+    expect(parsed.query).not.toContain("affectedVersionRangesCount");
+    expect(parsed.query).not.toContain("affectedVersionRangesTruncated");
+    expect(parsed.query).not.toContain("affectsInspectedVersion");
+    expect(parsed.variables).toMatchObject({
+      packages: [
+        {
+          registry: "NPM",
+          name: "express",
+          currentVersion: "4.18.0",
+          targetVersion: "5.0.0",
+        },
+      ],
+      includeTransitiveSecurity: false,
+      includeDependencyIssues: true,
+      changelogLimit: 20,
+      minSeverity: 7,
+    });
+    expect(result.summary.withAddedAdvisories).toBe(1);
+    expect(result.reviews[0]?.security.added[0]?.severityLabel).toBe("HIGH");
+    expect(result.reviews[0]?.changelog.source).toBeUndefined();
+    expect(result.reviews[0]?.compatibility).toBeUndefined();
+  });
+});
+
 describe("PackageIntelligenceServiceImpl — packageDependencies", () => {
   const ENDPOINT = "https://pkgseer.dev";
 

--- a/packages/core-internal/src/services/package-intelligence-service.ts
+++ b/packages/core-internal/src/services/package-intelligence-service.ts
@@ -190,6 +190,169 @@ export interface PackageUpgradeDependencyProbeParams {
   includeGroups?: boolean;
 }
 
+export interface PackageUpgradeReviewPackageParams {
+  registry: PkgseerRegistry;
+  name: string;
+  currentVersion: string;
+  targetVersion: string;
+}
+
+export interface PackageUpgradeReviewParams {
+  packages: PackageUpgradeReviewPackageParams[];
+  includeTransitiveSecurity: boolean;
+  includeDependencyIssues: boolean;
+  changelogLimit: number;
+  minSeverity?: number;
+}
+
+export interface PackageUpgradeAdvisorySummary {
+  id?: string;
+  aliases: string[];
+  summary?: string;
+  severity?: number;
+  severityLabel?: string;
+  fixedIn: string[];
+  isMalicious?: boolean;
+}
+
+export interface PackageUpgradeVersionVulnerabilitySummary {
+  version: string;
+  publishedAt?: string;
+  deprecated?: boolean;
+  deprecationReason?: string;
+  affectedCount: number;
+  nonAffectingCount: number;
+  allCount: number;
+  lastModifiedAt?: string;
+  advisories: PackageUpgradeAdvisorySummary[];
+}
+
+export interface PackageUpgradeTransitiveVulnerablePackage {
+  id: string;
+  registry: string;
+  name: string;
+  versions: string[];
+  affectedCount: number;
+  maxSeverityScore?: number;
+  maxSeverityLabel?: string;
+  advisoryIds: string[];
+}
+
+export interface PackageUpgradeTransitivePackagePage {
+  entries: PackageUpgradeTransitiveVulnerablePackage[];
+  totalCount: number;
+  truncated: boolean;
+}
+
+export interface PackageUpgradeTransitiveSecurity {
+  currentAffected: number;
+  targetAffected: number;
+  introducedPackages: string[];
+  fixedPackages: string[];
+  introducedPackageDetails: PackageUpgradeTransitivePackagePage;
+  fixedPackageDetails: PackageUpgradeTransitivePackagePage;
+  stillAffectedPackageDetails: PackageUpgradeTransitivePackagePage;
+}
+
+export interface PackageUpgradeSecurity {
+  current?: PackageUpgradeVersionVulnerabilitySummary;
+  target?: PackageUpgradeVersionVulnerabilitySummary;
+  added: PackageUpgradeAdvisorySummary[];
+  removed: PackageUpgradeAdvisorySummary[];
+  notAddressed: PackageUpgradeAdvisorySummary[];
+  fixed: PackageUpgradeAdvisorySummary[];
+  introduced: PackageUpgradeAdvisorySummary[];
+  unchanged: PackageUpgradeAdvisorySummary[];
+  transitive?: PackageUpgradeTransitiveSecurity;
+}
+
+export interface PackageUpgradeChangelogEntry {
+  version?: string;
+  publishedAt?: string;
+  htmlUrl?: string;
+  body?: string;
+  bodyPreview?: string;
+  headline?: string;
+  signals: string[];
+}
+
+export interface PackageUpgradeChangelog {
+  source?: string;
+  fallback?: string;
+  entries: PackageUpgradeChangelogEntry[];
+  sampledEntries: PackageUpgradeChangelogEntry[];
+  keywordEntries: PackageUpgradeChangelogEntry[];
+  totalKeywordEntries: number;
+  totalEntries: number;
+  totalEntriesWithBodies: number;
+  truncated: boolean;
+  hasReleaseNoteBodies: boolean;
+  breakingSignals: string[];
+  migrationSignals: string[];
+}
+
+export interface PackageUpgradeCompatibility {
+  peerDependencyChanges: string[];
+  notes: string[];
+}
+
+export interface PackageUpgradeDependencyChangeItem {
+  name: string;
+  registry?: string;
+  version?: string;
+  fromVersions: string[];
+  toVersions: string[];
+  constraint?: string;
+  type?: string;
+}
+
+export interface PackageUpgradeDependencyChangeGroup {
+  added: PackageUpgradeDependencyChangeItem[];
+  removed: PackageUpgradeDependencyChangeItem[];
+  changed: PackageUpgradeDependencyChangeItem[];
+}
+
+export interface PackageUpgradeDependencyChanges {
+  direct: PackageUpgradeDependencyChangeGroup;
+  transitive: PackageUpgradeDependencyChangeGroup;
+}
+
+export interface PackageUpgradeDependencyIssues {
+  currentTotal: number;
+  targetTotal: number;
+  introducedDeprecated: string[];
+  introducedDuplicates: string[];
+  introducedConflicts: string[];
+  introducedOutdated: string[];
+}
+
+export interface PackageUpgradeReview {
+  registry: string;
+  name: string;
+  currentVersion: string;
+  targetVersion: string;
+  latestVersion?: string;
+  versionDelta: string;
+  security: PackageUpgradeSecurity;
+  changelog: PackageUpgradeChangelog;
+  compatibility?: PackageUpgradeCompatibility;
+  dependencyChanges?: PackageUpgradeDependencyChanges;
+  dependencyIssues?: PackageUpgradeDependencyIssues;
+  unknowns: string[];
+}
+
+export interface PackageUpgradeReviewResponse {
+  summary: {
+    total: number;
+    withUnknowns: number;
+    withAddedAdvisories: number;
+    withBreakingSignals: number;
+    withDirectDependencyChanges: number;
+    withTransitiveVulnerabilityAdditions: number;
+  };
+  reviews: PackageUpgradeReview[];
+}
+
 export interface DirectDependency {
   name: string;
   versionConstraint?: string;
@@ -573,6 +736,9 @@ export interface PackageIntelligenceService {
   packageUpgradeDependencyProbe(
     params: PackageUpgradeDependencyProbeParams,
   ): Promise<DependencyReport>;
+  packageUpgradeReview(
+    params: PackageUpgradeReviewParams,
+  ): Promise<PackageUpgradeReviewResponse>;
   packageChangelog(params: PackageChangelogParams): Promise<ChangelogReport>;
   listPackageDocs(params: ListPackageDocsParams): Promise<PackageDocsList>;
   readPackageDoc(params: ReadPackageDocParams): Promise<PackageDocResult>;
@@ -1481,6 +1647,385 @@ query PackageUpgradeDependencyProbe(
 }`;
 
 // --------------------------------------------------------------------
+// Zod schema + query for packageUpgradeReview
+// --------------------------------------------------------------------
+
+const packageUpgradeAdvisorySchema = z.object({
+  id: z.string().nullable().optional(),
+  aliases: z.array(z.string()),
+  summary: z.string().nullable().optional(),
+  severity: z.number().nullable().optional(),
+  severityLabel: z.string().nullable().optional(),
+  fixedIn: z.array(z.string()),
+  isMalicious: z.boolean().nullable().optional(),
+});
+
+const packageUpgradeVersionVulnerabilitySummarySchema = z
+  .object({
+    version: z.string(),
+    publishedAt: z.string().nullable().optional(),
+    deprecated: z.boolean().nullable().optional(),
+    deprecationReason: z.string().nullable().optional(),
+    affectedCount: z.number().int(),
+    nonAffectingCount: z.number().int(),
+    allCount: z.number().int(),
+    lastModifiedAt: z.string().nullable().optional(),
+    advisories: z.array(packageUpgradeAdvisorySchema),
+  })
+  .nullable()
+  .optional();
+
+const packageUpgradeTransitivePackagePageSchema = z.object({
+  entries: z.array(
+    z.object({
+      id: z.string(),
+      registry: z.string(),
+      name: z.string(),
+      versions: z.array(z.string()),
+      affectedCount: z.number().int(),
+      maxSeverityScore: z.number().nullable().optional(),
+      maxSeverityLabel: z.string().nullable().optional(),
+      advisoryIds: z.array(z.string()),
+    }),
+  ),
+  totalCount: z.number().int(),
+  truncated: z.boolean(),
+});
+
+const packageUpgradeTransitiveSecuritySchema = z
+  .object({
+    currentAffected: z.number().int(),
+    targetAffected: z.number().int(),
+    introducedPackages: z.array(z.string()),
+    fixedPackages: z.array(z.string()),
+    introducedPackageDetails: packageUpgradeTransitivePackagePageSchema,
+    fixedPackageDetails: packageUpgradeTransitivePackagePageSchema,
+    stillAffectedPackageDetails: packageUpgradeTransitivePackagePageSchema,
+  })
+  .nullable()
+  .optional();
+
+const packageUpgradeSecuritySchema = z.object({
+  current: packageUpgradeVersionVulnerabilitySummarySchema,
+  target: packageUpgradeVersionVulnerabilitySummarySchema,
+  added: z.array(packageUpgradeAdvisorySchema),
+  removed: z.array(packageUpgradeAdvisorySchema),
+  notAddressed: z.array(packageUpgradeAdvisorySchema),
+  fixed: z.array(packageUpgradeAdvisorySchema),
+  introduced: z.array(packageUpgradeAdvisorySchema),
+  unchanged: z.array(packageUpgradeAdvisorySchema),
+  transitive: packageUpgradeTransitiveSecuritySchema,
+});
+
+const packageUpgradeChangelogEntrySchema = z.object({
+  version: z.string().nullable().optional(),
+  publishedAt: z.string().nullable().optional(),
+  htmlUrl: z.string().nullable().optional(),
+  body: z.string().nullable().optional(),
+  bodyPreview: z.string().nullable().optional(),
+  headline: z.string().nullable().optional(),
+  signals: z.array(z.string()),
+});
+
+const packageUpgradeChangelogSchema = z.object({
+  source: z.string().nullable().optional(),
+  fallback: z.string().nullable().optional(),
+  entries: z.array(packageUpgradeChangelogEntrySchema),
+  sampledEntries: z.array(packageUpgradeChangelogEntrySchema),
+  keywordEntries: z.array(packageUpgradeChangelogEntrySchema),
+  totalKeywordEntries: z.number().int(),
+  totalEntries: z.number().int(),
+  totalEntriesWithBodies: z.number().int(),
+  truncated: z.boolean(),
+  hasReleaseNoteBodies: z.boolean(),
+  breakingSignals: z.array(z.string()),
+  migrationSignals: z.array(z.string()),
+});
+
+const packageUpgradeCompatibilitySchema = z
+  .object({
+    peerDependencyChanges: z.array(z.string()),
+    notes: z.array(z.string()),
+  })
+  .nullable()
+  .optional();
+
+const packageUpgradeDependencyChangeItemSchema = z.object({
+  name: z.string(),
+  registry: z.string().nullable().optional(),
+  version: z.string().nullable().optional(),
+  fromVersions: z.array(z.string()),
+  toVersions: z.array(z.string()),
+  constraint: z.string().nullable().optional(),
+  type: z.string().nullable().optional(),
+});
+
+const packageUpgradeDependencyChangeGroupSchema = z.object({
+  added: z.array(packageUpgradeDependencyChangeItemSchema),
+  removed: z.array(packageUpgradeDependencyChangeItemSchema),
+  changed: z.array(packageUpgradeDependencyChangeItemSchema),
+});
+
+const packageUpgradeDependencyChangesSchema = z
+  .object({
+    direct: packageUpgradeDependencyChangeGroupSchema,
+    transitive: packageUpgradeDependencyChangeGroupSchema,
+  })
+  .nullable()
+  .optional();
+
+const packageUpgradeDependencyIssuesSchema = z
+  .object({
+    currentTotal: z.number().int(),
+    targetTotal: z.number().int(),
+    introducedDeprecated: z.array(z.string()),
+    introducedDuplicates: z.array(z.string()),
+    introducedConflicts: z.array(z.string()),
+    introducedOutdated: z.array(z.string()),
+  })
+  .nullable()
+  .optional();
+
+const packageUpgradeReviewSchema = z.object({
+  registry: z.string(),
+  name: z.string(),
+  currentVersion: z.string(),
+  targetVersion: z.string(),
+  latestVersion: z.string().nullable().optional(),
+  versionDelta: z.string(),
+  security: packageUpgradeSecuritySchema,
+  changelog: packageUpgradeChangelogSchema,
+  compatibility: packageUpgradeCompatibilitySchema,
+  dependencyChanges: packageUpgradeDependencyChangesSchema,
+  dependencyIssues: packageUpgradeDependencyIssuesSchema,
+  unknowns: z.array(z.string()),
+});
+
+const packageUpgradeReviewResponseSchema = z.object({
+  summary: z.object({
+    total: z.number().int(),
+    withUnknowns: z.number().int(),
+    withAddedAdvisories: z.number().int(),
+    withBreakingSignals: z.number().int(),
+    withDirectDependencyChanges: z.number().int(),
+    withTransitiveVulnerabilityAdditions: z.number().int(),
+  }),
+  reviews: z.array(packageUpgradeReviewSchema),
+});
+
+const packageUpgradeReviewGraphQLResponseSchema = z.object({
+  data: z
+    .object({
+      packageUpgradeReview: packageUpgradeReviewResponseSchema
+        .nullable()
+        .optional(),
+    })
+    .nullable()
+    .optional(),
+  errors: z.array(graphQLErrorSchema).optional(),
+});
+
+const PACKAGE_UPGRADE_REVIEW_QUERY = `
+query PackageUpgradeReview(
+  $packages: [PackageUpgradeReviewPackageInput!]!
+  $includeTransitiveSecurity: Boolean!
+  $includeDependencyIssues: Boolean!
+  $minSeverity: Float
+  $changelogLimit: Int!
+) {
+  packageUpgradeReview(
+    packages: $packages
+    includeTransitiveSecurity: $includeTransitiveSecurity
+    minSeverity: $minSeverity
+    changelogLimit: $changelogLimit
+  ) {
+    summary {
+      total
+      withUnknowns
+      withAddedAdvisories
+      withBreakingSignals
+      withDirectDependencyChanges
+      withTransitiveVulnerabilityAdditions
+    }
+    reviews {
+      registry
+      name
+      currentVersion
+      targetVersion
+      latestVersion
+      versionDelta
+      security {
+        current {
+          version
+          publishedAt
+          deprecated
+          deprecationReason
+          affectedCount
+          nonAffectingCount
+          allCount
+          lastModifiedAt
+          advisories {
+            ...PackageUpgradeAdvisoryFields
+          }
+        }
+        target {
+          version
+          publishedAt
+          deprecated
+          deprecationReason
+          affectedCount
+          nonAffectingCount
+          allCount
+          lastModifiedAt
+          advisories {
+            ...PackageUpgradeAdvisoryFields
+          }
+        }
+        added {
+          ...PackageUpgradeAdvisoryFields
+        }
+        removed {
+          ...PackageUpgradeAdvisoryFields
+        }
+        notAddressed {
+          ...PackageUpgradeAdvisoryFields
+        }
+        fixed {
+          ...PackageUpgradeAdvisoryFields
+        }
+        introduced {
+          ...PackageUpgradeAdvisoryFields
+        }
+        unchanged {
+          ...PackageUpgradeAdvisoryFields
+        }
+        transitive @include(if: $includeTransitiveSecurity) {
+          currentAffected
+          targetAffected
+          introducedPackages
+          fixedPackages
+          introducedPackageDetails(first: 50) {
+            ...PackageUpgradeTransitivePackagePageFields
+          }
+          fixedPackageDetails(first: 50) {
+            ...PackageUpgradeTransitivePackagePageFields
+          }
+          stillAffectedPackageDetails(first: 50) {
+            ...PackageUpgradeTransitivePackagePageFields
+          }
+        }
+      }
+      changelog {
+        source
+        fallback
+        entries {
+          ...PackageUpgradeChangelogEntryFields
+        }
+        sampledEntries {
+          ...PackageUpgradeChangelogEntryFields
+        }
+        keywordEntries {
+          ...PackageUpgradeChangelogEntryFields
+        }
+        totalKeywordEntries
+        totalEntries
+        totalEntriesWithBodies
+        truncated
+        hasReleaseNoteBodies
+        breakingSignals
+        migrationSignals
+      }
+      compatibility {
+        peerDependencyChanges
+        notes
+      }
+      dependencyChanges {
+        direct {
+          ...PackageUpgradeDependencyChangeGroupFields
+        }
+        transitive {
+          ...PackageUpgradeDependencyChangeGroupFields
+        }
+      }
+      dependencyIssues @include(if: $includeDependencyIssues) {
+        currentTotal
+        targetTotal
+        introducedDeprecated
+        introducedDuplicates
+        introducedConflicts
+        introducedOutdated
+      }
+      unknowns
+    }
+  }
+}
+
+fragment PackageUpgradeAdvisoryFields on PackageUpgradeAdvisorySummary {
+  id
+  aliases
+  summary
+  severity
+  severityLabel
+  fixedIn
+  isMalicious
+}
+
+fragment PackageUpgradeTransitivePackagePageFields on PackageUpgradeTransitivePackagePage {
+  entries {
+    id
+    registry
+    name
+    versions
+    affectedCount
+    maxSeverityScore
+    maxSeverityLabel
+    advisoryIds
+  }
+  totalCount
+  truncated
+}
+
+fragment PackageUpgradeChangelogEntryFields on PackageUpgradeChangelogEntry {
+  version
+  publishedAt
+  htmlUrl
+  body
+  bodyPreview
+  headline
+  signals
+}
+
+fragment PackageUpgradeDependencyChangeGroupFields on PackageUpgradeDependencyChangeGroup {
+  added {
+    name
+    registry
+    version
+    fromVersions
+    toVersions
+    constraint
+    type
+  }
+  removed {
+    name
+    registry
+    version
+    fromVersions
+    toVersions
+    constraint
+    type
+  }
+  changed {
+    name
+    registry
+    version
+    fromVersions
+    toVersions
+    constraint
+    type
+  }
+}`;
+
+// --------------------------------------------------------------------
 // Zod schema + query for packageChangelog
 // --------------------------------------------------------------------
 
@@ -2248,6 +2793,75 @@ export class PackageIntelligenceServiceImpl
     );
   }
 
+  async packageUpgradeReview(
+    params: PackageUpgradeReviewParams,
+  ): Promise<PackageUpgradeReviewResponse> {
+    return withTelemetrySpan("pkg-intel.upgrade-review.request", () =>
+      executeWithTokenRefresh({
+        getToken: () => this.tokenProvider.getToken(),
+        forceRefresh: () => this.tokenProvider.forceRefresh(),
+        shouldRefresh: (error) => error instanceof AuthenticationError,
+        executeWithToken: (token) =>
+          this.executePackageUpgradeReview(token, params),
+      }),
+    );
+  }
+
+  private async executePackageUpgradeReview(
+    token: string,
+    params: PackageUpgradeReviewParams,
+  ): Promise<PackageUpgradeReviewResponse> {
+    let response: PkgseerGraphqlResponse;
+    try {
+      response = await postPkgseerGraphql({
+        endpointUrl: this.endpointUrl,
+        token,
+        query: PACKAGE_UPGRADE_REVIEW_QUERY,
+        variables: {
+          packages: params.packages,
+          includeTransitiveSecurity: params.includeTransitiveSecurity,
+          includeDependencyIssues: params.includeDependencyIssues,
+          minSeverity: params.minSeverity,
+          changelogLimit: params.changelogLimit,
+        },
+        fetchFn: this.fetchFn,
+        clientHeaders: this.runtime.clientHeaders,
+        userAgent: this.runtime.userAgent,
+      });
+    } catch (cause) {
+      if (cause instanceof PkgseerTransportError) {
+        throw this.createTransportError(cause);
+      }
+      throw cause;
+    }
+
+    if (response.status < 200 || response.status >= 300) {
+      throw this.createHttpError(response);
+    }
+
+    const parsed = packageUpgradeReviewGraphQLResponseSchema.safeParse(
+      response.parsedBody,
+    );
+    if (!parsed.success) {
+      throw new MalformedPackageIntelligenceResponseError(
+        "Malformed response from the package-intelligence service.",
+      );
+    }
+
+    if (parsed.data.errors && parsed.data.errors.length > 0) {
+      throw this.createGraphQLError(parsed.data.errors);
+    }
+
+    const data = parsed.data.data?.packageUpgradeReview;
+    if (!data) {
+      throw new MalformedPackageIntelligenceResponseError(
+        "Empty response from the package-intelligence service.",
+      );
+    }
+
+    return stripNullProperties(data) as PackageUpgradeReviewResponse;
+  }
+
   private async executePackageUpgradeDependencyProbe(
     token: string,
     params: PackageUpgradeDependencyProbeParams,
@@ -2945,6 +3559,16 @@ export class PackageIntelligenceServiceImpl
         : undefined,
     };
   }
+}
+
+function stripNullProperties(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(stripNullProperties);
+  if (!value || typeof value !== "object") return value;
+  const result: Record<string, unknown> = {};
+  for (const [key, child] of Object.entries(value)) {
+    if (child !== null) result[key] = stripNullProperties(child);
+  }
+  return result;
 }
 
 function parseDetail(body: string): string | undefined {

--- a/packages/mcp/src/mcp/server.ts
+++ b/packages/mcp/src/mcp/server.ts
@@ -222,6 +222,7 @@ function createDescriptorServices(): McpToolServices {
       packageVulnerabilities: fail,
       packageDependencies: fail,
       packageUpgradeDependencyProbe: fail,
+      packageUpgradeReview: fail,
       packageChangelog: fail,
       listPackageDocs: fail,
       readPackageDoc: fail,

--- a/packages/mcp/src/services/test-helpers.ts
+++ b/packages/mcp/src/services/test-helpers.ts
@@ -9,6 +9,7 @@ import type {
   PackageDocsList,
   PackageIntelligenceService,
   PackageSummary,
+  PackageUpgradeReviewResponse,
   UnifiedSearchOutcome,
   VulnerabilityReport,
 } from "@githits/core-internal";
@@ -632,6 +633,76 @@ export const defaultPackageDocResult: PackageDocResult = {
   },
 };
 
+export const defaultPackageUpgradeReviewResponse: PackageUpgradeReviewResponse =
+  {
+    summary: {
+      total: 1,
+      withUnknowns: 0,
+      withAddedAdvisories: 0,
+      withBreakingSignals: 0,
+      withDirectDependencyChanges: 0,
+      withTransitiveVulnerabilityAdditions: 0,
+    },
+    reviews: [
+      {
+        registry: "NPM",
+        name: "express",
+        currentVersion: "4.18.0",
+        targetVersion: "5.0.0",
+        latestVersion: "5.0.0",
+        versionDelta: "MAJOR",
+        security: {
+          current: {
+            version: "4.18.0",
+            affectedCount: 0,
+            nonAffectingCount: 0,
+            allCount: 0,
+            advisories: [],
+          },
+          target: {
+            version: "5.0.0",
+            affectedCount: 0,
+            nonAffectingCount: 0,
+            allCount: 0,
+            advisories: [],
+          },
+          added: [],
+          removed: [],
+          notAddressed: [],
+          fixed: [],
+          introduced: [],
+          unchanged: [],
+        },
+        changelog: {
+          source: "RELEASES",
+          entries: [
+            {
+              version: "5.0.0",
+              bodyPreview: "Major release notes.",
+              headline: "Major release notes.",
+              signals: [],
+            },
+          ],
+          sampledEntries: [],
+          keywordEntries: [],
+          totalKeywordEntries: 0,
+          totalEntries: 1,
+          totalEntriesWithBodies: 1,
+          truncated: false,
+          hasReleaseNoteBodies: true,
+          breakingSignals: [],
+          migrationSignals: [],
+        },
+        compatibility: { peerDependencyChanges: [], notes: [] },
+        dependencyChanges: {
+          direct: { added: [], removed: [], changed: [] },
+          transitive: { added: [], removed: [], changed: [] },
+        },
+        unknowns: [],
+      },
+    ],
+  };
+
 /**
  * Creates a mock PackageIntelligenceService. Defaults resolve to the
  * fully-populated fixtures; override per-test as needed.
@@ -647,6 +718,9 @@ export function createMockPackageIntelligenceService(
     packageDependencies: mock(() => Promise.resolve(defaultDependencyReport)),
     packageUpgradeDependencyProbe: mock(() =>
       Promise.resolve(defaultDependencyReport),
+    ),
+    packageUpgradeReview: mock(() =>
+      Promise.resolve(defaultPackageUpgradeReviewResponse),
     ),
     packageChangelog: mock(() => Promise.resolve(defaultChangelogReport)),
     listPackageDocs: mock(() => Promise.resolve(defaultPackageDocsList)),

--- a/packages/mcp/src/shared/package-upgrade-review-response.test.ts
+++ b/packages/mcp/src/shared/package-upgrade-review-response.test.ts
@@ -1,122 +1,172 @@
 import { describe, expect, it, mock } from "bun:test";
-import type {
-  ChangelogReport,
-  DependencyReport,
-  PackageIntelligenceService,
-  TransitiveVulnerabilitySummary,
-  VulnerabilityReport,
-} from "@githits/core-internal";
-import {
-  createMockPackageIntelligenceService,
-  defaultPackageSummary,
-} from "../services/test-helpers.js";
+import type { PackageUpgradeReviewResponse } from "@githits/core-internal";
+import { createMockPackageIntelligenceService } from "../services/test-helpers.js";
 import { buildPackageUpgradeReviewRequest } from "./package-upgrade-review-request.js";
 import {
   buildPackageUpgradeReview,
   formatPackageUpgradeReviewTerminal,
 } from "./package-upgrade-review-response.js";
 
-function cleanVulnReport(
-  version: string,
-  deprecated = false,
-): VulnerabilityReport {
-  return {
-    package: {
-      name: "zod",
+const backendResponse: PackageUpgradeReviewResponse = {
+  summary: {
+    total: 1,
+    withUnknowns: 1,
+    withAddedAdvisories: 1,
+    withBreakingSignals: 1,
+    withDirectDependencyChanges: 1,
+    withTransitiveVulnerabilityAdditions: 1,
+  },
+  reviews: [
+    {
       registry: "NPM",
-      version,
-      deprecated,
-    },
-    security: {
-      affectedVulnerabilityCount: 0,
-      nonAffectingVulnerabilityCount: 0,
-      allVulnerabilityCount: 0,
-      currentVersionAffected: false,
-      vulnerabilities: [],
-    },
-  };
-}
-
-function serviceWith(
-  overrides: Partial<PackageIntelligenceService>,
-): PackageIntelligenceService {
-  return createMockPackageIntelligenceService({
-    packageSummary: mock(() =>
-      Promise.resolve({
-        ...defaultPackageSummary,
-        package: { ...defaultPackageSummary.package, name: "zod" },
-      }),
-    ),
-    packageUpgradeDependencyProbe: mock(() =>
-      Promise.resolve(cleanDependencyReport("4.4.3")),
-    ),
-    ...overrides,
-  });
-}
-
-function cleanDependencyReport(
-  version: string,
-  transitive?: DependencyReport["dependencies"],
-): DependencyReport {
-  return {
-    package: {
       name: "zod",
-      registry: "NPM",
-      version,
-      deprecated: false,
+      currentVersion: "4.3.6",
+      targetVersion: "4.4.3",
+      latestVersion: "4.4.3",
+      versionDelta: "MINOR",
+      security: {
+        current: {
+          version: "4.3.6",
+          deprecated: false,
+          affectedCount: 0,
+          nonAffectingCount: 0,
+          allCount: 0,
+          advisories: [],
+        },
+        target: {
+          version: "4.4.3",
+          deprecated: true,
+          deprecationReason: "bad release",
+          affectedCount: 1,
+          nonAffectingCount: 0,
+          allCount: 1,
+          advisories: [],
+        },
+        added: [
+          {
+            id: "GHSA-new",
+            aliases: [],
+            summary: "new advisory",
+            severity: 7.5,
+            severityLabel: "HIGH",
+            fixedIn: ["4.4.4"],
+            isMalicious: false,
+          },
+        ],
+        removed: [],
+        notAddressed: [],
+        fixed: [],
+        introduced: [],
+        unchanged: [],
+        transitive: {
+          currentAffected: 0,
+          targetAffected: 1,
+          introducedPackages: ["NPM:left-pad"],
+          fixedPackages: [],
+          introducedPackageDetails: {
+            entries: [
+              {
+                id: "npm:left-pad",
+                registry: "NPM",
+                name: "left-pad",
+                versions: ["1.0.0"],
+                affectedCount: 1,
+                maxSeverityScore: 4,
+                maxSeverityLabel: "MEDIUM",
+                advisoryIds: ["GHSA-transitive"],
+              },
+            ],
+            totalCount: 2,
+            truncated: true,
+          },
+          fixedPackageDetails: { entries: [], totalCount: 0, truncated: false },
+          stillAffectedPackageDetails: {
+            entries: [],
+            totalCount: 0,
+            truncated: false,
+          },
+        },
+      },
+      changelog: {
+        source: "RELEASES",
+        entries: [
+          {
+            version: "4.4.3",
+            bodyPreview: "Breaking: removed an API.",
+            headline: "Breaking: removed an API.",
+            signals: ["breaking", "removed"],
+          },
+        ],
+        sampledEntries: [],
+        keywordEntries: [
+          {
+            version: "4.4.3",
+            bodyPreview: "Breaking: removed an API.",
+            headline: "Breaking: removed an API.",
+            signals: ["breaking", "removed"],
+          },
+        ],
+        totalKeywordEntries: 1,
+        totalEntries: 1,
+        totalEntriesWithBodies: 1,
+        truncated: false,
+        hasReleaseNoteBodies: true,
+        breakingSignals: ["breaking"],
+        migrationSignals: [],
+      },
+      compatibility: { peerDependencyChanges: [], notes: [] },
+      dependencyChanges: {
+        direct: {
+          added: [
+            {
+              name: "left-pad",
+              registry: "NPM",
+              version: "1.0.0",
+              fromVersions: [],
+              toVersions: ["1.0.0"],
+              type: "RUNTIME",
+            },
+          ],
+          removed: [],
+          changed: [],
+        },
+        transitive: { added: [], removed: [], changed: [] },
+      },
+      dependencyIssues: {
+        currentTotal: 0,
+        targetTotal: 1,
+        introducedDeprecated: ["npm:left-pad@1.0.0"],
+        introducedDuplicates: [],
+        introducedConflicts: [],
+        introducedOutdated: [],
+      },
+      unknowns: ["changelog evidence incomplete"],
     },
-    dependencies: transitive,
-    dependencyGroups: { groups: [] },
-  };
-}
-
-function transitiveSummary(
-  packages: TransitiveVulnerabilitySummary["packages"],
-): TransitiveVulnerabilitySummary {
-  const count = packages.length;
-  const counts = {
-    totalVulnerabilities: count,
-    critical: 0,
-    high: 0,
-    medium: count,
-    low: 0,
-    unknown: 0,
-  };
-  return {
-    affected: counts,
-    nonAffecting: {
-      totalVulnerabilities: 0,
-      critical: 0,
-      high: 0,
-      medium: 0,
-      low: 0,
-      unknown: 0,
-    },
-    combined: counts,
-    totalPackagesAnalyzed: count,
-    affectedPackageCount: count,
-    packages,
-  };
-}
+  ],
+};
 
 describe("package upgrade review response", () => {
-  it("reports body-less package-version fallback changelog entries as missing evidence", async () => {
+  it("uses backend aggregate upgrade reviews and normalizes enum casing", async () => {
+    const packageUpgradeReview = mock((_params: unknown) =>
+      Promise.resolve(backendResponse),
+    );
+    const packageVulnerabilities = mock(() =>
+      Promise.reject(new Error("unused")),
+    );
+    const packageUpgradeDependencyProbe = mock(() =>
+      Promise.reject(new Error("unused")),
+    );
     const request = buildPackageUpgradeReviewRequest({
       registry: "npm",
       packageName: "zod",
       currentVersion: "4.3.6",
       targetVersion: "4.4.3",
+      includeDependencyIssues: true,
     });
-    const service = serviceWith({
-      packageVulnerabilities: mock((params) =>
-        Promise.resolve(cleanVulnReport(params.version ?? "4.4.3", false)),
-      ) as never,
-      packageChangelog: mock(() =>
-        Promise.resolve({
-          source: undefined,
-          entries: [{ version: "4.4.3" }, { version: "4.3.6" }],
-        } satisfies ChangelogReport),
-      ),
+    const service = createMockPackageIntelligenceService({
+      packageUpgradeReview: packageUpgradeReview as never,
+      packageVulnerabilities: packageVulnerabilities as never,
+      packageUpgradeDependencyProbe: packageUpgradeDependencyProbe as never,
     });
 
     const response = await buildPackageUpgradeReview(
@@ -125,141 +175,54 @@ describe("package upgrade review response", () => {
       request.options,
     );
 
-    expect(response.reviews[0]?.unknowns).toContain(
-      "changelog range only returned package-version fallback entries without release-note bodies",
-    );
-  });
-
-  it("diffs advisories by alias cluster instead of raw id", async () => {
-    const request = buildPackageUpgradeReviewRequest({
-      registry: "npm",
-      packageName: "zod",
-      currentVersion: "4.3.6",
-      targetVersion: "4.4.3",
+    expect(packageUpgradeReview).toHaveBeenCalledTimes(1);
+    expect(packageVulnerabilities).not.toHaveBeenCalled();
+    expect(packageUpgradeDependencyProbe).not.toHaveBeenCalled();
+    expect(packageUpgradeReview.mock.calls[0]?.[0]).toMatchObject({
+      packages: [
+        {
+          registry: "NPM",
+          name: "zod",
+          currentVersion: "4.3.6",
+          targetVersion: "4.4.3",
+        },
+      ],
+      includeTransitiveSecurity: true,
+      includeDependencyIssues: true,
+      changelogLimit: 20,
     });
-    const current: VulnerabilityReport = {
-      ...cleanVulnReport("4.3.6", false),
+    expect(response.reviews[0]).toMatchObject({
+      registry: "npm",
+      versionDelta: "minor",
       security: {
-        affectedVulnerabilityCount: 1,
-        nonAffectingVulnerabilityCount: 0,
-        allVulnerabilityCount: 1,
-        vulnerabilities: [
-          {
-            osvId: "GHSA-aaaa-bbbb-cccc",
-            aliases: ["CVE-2026-0001"],
-            severityScore: 5,
-            affectedVersionRangesCount: 1,
-            affectedVersionRangesTruncated: false,
-            affectsInspectedVersion: true,
-            matchedAffectedVersionRanges: ["<4.4.4"],
-            duplicateIds: [],
-          },
-        ],
+        added: [{ severityLabel: "high" }],
+        transitive: {
+          introducedPackages: ["npm:left-pad"],
+          introducedPackageDetails: [
+            { registry: "npm", maxSeverityLabel: "medium" },
+          ],
+          introducedPackageDetailsTotalCount: 2,
+          introducedPackageDetailsTruncated: true,
+        },
       },
-    };
-    const target: VulnerabilityReport = {
-      ...cleanVulnReport("4.4.3", false),
-      security: {
-        affectedVulnerabilityCount: 1,
-        nonAffectingVulnerabilityCount: 0,
-        allVulnerabilityCount: 1,
-        vulnerabilities: [
-          {
-            osvId: "CVE-2026-0001",
-            aliases: ["GHSA-aaaa-bbbb-cccc"],
-            severityScore: 5,
-            affectedVersionRangesCount: 1,
-            affectedVersionRangesTruncated: false,
-            affectsInspectedVersion: true,
-            matchedAffectedVersionRanges: ["<4.4.4"],
-            duplicateIds: [],
-          },
-        ],
+      changelog: { source: "releases" },
+      dependencyChanges: {
+        direct: { added: [{ registry: "npm", type: "runtime" }] },
       },
-    };
-    const service = serviceWith({
-      packageVulnerabilities: mock((params) =>
-        Promise.resolve(params.version === "4.3.6" ? current : target),
-      ) as never,
-      packageChangelog: mock(() =>
-        Promise.resolve({
-          source: "releases",
-          entries: [{ version: "4.4.3", body: "Patch fixes." }],
-        } satisfies ChangelogReport),
-      ),
-      packageUpgradeDependencyProbe: mock((params) =>
-        Promise.resolve(
-          cleanDependencyReport(params.version, {
-            transitive: { vulnerabilitySummary: transitiveSummary([]) },
-          }),
-        ),
-      ) as never,
     });
-
-    const response = await buildPackageUpgradeReview(
-      service,
-      request.packages,
-      request.options,
-    );
-
-    expect(response.reviews[0]?.security.introduced).toHaveLength(0);
-    expect(response.reviews[0]?.security.unchanged).toHaveLength(1);
   });
 
-  it("reports non-major changelog breaking signals", async () => {
+  it("formats normalized backend evidence without assessment language", async () => {
     const request = buildPackageUpgradeReviewRequest({
       registry: "npm",
       packageName: "zod",
       currentVersion: "4.3.6",
       targetVersion: "4.4.3",
+      includeDependencyIssues: true,
     });
-    const service = serviceWith({
-      packageVulnerabilities: mock((params) =>
-        Promise.resolve(cleanVulnReport(params.version ?? "4.4.3", false)),
-      ) as never,
-      packageChangelog: mock(() =>
-        Promise.resolve({
-          source: "releases",
-          entries: [{ version: "4.4.3", body: "Breaking: removed an API." }],
-        } satisfies ChangelogReport),
-      ),
-    });
-
-    const response = await buildPackageUpgradeReview(
-      service,
-      request.packages,
-      request.options,
-    );
-
-    expect(response.reviews[0]?.changelog.breakingSignals).toContain(
-      "breaking",
-    );
-  });
-
-  it("reports when direct vulnerability checks are severity-filtered", async () => {
-    const request = buildPackageUpgradeReviewRequest({
-      registry: "npm",
-      packageName: "zod",
-      currentVersion: "4.3.6",
-      targetVersion: "4.4.3",
-      minSeverity: "high",
-    });
-    const service = serviceWith({
-      packageVulnerabilities: mock((params) =>
-        Promise.resolve(cleanVulnReport(params.version ?? "4.4.3", false)),
-      ) as never,
-      packageChangelog: mock(() =>
-        Promise.resolve({
-          source: "releases",
-          entries: [{ version: "4.4.3", body: "Patch fixes." }],
-        } satisfies ChangelogReport),
-      ),
-      packageUpgradeDependencyProbe: mock((params) =>
-        Promise.resolve(
-          cleanDependencyReport(params.version, {
-            transitive: { vulnerabilitySummary: transitiveSummary([]) },
-          }),
-        ),
+    const service = createMockPackageIntelligenceService({
+      packageUpgradeReview: mock(() =>
+        Promise.resolve(backendResponse),
       ) as never,
     });
 
@@ -268,16 +231,26 @@ describe("package upgrade review response", () => {
       request.packages,
       request.options,
     );
+    const text = formatPackageUpgradeReviewTerminal(response);
 
-    expect(response.reviews[0]?.unknowns).toContain(
-      "direct vulnerability checks were filtered by min_severity",
+    expect(text).toContain("pkg_upgrade_review | 1 upgrades");
+    expect(text).toContain("npm:zod 4.3.6 -> 4.4.3 | minor");
+    expect(text).toContain("added in target=1");
+    expect(text).toContain("added packages=2");
+    expect(text).toContain("+1 more not returned by backend page");
+    expect(text).toContain("target deprecated: bad release");
+    expect(text).toContain(
+      "keyword hits: 1 entries (breaking); heuristic text match",
     );
-    expect(formatPackageUpgradeReviewTerminal(response)).not.toContain(
-      "transitive counts are not filtered by min_severity",
-    );
+    expect(text).toContain("introduced deprecated: npm:left-pad@1.0.0");
+    expect(text).not.toContain("recommendation");
+    expect(text).not.toContain("risk level");
   });
 
-  it("treats min_severity=low as an unfiltered upgrade-review check", async () => {
+  it("passes min_severity=low as an unfiltered backend request", async () => {
+    const packageUpgradeReview = mock((_params: unknown) =>
+      Promise.resolve(backendResponse),
+    );
     const request = buildPackageUpgradeReviewRequest({
       registry: "npm",
       packageName: "zod",
@@ -285,1085 +258,14 @@ describe("package upgrade review response", () => {
       targetVersion: "4.4.3",
       minSeverity: "low",
     });
-    const service = serviceWith({
-      packageVulnerabilities: mock((params) =>
-        Promise.resolve(cleanVulnReport(params.version ?? "4.4.3", false)),
-      ) as never,
-      packageChangelog: mock(() =>
-        Promise.resolve({
-          source: "releases",
-          entries: [{ version: "4.4.3", body: "Patch fixes." }],
-        } satisfies ChangelogReport),
-      ),
-    });
-
-    const response = await buildPackageUpgradeReview(
-      service,
-      request.packages,
-      request.options,
-    );
-
-    expect(request.options.minSeverity).toBeUndefined();
-    expect(response.reviews[0]?.unknowns).not.toContain(
-      "direct vulnerability checks were filtered by min_severity",
-    );
-  });
-
-  it("detects changelog signals outside the displayed changelog limit", async () => {
-    const request = buildPackageUpgradeReviewRequest({
-      registry: "npm",
-      packageName: "zod",
-      currentVersion: "4.3.6",
-      targetVersion: "4.4.3",
-    });
-    const service = serviceWith({
-      packageVulnerabilities: mock((params) =>
-        Promise.resolve(cleanVulnReport(params.version ?? "4.4.3", false)),
-      ) as never,
-      packageChangelog: mock(() =>
-        Promise.resolve({
-          source: "releases",
-          entries: [
-            ...Array.from({ length: 20 }, (_, index) => ({
-              version: `4.4.${23 - index}`,
-              body: "Patch fixes.",
-            })),
-            { version: "4.4.2", body: "Breaking: removed an API." },
-          ],
-        } satisfies ChangelogReport),
-      ),
-    });
-
-    const response = await buildPackageUpgradeReview(
-      service,
-      request.packages,
-      request.options,
-    );
-
-    expect(response.reviews[0]?.changelog.entries).toHaveLength(20);
-    expect(response.reviews[0]?.changelog.keywordEntries).toHaveLength(1);
-    expect(response.reviews[0]?.changelog.totalKeywordEntries).toBe(1);
-    expect(response.reviews[0]?.changelog.breakingSignals).toContain(
-      "breaking",
-    );
-    expect(formatPackageUpgradeReviewTerminal(response)).toContain(
-      "keyword hits: 1 entries (breaking, removed); heuristic text match",
-    );
-    expect(formatPackageUpgradeReviewTerminal(response)).toContain(
-      "[breaking]: Breaking: removed an API.",
-    );
-  });
-
-  it("renders peer dependency compatibility facts without advice", async () => {
-    const request = buildPackageUpgradeReviewRequest({
-      registry: "npm",
-      packageName: "zod",
-      currentVersion: "4.3.6",
-      targetVersion: "4.4.3",
-    });
-    const service = serviceWith({
-      packageVulnerabilities: mock((params) =>
-        Promise.resolve(cleanVulnReport(params.version ?? "4.4.3", false)),
-      ) as never,
-      packageChangelog: mock(() =>
-        Promise.resolve({
-          source: "releases",
-          entries: [{ version: "4.4.3", body: "Patch fixes." }],
-        } satisfies ChangelogReport),
-      ),
-      packageUpgradeDependencyProbe: mock((params) =>
-        Promise.resolve({
-          ...cleanDependencyReport(params.version),
-          dependencyGroups: {
-            groups:
-              params.version === "4.4.3"
-                ? [
-                    {
-                      name: "peer",
-                      lifecycle: "peer",
-                      conditionType: "always",
-                      selectionMode: "required",
-                      dependencies: [{ name: "react", constraint: ">=19" }],
-                    },
-                  ]
-                : [
-                    {
-                      name: "peer",
-                      lifecycle: "peer",
-                      conditionType: "always",
-                      selectionMode: "required",
-                      dependencies: [{ name: "react", constraint: ">=18" }],
-                    },
-                  ],
-          },
-        } satisfies DependencyReport),
-      ) as never,
-    });
-
-    const response = await buildPackageUpgradeReview(
-      service,
-      request.packages,
-      request.options,
-    );
-    const output = formatPackageUpgradeReviewTerminal(response);
-
-    expect(response.reviews[0]?.compatibility?.peerDependencyChanges).toEqual([
-      "added react@>=19",
-      "removed react@>=18",
-    ]);
-    expect(response.reviews[0]?.compatibility?.notes[0]).toBe(
-      "Consumer-project compatibility cannot be determined from package metadata alone.",
-    );
-    expect(output).toContain("compatibility");
-    expect(output).toContain("peer dependency metadata changes:");
-    expect(output).toContain("- added react@>=19");
-    expect(output).not.toContain("validate against");
-  });
-
-  it("renders deprecated target and malicious advisory facts", async () => {
-    const request = buildPackageUpgradeReviewRequest({
-      registry: "npm",
-      packageName: "zod",
-      currentVersion: "4.3.6",
-      targetVersion: "4.4.3",
-    });
-    const target: VulnerabilityReport = {
-      ...cleanVulnReport("4.4.3", true),
-      package: {
-        name: "zod",
-        registry: "NPM",
-        version: "4.4.3",
-        deprecated: true,
-        deprecationReason: "Use 4.4.4.",
-      },
-      security: {
-        affectedVulnerabilityCount: 1,
-        nonAffectingVulnerabilityCount: 0,
-        allVulnerabilityCount: 1,
-        vulnerabilities: [
-          {
-            osvId: "MAL-2026-0001",
-            summary: "Malicious package version",
-            severityScore: 9.8,
-            affectedVersionRangesCount: 1,
-            affectedVersionRangesTruncated: false,
-            affectsInspectedVersion: true,
-            matchedAffectedVersionRanges: ["=4.4.3"],
-            duplicateIds: [],
-            isMalicious: true,
-          },
-        ],
-      },
-    };
-    const service = serviceWith({
-      packageVulnerabilities: mock((params) =>
-        Promise.resolve(
-          params.version === "4.4.3"
-            ? target
-            : cleanVulnReport(params.version ?? "4.3.6", false),
-        ),
-      ) as never,
-      packageChangelog: mock(() =>
-        Promise.resolve({
-          source: "releases",
-          entries: [{ version: "4.4.3", body: "Patch fixes." }],
-        } satisfies ChangelogReport),
-      ),
-      packageUpgradeDependencyProbe: mock((params) =>
-        Promise.resolve({
-          ...cleanDependencyReport(params.version),
-          package:
-            params.version === "4.4.3"
-              ? target.package
-              : cleanDependencyReport(params.version).package,
-        } satisfies DependencyReport),
-      ) as never,
-    });
-
-    const response = await buildPackageUpgradeReview(
-      service,
-      request.packages,
-      request.options,
-    );
-    const output = formatPackageUpgradeReviewTerminal(response);
-
-    expect(response.reviews[0]?.security.target?.deprecated).toBe(true);
-    expect(response.reviews[0]?.security.added[0]?.isMalicious).toBe(true);
-    expect(output).toContain("target deprecated: Use 4.4.4.");
-    expect(output).toContain("MAL-2026-0001 critical(9.8) malicious");
-  });
-
-  it("reports current-vs-target transitive vulnerability diffs", async () => {
-    const request = buildPackageUpgradeReviewRequest({
-      registry: "npm",
-      packageName: "zod",
-      currentVersion: "4.3.6",
-      targetVersion: "4.4.3",
-      includeTransitiveSecurity: true,
-    });
-    const service = serviceWith({
-      packageVulnerabilities: mock((params) =>
-        Promise.resolve(cleanVulnReport(params.version ?? "4.4.3", false)),
-      ) as never,
-      packageChangelog: mock(() =>
-        Promise.resolve({
-          source: "releases",
-          entries: [{ version: "4.4.3", body: "Patch fixes." }],
-        } satisfies ChangelogReport),
-      ),
-      packageUpgradeDependencyProbe: mock((params) =>
-        Promise.resolve(
-          cleanDependencyReport(params.version, {
-            transitive: {
-              vulnerabilitySummary:
-                params.version === "4.4.3"
-                  ? transitiveSummary([
-                      {
-                        registry: "NPM",
-                        name: "dep",
-                        versions: ["1.0.0"],
-                        affectedCount: 1,
-                        nonAffectingCount: 0,
-                        totalCount: 1,
-                        advisoryIds: ["GHSA-dep"],
-                      },
-                    ])
-                  : transitiveSummary([]),
-            },
-          }),
-        ),
-      ) as never,
-    });
-
-    const response = await buildPackageUpgradeReview(
-      service,
-      request.packages,
-      request.options,
-    );
-
-    expect(
-      response.reviews[0]?.security.transitive?.introducedPackageDetails[0],
-    ).toMatchObject({
-      id: "npm:dep",
-      name: "dep",
-      advisoryIds: ["GHSA-dep"],
-    });
-  });
-
-  it("does not count non-affecting transitive packages as introduced vulnerabilities", async () => {
-    const request = buildPackageUpgradeReviewRequest({
-      registry: "npm",
-      packageName: "zod",
-      currentVersion: "4.3.6",
-      targetVersion: "4.4.3",
-      includeTransitiveSecurity: true,
-    });
-    const service = serviceWith({
-      packageVulnerabilities: mock((params) =>
-        Promise.resolve(cleanVulnReport(params.version ?? "4.4.3", false)),
-      ) as never,
-      packageChangelog: mock(() =>
-        Promise.resolve({
-          source: "releases",
-          entries: [{ version: "4.4.3", body: "Patch fixes." }],
-        } satisfies ChangelogReport),
-      ),
-      packageUpgradeDependencyProbe: mock((params) =>
-        Promise.resolve(
-          cleanDependencyReport(params.version, {
-            transitive: {
-              vulnerabilitySummary:
-                params.version === "4.4.3"
-                  ? transitiveSummary([
-                      {
-                        registry: "NPM",
-                        name: "dep",
-                        versions: ["1.0.0"],
-                        affectedCount: 0,
-                        nonAffectingCount: 1,
-                        totalCount: 1,
-                        advisoryIds: [],
-                      },
-                    ])
-                  : transitiveSummary([]),
-            },
-          }),
-        ),
-      ) as never,
-    });
-
-    const response = await buildPackageUpgradeReview(
-      service,
-      request.packages,
-      request.options,
-    );
-
-    expect(
-      response.reviews[0]?.security.transitive?.introducedPackages,
-    ).toEqual([]);
-    expect(
-      response.reviews[0]?.security.transitive?.introducedPackageDetails,
-    ).toEqual([]);
-  });
-
-  it("classifies same transitive advisory across version changes as still affected", async () => {
-    const request = buildPackageUpgradeReviewRequest({
-      registry: "npm",
-      packageName: "zod",
-      currentVersion: "4.3.6",
-      targetVersion: "4.4.3",
-      includeTransitiveSecurity: true,
-    });
-    const service = serviceWith({
-      packageVulnerabilities: mock((params) =>
-        Promise.resolve(cleanVulnReport(params.version ?? "4.4.3", false)),
-      ) as never,
-      packageChangelog: mock(() =>
-        Promise.resolve({
-          source: "releases",
-          entries: [{ version: "4.4.3", body: "Patch fixes." }],
-        } satisfies ChangelogReport),
-      ),
-      packageUpgradeDependencyProbe: mock((params) =>
-        Promise.resolve(
-          cleanDependencyReport(params.version, {
-            transitive: {
-              vulnerabilitySummary:
-                params.version === "4.4.3"
-                  ? transitiveSummary([
-                      {
-                        registry: "NPM",
-                        name: "dep",
-                        versions: ["2.0.0"],
-                        affectedCount: 1,
-                        nonAffectingCount: 0,
-                        totalCount: 1,
-                        advisoryIds: ["GHSA-same"],
-                      },
-                    ])
-                  : transitiveSummary([
-                      {
-                        registry: "NPM",
-                        name: "dep",
-                        versions: ["1.0.0"],
-                        affectedCount: 1,
-                        nonAffectingCount: 0,
-                        totalCount: 1,
-                        advisoryIds: ["GHSA-same"],
-                      },
-                    ]),
-            },
-          }),
-        ),
-      ) as never,
-    });
-
-    const response = await buildPackageUpgradeReview(
-      service,
-      request.packages,
-      request.options,
-    );
-
-    expect(
-      response.reviews[0]?.security.transitive?.introducedPackageDetails,
-    ).toEqual([]);
-    expect(
-      response.reviews[0]?.security.transitive?.fixedPackageDetails,
-    ).toEqual([]);
-    expect(
-      response.reviews[0]?.security.transitive?.stillAffectedPackageDetails[0],
-    ).toMatchObject({ id: "npm:dep", versions: ["2.0.0"] });
-  });
-
-  it("classifies alias-linked transitive advisories as still affected", async () => {
-    const request = buildPackageUpgradeReviewRequest({
-      registry: "npm",
-      packageName: "zod",
-      currentVersion: "4.3.6",
-      targetVersion: "4.4.3",
-      includeTransitiveSecurity: true,
-    });
-    const service = serviceWith({
-      packageVulnerabilities: mock((params) =>
-        Promise.resolve(cleanVulnReport(params.version ?? "4.4.3", false)),
-      ) as never,
-      packageChangelog: mock(() =>
-        Promise.resolve({
-          source: "releases",
-          entries: [{ version: "4.4.3", body: "Patch fixes." }],
-        } satisfies ChangelogReport),
-      ),
-      packageUpgradeDependencyProbe: mock((params) =>
-        Promise.resolve(
-          cleanDependencyReport(params.version, {
-            transitive: {
-              vulnerabilitySummary:
-                params.version === "4.4.3"
-                  ? transitiveSummary([
-                      {
-                        registry: "NPM",
-                        name: "dep",
-                        versions: ["2.0.0"],
-                        affectedCount: 1,
-                        nonAffectingCount: 0,
-                        totalCount: 1,
-                        advisoryIds: ["CVE-2026-0001"],
-                        advisoryOccurrences: [
-                          {
-                            version: "2.0.0",
-                            affectsResolvedVersion: true,
-                            matchedAffectedVersionRanges: ["<3.0.0"],
-                            fixVersionsAboveResolved: [],
-                            advisory: {
-                              osvId: "CVE-2026-0001",
-                              aliases: ["GHSA-aaaa-bbbb-cccc"],
-                            },
-                          },
-                        ],
-                      },
-                    ])
-                  : transitiveSummary([
-                      {
-                        registry: "NPM",
-                        name: "dep",
-                        versions: ["1.0.0"],
-                        affectedCount: 1,
-                        nonAffectingCount: 0,
-                        totalCount: 1,
-                        advisoryIds: ["GHSA-aaaa-bbbb-cccc"],
-                        advisoryOccurrences: [
-                          {
-                            version: "1.0.0",
-                            affectsResolvedVersion: true,
-                            matchedAffectedVersionRanges: ["<3.0.0"],
-                            fixVersionsAboveResolved: [],
-                            advisory: {
-                              osvId: "GHSA-aaaa-bbbb-cccc",
-                              aliases: ["CVE-2026-0001"],
-                            },
-                          },
-                        ],
-                      },
-                    ]),
-            },
-          }),
-        ),
-      ) as never,
-    });
-
-    const response = await buildPackageUpgradeReview(
-      service,
-      request.packages,
-      request.options,
-    );
-
-    expect(
-      response.reviews[0]?.security.transitive?.introducedPackageDetails,
-    ).toEqual([]);
-    expect(
-      response.reviews[0]?.security.transitive?.fixedPackageDetails,
-    ).toEqual([]);
-    expect(
-      response.reviews[0]?.security.transitive?.stillAffectedPackageDetails[0],
-    ).toMatchObject({ id: "npm:dep", advisoryIds: ["CVE-2026-0001"] });
-  });
-
-  it("keeps transitive advisory ids that are not covered by occurrence samples", async () => {
-    const request = buildPackageUpgradeReviewRequest({
-      registry: "npm",
-      packageName: "zod",
-      currentVersion: "4.3.6",
-      targetVersion: "4.4.3",
-      includeTransitiveSecurity: true,
-    });
-    const service = serviceWith({
-      packageVulnerabilities: mock((params) =>
-        Promise.resolve(cleanVulnReport(params.version ?? "4.4.3", false)),
-      ) as never,
-      packageChangelog: mock(() =>
-        Promise.resolve({
-          source: "releases",
-          entries: [{ version: "4.4.3", body: "Patch fixes." }],
-        } satisfies ChangelogReport),
-      ),
-      packageUpgradeDependencyProbe: mock((params) =>
-        Promise.resolve(
-          cleanDependencyReport(params.version, {
-            transitive: {
-              vulnerabilitySummary:
-                params.version === "4.4.3"
-                  ? transitiveSummary([
-                      {
-                        registry: "NPM",
-                        name: "dep",
-                        versions: ["2.0.0"],
-                        affectedCount: 2,
-                        nonAffectingCount: 0,
-                        totalCount: 2,
-                        advisoryIds: ["GHSA-same", "GHSA-new"],
-                        advisoryOccurrences: [
-                          {
-                            version: "2.0.0",
-                            affectsResolvedVersion: true,
-                            matchedAffectedVersionRanges: ["<3.0.0"],
-                            fixVersionsAboveResolved: [],
-                            advisory: { osvId: "GHSA-same" },
-                          },
-                        ],
-                      },
-                    ])
-                  : transitiveSummary([
-                      {
-                        registry: "NPM",
-                        name: "dep",
-                        versions: ["1.0.0"],
-                        affectedCount: 1,
-                        nonAffectingCount: 0,
-                        totalCount: 1,
-                        advisoryIds: ["GHSA-same"],
-                        advisoryOccurrences: [
-                          {
-                            version: "1.0.0",
-                            affectsResolvedVersion: true,
-                            matchedAffectedVersionRanges: ["<3.0.0"],
-                            fixVersionsAboveResolved: [],
-                            advisory: { osvId: "GHSA-same" },
-                          },
-                        ],
-                      },
-                    ]),
-            },
-          }),
-        ),
-      ) as never,
-    });
-
-    const response = await buildPackageUpgradeReview(
-      service,
-      request.packages,
-      request.options,
-    );
-
-    expect(
-      response.reviews[0]?.security.transitive?.introducedPackageDetails[0],
-    ).toMatchObject({ id: "npm:dep", advisoryIds: ["GHSA-same", "GHSA-new"] });
-    expect(
-      response.reviews[0]?.security.transitive?.stillAffectedPackageDetails[0],
-    ).toMatchObject({ id: "npm:dep" });
-  });
-
-  it("reports major upgrades even without detected breaking signals", async () => {
-    const request = buildPackageUpgradeReviewRequest({
-      registry: "npm",
-      packageName: "zod",
-      currentVersion: "4.3.6",
-      targetVersion: "5.0.0",
-    });
-    const service = serviceWith({
-      packageVulnerabilities: mock((params) =>
-        Promise.resolve(cleanVulnReport(params.version ?? "5.0.0", false)),
-      ) as never,
-      packageChangelog: mock(() =>
-        Promise.resolve({
-          source: "releases",
-          entries: [{ version: "5.0.0", body: "Release notes." }],
-        } satisfies ChangelogReport),
-      ),
-    });
-
-    const response = await buildPackageUpgradeReview(
-      service,
-      request.packages,
-      request.options,
-    );
-
-    expect(response.reviews[0]?.versionDelta).toBe("major");
-  });
-
-  it("classifies v-prefixed Swift versions", async () => {
-    const request = buildPackageUpgradeReviewRequest({
-      registry: "swift",
-      packageName: "github.com/apple/swift-crypto",
-      currentVersion: "v3.10.0",
-      targetVersion: "v4.5.0",
-      includeTransitiveSecurity: false,
-    });
-    const service = serviceWith({
-      packageVulnerabilities: mock((params) =>
-        Promise.resolve(cleanVulnReport(params.version ?? "4.5.0", false)),
-      ) as never,
-      packageChangelog: mock(() =>
-        Promise.resolve({
-          source: "releases",
-          entries: [{ version: "4.5.0", body: "Release notes." }],
-        } satisfies ChangelogReport),
-      ),
-    });
-
-    const response = await buildPackageUpgradeReview(
-      service,
-      request.packages,
-      request.options,
-    );
-
-    expect(response.reviews[0]?.versionDelta).toBe("major");
-  });
-
-  it("does not count the target root package being outdated as a transitive issue", async () => {
-    const request = buildPackageUpgradeReviewRequest({
-      registry: "npm",
-      packageName: "zod",
-      currentVersion: "4.3.6",
-      targetVersion: "4.4.3",
-      includeDependencyIssues: true,
-    });
-    const service = serviceWith({
-      packageVulnerabilities: mock((params) =>
-        Promise.resolve(cleanVulnReport(params.version ?? "4.4.3", false)),
-      ) as never,
-      packageChangelog: mock(() =>
-        Promise.resolve({
-          source: "releases",
-          entries: [{ version: "4.4.3", body: "Patch fixes." }],
-        } satisfies ChangelogReport),
-      ),
-      packageUpgradeDependencyProbe: mock((params) =>
-        Promise.resolve(
-          cleanDependencyReport(params.version, {
-            transitive: {
-              dependencyIssues: {
-                totalCount: 1,
-                deprecatedCount: 0,
-                outdatedCount: 1,
-                duplicateCount: 0,
-                conflictCount: 0,
-                deprecatedPackages: [],
-                duplicatePackages: [],
-                conflicts: [],
-                outdatedPackages:
-                  params.version === "4.4.3"
-                    ? [
-                        {
-                          registry: "NPM",
-                          name: "zod",
-                          latestVersion: "4.5.0",
-                          severity: "MINOR",
-                          versions: [{ version: "4.4.3", severity: "MINOR" }],
-                        },
-                      ]
-                    : [],
-              },
-            },
-          }),
-        ),
-      ) as never,
-    });
-
-    const response = await buildPackageUpgradeReview(
-      service,
-      request.packages,
-      request.options,
-    );
-
-    expect(response.reviews[0]?.dependencyIssues?.introducedOutdated).toEqual(
-      [],
-    );
-    expect(response.reviews[0]?.dependencyIssues?.introducedDeprecated).toEqual(
-      [],
-    );
-  });
-
-  it("reports requested dependency probe failures as unknowns", async () => {
-    const request = buildPackageUpgradeReviewRequest({
-      registry: "npm",
-      packageName: "zod",
-      currentVersion: "4.3.6",
-      targetVersion: "4.4.3",
-      includeDependencyIssues: true,
-    });
-    const service = serviceWith({
-      packageVulnerabilities: mock((params) =>
-        Promise.resolve(cleanVulnReport(params.version ?? "4.4.3", false)),
-      ) as never,
-      packageChangelog: mock(() =>
-        Promise.resolve({
-          source: "releases",
-          entries: [{ version: "4.4.3", body: "Patch fixes." }],
-        } satisfies ChangelogReport),
-      ),
-      packageUpgradeDependencyProbe: mock(() =>
-        Promise.reject(new Error("dependency probe unavailable")),
-      ) as never,
-    });
-
-    const response = await buildPackageUpgradeReview(
-      service,
-      request.packages,
-      request.options,
-    );
-
-    expect(response.reviews[0]?.unknowns.join("\n")).toContain(
-      "dependency probe failed",
-    );
-  });
-
-  it("reports default dependency-change probe failures as unknowns", async () => {
-    const request = buildPackageUpgradeReviewRequest({
-      registry: "npm",
-      packageName: "zod",
-      currentVersion: "4.3.6",
-      targetVersion: "4.4.3",
-    });
-    const service = serviceWith({
-      packageVulnerabilities: mock((params) =>
-        Promise.resolve(cleanVulnReport(params.version ?? "4.4.3", false)),
-      ) as never,
-      packageChangelog: mock(() =>
-        Promise.resolve({
-          source: "releases",
-          entries: [{ version: "4.4.3", body: "Patch fixes." }],
-        } satisfies ChangelogReport),
-      ),
-      packageUpgradeDependencyProbe: mock(() =>
-        Promise.reject(new Error("dependency probe unavailable")),
-      ) as never,
-    });
-
-    const response = await buildPackageUpgradeReview(
-      service,
-      request.packages,
-      request.options,
-    );
-
-    expect(response.reviews[0]?.unknowns.join("\n")).toContain(
-      "dependency probe failed",
-    );
-  });
-
-  it("reports direct and transitive dependency changes without root package noise", async () => {
-    const request = buildPackageUpgradeReviewRequest({
-      registry: "npm",
-      packageName: "zod",
-      currentVersion: "4.3.6",
-      targetVersion: "4.4.3",
-    });
-    const service = serviceWith({
-      packageVulnerabilities: mock((params) =>
-        Promise.resolve(cleanVulnReport(params.version ?? "4.4.3", false)),
-      ) as never,
-      packageChangelog: mock(() =>
-        Promise.resolve({
-          source: "releases",
-          entries: [{ version: "4.4.3", body: "Patch fixes." }],
-        } satisfies ChangelogReport),
-      ),
-      packageUpgradeDependencyProbe: mock((params) => {
-        const isTarget = params.version === "4.4.3";
-        return Promise.resolve({
-          package: {
-            name: "zod",
-            registry: "NPM",
-            version: params.version,
-            deprecated: false,
-          },
-          dependencies: {
-            direct: isTarget
-              ? [
-                  { name: "shared", versionConstraint: "^2.0.0" },
-                  { name: "added-direct", versionConstraint: "^1.0.0" },
-                ]
-              : [
-                  { name: "shared", versionConstraint: "^1.0.0" },
-                  { name: "removed-direct", versionConstraint: "^1.0.0" },
-                ],
-            transitive: {
-              dependencyGraph: {
-                formatVersion: 1,
-                nodes: isTarget
-                  ? [
-                      { registry: "synthetic", name: "root", version: "0.0.0" },
-                      { registry: "NPM", name: "zod", version: "4.4.3" },
-                      {
-                        registry: "NPM",
-                        name: "shared-transitive",
-                        version: "2.0.0",
-                      },
-                      {
-                        registry: "NPM",
-                        name: "added-transitive",
-                        version: "1.0.0",
-                      },
-                    ]
-                  : [
-                      { registry: "synthetic", name: "root", version: "0.0.0" },
-                      { registry: "NPM", name: "zod", version: "4.3.6" },
-                      {
-                        registry: "NPM",
-                        name: "shared-transitive",
-                        version: "1.0.0",
-                      },
-                      {
-                        registry: "NPM",
-                        name: "removed-transitive",
-                        version: "1.0.0",
-                      },
-                    ],
-                edges: [],
-              },
-            },
-          },
-          dependencyGroups: { groups: [] },
-        } satisfies DependencyReport);
-      }) as never,
-    });
-
-    const response = await buildPackageUpgradeReview(
-      service,
-      request.packages,
-      request.options,
-    );
-    const review = response.reviews[0];
-
-    expect(
-      review?.dependencyChanges?.direct.added.map((dep) => dep.name),
-    ).toEqual(["added-direct"]);
-    expect(
-      review?.dependencyChanges?.direct.removed.map((dep) => dep.name),
-    ).toEqual(["removed-direct"]);
-    expect(review?.dependencyChanges?.direct.changed[0]).toMatchObject({
-      name: "shared",
-      fromVersions: ["^1.0.0"],
-      toVersions: ["^2.0.0"],
-    });
-    expect(review?.dependencyChanges?.transitive.changed[0]).toMatchObject({
-      registry: "npm",
-      name: "shared-transitive",
-      fromVersions: ["1.0.0"],
-      toVersions: ["2.0.0"],
-    });
-    expect(
-      [
-        ...(review?.dependencyChanges?.transitive.added ?? []),
-        ...(review?.dependencyChanges?.transitive.removed ?? []),
-        ...(review?.dependencyChanges?.transitive.changed ?? []),
-      ].map((dep) => dep.name),
-    ).not.toContain("zod");
-    expect(
-      formatPackageUpgradeReviewTerminal(response, { verbose: true }),
-    ).toContain("- npm:shared-transitive 1.0.0 -> 2.0.0");
-  });
-
-  it("caps default package-level concurrency at three", async () => {
-    const request = buildPackageUpgradeReviewRequest({
-      packages: ["one", "two", "three", "four", "five"].map((name) => ({
-        registry: "npm",
-        packageName: name,
-        currentVersion: "1.0.0",
-        targetVersion: "1.0.1",
-      })),
-      includeTransitiveSecurity: false,
-    });
-    let active = 0;
-    let maxActive = 0;
-    const service = serviceWith({
-      packageSummary: mock(async (params) => {
-        active += 1;
-        maxActive = Math.max(maxActive, active);
-        await new Promise((resolve) => setTimeout(resolve, 5));
-        active -= 1;
-        return {
-          ...defaultPackageSummary,
-          package: {
-            ...defaultPackageSummary.package,
-            name: params.packageName,
-          },
-        };
-      }) as never,
-      packageVulnerabilities: mock((params) =>
-        Promise.resolve(cleanVulnReport(params.version ?? "1.0.1", false)),
-      ) as never,
-      packageChangelog: mock(() =>
-        Promise.resolve({
-          source: "releases",
-          entries: [{ version: "1.0.1", body: "Patch fixes." }],
-        } satisfies ChangelogReport),
-      ),
+    const service = createMockPackageIntelligenceService({
+      packageUpgradeReview: packageUpgradeReview as never,
     });
 
     await buildPackageUpgradeReview(service, request.packages, request.options);
 
-    expect(maxActive).toBeLessThanOrEqual(3);
-    expect(maxActive).toBeGreaterThan(1);
-  });
-
-  it("renders concrete evidence samples and follow-up commands", () => {
-    const output = formatPackageUpgradeReviewTerminal({
-      summary: {
-        total: 1,
-        withUnknowns: 0,
-        withAddedAdvisories: 0,
-        withBreakingSignals: 1,
-        withDirectDependencyChanges: 1,
-        withTransitiveVulnerabilityAdditions: 0,
-      },
-      reviews: [
-        {
-          registry: "npm",
-          name: "express",
-          currentVersion: "4.0.0",
-          targetVersion: "5.0.0",
-          versionDelta: "major",
-          security: {
-            current: {
-              version: "4.0.0",
-              deprecated: false,
-              affectedCount: 1,
-              nonAffectingCount: 0,
-              allCount: 1,
-              advisories: [],
-            },
-            target: {
-              version: "5.0.0",
-              deprecated: false,
-              affectedCount: 0,
-              nonAffectingCount: 0,
-              allCount: 0,
-              advisories: [],
-            },
-            added: [],
-            removed: [
-              {
-                id: "GHSA-test",
-                severity: 6.1,
-                severityLabel: "medium",
-                summary: "Removed advisory summary",
-                fixedIn: ["5.0.0"],
-              },
-            ],
-            notAddressed: [],
-            fixed: [],
-            introduced: [],
-            unchanged: [],
-          },
-          changelog: {
-            source: "releases",
-            entries: [
-              {
-                version: "5.0.0",
-                body: "Removed deprecated APIs.",
-                bodyPreview: "Removed deprecated APIs.",
-                headline: "Removed deprecated APIs.",
-                htmlUrl: "https://example.test/release",
-                signals: ["removed", "deprecated"],
-              },
-            ],
-            sampledEntries: [
-              {
-                version: "5.0.0",
-                body: "Removed deprecated APIs.",
-                bodyPreview: "Removed deprecated APIs.",
-                headline: "Removed deprecated APIs.",
-                htmlUrl: "https://example.test/release",
-                signals: ["removed", "deprecated"],
-              },
-            ],
-            keywordEntries: [
-              {
-                version: "5.0.0",
-                body: "Removed deprecated APIs.",
-                bodyPreview: "Removed deprecated APIs.",
-                headline: "Removed deprecated APIs.",
-                htmlUrl: "https://example.test/release",
-                signals: ["removed", "deprecated"],
-              },
-            ],
-            totalKeywordEntries: 1,
-            totalEntries: 1,
-            totalEntriesWithBodies: 1,
-            truncated: false,
-            hasReleaseNoteBodies: true,
-            breakingSignals: ["removed", "deprecated"],
-            migrationSignals: [],
-          },
-          dependencyChanges: {
-            direct: {
-              added: [],
-              removed: [],
-              changed: [
-                {
-                  name: "accepts",
-                  fromVersions: ["1.0.0"],
-                  toVersions: ["2.0.0"],
-                },
-              ],
-            },
-            transitive: { added: [], removed: [], changed: [] },
-          },
-          unknowns: [],
-        },
-      ],
+    expect(packageUpgradeReview.mock.calls[0]?.[0]).toMatchObject({
+      minSeverity: undefined,
     });
-
-    expect(output).toContain(
-      "vulnerabilities\n  direct package advisories: current version affected=1, target version affected=0, fixed by target=1",
-    );
-    expect(output).toContain("  fixed:");
-    expect(output).toContain("GHSA-test medium(6.1): Removed advisory summary");
-    expect(output).toContain("changes");
-    expect(output).toContain(
-      "keyword hits: 1 entries (removed, deprecated); heuristic text match",
-    );
-    expect(output).toContain("keyword hit entries:");
-    expect(output).toContain("[removed]: Removed deprecated APIs.");
-    expect(output).toContain("dependencies");
-    expect(output).toContain("- accepts 1.0.0 -> 2.0.0");
-    expect(output).not.toContain("follow-up:");
-    expect(output).not.toContain("verification:");
-  });
-
-  it("labels changelog samples as rudimentary and ignores no-breaking negation", async () => {
-    const request = buildPackageUpgradeReviewRequest({
-      registry: "npm",
-      packageName: "zod",
-      currentVersion: "4.3.6",
-      targetVersion: "4.4.3",
-    });
-    const service = serviceWith({
-      packageVulnerabilities: mock((params) =>
-        Promise.resolve(cleanVulnReport(params.version ?? "4.4.3", false)),
-      ) as never,
-      packageChangelog: mock(() =>
-        Promise.resolve({
-          source: "releases",
-          entries: [
-            {
-              version: "4.4.3",
-              body: "No breaking changes.\n\n- 91dcd30 removed unnecessary console logs",
-            },
-            {
-              version: "4.4.2",
-              body: "Migration docs updated.\n\n- 1234567 docs: update links",
-            },
-          ],
-        } satisfies ChangelogReport),
-      ),
-    });
-
-    const response = await buildPackageUpgradeReview(
-      service,
-      request.packages,
-      request.options,
-    );
-    const output = formatPackageUpgradeReviewTerminal(response);
-
-    expect(response.reviews[0]?.changelog.breakingSignals).not.toContain(
-      "breaking",
-    );
-    expect(output).toContain(
-      "keyword hits: 1 entries (removed, migration); heuristic text match",
-    );
-    expect(output).toContain("keyword hit entries:");
-    expect(output).toContain("[migration]: Migration docs updated.");
-    expect(output).not.toContain("91dcd30 removed unnecessary console logs");
   });
 });

--- a/packages/mcp/src/shared/package-upgrade-review-response.ts
+++ b/packages/mcp/src/shared/package-upgrade-review-response.ts
@@ -1,25 +1,12 @@
 import type {
-  ChangelogReport,
-  DependencyIssuesSummary,
-  DependencyReport,
+  PackageUpgradeReviewResponse as BackendPackageUpgradeReviewResponse,
   PackageIntelligenceService,
-  PackageVersionIdentity,
-  TransitiveDependencyVulnerability,
-  TransitiveVulnerabilitySummary,
-  VulnerabilityDetail,
-  VulnerabilityReport,
 } from "@githits/core-internal";
 import { colorize, highlight } from "./colors.js";
-import { mapPackageIntelligenceError } from "./package-intelligence-error-map.js";
-import {
-  buildUpgradeDependencyProbeParams,
-  type PackageUpgradeReviewOptions,
-  type UpgradeReviewPackageRequest,
+import type {
+  PackageUpgradeReviewOptions,
+  UpgradeReviewPackageRequest,
 } from "./package-upgrade-review-request.js";
-import {
-  dedupAdvisoriesByAlias,
-  vulnSeverityLabel,
-} from "./package-vulnerabilities-response.js";
 
 export type VersionDelta =
   | "patch"
@@ -69,8 +56,14 @@ export interface UpgradeTransitiveSecurity {
   introducedPackages: string[];
   fixedPackages: string[];
   introducedPackageDetails: UpgradeTransitiveVulnerablePackage[];
+  introducedPackageDetailsTotalCount: number;
+  introducedPackageDetailsTruncated: boolean;
   fixedPackageDetails: UpgradeTransitiveVulnerablePackage[];
+  fixedPackageDetailsTotalCount: number;
+  fixedPackageDetailsTruncated: boolean;
   stillAffectedPackageDetails: UpgradeTransitiveVulnerablePackage[];
+  stillAffectedPackageDetailsTotalCount: number;
+  stillAffectedPackageDetailsTruncated: boolean;
 }
 
 export interface UpgradeTransitiveVulnerablePackage {
@@ -82,11 +75,6 @@ export interface UpgradeTransitiveVulnerablePackage {
   maxSeverityScore?: number;
   maxSeverityLabel?: string;
   advisoryIds: string[];
-}
-
-interface TransitivePackageDiffEntry
-  extends UpgradeTransitiveVulnerablePackage {
-  advisoryKeys: string[];
 }
 
 export interface UpgradeChangelogEntry {
@@ -176,425 +164,250 @@ export interface UpgradeReviewResponse {
   reviews: UpgradeReview[];
 }
 
-export interface BuildPackageUpgradeReviewOptions {
-  concurrency?: number;
-}
-
 export interface FormatPackageUpgradeReviewTerminalOptions {
   verbose?: boolean;
   useColors?: boolean;
 }
 
-const DEFAULT_CONCURRENCY = 3;
 const BODY_PREVIEW_CHARS = 280;
-const DEFAULT_CHANGELOG_SAMPLE_LIMIT = 5;
-const SIGNAL_TERMS = [
-  "breaking",
-  "breaks",
-  "removed",
-  "drop support",
-  "migration",
-  "migrate",
-  "deprecated",
-  "renamed",
-] as const;
 
 export async function buildPackageUpgradeReview(
   service: PackageIntelligenceService,
   packages: readonly UpgradeReviewPackageRequest[],
   options: PackageUpgradeReviewOptions,
-  buildOptions: BuildPackageUpgradeReviewOptions = {},
 ): Promise<UpgradeReviewResponse> {
-  const concurrency = buildOptions.concurrency ?? DEFAULT_CONCURRENCY;
-  const reviews = await runWithConcurrency(packages, concurrency, (pkg) =>
-    buildSingleReview(service, pkg, options),
-  );
+  const response = await service.packageUpgradeReview({
+    packages: packages.map((pkg) => ({
+      registry: pkg.registry,
+      name: pkg.packageName,
+      currentVersion: pkg.currentVersion,
+      targetVersion: pkg.targetVersion,
+    })),
+    includeTransitiveSecurity: options.includeTransitiveSecurity,
+    includeDependencyIssues: options.includeDependencyIssues,
+    changelogLimit: options.changelogLimit,
+    minSeverity: options.minSeverity,
+  });
+  return normaliseBackendUpgradeReviewResponse(response);
+}
+
+function normaliseBackendUpgradeReviewResponse(
+  response: BackendPackageUpgradeReviewResponse,
+): UpgradeReviewResponse {
   return {
-    summary: {
-      total: reviews.length,
-      withUnknowns: reviews.filter((r) => r.unknowns.length > 0).length,
-      withAddedAdvisories: reviews.filter((r) => r.security.added.length > 0)
-        .length,
-      withBreakingSignals: reviews.filter((r) =>
-        hasBreakingSignals(r.changelog),
-      ).length,
-      withDirectDependencyChanges: reviews.filter((r) =>
-        hasDirectDependencyChurn(r.dependencyChanges),
-      ).length,
-      withTransitiveVulnerabilityAdditions: reviews.filter(
-        (r) => (r.security.transitive?.introducedPackages.length ?? 0) > 0,
-      ).length,
-    },
-    reviews,
+    summary: response.summary,
+    reviews: response.reviews.map((review) => ({
+      registry: lowerEnum(review.registry) ?? review.registry,
+      name: review.name,
+      currentVersion: review.currentVersion,
+      targetVersion: review.targetVersion,
+      latestVersion: review.latestVersion,
+      versionDelta: lowerEnum(review.versionDelta) as VersionDelta,
+      security: normaliseBackendSecurity(review.security),
+      changelog: normaliseBackendChangelog(review.changelog),
+      compatibility: review.compatibility,
+      dependencyChanges: review.dependencyChanges
+        ? normaliseBackendDependencyChanges(review.dependencyChanges)
+        : undefined,
+      dependencyIssues: review.dependencyIssues,
+      unknowns: review.unknowns,
+    })),
   };
 }
 
-async function buildSingleReview(
-  service: PackageIntelligenceService,
-  pkg: UpgradeReviewPackageRequest,
-  options: PackageUpgradeReviewOptions,
-): Promise<UpgradeReview> {
-  const versionDelta = classifyVersionDelta(
-    pkg.currentVersion,
-    pkg.targetVersion,
-  );
-  const [
-    summary,
-    currentVulns,
-    targetVulns,
-    changelog,
-    currentDeps,
-    targetDeps,
-  ] = await Promise.all([
-    capture(() =>
-      service.packageSummary({
-        registry: pkg.registry,
-        packageName: pkg.packageName,
-      }),
-    ),
-    capture(() =>
-      service.packageVulnerabilities({
-        registry: pkg.registry,
-        packageName: pkg.packageName,
-        version: pkg.currentVersion,
-        minSeverity: options.minSeverity,
-        advisoryScope: "AFFECTED",
-      }),
-    ),
-    capture(() =>
-      service.packageVulnerabilities({
-        registry: pkg.registry,
-        packageName: pkg.packageName,
-        version: pkg.targetVersion,
-        minSeverity: options.minSeverity,
-        advisoryScope: "AFFECTED",
-      }),
-    ),
-    capture(() =>
-      service.packageChangelog({
-        registry: pkg.registry,
-        packageName: pkg.packageName,
-        fromVersion: pkg.currentVersion,
-        toVersion: pkg.targetVersion,
-      }),
-    ),
-    capture(() =>
-      service.packageUpgradeDependencyProbe(
-        buildUpgradeDependencyProbeParams(pkg, pkg.currentVersion, options),
-      ),
-    ),
-    capture(() =>
-      service.packageUpgradeDependencyProbe(
-        buildUpgradeDependencyProbeParams(pkg, pkg.targetVersion, options),
-      ),
-    ),
-  ]);
-
-  const unknowns: string[] = [];
-  if (!summary.ok)
-    unknowns.push(
-      `package summary unavailable: ${formatCapturedError(summary.error)}`,
-    );
-  if (!currentVulns.ok)
-    unknowns.push(
-      `current-version vulnerability check failed: ${formatCapturedError(currentVulns.error)}`,
-    );
-  if (!targetVulns.ok)
-    unknowns.push(
-      `target-version vulnerability check failed: ${formatCapturedError(targetVulns.error)}`,
-    );
-  if (!changelog.ok)
-    unknowns.push(
-      `changelog unavailable: ${formatCapturedError(changelog.error)}`,
-    );
-  if (
-    options.includeTransitiveSecurity ||
-    options.includeDependencyIssues ||
-    options.includeDependencyChanges
-  ) {
-    if (!currentDeps.ok)
-      unknowns.push(
-        `current-version dependency probe failed: ${formatCapturedError(currentDeps.error)}`,
-      );
-    if (!targetDeps.ok)
-      unknowns.push(
-        `target-version dependency probe failed: ${formatCapturedError(targetDeps.error)}`,
-      );
-  }
-
-  const currentSecurity = currentVulns.ok
-    ? buildVersionVulnerabilitySummary(
-        currentVulns.value,
-        currentDeps.ok ? currentDeps.value.package : undefined,
-      )
-    : undefined;
-  const targetSecurity = targetVulns.ok
-    ? buildVersionVulnerabilitySummary(
-        targetVulns.value,
-        targetDeps.ok ? targetDeps.value.package : undefined,
-      )
-    : undefined;
-  const advisoryDiff = diffAdvisories(
-    currentVulns.ok ? (currentVulns.value.security?.vulnerabilities ?? []) : [],
-    targetVulns.ok ? (targetVulns.value.security?.vulnerabilities ?? []) : [],
-  );
-  const changelogBlock = changelog.ok
-    ? buildChangelogBlock(changelog.value, options.changelogLimit)
-    : emptyChangelog();
-  const transitive = buildTransitiveSecurity(
-    currentDeps.ok
-      ? currentDeps.value.dependencies?.transitive?.vulnerabilitySummary
-      : undefined,
-    targetDeps.ok
-      ? targetDeps.value.dependencies?.transitive?.vulnerabilitySummary
-      : undefined,
-    options,
-  );
-  const dependencyIssues = buildDependencyIssues(
-    currentDeps.ok
-      ? currentDeps.value.dependencies?.transitive?.dependencyIssues
-      : undefined,
-    targetDeps.ok
-      ? targetDeps.value.dependencies?.transitive?.dependencyIssues
-      : undefined,
-    options,
-    pkg,
-  );
-  const dependencyChanges = buildDependencyChanges(
-    currentDeps.ok ? currentDeps.value : undefined,
-    targetDeps.ok ? targetDeps.value : undefined,
-    pkg,
-  );
-  const compatibility = buildCompatibility(
-    currentDeps.ok ? currentDeps.value : undefined,
-    targetDeps.ok ? targetDeps.value : undefined,
-  );
-
-  if (
-    changelogBlock.fallback === "package_versions" &&
-    !changelogBlock.hasReleaseNoteBodies
-  ) {
-    unknowns.push(
-      "changelog range only returned package-version fallback entries without release-note bodies",
-    );
-  }
-  if (targetSecurity && targetSecurity.deprecated === undefined) {
-    unknowns.push("target version deprecation metadata is unavailable");
-  }
-
-  if (
-    options.minSeverityLabel !== undefined &&
-    options.minSeverityLabel !== "low"
-  ) {
-    unknowns.push("direct vulnerability checks were filtered by min_severity");
-  }
-
+function normaliseBackendSecurity(
+  security: BackendPackageUpgradeReviewResponse["reviews"][number]["security"],
+): UpgradeSecurity {
   return {
-    registry: pkg.registryLabel,
-    name: pkg.packageName,
-    currentVersion: pkg.currentVersion,
-    targetVersion: pkg.targetVersion,
-    latestVersion: summary.ok ? summary.value.package.latestVersion : undefined,
-    versionDelta,
-    security: {
-      current: currentSecurity,
-      target: targetSecurity,
-      added: advisoryDiff.introduced,
-      removed: advisoryDiff.fixed,
-      notAddressed: advisoryDiff.unchanged,
-      fixed: advisoryDiff.fixed,
-      introduced: advisoryDiff.introduced,
-      unchanged: advisoryDiff.unchanged,
-      transitive,
-    },
-    changelog: changelogBlock,
-    compatibility,
-    dependencyChanges,
-    dependencyIssues,
-    unknowns,
+    current: security.current
+      ? normaliseBackendVersionVulnerabilitySummary(security.current)
+      : undefined,
+    target: security.target
+      ? normaliseBackendVersionVulnerabilitySummary(security.target)
+      : undefined,
+    added: security.added.map(normaliseBackendAdvisory),
+    removed: security.removed.map(normaliseBackendAdvisory),
+    notAddressed: security.notAddressed.map(normaliseBackendAdvisory),
+    fixed: security.fixed.map(normaliseBackendAdvisory),
+    introduced: security.introduced.map(normaliseBackendAdvisory),
+    unchanged: security.unchanged.map(normaliseBackendAdvisory),
+    transitive: security.transitive
+      ? normaliseBackendTransitiveSecurity(security.transitive)
+      : undefined,
   };
 }
 
-function buildVersionVulnerabilitySummary(
-  report: VulnerabilityReport,
-  metadata: PackageVersionIdentity | undefined,
+function normaliseBackendVersionVulnerabilitySummary(
+  summary: NonNullable<
+    BackendPackageUpgradeReviewResponse["reviews"][number]["security"]["current"]
+  >,
 ): VersionVulnerabilitySummary {
-  const security = report.security;
   return {
-    version: report.package.version,
-    ...versionMetadata(metadata ?? report.package),
-    affectedCount: security?.affectedVulnerabilityCount ?? 0,
-    nonAffectingCount: security?.nonAffectingVulnerabilityCount ?? 0,
-    allCount: security?.allVulnerabilityCount ?? 0,
-    advisories: dedupAdvisoriesByAlias(security?.vulnerabilities ?? []).map(
-      toAdvisorySummary,
-    ),
+    version: summary.version,
+    publishedAt: summary.publishedAt,
+    deprecated: summary.deprecated,
+    deprecationReason: summary.deprecationReason,
+    affectedCount: summary.affectedCount,
+    nonAffectingCount: summary.nonAffectingCount,
+    allCount: summary.allCount,
+    advisories: summary.advisories.map(normaliseBackendAdvisory),
   };
 }
 
-function versionMetadata(
-  pkg: PackageVersionIdentity,
-): Pick<
-  VersionVulnerabilitySummary,
-  "publishedAt" | "deprecated" | "deprecationReason"
-> {
-  return {
-    publishedAt: pkg.publishedAt,
-    deprecated: pkg.deprecated,
-    deprecationReason: pkg.deprecationReason,
-  };
-}
-
-function diffAdvisories(
-  current: VulnerabilityDetail[],
-  target: VulnerabilityDetail[],
-): Pick<UpgradeSecurity, "fixed" | "introduced" | "unchanged"> {
-  const currentMap = advisoryMap(current);
-  const targetMap = advisoryMap(target);
-  const fixed: UpgradeAdvisorySummary[] = [];
-  const introduced: UpgradeAdvisorySummary[] = [];
-  const unchanged: UpgradeAdvisorySummary[] = [];
-  for (const [key, advisory] of currentMap) {
-    if (targetMap.has(key))
-      unchanged.push(toAdvisorySummary(targetMap.get(key) ?? advisory));
-    else fixed.push(toAdvisorySummary(advisory));
-  }
-  for (const [key, advisory] of targetMap) {
-    if (!currentMap.has(key)) introduced.push(toAdvisorySummary(advisory));
-  }
-  return { fixed, introduced, unchanged };
-}
-
-function advisoryMap(
-  advisories: VulnerabilityDetail[],
-): Map<string, VulnerabilityDetail> {
-  const map = new Map<string, VulnerabilityDetail>();
-  for (const advisory of dedupAdvisoriesByAlias(advisories)) {
-    map.set(advisoryKey(advisory), advisory);
-  }
-  return map;
-}
-
-function advisoryKey(advisory: {
-  osvId?: string;
-  aliases?: string[];
-  summary?: string;
-}): string {
-  const ids = [advisory.osvId, ...(advisory.aliases ?? [])].filter(
-    (id): id is string => Boolean(id),
-  );
-  return ids.length > 0
-    ? ids.sort().join("|")
-    : `summary:${advisory.summary ?? "unknown"}`;
-}
-
-function toAdvisorySummary(
-  advisory: VulnerabilityDetail,
+function normaliseBackendAdvisory(
+  advisory: BackendPackageUpgradeReviewResponse["reviews"][number]["security"]["added"][number],
 ): UpgradeAdvisorySummary {
-  const severity = advisory.severityScore;
   return {
-    id: advisory.osvId,
+    id: advisory.id,
     aliases: advisory.aliases,
     summary: advisory.summary,
-    severity,
-    severityLabel:
-      typeof severity === "number" ? vulnSeverityLabel(severity) : undefined,
-    fixedIn: advisory.fixedInVersions,
+    severity: advisory.severity,
+    severityLabel: lowerEnum(advisory.severityLabel),
+    fixedIn: advisory.fixedIn,
     isMalicious: advisory.isMalicious,
   };
 }
 
-function buildChangelogBlock(
-  report: ChangelogReport,
-  limit: number,
-): UpgradeChangelog {
-  const boundedEntries = report.entries.slice(0, limit);
-  const entries = boundedEntries.map((entry) => toUpgradeChangelogEntry(entry));
-  const allEntries = report.entries.map((entry) =>
-    toUpgradeChangelogEntry(entry),
-  );
-  const allKeywordEntries = allEntries.filter(
-    (entry) => (entry.signals?.length ?? 0) > 0,
-  );
-  const bodies = report.entries
-    .map((entry) => entry.body ?? "")
-    .filter((body) => body.trim().length > 0);
-  const signals = extractSignals(bodies.join("\n"));
+function normaliseBackendTransitiveSecurity(
+  transitive: NonNullable<
+    BackendPackageUpgradeReviewResponse["reviews"][number]["security"]["transitive"]
+  >,
+): UpgradeTransitiveSecurity {
   return {
-    source: report.source,
-    fallback: report.source ? undefined : "package_versions",
-    entries,
-    sampledEntries: sampleChangelogEntries(entries),
-    keywordEntries: allKeywordEntries,
-    totalKeywordEntries: allKeywordEntries.length,
-    totalEntries: report.entries.length,
-    totalEntriesWithBodies: bodies.length,
-    truncated: report.entries.length > entries.length,
-    hasReleaseNoteBodies: bodies.length > 0,
-    breakingSignals: signals.filter(
-      (signal) => signal !== "migration" && signal !== "migrate",
+    currentAffected: transitive.currentAffected,
+    targetAffected: transitive.targetAffected,
+    introducedPackages: transitive.introducedPackages.map(
+      normaliseRegistryPrefix,
     ),
-    migrationSignals: signals.filter(
-      (signal) => signal === "migration" || signal === "migrate",
+    fixedPackages: transitive.fixedPackages.map(normaliseRegistryPrefix),
+    introducedPackageDetails: transitive.introducedPackageDetails.entries.map(
+      normaliseBackendTransitivePackage,
     ),
+    introducedPackageDetailsTotalCount:
+      transitive.introducedPackageDetails.totalCount,
+    introducedPackageDetailsTruncated:
+      transitive.introducedPackageDetails.truncated,
+    fixedPackageDetails: transitive.fixedPackageDetails.entries.map(
+      normaliseBackendTransitivePackage,
+    ),
+    fixedPackageDetailsTotalCount: transitive.fixedPackageDetails.totalCount,
+    fixedPackageDetailsTruncated: transitive.fixedPackageDetails.truncated,
+    stillAffectedPackageDetails:
+      transitive.stillAffectedPackageDetails.entries.map(
+        normaliseBackendTransitivePackage,
+      ),
+    stillAffectedPackageDetailsTotalCount:
+      transitive.stillAffectedPackageDetails.totalCount,
+    stillAffectedPackageDetailsTruncated:
+      transitive.stillAffectedPackageDetails.truncated,
   };
 }
 
-function toUpgradeChangelogEntry(entry: {
-  version?: string;
-  publishedAt?: string;
-  htmlUrl?: string;
-  body?: string;
-}): UpgradeChangelogEntry {
-  const signals = extractSignals(changelogSignalText(entry.body));
+function normaliseBackendDependencyChanges(
+  changes: NonNullable<
+    BackendPackageUpgradeReviewResponse["reviews"][number]["dependencyChanges"]
+  >,
+): UpgradeDependencyChanges {
+  return {
+    direct: normaliseBackendDependencyChangeGroup(changes.direct),
+    transitive: normaliseBackendDependencyChangeGroup(changes.transitive),
+  };
+}
+
+function normaliseBackendDependencyChangeGroup(
+  group: BackendPackageUpgradeReviewResponse["reviews"][number]["dependencyChanges"] extends infer T
+    ? T extends { direct: infer Group }
+      ? Group
+      : never
+    : never,
+): UpgradeDependencyChangeGroup {
+  return {
+    added: group.added.map(normaliseBackendDependencyChangeItem),
+    removed: group.removed.map(normaliseBackendDependencyChangeItem),
+    changed: group.changed.map(normaliseBackendDependencyChangeItem),
+  };
+}
+
+function normaliseBackendDependencyChangeItem(
+  item: BackendPackageUpgradeReviewResponse["reviews"][number]["dependencyChanges"] extends infer T
+    ? T extends { direct: { added: Array<infer Item> } }
+      ? Item
+      : never
+    : never,
+): UpgradeDependencyChangeItem {
+  return {
+    name: item.name,
+    registry: lowerEnum(item.registry),
+    version: item.version,
+    fromVersions: item.fromVersions,
+    toVersions: item.toVersions,
+    constraint: item.constraint,
+    type: lowerEnum(item.type),
+  };
+}
+
+function normaliseBackendTransitivePackage(
+  pkg: BackendPackageUpgradeReviewResponse["reviews"][number]["security"]["transitive"] extends infer T
+    ? T extends { introducedPackageDetails: { entries: Array<infer Entry> } }
+      ? Entry
+      : never
+    : never,
+): UpgradeTransitiveVulnerablePackage {
+  return {
+    id: pkg.id,
+    registry: lowerEnum(pkg.registry) ?? pkg.registry,
+    name: pkg.name,
+    versions: pkg.versions,
+    affectedCount: pkg.affectedCount,
+    maxSeverityScore: pkg.maxSeverityScore,
+    maxSeverityLabel: lowerEnum(pkg.maxSeverityLabel),
+    advisoryIds: pkg.advisoryIds,
+  };
+}
+
+function normaliseBackendChangelog(
+  changelog: BackendPackageUpgradeReviewResponse["reviews"][number]["changelog"],
+): UpgradeChangelog {
+  return {
+    source: lowerEnum(changelog.source),
+    fallback: lowerEnum(changelog.fallback) as "package_versions" | undefined,
+    entries: changelog.entries.map(normaliseBackendChangelogEntry),
+    sampledEntries: changelog.sampledEntries.map(
+      normaliseBackendChangelogEntry,
+    ),
+    keywordEntries: changelog.keywordEntries.map(
+      normaliseBackendChangelogEntry,
+    ),
+    totalKeywordEntries: changelog.totalKeywordEntries,
+    totalEntries: changelog.totalEntries,
+    totalEntriesWithBodies: changelog.totalEntriesWithBodies,
+    truncated: changelog.truncated,
+    hasReleaseNoteBodies: changelog.hasReleaseNoteBodies,
+    breakingSignals: changelog.breakingSignals,
+    migrationSignals: changelog.migrationSignals,
+  };
+}
+
+function normaliseBackendChangelogEntry(
+  entry: BackendPackageUpgradeReviewResponse["reviews"][number]["changelog"]["entries"][number],
+): UpgradeChangelogEntry {
   return {
     version: entry.version ?? null,
     publishedAt: entry.publishedAt,
     htmlUrl: entry.htmlUrl,
     body: entry.body,
-    bodyPreview: preview(entry.body),
-    headline: headlineParagraph(entry.body),
-    signals: signals.length > 0 ? signals : undefined,
+    bodyPreview: entry.bodyPreview,
+    headline: entry.headline,
+    signals: entry.signals.length > 0 ? entry.signals : undefined,
   };
 }
 
-function sampleChangelogEntries(
-  entries: UpgradeChangelogEntry[],
-): UpgradeChangelogEntry[] {
-  const sample = new Map<string, UpgradeChangelogEntry>();
-  for (const entry of entries.slice(0, 1)) {
-    sample.set(changelogEntryKey(entry), entry);
-  }
-  for (const entry of entries.filter(hasUsefulHeadline)) {
-    if (sample.size >= DEFAULT_CHANGELOG_SAMPLE_LIMIT) break;
-    sample.set(changelogEntryKey(entry), entry);
-  }
-  return [...sample.values()].slice(0, DEFAULT_CHANGELOG_SAMPLE_LIMIT);
+function lowerEnum(value: string | undefined): string | undefined {
+  return value?.toLowerCase();
 }
 
-function hasUsefulHeadline(entry: UpgradeChangelogEntry): boolean {
-  const headline = entry.headline?.trim().toLowerCase();
-  if (!headline) return false;
-  return headline !== "- no changes" && headline !== "no changes";
-}
-
-function changelogEntryKey(entry: UpgradeChangelogEntry): string {
-  return `${entry.version ?? "unknown"}:${entry.publishedAt ?? ""}:${entry.htmlUrl ?? ""}`;
-}
-
-function emptyChangelog(): UpgradeChangelog {
-  return {
-    entries: [],
-    sampledEntries: [],
-    keywordEntries: [],
-    totalKeywordEntries: 0,
-    totalEntries: 0,
-    totalEntriesWithBodies: 0,
-    truncated: false,
-    hasReleaseNoteBodies: false,
-    breakingSignals: [],
-    migrationSignals: [],
-  };
+function normaliseRegistryPrefix(value: string): string {
+  return value.replace(/^([A-Z_]+):/, (prefix) => prefix.toLowerCase());
 }
 
 function preview(body: string | undefined): string | undefined {
@@ -604,29 +417,6 @@ function preview(body: string | undefined): string | undefined {
   return compact.length > BODY_PREVIEW_CHARS
     ? `${compact.slice(0, BODY_PREVIEW_CHARS)}...`
     : compact;
-}
-
-function headlineParagraph(body: string | undefined): string | undefined {
-  if (!body) return undefined;
-  const lines = changelogSignalText(body).replace(/\r\n/g, "\n").split("\n");
-  const paragraph: string[] = [];
-  for (const rawLine of lines) {
-    const line = rawLine.trim();
-    if (line.length === 0) {
-      if (paragraph.length > 0) break;
-      continue;
-    }
-    if (looksLikeCommitListLine(line) && paragraph.length === 0) continue;
-    if (looksLikeLowValueHeading(line)) continue;
-    if (looksLikeVersionOnlyHeading(line)) continue;
-    const normalised = normaliseChangelogLine(line);
-    if (isGenericChangelogHeading(normalised)) continue;
-    paragraph.push(normalised);
-    if (paragraph.join(" ").length >= BODY_PREVIEW_CHARS) break;
-  }
-  const text = paragraph.join(" ").trim();
-  if (!text || looksLikePullRequestList(text)) return undefined;
-  return preview(text);
 }
 
 function changelogSignalText(body: string | undefined): string {
@@ -652,207 +442,12 @@ function looksLikeCommitListLine(line: string): boolean {
   return /^[-*]\s+[0-9a-f]{7,40}\b/i.test(line);
 }
 
-function looksLikeLowValueHeading(line: string): boolean {
-  return /^#{1,6}\s+(commits?|contributors?)\b/i.test(line);
-}
-
-function looksLikeVersionOnlyHeading(line: string): boolean {
-  return /^#{1,6}\s*v?\d+\.\d+\.\d+(?:[-\w.]*)?\s*$/i.test(line);
-}
-
-function looksLikePullRequestList(text: string): boolean {
-  const pullMentions = (text.match(/\/pull\/\d+/g) ?? []).length;
-  const authorMentions = (text.match(/\sby\s@/g) ?? []).length;
-  return pullMentions >= 2 || authorMentions >= 2;
-}
-
-function extractSignals(text: string): string[] {
-  return SIGNAL_TERMS.filter((term) => matchesSignalTerm(text, term));
-}
-
 function matchesSignalTerm(text: string, term: string): boolean {
   const lower = text.toLowerCase();
   if (term === "breaking" || term === "breaks") {
     if (/\b(no|without|not)\s+breaking\s+changes?\b/i.test(text)) return false;
   }
   return lower.includes(term);
-}
-
-function buildTransitiveSecurity(
-  current: TransitiveVulnerabilitySummary | undefined,
-  target: TransitiveVulnerabilitySummary | undefined,
-  options: PackageUpgradeReviewOptions,
-): UpgradeTransitiveSecurity | undefined {
-  if (!options.includeTransitiveSecurity || (!current && !target))
-    return undefined;
-  const currentMap = transitiveVulnerablePackageMap(current?.packages ?? []);
-  const targetMap = transitiveVulnerablePackageMap(target?.packages ?? []);
-  const introducedPackages = [...targetMap.keys()]
-    .filter((key) =>
-      hasAddedTransitiveAdvisory(currentMap.get(key), targetMap.get(key)),
-    )
-    .sort();
-  const fixedPackages = [...currentMap.keys()]
-    .filter((key) =>
-      hasRemovedTransitiveAdvisory(currentMap.get(key), targetMap.get(key)),
-    )
-    .sort();
-  const stillAffectedPackages = [...targetMap.keys()]
-    .filter((key) =>
-      hasSharedTransitiveAdvisory(currentMap.get(key), targetMap.get(key)),
-    )
-    .sort();
-  return {
-    currentAffected: current?.affectedPackageCount ?? 0,
-    targetAffected: target?.affectedPackageCount ?? 0,
-    introducedPackages,
-    fixedPackages,
-    introducedPackageDetails: introducedPackages
-      .map((key) => targetMap.get(key))
-      .map(toPublicTransitivePackage)
-      .filter((pkg): pkg is UpgradeTransitiveVulnerablePackage => Boolean(pkg)),
-    fixedPackageDetails: fixedPackages
-      .map((key) => currentMap.get(key))
-      .map(toPublicTransitivePackage)
-      .filter((pkg): pkg is UpgradeTransitiveVulnerablePackage => Boolean(pkg)),
-    stillAffectedPackageDetails: stillAffectedPackages
-      .map((key) => targetMap.get(key))
-      .map(toPublicTransitivePackage)
-      .filter((pkg): pkg is UpgradeTransitiveVulnerablePackage => Boolean(pkg)),
-  };
-}
-
-function hasAddedTransitiveAdvisory(
-  current: TransitivePackageDiffEntry | undefined,
-  target: TransitivePackageDiffEntry | undefined,
-): boolean {
-  if (!target) return false;
-  if (!current) return true;
-  const currentAdvisories = new Set(current.advisoryKeys);
-  return target.advisoryKeys.some((id) => !currentAdvisories.has(id));
-}
-
-function hasRemovedTransitiveAdvisory(
-  current: TransitivePackageDiffEntry | undefined,
-  target: TransitivePackageDiffEntry | undefined,
-): boolean {
-  if (!current) return false;
-  if (!target) return true;
-  const targetAdvisories = new Set(target.advisoryKeys);
-  return current.advisoryKeys.some((id) => !targetAdvisories.has(id));
-}
-
-function hasSharedTransitiveAdvisory(
-  current: TransitivePackageDiffEntry | undefined,
-  target: TransitivePackageDiffEntry | undefined,
-): boolean {
-  if (!current || !target) return false;
-  if (current.advisoryKeys.length === 0 || target.advisoryKeys.length === 0) {
-    return current.affectedCount > 0 && target.affectedCount > 0;
-  }
-  const currentAdvisories = new Set(current.advisoryKeys);
-  return target.advisoryKeys.some((id) => currentAdvisories.has(id));
-}
-
-function transitiveVulnerablePackageMap(
-  packages: readonly {
-    registry: string;
-    name: string;
-    versions: string[];
-    affectedCount: number;
-    maxSeverityScore?: number;
-    maxSeverityLabel?: string;
-    advisoryIds: string[];
-    advisoryOccurrences?: TransitiveDependencyVulnerability[];
-  }[],
-): Map<string, TransitivePackageDiffEntry> {
-  const map = new Map<string, TransitivePackageDiffEntry>();
-  for (const pkg of packages) {
-    if (pkg.affectedCount <= 0) continue;
-    const id = transitiveVulnerablePackageId(pkg);
-    map.set(id, {
-      id,
-      registry: pkg.registry.toLowerCase(),
-      name: pkg.name,
-      versions: pkg.versions,
-      affectedCount: pkg.affectedCount,
-      maxSeverityScore: pkg.maxSeverityScore,
-      maxSeverityLabel: pkg.maxSeverityLabel,
-      advisoryIds: pkg.advisoryIds,
-      advisoryKeys: transitiveAdvisoryKeys(pkg),
-    });
-  }
-  return map;
-}
-
-function transitiveAdvisoryKeys(pkg: {
-  advisoryIds: string[];
-  advisoryOccurrences?: TransitiveDependencyVulnerability[];
-}): string[] {
-  const occurrenceKeys = (pkg.advisoryOccurrences ?? []).map((occurrence) =>
-    advisoryKey(occurrence.advisory),
-  );
-  const occurrenceIds = new Set(
-    (pkg.advisoryOccurrences ?? []).flatMap((occurrence) => [
-      occurrence.advisory.osvId,
-      ...(occurrence.advisory.aliases ?? []),
-    ]),
-  );
-  const rawFallbackIds = pkg.advisoryIds.filter((id) => !occurrenceIds.has(id));
-  return [...new Set([...occurrenceKeys, ...rawFallbackIds])].sort();
-}
-
-function toPublicTransitivePackage(
-  pkg: TransitivePackageDiffEntry | undefined,
-): UpgradeTransitiveVulnerablePackage | undefined {
-  if (!pkg) return undefined;
-  const { advisoryKeys: _advisoryKeys, ...publicPackage } = pkg;
-  return publicPackage;
-}
-
-function transitiveVulnerablePackageId(pkg: {
-  registry: string;
-  name: string;
-}): string {
-  return `${pkg.registry.toLowerCase()}:${pkg.name}`;
-}
-
-function buildDependencyIssues(
-  current: DependencyIssuesSummary | undefined,
-  target: DependencyIssuesSummary | undefined,
-  options: PackageUpgradeReviewOptions,
-  rootPackage: UpgradeReviewPackageRequest,
-): UpgradeDependencyIssues | undefined {
-  if (!options.includeDependencyIssues || (!current && !target))
-    return undefined;
-  const currentDeprecated = issueSet(current?.deprecatedPackages ?? []);
-  const targetDeprecated = issueSet(target?.deprecatedPackages ?? []);
-  const currentDuplicates = issueSet(current?.duplicatePackages ?? []);
-  const targetDuplicates = issueSet(target?.duplicatePackages ?? []);
-  const currentConflicts = issueSet(current?.conflicts ?? []);
-  const targetConflicts = issueSet(target?.conflicts ?? []);
-  const currentOutdated = issueSet(
-    (current?.outdatedPackages ?? []).filter(
-      (pkg) => !isRootPackageIssue(pkg, rootPackage),
-    ),
-  );
-  const targetOutdated = issueSet(
-    (target?.outdatedPackages ?? []).filter(
-      (pkg) => !isRootPackageIssue(pkg, rootPackage),
-    ),
-  );
-  const introducedDeprecated = diffSet(targetDeprecated, currentDeprecated);
-  const introducedDuplicates = diffSet(targetDuplicates, currentDuplicates);
-  const introducedConflicts = diffSet(targetConflicts, currentConflicts);
-  const introducedOutdated = diffSet(targetOutdated, currentOutdated);
-  return {
-    currentTotal: current?.totalCount ?? 0,
-    targetTotal: target?.totalCount ?? 0,
-    introducedDeprecated,
-    introducedDuplicates,
-    introducedConflicts,
-    introducedOutdated,
-  };
 }
 
 function hasIntroducedDependencyIssues(
@@ -865,314 +460,6 @@ function hasIntroducedDependencyIssues(
     issues.introducedConflicts.length > 0 ||
     issues.introducedOutdated.length > 0
   );
-}
-
-function buildDependencyChanges(
-  current: DependencyReport | undefined,
-  target: DependencyReport | undefined,
-  rootPackage: UpgradeReviewPackageRequest,
-): UpgradeDependencyChanges | undefined {
-  if (!current && !target) return undefined;
-  return {
-    direct: diffDependencyMaps(
-      directDependencyMap(current),
-      directDependencyMap(target),
-    ),
-    transitive: diffDependencyMaps(
-      transitiveDependencyMap(current, rootPackage),
-      transitiveDependencyMap(target, rootPackage),
-    ),
-  };
-}
-
-function directDependencyMap(
-  report: DependencyReport | undefined,
-): Map<string, UpgradeDependencyChangeItem> {
-  const entries = report?.dependencies?.direct ?? [];
-  const map = new Map<string, UpgradeDependencyChangeItem>();
-  for (const dep of entries) {
-    const key = `direct:${dep.name}`;
-    map.set(key, {
-      name: dep.name,
-      constraint: dep.versionConstraint,
-      type: dep.type,
-      version: dep.versionConstraint,
-      fromVersions: dep.versionConstraint ? [dep.versionConstraint] : [],
-      toVersions: dep.versionConstraint ? [dep.versionConstraint] : [],
-    });
-  }
-  return map;
-}
-
-function transitiveDependencyMap(
-  report: DependencyReport | undefined,
-  rootPackage: UpgradeReviewPackageRequest,
-): Map<string, UpgradeDependencyChangeItem> {
-  const nodes = report?.dependencies?.transitive?.dependencyGraph?.nodes ?? [];
-  const map = new Map<string, UpgradeDependencyChangeItem>();
-  for (const node of nodes) {
-    const registry = node.registry.toLowerCase();
-    if (registry === "synthetic") continue;
-    if (
-      registry === rootPackage.registryLabel &&
-      node.name === rootPackage.packageName
-    )
-      continue;
-    const key = `${registry}:${node.name}`;
-    const existing = map.get(key);
-    const versions = new Set(existing?.toVersions ?? []);
-    if (node.version) versions.add(node.version);
-    map.set(key, {
-      registry,
-      name: node.name,
-      version: node.version,
-      fromVersions: existing?.fromVersions ?? [],
-      toVersions: [...versions].sort(compareVersionStrings),
-    });
-  }
-  return map;
-}
-
-function diffDependencyMaps(
-  current: Map<string, UpgradeDependencyChangeItem>,
-  target: Map<string, UpgradeDependencyChangeItem>,
-): UpgradeDependencyChangeGroup {
-  const added: UpgradeDependencyChangeItem[] = [];
-  const removed: UpgradeDependencyChangeItem[] = [];
-  const changed: UpgradeDependencyChangeItem[] = [];
-
-  for (const [key, currentItem] of current) {
-    const targetItem = target.get(key);
-    if (!targetItem) {
-      removed.push(withVersionDirection(currentItem, "from"));
-      continue;
-    }
-    const fromVersions = itemVersions(currentItem);
-    const toVersions = itemVersions(targetItem);
-    if (!sameStringArray(fromVersions, toVersions)) {
-      changed.push({
-        name: targetItem.name,
-        registry: targetItem.registry ?? currentItem.registry,
-        type: targetItem.type ?? currentItem.type,
-        constraint: targetItem.constraint,
-        fromVersions,
-        toVersions,
-      });
-    }
-  }
-
-  for (const [key, targetItem] of target) {
-    if (!current.has(key)) added.push(withVersionDirection(targetItem, "to"));
-  }
-
-  return {
-    added: sortDependencyItems(added),
-    removed: sortDependencyItems(removed),
-    changed: sortDependencyItems(changed),
-  };
-}
-
-function withVersionDirection(
-  item: UpgradeDependencyChangeItem,
-  direction: "from" | "to",
-): UpgradeDependencyChangeItem {
-  const versions = itemVersions(item);
-  return {
-    ...item,
-    fromVersions: direction === "from" ? versions : [],
-    toVersions: direction === "to" ? versions : [],
-  };
-}
-
-function itemVersions(item: UpgradeDependencyChangeItem): string[] {
-  const versions = item.toVersions?.length
-    ? item.toVersions
-    : item.fromVersions?.length
-      ? item.fromVersions
-      : item.version
-        ? [item.version]
-        : item.constraint
-          ? [item.constraint]
-          : [];
-  return [...new Set(versions)].sort(compareVersionStrings);
-}
-
-function sameStringArray(a: string[], b: string[]): boolean {
-  if (a.length !== b.length) return false;
-  return a.every((value, index) => value === b[index]);
-}
-
-function sortDependencyItems<T extends UpgradeDependencyChangeItem>(
-  items: T[],
-): T[] {
-  return items
-    .slice()
-    .sort((a, b) => dependencyLabel(a).localeCompare(dependencyLabel(b)));
-}
-
-function dependencyLabel(item: UpgradeDependencyChangeItem): string {
-  return `${item.registry ?? ""}:${item.name}`;
-}
-
-function compareVersionStrings(a: string, b: string): number {
-  return a.localeCompare(b, undefined, { numeric: true, sensitivity: "base" });
-}
-
-function isRootPackageIssue(
-  pkg: { registry?: string; name: string },
-  rootPackage: UpgradeReviewPackageRequest,
-): boolean {
-  return (
-    pkg.name === rootPackage.packageName &&
-    (pkg.registry === undefined ||
-      pkg.registry.toLowerCase() === rootPackage.registryLabel.toLowerCase())
-  );
-}
-
-function issueSet(
-  packages: readonly {
-    registry?: string;
-    name: string;
-    versions: Array<string | { version: string }>;
-  }[],
-): Set<string> {
-  return new Set(
-    packages.map(
-      (pkg) =>
-        `${pkg.registry ?? "unknown"}:${pkg.name}@${pkg.versions
-          .map((version) =>
-            typeof version === "string" ? version : version.version,
-          )
-          .join(",")}`,
-    ),
-  );
-}
-
-function diffSet(target: Set<string>, current: Set<string>): string[] {
-  return [...target].filter((key) => !current.has(key)).sort();
-}
-
-function buildCompatibility(
-  current: DependencyReport | undefined,
-  target: DependencyReport | undefined,
-): UpgradeCompatibility | undefined {
-  const currentPeers = groupSignatureSet(current);
-  const targetPeers = groupSignatureSet(target);
-  const added = [...targetPeers]
-    .filter((entry) => !currentPeers.has(entry))
-    .map((entry) => `added ${entry}`);
-  const removed = [...currentPeers]
-    .filter((entry) => !targetPeers.has(entry))
-    .map((entry) => `removed ${entry}`);
-  const peerDependencyChanges = [...added, ...removed].sort();
-  if (peerDependencyChanges.length === 0) return undefined;
-  return {
-    peerDependencyChanges,
-    notes: [
-      "Consumer-project compatibility cannot be determined from package metadata alone.",
-    ],
-  };
-}
-
-function groupSignatureSet(report: DependencyReport | undefined): Set<string> {
-  const groups = report?.dependencyGroups?.groups ?? [];
-  return new Set(
-    groups
-      .filter((group) => group.lifecycle === "peer")
-      .flatMap((group) =>
-        group.dependencies.map((dep) => `${dep.name}@${dep.constraint ?? "*"}`),
-      ),
-  );
-}
-
-function hasDirectDependencyChurn(
-  changes: UpgradeDependencyChanges | undefined,
-): boolean {
-  if (!changes) return false;
-  return (
-    changes.direct.added.length > 0 ||
-    changes.direct.removed.length > 0 ||
-    changes.direct.changed.length > 0
-  );
-}
-
-function hasBreakingSignals(changelog: UpgradeChangelog): boolean {
-  return (
-    changelog.breakingSignals.length > 0 ||
-    changelog.migrationSignals.length > 0
-  );
-}
-
-function classifyVersionDelta(current: string, target: string): VersionDelta {
-  const a = parseVersion(current);
-  const b = parseVersion(target);
-  if (!a || !b) return "unknown";
-  const cmp = compareParsedVersions(a, b);
-  if (cmp > 0) return "downgrade";
-  if (cmp === 0) return "same";
-  if (b.prerelease && !a.prerelease) return "prerelease";
-  if (a.major !== b.major) return "major";
-  if (a.minor !== b.minor) return "minor";
-  if (a.patch !== b.patch) return "patch";
-  return "unknown";
-}
-
-function parseVersion(
-  value: string,
-):
-  | { major: number; minor: number; patch: number; prerelease?: string }
-  | undefined {
-  const match = /^v?(\d+)\.(\d+)\.(\d+)(?:[-+]([^\s]+))?$/i.exec(value);
-  if (!match) return undefined;
-  return {
-    major: Number.parseInt(match[1] ?? "0", 10),
-    minor: Number.parseInt(match[2] ?? "0", 10),
-    patch: Number.parseInt(match[3] ?? "0", 10),
-    prerelease: match[4],
-  };
-}
-
-function compareParsedVersions(
-  a: { major: number; minor: number; patch: number },
-  b: { major: number; minor: number; patch: number },
-): number {
-  return a.major - b.major || a.minor - b.minor || a.patch - b.patch;
-}
-
-async function runWithConcurrency<T, R>(
-  items: readonly T[],
-  concurrency: number,
-  fn: (item: T) => Promise<R>,
-): Promise<R[]> {
-  const results: R[] = [];
-  let next = 0;
-  const workers = Array.from(
-    { length: Math.max(1, Math.min(concurrency, items.length)) },
-    async () => {
-      while (next < items.length) {
-        const index = next++;
-        const item = items[index];
-        if (item !== undefined) results[index] = await fn(item);
-      }
-    },
-  );
-  await Promise.all(workers);
-  return results;
-}
-
-type Captured<T> = { ok: true; value: T } | { ok: false; error: unknown };
-
-async function capture<T>(fn: () => Promise<T>): Promise<Captured<T>> {
-  try {
-    return { ok: true, value: await fn() };
-  } catch (error) {
-    return { ok: false, error };
-  }
-}
-
-function formatCapturedError(error: unknown): string {
-  const mapped = mapPackageIntelligenceError(error);
-  return `${mapped.code}: ${mapped.message}`;
 }
 
 export function formatPackageUpgradeReviewTerminal(
@@ -1294,25 +581,31 @@ function formatTransitiveVulnerabilitySubsection(
 ): string[] {
   if (!transitive) return ["  transitive package advisories: not checked"];
   const lines = [
-    `  transitive package advisories: current affected packages=${transitive.currentAffected}, target affected packages=${transitive.targetAffected}, fixed packages=${transitive.fixedPackageDetails.length}, added packages=${transitive.introducedPackageDetails.length}`,
+    `  transitive package advisories: current affected packages=${transitive.currentAffected}, target affected packages=${transitive.targetAffected}, fixed packages=${transitive.fixedPackageDetailsTotalCount}, added packages=${transitive.introducedPackageDetailsTotalCount}, still affected package details=${transitive.stillAffectedPackageDetailsTotalCount}`,
   ];
   const limit = options.verbose ? Number.POSITIVE_INFINITY : 5;
   appendTransitivePackageLines(
     lines,
     "added affected packages",
     transitive.introducedPackageDetails,
+    transitive.introducedPackageDetailsTotalCount,
+    transitive.introducedPackageDetailsTruncated,
     limit,
   );
   appendTransitivePackageLines(
     lines,
     "still affected packages",
     transitive.stillAffectedPackageDetails,
+    transitive.stillAffectedPackageDetailsTotalCount,
+    transitive.stillAffectedPackageDetailsTruncated,
     limit,
   );
   appendTransitivePackageLines(
     lines,
     "fixed affected packages",
     transitive.fixedPackageDetails,
+    transitive.fixedPackageDetailsTotalCount,
+    transitive.fixedPackageDetailsTruncated,
     limit,
   );
   return lines;
@@ -1322,16 +615,24 @@ function appendTransitivePackageLines(
   lines: string[],
   label: string,
   packages: UpgradeTransitiveVulnerablePackage[],
+  totalCount: number,
+  truncated: boolean,
   limit: number,
 ): void {
-  if (packages.length === 0) return;
+  if (totalCount === 0) return;
   lines.push(`  ${label}:`);
-  for (const pkg of packages.slice(0, limit)) {
+  const visible = packages.slice(0, limit);
+  for (const pkg of visible) {
     lines.push(`    - ${formatTransitivePackage(pkg)}`);
   }
-  const remaining = packages.length - limit;
-  if (remaining > 0)
-    lines.push(`    - ... +${remaining} more with verbose output`);
+  const verboseRemaining = Math.max(0, packages.length - visible.length);
+  if (verboseRemaining > 0)
+    lines.push(`    - ... +${verboseRemaining} more with verbose output`);
+  const backendRemaining = Math.max(0, totalCount - packages.length);
+  if (truncated || backendRemaining > 0)
+    lines.push(
+      `    - ... +${backendRemaining} more not returned by backend page`,
+    );
 }
 
 function formatTransitivePackage(
@@ -1398,6 +699,10 @@ function appendPlainChangelogEntries(
   for (const entry of visibleEntries) {
     lines.push(...formatPlainChangelogEntry(entry));
   }
+}
+
+function changelogEntryKey(entry: UpgradeChangelogEntry): string {
+  return `${entry.version ?? "unknown"}:${entry.publishedAt ?? ""}:${entry.htmlUrl ?? ""}`;
 }
 
 function formatCompatibilitySection(

--- a/packages/mcp/src/tools/package-upgrade-review.test.ts
+++ b/packages/mcp/src/tools/package-upgrade-review.test.ts
@@ -1,34 +1,9 @@
 import { describe, expect, it, mock } from "bun:test";
-import type {
-  DependencyReport,
-  VulnerabilityReport,
-} from "@githits/core-internal";
 import { createMockPackageIntelligenceService } from "../services/test-helpers.js";
 import { createPackageUpgradeReviewTool } from "./package-upgrade-review.js";
 
 function parseText(result: { content: Array<{ text: string }> }): unknown {
   return JSON.parse(result.content[0]?.text ?? "");
-}
-
-function cleanVuln(version: string): VulnerabilityReport {
-  return {
-    package: { name: "express", registry: "NPM", version, deprecated: false },
-    security: {
-      affectedVulnerabilityCount: 0,
-      nonAffectingVulnerabilityCount: 0,
-      allVulnerabilityCount: 0,
-      currentVersionAffected: false,
-      vulnerabilities: [],
-    },
-  };
-}
-
-function deps(version: string): DependencyReport {
-  return {
-    package: { name: "express", registry: "NPM", version, deprecated: false },
-    dependencies: { direct: [] },
-    dependencyGroups: { groups: [] },
-  };
 }
 
 describe("createPackageUpgradeReviewTool", () => {
@@ -54,16 +29,22 @@ describe("createPackageUpgradeReviewTool", () => {
     ]);
   });
 
-  it("calls service methods with normalized single-package params", async () => {
-    const packageVulnerabilities = mock((params) =>
-      Promise.resolve(cleanVuln(params.version ?? "5.0.0")),
-    );
-    const packageUpgradeDependencyProbe = mock((params) =>
-      Promise.resolve(deps(params.version)),
+  it("calls the aggregate service method with normalized single-package params", async () => {
+    const packageUpgradeReview = mock((params) =>
+      Promise.resolve({
+        summary: {
+          total: params.packages.length,
+          withUnknowns: 0,
+          withAddedAdvisories: 0,
+          withBreakingSignals: 0,
+          withDirectDependencyChanges: 0,
+          withTransitiveVulnerabilityAdditions: 0,
+        },
+        reviews: [],
+      }),
     );
     const service = createMockPackageIntelligenceService({
-      packageVulnerabilities: packageVulnerabilities as never,
-      packageUpgradeDependencyProbe: packageUpgradeDependencyProbe as never,
+      packageUpgradeReview: packageUpgradeReview as never,
     });
     const tool = createPackageUpgradeReviewTool(service);
 
@@ -80,38 +61,27 @@ describe("createPackageUpgradeReviewTool", () => {
       {},
     );
 
-    expect(packageVulnerabilities).toHaveBeenCalledTimes(2);
-    expect(packageVulnerabilities.mock.calls[0]?.[0]).toMatchObject({
-      registry: "NPM",
-      packageName: "express",
-      version: "4.18.0",
-      minSeverity: 7,
-      advisoryScope: "AFFECTED",
-    });
-    expect(packageUpgradeDependencyProbe).toHaveBeenCalledTimes(2);
-    expect(packageUpgradeDependencyProbe.mock.calls[0]?.[0]).toMatchObject({
-      registry: "NPM",
-      packageName: "express",
-      version: "4.18.0",
+    expect(packageUpgradeReview).toHaveBeenCalledTimes(1);
+    expect(packageUpgradeReview.mock.calls[0]?.[0]).toMatchObject({
+      packages: [
+        {
+          registry: "NPM",
+          name: "express",
+          currentVersion: "4.18.0",
+          targetVersion: "5.0.0",
+        },
+      ],
       minSeverity: 7,
       includeTransitiveSecurity: true,
       includeDependencyIssues: true,
-      includeDependencyChanges: true,
+      changelogLimit: 20,
     });
   });
 
   it("ignores empty optional mode fields emitted by tool-call harnesses", async () => {
-    const packageVulnerabilities = mock((params) =>
-      Promise.resolve(cleanVuln(params.version ?? "5.0.0")),
+    const tool = createPackageUpgradeReviewTool(
+      createMockPackageIntelligenceService(),
     );
-    const packageUpgradeDependencyProbe = mock((params) =>
-      Promise.resolve(deps(params.version)),
-    );
-    const service = createMockPackageIntelligenceService({
-      packageVulnerabilities: packageVulnerabilities as never,
-      packageUpgradeDependencyProbe: packageUpgradeDependencyProbe as never,
-    });
-    const tool = createPackageUpgradeReviewTool(service);
 
     const single = await tool.handler(
       {
@@ -168,15 +138,9 @@ describe("createPackageUpgradeReviewTool", () => {
   });
 
   it("returns text by default and JSON when requested", async () => {
-    const service = createMockPackageIntelligenceService({
-      packageVulnerabilities: mock((params) =>
-        Promise.resolve(cleanVuln(params.version ?? "5.0.0")),
-      ) as never,
-      packageUpgradeDependencyProbe: mock((params) =>
-        Promise.resolve(deps(params.version)),
-      ) as never,
-    });
-    const tool = createPackageUpgradeReviewTool(service);
+    const tool = createPackageUpgradeReviewTool(
+      createMockPackageIntelligenceService(),
+    );
 
     const text = await tool.handler(
       {

--- a/scripts/mcp-call.ts
+++ b/scripts/mcp-call.ts
@@ -33,6 +33,11 @@ const args = JSON.parse(rawArgs) as Record<string, unknown>;
 const transport = new StdioClientTransport({
   command: "bun",
   args: ["run", "dev", "mcp", "start"],
+  env: Object.fromEntries(
+    Object.entries(process.env).filter(
+      (entry): entry is [string, string] => entry[1] !== undefined,
+    ),
+  ),
 });
 const client = new Client({
   name: "githits-mcp-parity-smoke",

--- a/scripts/mcp-smoke.ts
+++ b/scripts/mcp-smoke.ts
@@ -121,9 +121,17 @@ async function assertUnauthenticatedBehavior(): Promise<void> {
 
 async function main(): Promise<void> {
   await assertUnauthenticatedBehavior();
-  await withMcpClient(undefined, async (client) => {
+  await withMcpClient(inheritedEnv(), async (client) => {
     await runMcpSmoke(createSmokeCaller(client), { logger: console });
   });
+}
+
+function inheritedEnv(): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(process.env).filter(
+      (entry): entry is [string, string] => entry[1] !== undefined,
+    ),
+  );
 }
 
 try {

--- a/src/commands/mcp.test.ts
+++ b/src/commands/mcp.test.ts
@@ -164,7 +164,7 @@ describe("createMcpServer", () => {
     expect(events).toEqual(["start:get_example", "end:get_example"]);
   });
 
-  it("runs one tool execution hook around pkg_upgrade_review despite composed downstream probes", async () => {
+  it("runs one tool execution hook around pkg_upgrade_review aggregate call", async () => {
     const services = createTestServices();
     const traceTool: McpToolExecutionHook = mock(
       async (toolName, runHandler) => {
@@ -195,14 +195,17 @@ describe("createMcpServer", () => {
     expect(result.isError).toBeUndefined();
     expect(traceTool).toHaveBeenCalledTimes(1);
     expect(
-      services.packageIntelligenceService.packageSummary,
+      services.packageIntelligenceService.packageUpgradeReview,
     ).toHaveBeenCalledTimes(1);
     expect(
+      services.packageIntelligenceService.packageSummary,
+    ).not.toHaveBeenCalled();
+    expect(
       services.packageIntelligenceService.packageVulnerabilities,
-    ).toHaveBeenCalledTimes(2);
+    ).not.toHaveBeenCalled();
     expect(
       services.packageIntelligenceService.packageUpgradeDependencyProbe,
-    ).toHaveBeenCalledTimes(2);
+    ).not.toHaveBeenCalled();
   });
 
   it("function providers receive undefined extra deterministically", async () => {

--- a/src/commands/pkg/upgrade-review.test.ts
+++ b/src/commands/pkg/upgrade-review.test.ts
@@ -1,6 +1,16 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it, mock } from "bun:test";
 import { InvalidPackageSpecError } from "@githits/mcp/internal";
-import { parseUpgradeReviewPackageOption } from "./upgrade-review.js";
+import { createMockPackageIntelligenceService } from "../../services/test-helpers.js";
+import {
+  parseUpgradeReviewPackageOption,
+  pkgUpgradeReviewAction,
+} from "./upgrade-review.js";
+
+const originalStdoutWrite = process.stdout.write;
+
+afterEach(() => {
+  process.stdout.write = originalStdoutWrite;
+});
 
 describe("parseUpgradeReviewPackageOption", () => {
   it("accepts shell-safe double-dot package ranges", () => {
@@ -30,5 +40,34 @@ describe("parseUpgradeReviewPackageOption", () => {
     expect(() => parseUpgradeReviewPackageOption("npm:zod@4.3.6-")).toThrow(
       "The shell likely treated '>' as output redirection",
     );
+  });
+
+  it("writes JSON through stdout.write instead of console.log", async () => {
+    let output = "";
+    process.stdout.write = ((chunk: string | Uint8Array) => {
+      output += chunk.toString();
+      return true;
+    }) as typeof process.stdout.write;
+    const consoleLog = mock(() => undefined);
+    const originalConsoleLog = console.log;
+    console.log = consoleLog as typeof console.log;
+    try {
+      await pkgUpgradeReviewAction(
+        "npm:express@5.0.0",
+        { to: "5.2.1", json: true, transitiveSecurity: false },
+        {
+          packageIntelligenceService: createMockPackageIntelligenceService(),
+          codeNavigationUrl: "https://pkgseer.dev",
+          hasValidToken: true,
+          mcpUrl: "https://mcp.githits.com",
+        },
+      );
+    } finally {
+      console.log = originalConsoleLog;
+    }
+
+    expect(consoleLog).not.toHaveBeenCalled();
+    expect(JSON.parse(output).summary.total).toBe(1);
+    expect(output.endsWith("\n")).toBe(true);
   });
 });

--- a/src/commands/pkg/upgrade-review.ts
+++ b/src/commands/pkg/upgrade-review.ts
@@ -66,7 +66,7 @@ export async function pkgUpgradeReviewAction(
     );
 
     if (options.json) {
-      console.log(JSON.stringify(response));
+      process.stdout.write(`${JSON.stringify(response)}\n`);
       return;
     }
     process.stdout.write(

--- a/src/services/test-helpers.ts
+++ b/src/services/test-helpers.ts
@@ -10,6 +10,7 @@ import type {
   PackageDocsList,
   PackageIntelligenceService,
   PackageSummary,
+  PackageUpgradeReviewResponse,
   TokenProvider,
   UnifiedSearchOutcome,
   VulnerabilityReport,
@@ -858,6 +859,76 @@ export const defaultPackageDocResult: PackageDocResult = {
   },
 };
 
+export const defaultPackageUpgradeReviewResponse: PackageUpgradeReviewResponse =
+  {
+    summary: {
+      total: 1,
+      withUnknowns: 0,
+      withAddedAdvisories: 0,
+      withBreakingSignals: 0,
+      withDirectDependencyChanges: 0,
+      withTransitiveVulnerabilityAdditions: 0,
+    },
+    reviews: [
+      {
+        registry: "NPM",
+        name: "express",
+        currentVersion: "4.18.0",
+        targetVersion: "5.0.0",
+        latestVersion: "5.0.0",
+        versionDelta: "MAJOR",
+        security: {
+          current: {
+            version: "4.18.0",
+            affectedCount: 0,
+            nonAffectingCount: 0,
+            allCount: 0,
+            advisories: [],
+          },
+          target: {
+            version: "5.0.0",
+            affectedCount: 0,
+            nonAffectingCount: 0,
+            allCount: 0,
+            advisories: [],
+          },
+          added: [],
+          removed: [],
+          notAddressed: [],
+          fixed: [],
+          introduced: [],
+          unchanged: [],
+        },
+        changelog: {
+          source: "RELEASES",
+          entries: [
+            {
+              version: "5.0.0",
+              bodyPreview: "Major release notes.",
+              headline: "Major release notes.",
+              signals: [],
+            },
+          ],
+          sampledEntries: [],
+          keywordEntries: [],
+          totalKeywordEntries: 0,
+          totalEntries: 1,
+          totalEntriesWithBodies: 1,
+          truncated: false,
+          hasReleaseNoteBodies: true,
+          breakingSignals: [],
+          migrationSignals: [],
+        },
+        compatibility: { peerDependencyChanges: [], notes: [] },
+        dependencyChanges: {
+          direct: { added: [], removed: [], changed: [] },
+          transitive: { added: [], removed: [], changed: [] },
+        },
+        unknowns: [],
+      },
+    ],
+  };
+
 /**
  * Creates a mock PackageIntelligenceService. Defaults resolve to the
  * fully-populated fixtures; override per-test as needed.
@@ -873,6 +944,9 @@ export function createMockPackageIntelligenceService(
     packageDependencies: mock(() => Promise.resolve(defaultDependencyReport)),
     packageUpgradeDependencyProbe: mock(() =>
       Promise.resolve(defaultDependencyReport),
+    ),
+    packageUpgradeReview: mock(() =>
+      Promise.resolve(defaultPackageUpgradeReviewResponse),
     ),
     packageChangelog: mock(() => Promise.resolve(defaultChangelogReport)),
     listPackageDocs: mock(() => Promise.resolve(defaultPackageDocsList)),

--- a/src/tools/package-upgrade-review-parity.test.ts
+++ b/src/tools/package-upgrade-review-parity.test.ts
@@ -11,7 +11,10 @@ import {
   type PkgUpgradeReviewCommandDependencies,
   pkgUpgradeReviewAction,
 } from "../commands/pkg/upgrade-review.js";
-import { createMockPackageIntelligenceService } from "../services/test-helpers.js";
+import {
+  createMockPackageIntelligenceService,
+  defaultPackageUpgradeReviewResponse,
+} from "../services/test-helpers.js";
 import {
   createParityMcpTool,
   isProcessExitSentinel,
@@ -34,23 +37,27 @@ async function cliJson(
   options: Parameters<typeof pkgUpgradeReviewAction>[1] = {},
   deps: PkgUpgradeReviewCommandDependencies = cliDeps(),
 ): Promise<unknown> {
-  const logSpy = spyOn(console, "log").mockImplementation(() => {});
   const errSpy = spyOn(console, "error").mockImplementation(() => {});
   const exitSpy = spyOn(process, "exit").mockImplementation(() => {
     throw new Error("process.exit");
   });
+  const originalStdoutWrite = process.stdout.write;
+  let stdout = "";
+  process.stdout.write = ((chunk: string | Uint8Array) => {
+    stdout += chunk.toString();
+    return true;
+  }) as typeof process.stdout.write;
   try {
     try {
       await pkgUpgradeReviewAction(spec, { ...options, json: true }, deps);
     } catch (error) {
       if (!isProcessExitSentinel(error)) throw error;
     }
-    const fromLog = logSpy.mock.calls[0]?.[0] as string | undefined;
     const fromErr = errSpy.mock.calls[0]?.[0] as string | undefined;
-    const raw = fromLog ?? fromErr;
+    const raw = stdout.trim() || fromErr;
     return raw ? JSON.parse(raw) : undefined;
   } finally {
-    logSpy.mockRestore();
+    process.stdout.write = originalStdoutWrite;
     errSpy.mockRestore();
     exitSpy.mockRestore();
   }
@@ -124,16 +131,30 @@ describe("package_upgrade_review parity", () => {
     expect(cli).toEqual(json);
   });
 
-  it("PARITY-JSON-KEYS: batch per-package unknown CLI === MCP", async () => {
+  it("PARITY-JSON-KEYS: backend unknown evidence CLI === MCP", async () => {
     const service = createMockPackageIntelligenceService({
-      packageVulnerabilities: mock((params) => {
-        if (params.packageName === "zod") {
-          return Promise.reject(new Error("vulnerability lookup failed"));
-        }
-        return createMockPackageIntelligenceService().packageVulnerabilities(
-          params,
-        );
-      }) as never,
+      packageUpgradeReview: mock(() =>
+        Promise.resolve({
+          summary: {
+            total: 2,
+            withUnknowns: 1,
+            withAddedAdvisories: 0,
+            withBreakingSignals: 0,
+            withDirectDependencyChanges: 0,
+            withTransitiveVulnerabilityAdditions: 0,
+          },
+          reviews: [
+            defaultPackageUpgradeReviewResponse.reviews[0]!,
+            {
+              ...defaultPackageUpgradeReviewResponse.reviews[0]!,
+              name: "zod",
+              currentVersion: "4.3.6",
+              targetVersion: "4.4.3",
+              unknowns: ["vulnerability check failed: backend timeout"],
+            },
+          ],
+        }),
+      ) as never,
     });
     const cli = await cliJson(
       undefined,


### PR DESCRIPTION
## Summary
- switch pkg_upgrade_review to the aggregate packageUpgradeReview backend query with no client-side fanout fallback
- preserve CLI/MCP JSON/text parity while normalizing backend enum casing
- expose transitive vulnerability detail page total/truncation metadata and fix large CLI JSON output writes
- pass smoke env through MCP helper scripts and update implementation docs/tests

## Verification
- bun test src/commands/pkg/upgrade-review.test.ts packages/mcp/src/shared/package-upgrade-review-response.test.ts packages/mcp/src/tools/package-upgrade-review.test.ts src/tools/package-upgrade-review-parity.test.ts packages/core-internal/src/services/package-intelligence-service.test.ts
- bun run typecheck
- bun run format:check
- bun run lint
- bun run build
- bun run smoke:cli against production defaults
- bun run smoke:mcp against production defaults
- production manual checks for pkg upgrade-review flags, npx githits@0.5.0 comparison, and support-signal backend fix

## Release Notes
- Changes both root CLI behavior and MCP tool behavior; @githits/mcp should be bumped with the root package when releasing.
- Public JSON adds transitive detail page completeness fields (*TotalCount / *Truncated).
