### PR TITLE
fix: surface unresolved repo ref suggestions

### DIFF
--- a/packages/core-internal/src/services/code-navigation-service.test.ts
+++ b/packages/core-internal/src/services/code-navigation-service.test.ts
@@ -12,6 +12,7 @@ import {
   CodeNavigationBackendError,
   CodeNavigationFileNotFoundError,
   CodeNavigationIndexingError,
+  CodeNavigationRefNotFoundError,
   CodeNavigationServiceImpl,
 } from "./code-navigation-service.js";
 import { createMockTokenProvider } from "./test-helpers.js";
@@ -861,6 +862,57 @@ describe("CodeNavigationServiceImpl", () => {
       expect((error as CodeNavigationBackendError).graphqlCode).toBe(
         "GREP_FILE_TOO_LARGE",
       );
+    }
+  });
+
+  it("classifies GraphQL REF_NOT_FOUND with available ref suggestions", async () => {
+    mockFetch(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            errors: [
+              {
+                message:
+                  "Repository ref cannot be resolved for openai/codex@1.2.3. Did you mean codex@1.2.3, v1.2.3?",
+                extensions: {
+                  code: "REF_NOT_FOUND",
+                  retryable: false,
+                  repo_url: "https://github.com/openai/codex",
+                  git_ref: "1.2.3",
+                  available_refs: [
+                    { ref: "codex@1.2.3", version: null },
+                    { ref: "v1.2.3", version: null },
+                  ],
+                },
+              },
+            ],
+          }),
+          { status: 200 },
+        ),
+      ),
+    );
+    const service = new CodeNavigationServiceImpl(
+      BASE_URL,
+      createMockTokenProvider(),
+    );
+
+    try {
+      await service.search({
+        targets: [
+          { repoUrl: "https://github.com/openai/codex", gitRef: "1.2.3" },
+        ],
+        query: "ThreadCompactStartParams",
+      });
+      throw new Error("expected REF_NOT_FOUND");
+    } catch (error) {
+      expect(error).toBeInstanceOf(CodeNavigationRefNotFoundError);
+      const typed = error as CodeNavigationRefNotFoundError;
+      expect(typed.repoUrl).toBe("https://github.com/openai/codex");
+      expect(typed.requestedRef).toBe("1.2.3");
+      expect(typed.availableRefs).toEqual([
+        { ref: "codex@1.2.3", version: undefined },
+        { ref: "v1.2.3", version: undefined },
+      ]);
     }
   });
 

--- a/packages/core-internal/src/services/code-navigation-service.ts
+++ b/packages/core-internal/src/services/code-navigation-service.ts
@@ -570,6 +570,23 @@ export class CodeNavigationVersionNotFoundError extends Error {
 }
 
 /**
+ * Raised when a repository target exists but the requested git ref does
+ * not resolve. Carries backend-provided ref suggestions for callers to
+ * surface as "did you mean" recovery hints.
+ */
+export class CodeNavigationRefNotFoundError extends Error {
+  constructor(
+    message: string,
+    public readonly repoUrl: string | undefined,
+    public readonly requestedRef: string | undefined,
+    public readonly availableRefs: AvailableRef[] | undefined,
+  ) {
+    super(message);
+    this.name = "CodeNavigationRefNotFoundError";
+  }
+}
+
+/**
  * Raised when the caller submitted invalid input that the backend
  * rejected with `VALIDATION_ERROR` (e.g. query too long). Treated as
  * a client error (non-retryable, INVALID_ARGUMENT on the mapped
@@ -1930,6 +1947,22 @@ export class CodeNavigationServiceImpl implements CodeNavigationService {
             ? extensions.latest_indexed
             : undefined,
           parseAvailableVersions(extensions),
+        );
+
+      case "REF_NOT_FOUND":
+        return new CodeNavigationRefNotFoundError(
+          message,
+          typeof extensions?.repo_url === "string"
+            ? extensions.repo_url
+            : typeof extensions?.repoUrl === "string"
+              ? extensions.repoUrl
+              : undefined,
+          typeof extensions?.git_ref === "string"
+            ? extensions.git_ref
+            : typeof extensions?.gitRef === "string"
+              ? extensions.gitRef
+              : undefined,
+          parseAvailableRefs(extensions),
         );
 
       case "NOT_FOUND":

--- a/packages/mcp/src/shared/code-navigation-error-map.test.ts
+++ b/packages/mcp/src/shared/code-navigation-error-map.test.ts
@@ -9,6 +9,7 @@ import {
   CodeNavigationGraphQLError,
   CodeNavigationIndexingError,
   CodeNavigationNetworkError,
+  CodeNavigationRefNotFoundError,
   CodeNavigationTargetNotFoundError,
   CodeNavigationUnresolvableError,
   CodeNavigationValidationError,
@@ -96,6 +97,38 @@ describe("mapCodeNavigationError", () => {
         ],
       },
     });
+  });
+
+  it("classifies CodeNavigationRefNotFoundError as REF_NOT_FOUND with suggestions", () => {
+    const err = new CodeNavigationRefNotFoundError(
+      "Repository ref cannot be resolved for openai/codex@1.2.3.",
+      "https://github.com/openai/codex",
+      "1.2.3",
+      [{ ref: "codex@1.2.3" }, { ref: "v1.2.3" }],
+    );
+    expect(mapCodeNavigationError(err)).toEqual({
+      code: "REF_NOT_FOUND",
+      message:
+        "Repository ref cannot be resolved for openai/codex@1.2.3. Did you mean codex@1.2.3, v1.2.3?",
+      retryable: false,
+      details: {
+        repoUrl: "https://github.com/openai/codex",
+        requestedRef: "1.2.3",
+        availableRefs: [{ ref: "codex@1.2.3" }, { ref: "v1.2.3" }],
+      },
+    });
+  });
+
+  it("does not duplicate backend REF_NOT_FOUND suggestions", () => {
+    const err = new CodeNavigationRefNotFoundError(
+      "Repository ref cannot be resolved. Did you mean v1.2.3?",
+      undefined,
+      undefined,
+      [{ ref: "v1.2.3" }],
+    );
+    expect(mapCodeNavigationError(err).message).toBe(
+      "Repository ref cannot be resolved. Did you mean v1.2.3?",
+    );
   });
 
   it("classifies CodeNavigationIndexingError as INDEXING with details", () => {
@@ -376,6 +409,7 @@ describe("mapCodeNavigationError debug instrumentation", () => {
       new CodeNavigationTargetNotFoundError("x"),
       new CodeNavigationFileNotFoundError("x", "some/path"),
       new CodeNavigationIndexingError("x"),
+      new CodeNavigationRefNotFoundError("x", undefined, undefined, undefined),
       new CodeNavigationUnresolvableError("x"),
       new CodeNavigationAccessError("x"),
       new AuthenticationError("x"),

--- a/packages/mcp/src/shared/code-navigation-error-map.ts
+++ b/packages/mcp/src/shared/code-navigation-error-map.ts
@@ -12,6 +12,7 @@ import {
   CodeNavigationGraphQLError,
   CodeNavigationIndexingError,
   CodeNavigationNetworkError,
+  CodeNavigationRefNotFoundError,
   CodeNavigationTargetNotFoundError,
   CodeNavigationUnresolvableError,
   CodeNavigationValidationError,
@@ -58,6 +59,10 @@ export interface MappedErrorDetails {
   requestedVersion?: string;
   /** Fully-qualified package identifier (for `VERSION_NOT_FOUND`). */
   package?: string;
+  /** Repository URL for `REF_NOT_FOUND`. */
+  repoUrl?: string;
+  /** Git ref the caller asked for (for `REF_NOT_FOUND`). */
+  requestedRef?: string;
   /** The file path the caller asked for (for `FILE_NOT_FOUND`). */
   filePath?: string;
   /** Installed CLI version when an update is required. */
@@ -139,6 +144,20 @@ function classify(error: unknown): MappedError {
       details: error.availableVersions
         ? { availableVersions: error.availableVersions }
         : undefined,
+    };
+  }
+  if (error instanceof CodeNavigationRefNotFoundError) {
+    const details: MappedErrorDetails = {};
+    if (error.repoUrl) details.repoUrl = error.repoUrl;
+    if (error.requestedRef) details.requestedRef = error.requestedRef;
+    if (error.availableRefs && error.availableRefs.length > 0) {
+      details.availableRefs = error.availableRefs;
+    }
+    return {
+      code: "REF_NOT_FOUND",
+      message: addRefSuggestions(error.message, error.availableRefs),
+      retryable: false,
+      details: Object.keys(details).length > 0 ? details : undefined,
     };
   }
   if (error instanceof CodeNavigationFileNotFoundError) {
@@ -291,6 +310,20 @@ function classifyBackendError(error: CodeNavigationBackendError): MappedError {
     default:
       return build("BACKEND_ERROR", false);
   }
+}
+
+function addRefSuggestions(
+  message: string,
+  refs: AvailableRef[] | undefined,
+): string {
+  if (!refs || refs.length === 0 || /did you mean/i.test(message)) {
+    return message;
+  }
+  const suggestions = refs
+    .slice(0, 5)
+    .map((entry) => entry.ref)
+    .join(", ");
+  return `${message} Did you mean ${suggestions}?`;
 }
 
 /**

--- a/packages/mcp/src/shared/unified-search-response.test.ts
+++ b/packages/mcp/src/shared/unified-search-response.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "bun:test";
-import type {
-  UnifiedSearchOutcome,
-  UnifiedSearchParams,
+import {
+  CodeNavigationRefNotFoundError,
+  type UnifiedSearchOutcome,
+  type UnifiedSearchParams,
 } from "@githits/core-internal";
 import { defaultUnifiedSearchOutcome } from "../services/test-helpers.js";
 import {
@@ -1003,6 +1004,29 @@ describe("buildUnifiedSearchErrorPayload", () => {
       error: "boom",
       code: "UNKNOWN",
       retryable: false,
+    });
+  });
+
+  it("includes REF_NOT_FOUND ref suggestions in message and details", () => {
+    const payload = buildUnifiedSearchErrorPayload(
+      new CodeNavigationRefNotFoundError(
+        "Repository ref cannot be resolved for openai/codex@1.2.3.",
+        "https://github.com/openai/codex",
+        "1.2.3",
+        [{ ref: "codex@1.2.3" }, { ref: "v1.2.3" }],
+      ),
+    );
+
+    expect(payload).toEqual({
+      error:
+        "Repository ref cannot be resolved for openai/codex@1.2.3. Did you mean codex@1.2.3, v1.2.3?",
+      code: "REF_NOT_FOUND",
+      retryable: false,
+      details: {
+        repoUrl: "https://github.com/openai/codex",
+        requestedRef: "1.2.3",
+        availableRefs: [{ ref: "codex@1.2.3" }, { ref: "v1.2.3" }],
+      },
     });
   });
 });


### PR DESCRIPTION
## Summary
- parse REF_NOT_FOUND available_refs from code-navigation GraphQL error extensions
- expose repoUrl, requestedRef, and availableRefs in CLI/MCP error details
- append did-you-mean text only when the backend message does not already include suggestions

## Verification
- code reviewer: no findings
- bun test packages/core-internal/src/services/code-navigation-service.test.ts packages/mcp/src/shared/code-navigation-error-map.test.ts packages/mcp/src/shared/unified-search-response.test.ts
- bun run build
- bun test
- dev CLI JSON: github:facebook/react#19.2.0 returns REF_NOT_FOUND with details.availableRefs
- dev MCP JSON/text: github:facebook/react#19.2.0 surfaces v19.2.0 suggestion

## Notes
- github:openai/codex#1.2.3 currently returns REF_NOT_FOUND without availableRefs because the dev backend does not suggest refs for that case yet; the client now handles future available_refs coverage without another change.