### PR TITLE
chore: prepare CLI and MCP releases

### DIFF
--- a/.agents/skills/githits-release/SKILL.md
+++ b/.agents/skills/githits-release/SKILL.md
@@ -16,6 +16,7 @@ Use this skill for GitHits release work, version-bump PRs, release-readiness rev
 - Root `githits` and `@githits/mcp` have separate release flows. Bump both only when both surfaces changed.
 - For root `githits` releases, bump `package.json`, `.plugin/plugin.json`, `.claude-plugin/plugin.json`, `plugins/claude/.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, and `gemini-extension.json` together.
 - For `@githits/mcp` releases, bump `packages/mcp/package.json` only when MCP package API, tool behavior, instructions, schemas, MCP auth/error behavior, or remote-server-facing public types changed.
+- For coordinated CLI and MCP releases, keep the MCP minor aligned with the CLI minor for discoverability. Start the first MCP release for a CLI minor at `X.Y.0`, then bump MCP patch for later MCP-package-visible changes in that CLI minor. Do not bump MCP for CLI-only changes.
 - Run or rely on package-scoped version checks to verify root plugin versions stay aligned and MCP versions are intentionally independent.
 - Collect a changelog of user-visible changes before release. Include CLI behavior, MCP tool behavior, Agent Skills, auth/error UX, output format changes, and agent-facing instruction changes.
 - Review public skills before signoff whenever user-facing CLI/MCP behavior changed. After the behavior is released or included in the same release branch, update `skills/githits-code/SKILL.md`, `skills/githits-package/SKILL.md`, and their references so `skills.sh` users get instructions that match the released surface.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "GitHits plugins for Claude Code - code examples from global open source",
-    "version": "0.5.0"
+    "version": "0.5.1"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Code examples from global open source for developers and AI assistants",
   "author": {
     "name": "GitHits"

--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Code examples from global open source for developers and AI assistants",
   "author": {
     "name": "GitHits"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,7 @@ See `docs/guidelines/TESTING.md` for comprehensive patterns.
 - Root `src/**` is still the published `githits` CLI implementation until the CLI package move completes. It owns Commander commands, local auth storage, browser login, init/setup flows, local stdio MCP startup, and plugin/assistant packaging assets.
 - `packages/core-internal` is private source. It owns transport-neutral service clients, service interfaces, shared request/header/telemetry primitives, neutral service errors, PKCE helpers, and `TokenProvider`. Never publish or leak `@githits/core-internal` into public artifacts.
 - `packages/mcp` is the public `@githits/mcp` package. Its public tool/server API is `packages/mcp/src/index.ts`: transport-neutral MCP server creation, tool registration, descriptors, instructions, request-scoped service provider types, and MCP service types. Its public runtime/client API is `packages/mcp/src/client.ts`, exported as `@githits/mcp/client`, for remote MCP servers that need concrete service implementations and token/header/config helpers.
+- `@githits/mcp/smoke-test` is a public validation helper entrypoint for remote MCP servers. It exports smoke assertions and `runMcpSmoke()` without depending on local CLI startup.
 - `@githits/mcp/internal` is a workspace-only alias for root CLI transition helpers. External packages and the future remote MCP server repo must never import it. If remote server work needs something internal, promote the smallest stable API through `@githits/mcp` instead.
 - Public package artifacts for both root `githits` and `@githits/mcp` must not contain `@githits/core-internal`, `workspace:*`, `@githits/mcp/internal`, or private source aliases in JS, declarations, or manifests.
 
@@ -111,6 +112,7 @@ See `docs/guidelines/TESTING.md` for comprehensive patterns.
 - `githits` and `@githits/mcp` have separate release flows. They may be bumped together when both surfaces changed, but CLI-only changes should not bump `@githits/mcp`.
 - Root `githits` release versions must stay aligned with plugin/assistant manifests: `.plugin/plugin.json`, `.claude-plugin/plugin.json`, `plugins/claude/.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, and `gemini-extension.json`.
 - `@githits/mcp` release versions live in `packages/mcp/package.json` and should change only for MCP package API, tool behavior, MCP instructions, schemas, MCP auth/error behavior, or remote-server-facing public type changes.
+- For coordinated CLI and MCP releases, keep the MCP minor aligned with the CLI minor for discoverability. The first MCP release for a CLI minor starts at `X.Y.0`; later MCP-package-visible changes in that CLI minor bump the MCP patch.
 - Validate package behavior from outside root path aliases. Repo-local imports can hide package export-map or declaration problems.
 
 ### Common Pitfalls

--- a/bun.lock
+++ b/bun.lock
@@ -40,7 +40,7 @@
     },
     "packages/mcp": {
       "name": "@githits/mcp",
-      "version": "0.4.15",
+      "version": "0.5.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "^4.4.3",

--- a/docs/guidelines/REVIEW_GUIDELINES.md
+++ b/docs/guidelines/REVIEW_GUIDELINES.md
@@ -30,7 +30,7 @@ Checklist for reviewing code changes in githits-cli.
 - [ ] JSDoc comments for public functions
 - [ ] Comments explain "why" not just "what"
 - [ ] Implementation docs updated if needed
-- [ ] CLAUDE.md updated if patterns change
+- [ ] `AGENTS.md` updated if agent-facing patterns change
 
 ## Build & Lint
 

--- a/docs/implementation/init-setup-output.md
+++ b/docs/implementation/init-setup-output.md
@@ -35,8 +35,10 @@ Install and uninstall share one renderer and read consistently.
 - `src/commands/init/setup-handlers.ts` — executors emit the change data:
   - `executeConfigFileSetup`: `created` when the file was absent, `updated` when
     it pre-existed (even if empty), `unchanged` when already configured.
-  - `executeCliSetup`: one change per command (`ran` / `unchanged`), so
-    multi-command setups (e.g. Claude Code) report each step.
+  - `executeCliSetup`: one change per command (`ran` / `unchanged`), preserving
+    the full structured result for JSON output. Text output hides unchanged
+    command rows unless every command was unnecessary; then it renders the
+    read-only check command as `checked via <command>` when one exists.
   - `executeCompositeSetup`: concatenates executed-step changes with
     synthesized `unchanged` changes for pre-skipped steps (so Pi shows all
     sub-steps).
@@ -75,8 +77,10 @@ on its own rendering path.
 
 ## Conventions
 
-- Config-file tools show a path; CLI-configured tools (Claude Code, Codex,
-  Gemini at user scope) show the command — never a fabricated path. In project
-  scope Claude Code and Codex are config-file and do show paths.
+- Config-file tools show a path. CLI-configured tools (Claude Code, Codex,
+  Gemini at user scope) show commands that actually ran, or `checked via
+  <command>` for already-configured rows when a read-only check command proved
+  no setup command was needed — never a fabricated path. In project scope Claude
+  Code and Codex are config-file and do show paths.
 - `format: json` / `--json` carry the structured `changes`; the friendly
   trailing block is text-only.

--- a/docs/implementation/mcp-cli-parity.md
+++ b/docs/implementation/mcp-cli-parity.md
@@ -10,15 +10,16 @@ default to compact `text-v1` where available, while CLI has human
 terminal output and `--json`. Structured parity is enforced through CLI
 `--json` and MCP `format: "json"`.
 
-Live smoke coverage lives in `scripts/mcp-smoke.ts` and
-`scripts/cli-smoke.ts`, run with `bun run smoke:mcp` and
-`bun run smoke:cli`. These suites intentionally avoid exact-output
-snapshots because backend ranking and release metadata can change. They
-assert durable UX invariants instead: server/command startup, registered
-tools, auth handling, compact default text, parseable JSON opt-in,
-MCP-native hints, CLI terminal affordances, and JSON envelope shape. When
-adding or changing a dual-surface tool, update both smoke scripts if the
-covered live UX contract changes.
+Live smoke coverage runs through `scripts/mcp-smoke.ts` and
+`scripts/cli-smoke.ts` via `bun run smoke:mcp` and `bun run smoke:cli`. The MCP
+smoke invariants live in `packages/mcp/src/smoke-test.ts` and are exported as
+`@githits/mcp/smoke-test` so remote MCP servers can reuse the same validation.
+These suites intentionally avoid exact-output snapshots because backend ranking
+and release metadata can change. They assert durable UX invariants instead:
+server/command startup, registered tools, auth handling, compact default text,
+parseable JSON opt-in, MCP-native hints, CLI terminal affordances, and JSON
+envelope shape. When adding or changing a dual-surface tool, update the shared
+MCP smoke runner and CLI smoke script if the covered live UX contract changes.
 
 The dual-surface tools today are:
 

--- a/docs/implementation/workspace-packages.md
+++ b/docs/implementation/workspace-packages.md
@@ -34,12 +34,15 @@ manifest move is complete.
 ## Public API Boundaries
 
 - External consumers, including the future remote MCP server repo, must import
-  only from `@githits/mcp`, `@githits/mcp/client`, and
-  `@githits/mcp/package.json`.
+  only from `@githits/mcp`, `@githits/mcp/client`,
+  `@githits/mcp/smoke-test`, and `@githits/mcp/package.json`.
 - `@githits/mcp/client` is the public runtime/client entry for remote MCP server
   composition. It re-exports bundled service implementations, token/header
   helpers, URL/config helpers, telemetry helpers, and registry helpers without
   publishing `@githits/core-internal`.
+- `@githits/mcp/smoke-test` is the public validation-helper entry for remote MCP
+  servers. It re-exports the shared smoke runner and assertions used by the
+  local CLI smoke script without requiring local stdio startup.
 - `@githits/mcp/internal` is not a package export. It exists only as a root
   workspace TypeScript alias for CLI transition code and internal tests.
 - If remote MCP server setup needs a helper that currently lives behind
@@ -53,6 +56,10 @@ manifest move is complete.
 
 - Root `githits` and public `@githits/mcp` releases are independent. Coordinated
   releases are allowed, but version equality is not required.
+- When both are released together, keep the MCP minor aligned with the CLI minor
+  for discoverability. The first MCP release for a CLI minor starts at
+  `X.Y.0`; further MCP-package-visible changes in that CLI minor bump the MCP
+  patch. Do not bump MCP just for CLI-only changes.
 - CLI-only changes should update only the root `githits` version and its
   plugin/assistant manifests.
 - `@githits/mcp` should bump only when its public API, tool behavior, MCP

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Code examples from global open source for developers and AI assistants.",
   "mcpServers": {
     "githits": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "githits",
   "description": "CLI companion for GitHits - code examples from global open source for developers and AI assistants",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "type": "module",
   "workspaces": [
     "packages/*"

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -11,9 +11,10 @@ This package exposes transport-neutral helpers for servers that want the GitHits
 - `getMcpToolDescriptors()` returns static tool metadata without requiring concrete services.
 - `buildMcpInstructions(options?)` builds the GitHits MCP instruction block.
 - `@githits/mcp/client` exports concrete GitHits service implementations, static token providers, URL/config helpers, request-header helpers, telemetry helpers, and registry helpers for remote MCP servers.
+- `@githits/mcp/smoke-test` exports reusable smoke assertions and `runMcpSmoke()` for remote MCP server validation.
 
-The package expects callers to provide service implementations through `McpToolServices` or a request-scoped `McpToolServicesProvider`.
+The package expects callers to provide service implementations through `McpToolServices` or a request-scoped `McpToolServicesProvider`. Servers can pass `traceTool` to `createMcpServer()` or `registerMcpTools()` to wrap public tool execution for instrumentation without receiving arguments or auth data.
 
-Only imports from `@githits/mcp`, `@githits/mcp/client`, and `@githits/mcp/package.json` are public. The workspace alias `@githits/mcp/internal` is not exported, is not supported for external consumers, and must not be used by remote MCP server implementations.
+Only imports from `@githits/mcp`, `@githits/mcp/client`, `@githits/mcp/smoke-test`, and `@githits/mcp/package.json` are public. The workspace alias `@githits/mcp/internal` is not exported, is not supported for external consumers, and must not be used by remote MCP server implementations.
 
 Remote MCP servers should provide request-scoped services through `createMcpServer()` and keep transport, auth/session handling, deployment config, and observability outside this package.

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@githits/mcp",
-  "version": "0.4.15",
+  "version": "0.5.0",
   "description": "Reusable MCP server APIs and tools for GitHits",
   "type": "module",
   "files": [

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Code examples from global open source for developers and AI assistants",
   "author": {
     "name": "GitHits"

--- a/skills/githits-package/SKILL.md
+++ b/skills/githits-package/SKILL.md
@@ -52,7 +52,7 @@ githits pkg upgrade-review --package npm:zod@4.3.6..4.4.3 --package npm:lint-sta
 - Need security status for a specific installed version: use `githits pkg vulns <registry:name@version>`.
 - Need historical advisories that do not affect the inspected version: use `pkg vulns --scope non_affecting`; use `--scope all` for affected plus historical rows.
 - Need dependency footprint: start with `pkg deps`; add `--lifecycle all` for non-runtime groups and `--depth <n>` for aggregate transitive graph data.
-- Need upgrade evidence for dependency updates, outdated package bumps, or lockfile changes: prefer `pkg upgrade-review` because it compares current vs target vulnerabilities, changelog range evidence, deprecation metadata, peer changes, dependency changes, and optional transitive evidence. It reports facts only; you still own the final assessment.
+- Need upgrade evidence for dependency updates, outdated package bumps, or lockfile changes: prefer `pkg upgrade-review` because it compares current vs target vulnerabilities, changelog range evidence, deprecation metadata, peer changes, dependency changes, and transitive security evidence by default. It reports facts only; you still own the final assessment.
 - Need release notes without a current-to-target comparison: use `pkg changelog`; use `--from`/`--to` for ranges and `--no-body` for compact timelines.
 
 ## Gotchas

--- a/skills/githits-package/references/package.md
+++ b/skills/githits-package/references/package.md
@@ -36,7 +36,7 @@ Do not use `registry:name@version` for changelog. Use `--to <version>`.
 
 Batch form: `githits pkg upgrade-review --package <registry:name@current>..<target> --package <registry:name@current>..<target>`.
 
-Evidence includes current and target direct vulnerabilities, changelog range evidence, target deprecation metadata, peer dependency changes, dependency changes, and optional transitive security or dependency-issue diffs.
+Evidence includes current and target direct vulnerabilities, changelog range evidence, target deprecation metadata, peer dependency changes, dependency changes, and transitive security by default. Dependency-issue diffs are opt-in with `--dependency-issues`.
 
 Flags: `--package <spec>`, `--to <version>`, `--no-transitive-security`, `--dependency-issues`, `--min-severity low|medium|high|critical`, `--verbose`, `--json`.
 


### PR DESCRIPTION
## Summary
- bump root githits release manifests to 0.5.1
- bump @githits/mcp to 0.5.0 and document coordinated CLI/MCP versioning
- update MCP package docs, release skill guidance, implementation docs, and package skill instructions for recent changes

## Verification
- bun run build
- bun test
- bun run validate:packages:mcp-publish
- bun run smoke:mcp
- bun run smoke:cli
- focused pkg_upgrade_review unit/parity/live checks