### PR TITLE
fix: skip published MCP release tags

### DIFF
--- a/.github/workflows/mcp-release.yml
+++ b/.github/workflows/mcp-release.yml
@@ -129,13 +129,21 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
+          if npm view "@githits/mcp@$VERSION" version >/dev/null 2>&1; then
+            NPM_PUBLISHED=true
+            echo "npm_published=true" >> "$GITHUB_OUTPUT"
+          else
+            NPM_PUBLISHED=false
+            echo "npm_published=false" >> "$GITHUB_OUTPUT"
+          fi
+
           TAG_EXISTS=false
           TAG_REF="refs/tags/$TAG"
           if git rev-parse --verify "$TAG_REF^{commit}" >/dev/null 2>&1; then
             TAG_EXISTS=true
             TAG_COMMIT=$(git rev-parse "$TAG_REF^{commit}")
             HEAD_COMMIT=$(git rev-parse HEAD)
-            if [ "$TAG_COMMIT" != "$HEAD_COMMIT" ]; then
+            if [ "$NPM_PUBLISHED" != "true" ] && [ "$TAG_COMMIT" != "$HEAD_COMMIT" ]; then
               echo "::error::Existing tag $TAG points to $TAG_COMMIT, not HEAD $HEAD_COMMIT"
               exit 1
             fi
@@ -150,14 +158,11 @@ jobs:
             echo "release_exists=false" >> "$GITHUB_OUTPUT"
           fi
 
-          if npm view "@githits/mcp@$VERSION" version >/dev/null 2>&1; then
+          if [ "$NPM_PUBLISHED" = "true" ]; then
             if [ "$TAG_EXISTS" != "true" ]; then
               echo "::error::@githits/mcp@$VERSION is already published, but $TAG is missing. Refusing to mint an unverifiable release tag."
               exit 1
             fi
-            echo "npm_published=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "npm_published=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Create MCP git tag

--- a/src/package-release-boundaries.test.ts
+++ b/src/package-release-boundaries.test.ts
@@ -70,10 +70,22 @@ describe("package release boundaries", () => {
     const publishIndex = workflow.indexOf(
       "- name: Publish @githits/mcp to npm",
     );
+    const npmPublishedCheckIndex = workflow.indexOf(
+      'if npm view "@githits/mcp@$VERSION" version',
+    );
+    const tagHeadCheckIndex = workflow.indexOf(
+      "Existing tag $TAG points to $TAG_COMMIT, not HEAD $HEAD_COMMIT",
+    );
 
     expect(workflow).toContain('TAG_REF="refs/tags/$TAG"');
     expect(workflow).toContain('git rev-parse --verify "$TAG_REF^{commit}"');
+    expect(workflow).toContain(
+      'if [ "$NPM_PUBLISHED" != "true" ] && [ "$TAG_COMMIT" != "$HEAD_COMMIT" ]; then',
+    );
     expect(workflow).toContain('git push origin "refs/tags/$TAG"');
+    expect(npmPublishedCheckIndex).toBeGreaterThan(-1);
+    expect(tagHeadCheckIndex).toBeGreaterThan(-1);
+    expect(npmPublishedCheckIndex).toBeLessThan(tagHeadCheckIndex);
     expect(createTagIndex).toBeGreaterThan(-1);
     expect(publishIndex).toBeGreaterThan(-1);
     expect(createTagIndex).toBeLessThan(publishIndex);


### PR DESCRIPTION
## Summary
- check whether @githits/mcp@VERSION is already published before enforcing that mcp-vVERSION points at HEAD
- keep the tag-to-HEAD guard for unpublished MCP versions that could publish from the workflow
- add a release-boundary regression assertion for the guard ordering and condition

## Tests
- bun test src/package-release-boundaries.test.ts
- bunx biome format src/package-release-boundaries.test.ts .github/workflows/mcp-release.yml
- pre-commit hook: bun run typecheck