### PR TITLE
chore: prepare 0.6.0 release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "GitHits plugins for Claude Code - code examples from global open source",
-    "version": "0.5.4"
+    "version": "0.6.0"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.5.4",
+  "version": "0.6.0",
   "description": "Code examples from global open source for developers and AI assistants",
   "author": {
     "name": "GitHits"

--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.5.4",
+  "version": "0.6.0",
   "description": "Code examples from global open source for developers and AI assistants",
   "author": {
     "name": "GitHits"

--- a/bun.lock
+++ b/bun.lock
@@ -42,7 +42,7 @@
     },
     "packages/mcp": {
       "name": "@githits/mcp",
-      "version": "0.5.3",
+      "version": "0.6.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "^4.4.3",

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.5.4",
+  "version": "0.6.0",
   "description": "Code examples from global open source for developers and AI assistants.",
   "mcpServers": {
     "githits": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "description": "Code examples from global open source for developers and AI assistants",
+  "description": "Version-aware open-source context for agentic software development",
   "version": "0.6.0",
   "type": "module",
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "githits",
   "description": "CLI companion for GitHits - code examples from global open source for developers and AI assistants",
-  "version": "0.5.4",
+  "version": "0.6.0",
   "type": "module",
   "workspaces": [
     "packages/*"
@@ -33,7 +33,7 @@
     "githits": "dist/cli.js"
   },
   "scripts": {
-    "build": "bunup && chmod +x dist/cli.js",
+    "build": "bunup && bun -e \"import { chmodSync } from 'node:fs'; chmodSync('dist/cli.js', 0o755);\"",
     "dev": "bun run ./src/cli.ts",
     "inspector": "npx @modelcontextprotocol/inspector bun run dev mcp",
     "smoke:cli": "bun run scripts/cli-smoke.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "description": "CLI companion for GitHits - code examples from global open source for developers and AI assistants",
+  "description": "Code examples from global open source for developers and AI assistants",
   "version": "0.6.0",
   "type": "module",
   "workspaces": [

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@githits/mcp",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "description": "Reusable MCP server APIs and tools for GitHits",
   "type": "module",
   "files": [

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.5.4",
+  "version": "0.6.0",
   "description": "Code examples from global open source for developers and AI assistants",
   "author": {
     "name": "GitHits"


### PR DESCRIPTION
## Summary
- Bump root `githits`, plugin manifests, Claude marketplace metadata, Gemini extension, and lock metadata to `0.6.0`.
- Bump `@githits/mcp` to `0.6.0` for the MCP instruction update included in this release.
- Align the root npm package description with the README positioning: version-aware open-source context for agentic software development.
- Make the root build script use Node `chmodSync` so release validation works on Windows as well as POSIX shells.

## User-visible changelog
- Add guided GitHits MCP init flows and supporting agent guidance.
- Add the public `githits-mcp` skill guidance for clients that support Agent Skills.
- Update MCP instructions to point agents toward the supporting skill/agent-instructions setup.
- Refresh README/docs and include dependency/tooling maintenance since `v0.5.4`.

## Validation
- `bun test`
- `bun run build`
- `bun run validate:packages`
- `bun run validate:packages:mcp-publish`
- `bun run smoke:cli`
- `bun run smoke:mcp`
- `bun test src/plugin-version-consistency.test.ts src/plugin-config.test.ts src/plugin-manifest.test.ts src/package-release-boundaries.test.ts src/skills-packaging.test.ts`
- `bun run agent:e2e --agent codex --server local --workload eval/agentic/workloads/express-router.md --out .agent-eval/runs/release-0.6.0-codex-mcp`
- Claude MCP eval artifact reviewed: run used GitHits tools successfully and reported no instruction issues, but the harness marked it failed because Claude prepended prose before its JSON object.

`githits@0.6.0` and `@githits/mcp@0.6.0` were both unpublished when checked with `npm view`.