### PR TITLE
chore: release 0.6.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "GitHits plugins for Claude Code - code examples from global open source",
-    "version": "0.6.0"
+    "version": "0.6.1"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Code examples from global open source for developers and AI assistants",
   "author": {
     "name": "GitHits"

--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Code examples from global open source for developers and AI assistants",
   "author": {
     "name": "GitHits"

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Code examples from global open source for developers and AI assistants.",
   "mcpServers": {
     "githits": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "githits",
   "description": "Version-aware open-source context for agentic software development",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "workspaces": [
     "packages/*"

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Code examples from global open source for developers and AI assistants",
   "author": {
     "name": "GitHits"

--- a/scripts/cli-smoke.ts
+++ b/scripts/cli-smoke.ts
@@ -445,38 +445,74 @@ async function assertUnauthenticatedBehavior(): Promise<void> {
 }
 
 async function assertLiveOrAuthRequired(): Promise<boolean> {
-  const result = await runCli(["languages", "python", "--json"]);
-  if (result.exitCode === 0) {
-    const payload = parseJson(result.stdout, "languages auth probe");
-    assert(Array.isArray(payload), "languages auth probe: expected array");
+  const languagesResult = await runCli(["languages", "python", "--json"]);
+  if (languagesResult.exitCode !== 0) {
+    const jsonAuthPayload = assertCleanErrorEnvelope(
+      languagesResult.stderr,
+      "languages auth probe",
+    );
+    if (jsonAuthPayload.code === "AUTH_REQUIRED") {
+      console.log("AUTH_REQUIRED: live CLI smoke skipped");
+      return false;
+    }
+
+    // Non-JSON auth guidance currently comes from requireAuth(), which writes
+    // friendly instructions to stdout before throwing. Accept either stream so
+    // this smoke gate validates guidance without forcing a broader CLI
+    // stream-policy change.
+    const authGuidance =
+      `${languagesResult.stderr}\n${languagesResult.stdout}`.trim();
+    assert(
+      authGuidance.includes("Authentication required"),
+      "auth probe missing authentication guidance",
+    );
+    assert(
+      authGuidance.includes("githits login"),
+      "auth probe missing login guidance",
+    );
+    console.log("AUTH_REQUIRED: live CLI smoke skipped");
+    return false;
+  }
+
+  const languagesPayload = parseJson(
+    languagesResult.stdout,
+    "languages auth probe",
+  );
+  assert(
+    Array.isArray(languagesPayload),
+    "languages auth probe: expected array",
+  );
+
+  const packageResult = await runCli(["pkg", "info", "npm:express", "--json"]);
+  if (packageResult.exitCode === 0) {
+    const payload = parseJson(packageResult.stdout, "package auth probe");
+    assertRecord(payload, "package auth probe");
+    assert(payload.name === "express", "package auth probe: expected express");
     return true;
   }
 
   assert(
-    result.exitCode !== 0,
-    "languages auth probe: expected non-zero auth failure",
+    packageResult.exitCode !== 0,
+    "package auth probe: expected non-zero auth failure",
   );
   const jsonAuthPayload = assertCleanErrorEnvelope(
-    result.stderr,
-    "languages auth probe",
+    packageResult.stderr,
+    "package auth probe",
   );
   if (jsonAuthPayload.code === "AUTH_REQUIRED") {
     console.log("AUTH_REQUIRED: live CLI smoke skipped");
     return false;
   }
 
-  // Non-JSON auth guidance currently comes from requireAuth(), which writes
-  // friendly instructions to stdout before throwing. Accept either stream so
-  // this smoke gate validates guidance without forcing a broader CLI
-  // stream-policy change.
-  const authGuidance = `${result.stderr}\n${result.stdout}`.trim();
+  const authGuidance =
+    `${packageResult.stderr}\n${packageResult.stdout}`.trim();
   assert(
     authGuidance.includes("Authentication required"),
-    "auth probe missing authentication guidance",
+    "package auth probe missing authentication guidance",
   );
   assert(
     authGuidance.includes("githits login"),
-    "auth probe missing login guidance",
+    "package auth probe missing login guidance",
   );
   console.log("AUTH_REQUIRED: live CLI smoke skipped");
   return false;


### PR DESCRIPTION
## Summary
- Bump root `githits` and plugin/assistant manifests from `0.6.0` to `0.6.1` for the CLI-only patch release.
- Keep `@githits/mcp` at `0.6.0`; no MCP package-visible changes are included.
- Harden `bun run smoke:cli` so authenticated live package/source coverage only runs when that auth path is available.

## User-visible changelog
- Fixes `githits init --no-browser` so headless/SSH setup can print the sign-in URL instead of trying to open a local browser.

## Validation
- `bun test`
- `bun run typecheck`
- `bun run build`
- `bun run validate:packages`
- `bun run smoke:cli`
- `bunx biome format package.json scripts/cli-smoke.ts .plugin/plugin.json .claude-plugin/plugin.json plugins/claude/.claude-plugin/plugin.json .claude-plugin/marketplace.json gemini-extension.json`
- `git diff --check`