### PR TITLE
chore: prepare 0.5.2 release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "GitHits plugins for Claude Code - code examples from global open source",
-    "version": "0.5.1"
+    "version": "0.5.2"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Code examples from global open source for developers and AI assistants",
   "author": {
     "name": "GitHits"

--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Code examples from global open source for developers and AI assistants",
   "author": {
     "name": "GitHits"

--- a/bun.lock
+++ b/bun.lock
@@ -40,7 +40,7 @@
     },
     "packages/mcp": {
       "name": "@githits/mcp",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "^4.4.3",

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Code examples from global open source for developers and AI assistants.",
   "mcpServers": {
     "githits": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "githits",
   "description": "CLI companion for GitHits - code examples from global open source for developers and AI assistants",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "type": "module",
   "workspaces": [
     "packages/*"

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@githits/mcp",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Reusable MCP server APIs and tools for GitHits",
   "type": "module",
   "files": [

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Code examples from global open source for developers and AI assistants",
   "author": {
     "name": "GitHits"


### PR DESCRIPTION
## Summary

- Bump root `githits` package and plugin/assistant manifests to `0.5.2`.
- Bump `@githits/mcp` to `0.5.1` because the release range includes MCP-visible code navigation behavior changes.
- Leave documentation unchanged because existing implementation docs and public skill references already cover the shipped behavior.

## User-facing changes

- Repository targets in search/code output now canonicalize as `github:owner/repo#ref`, preserving refs that contain `@`.
- Missing repository refs now surface suggested refs in CLI/MCP error details when the backend provides them.
- Code-navigation output separates immediately queryable refs from fuzzy suggested refs.
- MCP package publishing now runs automatically after `Main` succeeds and skips cleanly when the MCP version is already published.

## Verification

- `bun test`
- `bun run build`
- `bun run validate:packages`
- `bun run smoke:cli`
- `bun run smoke:mcp`
- `git diff --check`
- `npm view githits@0.5.2 version` returned unpublished 404
- `npm view @githits/mcp@0.5.1 version` returned unpublished 404
