### PR TITLE
fix: surface indexing duration estimates

### DIFF
--- a/packages/core-internal/src/services/code-navigation-service.test.ts
+++ b/packages/core-internal/src/services/code-navigation-service.test.ts
@@ -210,6 +210,13 @@ describe("CodeNavigationServiceImpl", () => {
                 codeIndexState: "INDEXING",
                 indexingRef: "ref_xyz",
                 availableVersions: [{ version: "4.21.0", ref: "v4.21.0" }],
+                indexingEstimate: {
+                  lowerSeconds: 7,
+                  upperSeconds: 19,
+                  elapsedSeconds: 12,
+                  sampleCount: 9,
+                  source: "same_repository_refs",
+                },
                 targetResolution: {
                   requested: {
                     repoUrl: "https://github.com/expressjs/express",
@@ -245,6 +252,20 @@ describe("CodeNavigationServiceImpl", () => {
       expect(error).toBeInstanceOf(CodeNavigationIndexingError);
       const typed = error as CodeNavigationIndexingError;
       expect(typed.indexingRef).toBe("ref_xyz");
+      expect(typed.message).toContain("Running for 12 seconds.");
+      expect(typed.message).toContain(
+        "Similar refs usually index in 7 to 19 seconds.",
+      );
+      expect(typed.message).not.toContain(
+        "Indexing usually completes within 30 seconds",
+      );
+      expect(typed.indexingEstimate).toEqual({
+        lowerSeconds: 7,
+        upperSeconds: 19,
+        elapsedSeconds: 12,
+        sampleCount: 9,
+        source: "same_repository_refs",
+      });
       expect(typed.availableVersions).toEqual([
         { version: "4.21.0", ref: "v4.21.0" },
       ]);
@@ -417,7 +438,7 @@ describe("CodeNavigationServiceImpl", () => {
   // ------------------------------------------------------------------
 
   it("normalises a successful fetchCodeContext response", async () => {
-    mockFetch(() =>
+    const fn = mockFetch(() =>
       Promise.resolve(
         new Response(
           JSON.stringify({
@@ -449,6 +470,9 @@ describe("CodeNavigationServiceImpl", () => {
     expect(result.filePath).toBe("src/hello.js");
     expect(result.content).toContain("console.log");
     expect(result.isBinary).toBe(false);
+    const [, init] = fn.mock.calls[0] as unknown as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body.query).toContain("indexingEstimate");
   });
 
   it("preserves isBinary + null content from fetchCodeContext", async () => {
@@ -894,6 +918,62 @@ describe("CodeNavigationServiceImpl", () => {
     }
   });
 
+  it("formats PACKAGE_INDEXING estimates from structured extensions", async () => {
+    mockFetch(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            errors: [
+              {
+                message: "Target is indexing",
+                extensions: {
+                  code: "PACKAGE_INDEXING",
+                  indexing_ref: "idx-error",
+                  hint: "Backend says this ref is queued for indexing.",
+                  indexingEstimate: {
+                    lower_seconds: 1,
+                    upper_seconds: 1,
+                    elapsed_seconds: 3,
+                    sample_count: 4,
+                    source: "same_repository_refs",
+                  },
+                },
+              },
+            ],
+          }),
+          { status: 200 },
+        ),
+      ),
+    );
+    const service = new CodeNavigationServiceImpl(
+      BASE_URL,
+      createMockTokenProvider(),
+    );
+
+    try {
+      await service.listFiles({
+        target: { registry: "NPM", packageName: "express" },
+      });
+      throw new Error("expected listFiles to throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(CodeNavigationIndexingError);
+      const typed = error as CodeNavigationIndexingError;
+      expect(typed.message).toContain("Running for 3 seconds.");
+      expect(typed.message).toContain(
+        "Similar refs usually index in 1 second.",
+      );
+      expect(typed.message).not.toContain("Backend says");
+      expect(typed.message).toContain("--wait 60000");
+      expect(typed.indexingEstimate).toEqual({
+        lowerSeconds: 1,
+        upperSeconds: 1,
+        elapsedSeconds: 3,
+        sampleCount: 4,
+        source: "same_repository_refs",
+      });
+    }
+  });
+
   it("throws CodeNavigationBackendError when backend emits GREP_FILE_TOO_LARGE", async () => {
     mockFetch(() =>
       Promise.resolve(
@@ -1158,6 +1238,7 @@ describe("CodeNavigationServiceImpl", () => {
       symbolFields: ["name", "qualified_path", "kind"],
       waitTimeoutMs: 5000,
     });
+    expect(body.query).toContain("indexingEstimate");
     expect(body.query).toContain("symbol {");
     expect(body.query).toContain("name");
     expect(body.query).toContain("qualifiedPath");
@@ -1205,5 +1286,6 @@ describe("CodeNavigationServiceImpl", () => {
       limit: 100,
       waitTimeoutMs: 5000,
     });
+    expect(body.query).toContain("indexingEstimate");
   });
 });

--- a/packages/core-internal/src/services/code-navigation-service.ts
+++ b/packages/core-internal/src/services/code-navigation-service.ts
@@ -326,6 +326,14 @@ export interface AvailableVersion {
   ref: string;
 }
 
+export interface IndexingDurationEstimate {
+  lowerSeconds?: number;
+  upperSeconds?: number;
+  elapsedSeconds?: number;
+  sampleCount?: number;
+  source?: string;
+}
+
 /**
  * Input for {@link CodeNavigationService.listFiles}.
  */
@@ -504,6 +512,9 @@ export class CodeNavigationIndexingError extends Error {
     public readonly availableVersions?: AvailableVersion[],
     public readonly availableRefs?: AvailableRef[],
     public readonly targetResolution: TargetResolution | undefined = undefined,
+    public readonly indexingEstimate:
+      | IndexingDurationEstimate
+      | undefined = undefined,
   ) {
     super(message);
     this.name = "CodeNavigationIndexingError";
@@ -712,6 +723,15 @@ availableRefs {
   ref
 }
 ${DISCOVERY_TARGET_PROGRESS_SUGGESTED_REFS_SELECTION}`;
+
+const INDEXING_DURATION_ESTIMATE_SELECTION = `
+indexingEstimate {
+  lowerSeconds
+  upperSeconds
+  elapsedSeconds
+  sampleCount
+  source
+}`;
 
 const UNIFIED_SEARCH_QUERY = `
 query UnifiedSearch(
@@ -1030,6 +1050,17 @@ const availableVersionSchema = z.object({
   ref: z.string(),
 });
 
+const indexingDurationEstimateSchema = z
+  .object({
+    lowerSeconds: z.number().int().nullable().optional(),
+    upperSeconds: z.number().int().nullable().optional(),
+    elapsedSeconds: z.number().int().nullable().optional(),
+    sampleCount: z.number().int().nullable().optional(),
+    source: z.string().nullable().optional(),
+  })
+  .nullable()
+  .optional();
+
 const targetResolutionIdentitySchema = z
   .object({
     kind: z.string().nullable().optional(),
@@ -1273,6 +1304,7 @@ const listRepoFilesResponseSchema = z.object({
   codeIndexState: z.string(),
   indexingRef: z.string().nullable().optional(),
   availableVersions: z.array(availableVersionSchema).nullable().optional(),
+  indexingEstimate: indexingDurationEstimateSchema,
 });
 
 const listRepoFilesGraphQLResponseSchema = z.object({
@@ -1352,6 +1384,7 @@ query ListRepoFiles(
       version
       ref
     }
+    ${INDEXING_DURATION_ESTIMATE_SELECTION}
   }
 }`;
 
@@ -1372,6 +1405,7 @@ const codeContextResponseSchema = z.object({
   codeIndexState: z.string(),
   indexingRef: z.string().nullable().optional(),
   availableVersions: z.array(availableVersionSchema).nullable().optional(),
+  indexingEstimate: indexingDurationEstimateSchema,
   targetResolution: targetResolutionSchema,
 });
 
@@ -1420,6 +1454,7 @@ query FetchCodeContext(
     codeIndexState
     indexingRef
     ${CODE_CONTEXT_AVAILABLE_VERSIONS_SELECTION}
+    ${INDEXING_DURATION_ESTIMATE_SELECTION}
     ${TARGET_RESOLUTION_SELECTION}
   }
 }`;
@@ -1482,6 +1517,7 @@ const grepRepoResponseSchema = z.object({
   codeIndexState: z.string(),
   indexingRef: z.string().nullable().optional(),
   availableVersions: z.array(availableVersionSchema).nullable().optional(),
+  indexingEstimate: indexingDurationEstimateSchema,
 });
 
 const grepRepoGraphQLResponseSchema = z.object({
@@ -1606,6 +1642,7 @@ query GrepRepo(
       version
       ref
     }
+    ${INDEXING_DURATION_ESTIMATE_SELECTION}
   }
 }`;
 }
@@ -1900,6 +1937,7 @@ export class CodeNavigationServiceImpl implements CodeNavigationService {
         ? extensions.retryable
         : undefined;
     const indexingRef = getGraphQLIndexingRef(errors);
+    const indexingEstimate = parseIndexingDurationEstimate(extensions);
 
     if (isClientUpdateRequiredGraphQLError({ message, code })) {
       return new ClientUpdateRequiredError(
@@ -1932,11 +1970,16 @@ export class CodeNavigationServiceImpl implements CodeNavigationService {
     switch (code) {
       case "PACKAGE_INDEXING":
         return new CodeNavigationIndexingError(
-          this.createIndexingMessage(indexingRef),
+          this.createIndexingMessage(
+            indexingRef,
+            indexingEstimate,
+            typeof extensions?.hint === "string" ? extensions.hint : undefined,
+          ),
           indexingRef,
           parseAvailableVersions(extensions),
           parseAvailableRefs(extensions),
           parseTargetResolution(extensions),
+          indexingEstimate,
         );
 
       case "GREP_PATTERN_TOO_SHORT":
@@ -2063,14 +2106,21 @@ export class CodeNavigationServiceImpl implements CodeNavigationService {
     return new CodeNavigationBackendError(message, undefined, code, retryable);
   }
 
-  private createIndexingMessage(indexingRef?: string): string {
-    // Backend p50 indexing time ~11 s, mean ~17 s, backend ceiling 60
-    // s. Give callers both a concrete "retry shortly" expectation and
-    // the option to block until ready via a longer wait timeout.
-    const base =
-      "Target is still indexing. Indexing usually completes within 30 seconds. Retry this request, or pass a longer wait timeout (CLI: `--wait 60000`, MCP: `wait_timeout_ms: 60000`) to block until ready.";
+  private createIndexingMessage(
+    indexingRef?: string,
+    estimate?: IndexingDurationEstimate,
+    backendHint?: string,
+  ): string {
+    const retryGuidance =
+      "Retry, or wait until ready with CLI `--wait 60000` / MCP `wait_timeout_ms: 60000`.";
+    const estimateMessage = formatIndexingDurationEstimate(estimate);
+    const base = estimateMessage
+      ? `Target is indexing. ${estimateMessage} ${retryGuidance}`
+      : backendHint
+        ? appendRetryGuidance(backendHint, retryGuidance)
+        : `Target is indexing. Usually completes within 30 seconds. ${retryGuidance}`;
     if (indexingRef) {
-      return `${base} Indexing reference: ${indexingRef}.`;
+      return `${base} Indexing ref: ${indexingRef}.`;
     }
     return base;
   }
@@ -2244,18 +2294,24 @@ export class CodeNavigationServiceImpl implements CodeNavigationService {
     indexingRef?: string | null;
     availableVersions?: Array<{ version?: string | null; ref: string }> | null;
     targetResolution?: z.infer<typeof targetResolutionSchema>;
+    indexingEstimate?: z.infer<typeof indexingDurationEstimateSchema>;
   }): void {
     if (data.codeIndexState === "INDEXING") {
       const targetResolution = normaliseTargetResolution(data.targetResolution);
+      const indexingEstimate = normaliseIndexingDurationEstimate(
+        data.indexingEstimate,
+      );
       throw new CodeNavigationIndexingError(
         this.createIndexingMessage(
           data.indexingRef ?? targetResolution?.indexingRef,
+          indexingEstimate,
         ),
         data.indexingRef ?? targetResolution?.indexingRef,
         normaliseAvailableVersions(data.availableVersions) ??
           targetResolution?.availableVersions,
         targetResolution?.availableRefs,
         targetResolution,
+        indexingEstimate,
       );
     }
   }
@@ -2704,6 +2760,84 @@ function parseTargetResolution(
   const parsed = targetResolutionSchema.safeParse(raw);
   if (!parsed.success) return undefined;
   return normaliseTargetResolution(parsed.data);
+}
+
+function parseIndexingDurationEstimate(
+  extensions: Record<string, unknown> | undefined,
+): IndexingDurationEstimate | undefined {
+  const raw =
+    extensions?.estimated_indexing_duration ??
+    extensions?.estimatedIndexingDuration ??
+    extensions?.indexing_estimate ??
+    extensions?.indexingEstimate;
+  const parsed = indexingDurationEstimateSchema.safeParse(
+    normaliseRawIndexingDurationEstimate(raw),
+  );
+  if (!parsed.success) return undefined;
+  return normaliseIndexingDurationEstimate(parsed.data);
+}
+
+function normaliseRawIndexingDurationEstimate(raw: unknown): unknown {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return raw;
+  const record = raw as Record<string, unknown>;
+  return {
+    lowerSeconds: record.lowerSeconds ?? record.lower_seconds,
+    upperSeconds: record.upperSeconds ?? record.upper_seconds,
+    elapsedSeconds: record.elapsedSeconds ?? record.elapsed_seconds,
+    sampleCount: record.sampleCount ?? record.sample_count,
+    source: record.source,
+  };
+}
+
+function normaliseIndexingDurationEstimate(
+  estimate: z.infer<typeof indexingDurationEstimateSchema>,
+): IndexingDurationEstimate | undefined {
+  if (!estimate) return undefined;
+  const out: IndexingDurationEstimate = {};
+  if (typeof estimate.lowerSeconds === "number") {
+    out.lowerSeconds = estimate.lowerSeconds;
+  }
+  if (typeof estimate.upperSeconds === "number") {
+    out.upperSeconds = estimate.upperSeconds;
+  }
+  if (typeof estimate.elapsedSeconds === "number") {
+    out.elapsedSeconds = estimate.elapsedSeconds;
+  }
+  if (typeof estimate.sampleCount === "number") {
+    out.sampleCount = estimate.sampleCount;
+  }
+  if (typeof estimate.source === "string") out.source = estimate.source;
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+function formatIndexingDurationEstimate(
+  estimate: IndexingDurationEstimate | undefined,
+): string | undefined {
+  if (!estimate) return undefined;
+  const parts: string[] = [];
+  if (typeof estimate.elapsedSeconds === "number") {
+    parts.push(`Running for ${formatSeconds(estimate.elapsedSeconds)}.`);
+  }
+  if (
+    typeof estimate.lowerSeconds === "number" &&
+    typeof estimate.upperSeconds === "number"
+  ) {
+    const duration =
+      estimate.lowerSeconds === estimate.upperSeconds
+        ? formatSeconds(estimate.lowerSeconds)
+        : `${estimate.lowerSeconds} to ${formatSeconds(estimate.upperSeconds)}`;
+    parts.push(`Similar refs usually index in ${duration}.`);
+  }
+  return parts.length > 0 ? parts.join(" ") : undefined;
+}
+
+function formatSeconds(seconds: number): string {
+  return `${seconds} ${seconds === 1 ? "second" : "seconds"}`;
+}
+
+function appendRetryGuidance(hint: string, retryGuidance: string): string {
+  if (hint.includes("--wait") || hint.includes("wait_timeout_ms")) return hint;
+  return `${hint} ${retryGuidance}`;
 }
 
 function parseAvailableArtifacts(raw: unknown): AvailableVersion[] | undefined {

--- a/packages/mcp/src/shared/code-navigation-error-map.test.ts
+++ b/packages/mcp/src/shared/code-navigation-error-map.test.ts
@@ -156,6 +156,9 @@ describe("mapCodeNavigationError", () => {
       "Indexing in progress",
       "idx-42",
       [{ version: "5.2.1", ref: "v5.2.1" }],
+      undefined,
+      undefined,
+      { lowerSeconds: 7, upperSeconds: 19, sampleCount: 9 },
     );
     expect(mapCodeNavigationError(err)).toEqual({
       code: "INDEXING",
@@ -164,6 +167,7 @@ describe("mapCodeNavigationError", () => {
       details: {
         indexingRef: "idx-42",
         availableVersions: [{ version: "5.2.1", ref: "v5.2.1" }],
+        indexingEstimate: { lowerSeconds: 7, upperSeconds: 19, sampleCount: 9 },
       },
     });
   });

--- a/packages/mcp/src/shared/code-navigation-error-map.ts
+++ b/packages/mcp/src/shared/code-navigation-error-map.ts
@@ -18,6 +18,7 @@ import {
   CodeNavigationValidationError,
   CodeNavigationVersionNotFoundError,
   debugLog,
+  type IndexingDurationEstimate,
   MalformedCodeNavigationResponseError,
   type SuggestedRef,
   type TargetResolution,
@@ -49,6 +50,7 @@ export interface MappedErrorDetails {
   suggestedRefs?: SuggestedRef[];
   targetResolution?: TargetResolution;
   indexingRef?: string;
+  indexingEstimate?: IndexingDurationEstimate;
   status?: number;
   graphqlCode?: string;
   /**
@@ -184,6 +186,9 @@ function classify(error: unknown): MappedError {
     }
     if (error.targetResolution) {
       details.targetResolution = error.targetResolution;
+    }
+    if (error.indexingEstimate) {
+      details.indexingEstimate = error.indexingEstimate;
     }
     return {
       code: "INDEXING",

--- a/packages/mcp/src/shared/unified-search-text.test.ts
+++ b/packages/mcp/src/shared/unified-search-text.test.ts
@@ -295,14 +295,14 @@ describe("renderUnifiedSearchSuccess", () => {
 describe("renderUnifiedSearchError", () => {
   it("renders a basic error", () => {
     const error: UnifiedSearchErrorPayload = {
-      error: "Target is still indexing.",
+      error: "Target is indexing.",
       code: "INDEXING",
       retryable: true,
       details: { indexingRef: "ref_xyz" },
     };
     const text = renderUnifiedSearchError(error);
     expect(text).toContain("search | ERROR | code=INDEXING | retryable");
-    expect(text).toContain("Target is still indexing.");
+    expect(text).toContain("Target is indexing.");
     expect(text).toContain("details:");
     expect(text).toContain("  indexingRef: ref_xyz");
   });

--- a/packages/mcp/src/tools/list-files.test.ts
+++ b/packages/mcp/src/tools/list-files.test.ts
@@ -354,7 +354,7 @@ describe("createListFilesTool — service errors", () => {
       listFiles: mock(() =>
         Promise.reject(
           new CodeNavigationIndexingError(
-            "Target is still indexing.",
+            "Target is indexing.",
             "ref_abc",
             [{ version: "4.21.0", ref: "v4.21.0" }],
             [{ ref: "main" }],

--- a/src/commands/code/code-nav-cli-helpers.ts
+++ b/src/commands/code/code-nav-cli-helpers.ts
@@ -93,7 +93,7 @@ export function formatIndexingError(mapped: MappedError): string {
   if (mapped.code !== "INDEXING") return formatMappedErrorForTerminal(mapped);
   const detail = mapped.details ?? {};
   const lines = [mapped.message];
-  if (detail.indexingRef) lines.push(`  indexingRef: ${detail.indexingRef}`);
+  if (detail.indexingRef) lines.push(`  indexing ref: ${detail.indexingRef}`);
   const versions = detail.availableVersions;
   if (versions && versions.length > 0) {
     const shown = versions
@@ -102,7 +102,7 @@ export function formatIndexingError(mapped: MappedError): string {
       .join(", ");
     const more = versions.length - 5;
     const suffix = more > 0 ? ` (+${more} more)` : "";
-    lines.push(`  already-indexed versions: ${shown}${suffix}`);
+    lines.push(`  indexed refs/versions: ${shown}${suffix}`);
   }
   const refs = detail.availableRefs;
   if (refs && refs.length > 0) {
@@ -112,7 +112,7 @@ export function formatIndexingError(mapped: MappedError): string {
       .join(", ");
     const more = refs.length - 5;
     const suffix = more > 0 ? ` (+${more} more)` : "";
-    lines.push(`  already-indexed refs: ${shown}${suffix}`);
+    lines.push(`  indexed refs: ${shown}${suffix}`);
   }
   return lines.join("\n");
 }

--- a/src/commands/code/files.test.ts
+++ b/src/commands/code/files.test.ts
@@ -507,7 +507,7 @@ describe("pkgFilesAction", () => {
     exitSpy.mockRestore();
   });
 
-  it("enriches INDEXING error with indexingRef + already-indexed versions", async () => {
+  it("enriches INDEXING error with indexing ref + indexed refs/versions", async () => {
     const errorSpy = spyOn(console, "error").mockImplementation(() => {});
     const exitSpy = spyOn(process, "exit").mockImplementation(() => {
       throw new Error("process.exit");
@@ -515,14 +515,10 @@ describe("pkgFilesAction", () => {
     const service = createMockCodeNavigationService({
       listFiles: mock(() =>
         Promise.reject(
-          new CodeNavigationIndexingError(
-            "Target is still indexing.",
-            "ref_xyz",
-            [
-              { version: "4.21.0", ref: "v4.21.0" },
-              { version: "4.20.1", ref: "v4.20.1" },
-            ],
-          ),
+          new CodeNavigationIndexingError("Target is indexing.", "ref_xyz", [
+            { version: "4.21.0", ref: "v4.21.0" },
+            { version: "4.20.1", ref: "v4.20.1" },
+          ]),
         ),
       ),
     });
@@ -538,8 +534,8 @@ describe("pkgFilesAction", () => {
     }
     const output = errorSpy.mock.calls[0]?.[0] as string;
     expect(output).toContain("indexing");
-    expect(output).toContain("indexingRef: ref_xyz");
-    expect(output).toContain("already-indexed versions: 4.21.0, 4.20.1");
+    expect(output).toContain("indexing ref: ref_xyz");
+    expect(output).toContain("indexed refs/versions: 4.21.0, 4.20.1");
     errorSpy.mockRestore();
     exitSpy.mockRestore();
   });

--- a/src/commands/code/files.ts
+++ b/src/commands/code/files.ts
@@ -246,8 +246,8 @@ By default each result is a bare path for easy piping; pass
 --verbose to include language / file-type / size annotations.
 
 On an INDEXING response, the dependency is being indexed on-demand
-— retry with a longer --wait (up to 60000 ms) or pick one of the
-already-indexed versions surfaced in the error detail.`;
+— retry with a longer --wait (up to 60000 ms) or use an indexed
+ref/version from the error detail.`;
 
 export function registerCodeFilesCommand(pkgCommand: Command): Command {
   return pkgCommand

--- a/src/commands/code/grep.test.ts
+++ b/src/commands/code/grep.test.ts
@@ -591,7 +591,7 @@ describe("pkgGrepAction", () => {
     } catch {
       /* expected */
     }
-    expect(errorSpy.mock.calls[0]?.[0]).toContain("indexingRef: ref_abc");
+    expect(errorSpy.mock.calls[0]?.[0]).toContain("indexing ref: ref_abc");
     errorSpy.mockRestore();
     exitSpy.mockRestore();
   });

--- a/src/commands/code/read.test.ts
+++ b/src/commands/code/read.test.ts
@@ -482,8 +482,8 @@ describe("pkgReadAction", () => {
       /* expected */
     }
     const output = errorSpy.mock.calls[0]?.[0] as string;
-    expect(output).toContain("indexingRef: ref_xyz");
-    expect(output).toContain("already-indexed versions: 4.21.0");
+    expect(output).toContain("indexing ref: ref_xyz");
+    expect(output).toContain("indexed refs/versions: 4.21.0");
     errorSpy.mockRestore();
     exitSpy.mockRestore();
   });

--- a/src/tools/list-files-parity.test.ts
+++ b/src/tools/list-files-parity.test.ts
@@ -269,11 +269,9 @@ describe("list_files parity", () => {
   it("PARITY-ERROR-ENVELOPE: INDEXING identical on both surfaces", async () => {
     const fn = mock(() =>
       Promise.reject(
-        new CodeNavigationIndexingError(
-          "Target is still indexing.",
-          "ref_abc",
-          [{ version: "4.21.0", ref: "v4.21.0" }],
-        ),
+        new CodeNavigationIndexingError("Target is indexing.", "ref_abc", [
+          { version: "4.21.0", ref: "v4.21.0" },
+        ]),
       ),
     );
     const cli = await cliJson(


### PR DESCRIPTION
## Summary
- request and parse backend indexing duration estimates for code navigation indexing paths
- render compact estimate copy for CLI/MCP users while preserving structured estimate fields in error details
- update indexing error detail labels and tests for CLI/MCP parity

## Review
- code-reviewer found one medium issue around error-extension aliases; fixed by accepting indexingEstimate/indexing_estimate aliases and adding coverage

## Verification
- bun test
- bun run typecheck
- bun run build
- bun run smoke:cli
- bun run smoke:mcp
- live production INDEXING probe returned compact estimate copy and structured indexingEstimate
