### PR TITLE
Fix init no-browser auth flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,9 +163,9 @@ npx githits@latest login
 Browser OAuth is recommended for local development. Credentials are stored in
 the system keychain by default and refreshed automatically. Useful flags:
 
-- `--no-browser` prints a login URL for SSH, containers, or headless sessions
-- `--force` re-authenticates even if you are already logged in
-- `--port <port>` uses a specific local callback port
+- `init --no-browser` or `login --no-browser` prints a login URL for SSH, containers, or headless sessions
+- `login --force` re-authenticates even if you are already logged in
+- `login --port <port>` uses a specific local callback port
 
 For CI or non-interactive environments, use an API token:
 

--- a/docs/implementation/auth.md
+++ b/docs/implementation/auth.md
@@ -23,7 +23,7 @@ The two methods exist because OAuth provides full access but requires a browser,
 
 The login command (`src/commands/login.ts`) orchestrates a 9-step OAuth flow (matching the `// Step N:` comments in the code):
 
-1. **Discover endpoints** — Fetch `.well-known/oauth-authorization-server` from the MCP URL
+1. **Discover endpoints** — Fetch `.well-known/oauth-authorization-server` from the MCP URL. Production OAuth endpoints are served by the GitHits Supabase account host at `https://accounts.githits.com`.
 2. **Load or register client via DCR** — Reuse stored client from `client.json`, or register a new one. Re-registers if `--port` changes the redirect URI.
 3. **Generate PKCE params** — Create `code_verifier`, `code_challenge` (S256), and `state`
 4. **Build auth URL** — Construct the authorization URL with PKCE challenge

--- a/docs/implementation/cli-commands.md
+++ b/docs/implementation/cli-commands.md
@@ -8,7 +8,7 @@ The CLI exposes setup/auth commands, `doctor`, `example`, `languages`, `feedback
 
 | Command | Required Args | Options | Description |
 |---|---|---|---|
-| `init` | — | `-y, --yes`, `--skip-login`, `--project`, `--detect-agents`, `--install-agents <ids>`, `--json` | Authenticate and set up MCP server for coding agents; interactive setup asks whether to configure user-level or project-level MCP where supported; staged flags support agent-safe non-interactive onboarding |
+| `init` | — | `-y, --yes`, `--skip-login`, `--no-browser`, `--project`, `--detect-agents`, `--install-agents <ids>`, `--json` | Authenticate and set up MCP server for coding agents; interactive setup asks whether to configure user-level or project-level MCP where supported; staged flags support agent-safe non-interactive onboarding |
 | `init uninstall` | — | `-y, --yes`, `--project` | Remove GitHits MCP server configuration from coding agents or supported project-local MCP files |
 | `example <query>` | `<query>` | `-l, --lang <language>`, `--license <mode>`, `--explain`, `--json` | Search for code examples |
 | `search <query>` | `--in <target>` | `--source <source>`, `--kind <kind>`, `--category <category>`, `--path-prefix <prefix>`, `--intent <intent>`, `--public`, `--name <name>`, `--lang <language>`, `--allow-partial`, `--limit <n>`, `--offset <n>`, `--wait <seconds>`, `--json` | Unified indexed search across dependency/repository code, docs, and symbols. Defaults to 10 results. |
@@ -33,6 +33,7 @@ The CLI exposes setup/auth commands, `doctor`, `example`, `languages`, `feedback
 githits init                                      # Interactive: authenticate, scan, configure unconfigured agents
 githits init --yes                                # Interactive shortcut: configure all detected unconfigured agents
 githits init --skip-login                         # Skip authentication, configure tools only
+githits init --no-browser                         # Print sign-in URL instead of opening a browser
 npx -y githits@latest init --detect-agents        # Agent-safe discovery: scan and print detected agent IDs/statuses
 npx -y githits@latest init --detect-agents --json # Machine-readable discovery output for agents
 npx -y githits@latest init --install-agents cursor # Agent-safe install: configure only explicit detected IDs
@@ -44,7 +45,7 @@ githits init uninstall --project                  # Explicit project-level unins
 githits init uninstall --project --yes            # Non-interactive project-level uninstall
 ```
 
-Authenticates with GitHits (via OAuth in the browser), then scans for available coding agents, checks which are already configured, and sets up unconfigured ones with your confirmation. All agents are pre-checked before any setup begins, so the status display is fully resolved. CLI agents are considered available only when their executable is on `PATH`; related dot-directories alone do not count. Config-file agents remain filesystem-detected using their known app/config directories. If already authenticated, the login step is skipped automatically. If login fails, the user is prompted to continue with tool setup anyway. If all detected agents are already configured, exits early with a summary.
+Authenticates with GitHits (via OAuth in the browser), then scans for available coding agents, checks which are already configured, and sets up unconfigured ones with your confirmation. Use `--no-browser` in SSH or display-less sessions to print the sign-in URL instead of opening a browser on the current machine. All agents are pre-checked before any setup begins, so the status display is fully resolved. CLI agents are considered available only when their executable is on `PATH`; related dot-directories alone do not count. Config-file agents remain filesystem-detected using their known app/config directories. If already authenticated, the login step is skipped automatically. If login fails, the user is prompted to continue with tool setup anyway. If all detected agents are already configured, exits early with a summary.
 
 Interactive MCP setup asks where GitHits should be configured. User-level setup preserves the existing global/user config behavior for all supported tools. Project-level setup is partial because MCP project config conventions differ by tool; GitHits only offers project setup for tools with verified project-local MCP support: Claude Code (`.mcp.json`), Cursor (`.cursor/mcp.json`), VS Code / Copilot (`.vscode/mcp.json` with `type = "stdio"` server entries), Codex CLI (`.codex/config.toml`), Pi (`.mcp.json` with `pi-mcp-adapter` installed when needed), Gemini CLI (`.gemini/settings.json`), and OpenCode (`opencode.json`). Detected tools without verified project-local MCP support are shown as skipped with a reason. Project config contains no secrets, but it may be committed to source control like other project tooling configuration. Gemini may ignore project settings in untrusted workspaces.
 

--- a/src/commands/init/init.test.ts
+++ b/src/commands/init/init.test.ts
@@ -3310,6 +3310,47 @@ describe("initAction", () => {
       expect(fs.atomicWriteFile).toHaveBeenCalled();
     });
 
+    it("prints login URL instead of opening browser with --no-browser", async () => {
+      const fs = createFsWithDetection(["/home/test/.cursor"]);
+      const browserService = createMockBrowserService();
+      const promptService = createMockPromptService({
+        confirm3: mock(() => Promise.resolve("yes" as ConfirmChoice)),
+      });
+      const createLoginDeps = mock(() =>
+        Promise.resolve({
+          authService: createMockAuthService(),
+          authStorage: createMockAuthStorage(),
+          browserService,
+          mcpUrl: "https://mcp.githits.com",
+        }),
+      );
+
+      await initAction(
+        { browser: false },
+        {
+          fileSystemService: fs,
+          promptService,
+          execService: createMockExecService(),
+          createLoginDeps,
+        },
+      );
+
+      const logCalls = getLogOutput();
+      expect(browserService.open).not.toHaveBeenCalled();
+      expect(
+        logCalls.some((msg) => msg.includes("We'll print a sign-in URL")),
+      ).toBe(true);
+      expect(
+        logCalls.some((msg) => msg.includes("Open this URL in your browser:")),
+      ).toBe(true);
+      expect(
+        logCalls.some((msg) =>
+          msg.includes("https://accounts.githits.com/oauth/authorize"),
+        ),
+      ).toBe(true);
+      expect(fs.atomicWriteFile).toHaveBeenCalled();
+    });
+
     it("prompts to continue when login fails", async () => {
       const fs = createFsWithDetection(["/home/test/.cursor"]);
       const promptService = createMockPromptService({
@@ -5824,6 +5865,7 @@ describe("registerInitCommand", () => {
     expect(optionLongNames).toContain("--project");
     expect(optionLongNames).toContain("--guidance");
     expect(optionLongNames).toContain("--no-guidance");
+    expect(optionLongNames).toContain("--no-browser");
   });
 
   it("registers uninstall options as boolean options", () => {

--- a/src/commands/init/init.ts
+++ b/src/commands/init/init.ts
@@ -84,6 +84,8 @@ export interface InitOptions {
   yes?: boolean;
   /** Skip the login step */
   skipLogin?: boolean;
+  /** Print the login URL instead of opening a browser */
+  browser?: boolean;
   /** Scan supported agents without installing anything */
   detectAgents?: boolean;
   /** Comma-separated agent IDs to install non-interactively */
@@ -677,7 +679,7 @@ const AUTH_START_CHOICES: SelectChoice<InitAuthStartChoice>[] = [
   {
     name: "Sign in now",
     value: "sign_in",
-    description: "Open your browser and connect this CLI to GitHits.",
+    description: "Connect this CLI to GitHits.",
   },
   {
     name: "Skip for now",
@@ -1918,12 +1920,16 @@ async function runInstallAgentsMode(
   console.log();
 }
 
-function printAuthExplanation(): void {
+function printAuthExplanation(options: InitOptions): void {
   console.log(
     "    GitHits authentication is required before your agent can use GitHits tools.",
   );
   console.log();
-  console.log("    We'll open your browser to connect your account.");
+  if (options.browser === false) {
+    console.log("    We'll print a sign-in URL to open in your browser.");
+  } else {
+    console.log("    We'll open your browser to connect your account.");
+  }
   console.log("    Credentials are stored securely in your OS keychain.");
   console.log();
   console.log("    No API keys or secrets are written into your MCP config.");
@@ -1959,12 +1965,14 @@ async function runInitAuthentication(
         return "authenticated";
       }
 
-      printAuthExplanation();
+      printAuthExplanation(options);
       if (!options.yes) {
         let authChoice: InitAuthStartChoice;
         try {
           authChoice = await promptService.select(
-            "  Continue with browser sign-in?",
+            options.browser === false
+              ? "  Continue with sign-in and print the URL?"
+              : "  Continue with browser sign-in?",
             AUTH_START_CHOICES,
             "sign_in",
           );
@@ -1993,7 +2001,12 @@ async function runInitAuthentication(
         }
       }
 
-      loginResult = await loginFlow({}, loginDeps, createInitLoginOutput());
+      const loginOptions = options.browser === false ? { browser: false } : {};
+      loginResult = await loginFlow(
+        loginOptions,
+        loginDeps,
+        createInitLoginOutput(),
+      );
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);
       loginResult = { status: "failed", message: msg };
@@ -3999,6 +4012,7 @@ export function registerInitCommand(program: Command) {
     .description(INIT_DESCRIPTION)
     .option("-y, --yes", "Skip prompts, configure all detected tools")
     .option("--skip-login", "Skip authentication step")
+    .option("--no-browser", "Print sign-in URL instead of opening browser")
     .option("--project", "Configure project-level MCP in the current directory")
     .option("--guidance", "Install supporting GitHits skill and instructions")
     .option("--no-guidance", "Install plain MCP without supporting guidance")

--- a/src/commands/login.test.ts
+++ b/src/commands/login.test.ts
@@ -488,7 +488,11 @@ describe("loginFlow", () => {
       "Could not open browser automatically: no display\n",
     );
     expect(writes).toContain("Open this URL in your browser:\n");
-    expect(writes).toContain("  http://example.com/auth\n");
+    expect(
+      writes.some((message) =>
+        message.startsWith("  https://accounts.githits.com/oauth/authorize?"),
+      ),
+    ).toBe(true);
   });
 
   it("closes callback server and clears fresh client when authentication wait fails", async () => {

--- a/src/services/test-helpers.ts
+++ b/src/services/test-helpers.ts
@@ -35,9 +35,9 @@ import type { UpdateCheckService } from "./update-check-service.js";
  * Default OAuth metadata for testing.
  */
 export const defaultOAuthMetadata: OAuthMetadata = {
-  authorizationEndpoint: "https://auth.example.com/oauth/authorize",
-  tokenEndpoint: "https://auth.example.com/oauth/token",
-  registrationEndpoint: "https://auth.example.com/oauth/register",
+  authorizationEndpoint: "https://accounts.githits.com/oauth/authorize",
+  tokenEndpoint: "https://accounts.githits.com/oauth/token",
+  registrationEndpoint: "https://accounts.githits.com/oauth/register",
 };
 
 /**
@@ -92,7 +92,16 @@ export function createMockAuthService(
       }),
     ),
     generatePkceParams: mock(() => defaultPkceParams),
-    buildAuthUrl: mock(() => "http://example.com/auth"),
+    buildAuthUrl: mock((params: Parameters<AuthService["buildAuthUrl"]>[0]) => {
+      const url = new URL(params.authorizationEndpoint);
+      url.searchParams.set("response_type", "code");
+      url.searchParams.set("client_id", params.clientId);
+      url.searchParams.set("redirect_uri", params.redirectUri);
+      url.searchParams.set("state", params.state);
+      url.searchParams.set("code_challenge", params.codeChallenge);
+      url.searchParams.set("code_challenge_method", "S256");
+      return url.toString();
+    }),
     startCallbackServer: mock(() =>
       Promise.resolve({
         result: Promise.resolve(defaultCallbackResult),


### PR DESCRIPTION
## Summary
- add `githits init --no-browser` and route it through the existing manual login URL flow
- adjust init sign-in copy for SSH/headless sessions
- update auth fixtures and docs to use the production `accounts.githits.com` OAuth host

## Tests
- `bun test src/commands/login.test.ts`
- `bun test src/commands/init/init.test.ts`
- `bun run typecheck`
- `bun run smoke:cli`
- `bun run smoke:mcp`