### PR TITLE
Add MCP registry publishing

### DIFF
--- a/.agents/skills/githits-release/SKILL.md
+++ b/.agents/skills/githits-release/SKILL.md
@@ -3,7 +3,8 @@ name: githits-release
 description: >-
   Use when preparing, reviewing, or executing a GitHits CLI release. Covers
   release-version consistency, plugin manifests, user-visible changelog notes,
-  MCP instruction quality, and the special lifecycle for published Agent Skills.
+  MCP instruction quality, MCP registry publishing/versioning, and the special
+  lifecycle for published Agent Skills.
 compatibility: Project-local skill for GitHits maintainers; not packaged for end users.
 metadata:
   internal: true
@@ -14,15 +15,30 @@ Use this skill for GitHits release work, version-bump PRs, release-readiness rev
 ## Release Checklist
 
 - Root `githits` and `@githits/mcp` have separate release flows. Bump both only when both surfaces changed.
-- For root `githits` releases, bump `package.json`, `.plugin/plugin.json`, `.claude-plugin/plugin.json`, `plugins/claude/.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, and `gemini-extension.json` together.
+- For root `githits` releases, bump `package.json`, `server.json`, `.plugin/plugin.json`, `.claude-plugin/plugin.json`, `plugins/claude/.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, and `gemini-extension.json` together.
 - For `@githits/mcp` releases, bump `packages/mcp/package.json` only when MCP package API, tool behavior, instructions, schemas, MCP auth/error behavior, or remote-server-facing public types changed.
 - For coordinated CLI and MCP releases, keep the MCP minor aligned with the CLI minor for discoverability. Start the first MCP release for a CLI minor at `X.Y.0`, then bump MCP patch for later MCP-package-visible changes in that CLI minor. Do not bump MCP for CLI-only changes.
 - After merge, the root release workflow and MCP release workflow both run from the successful `Main` workflow on `main`. The MCP workflow publishes only when `@githits/mcp@<version>` is not already on npm; use its manual `workflow_dispatch` path only for recovery or explicit dry runs.
+- The root release workflow also publishes `server.json` to the official MCP registry as `com.githits/githits` after npm publishes `githits@<version>`. Treat the MCP registry entry as part of the root `githits` release, not the `@githits/mcp` package release.
+- Keep `server.json.version`, the npm package entry version in `server.json`, and root `package.json.version` aligned. The release workflow rewrites a temporary registry manifest from `package.json`, but the committed `server.json` should still reflect the intended next root release for review and local validation.
+- Keep root `package.json#mcpName` equal to `com.githits/githits`; npm registry ownership validation depends on the published package manifest matching `server.json.name`.
 - Run or rely on package-scoped version checks to verify root plugin versions stay aligned and MCP versions are intentionally independent.
 - Collect a changelog of user-visible changes before release. Include CLI behavior, MCP tool behavior, Agent Skills, auth/error UX, output format changes, and agent-facing instruction changes.
 - Review public skills before signoff whenever user-facing CLI/MCP behavior changed. After the behavior is released or included in the same release branch, update `skills/githits-code/SKILL.md`, `skills/githits-package/SKILL.md`, and their references so `skills.sh` users get instructions that match the released surface.
 - Keep PR titles and labels release-note friendly; GitHub release notes are generated from merged PRs and `.github/release.yml` categories.
 - Run `bun run build` before release-readiness signoff. Run targeted smoke/eval commands when MCP tools, CLI commands, shared formatters, auth/error envelopes, Agent Skills, or agent-facing instructions changed.
+
+## MCP Registry
+
+- Registry name: `com.githits/githits`.
+- Registry `server.json` should list both supported transports when available: hosted remote MCP at `https://mcp.githits.com` and npm stdio via the root `githits` package with `packageArguments` equivalent to `githits mcp start`.
+- Do not encode `npx githits@latest` literally in `server.json`. The registry package entry uses `runtimeHint: "npx"`, `identifier: "githits"`, the exact release `version`, and package arguments. This represents the pinned release artifact, while docs can continue to show `npx githits@latest mcp start` for manual setup.
+- Publish to the MCP registry only after `githits@<version>` is published to npm, because registry validation checks the npm package metadata.
+- MCP registry publishing uses GitHub Actions OIDC, the `production` environment, and the Azure Key Vault-backed signer. Do not add an Azure client secret, Key Vault secret, exported signing key, npm token, or raw registry private key.
+- Required GitHub production environment secrets are identifiers used for masking and OIDC wiring: `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`, `AZURE_CLIENT_ID`, `MCP_REGISTRY_KEY_VAULT_NAME`, and `MCP_REGISTRY_SIGNING_KEY_NAME`. Do not print them, dump environment variables, or enable shell tracing.
+- Before releasing a registry update, verify `mcp-publisher validate server.json` locally with the pinned publisher version when practical.
+- Before the first registry publish, verify the domain proof is deployed at `https://githits.com/.well-known/mcp-registry-auth`.
+- For remote MCP auth, do not add static `Authorization` header metadata to `server.json`. The official registry remote transport schema supports URL, optional user-provided headers, and URL variables; OAuth is discovered from the remote MCP server through its `WWW-Authenticate` response and `/.well-known/oauth-protected-resource` metadata. Validate `https://mcp.githits.com/.well-known/oauth-protected-resource` returns 200 and unauthenticated remote MCP requests return the expected 401 with `resource_metadata`.
 
 ## Agent Skills Lifecycle
 

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "GitHits plugins for Claude Code - code examples from global open source",
-    "version": "0.6.1"
+    "version": "0.6.2"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Code examples from global open source for developers and AI assistants",
   "author": {
     "name": "GitHits"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,13 @@ jobs:
         # Only run if Main workflow succeeded
         if: github.event.workflow_run.conclusion == 'success'
         runs-on: ubuntu-latest
+        environment: production
         permissions:
             contents: write
             id-token: write # Required for OIDC trusted publishing
+        env:
+            MCP_PUBLISHER_VERSION: v1.7.9
+            MCP_PUBLISHER_LINUX_AMD64_SHA256: ab128162b0616090b47cf245afe0a23f3ef08936fdce19074f5ba0a4469281ac
         steps:
             - name: Checkout
               uses: actions/checkout@v7
@@ -91,6 +95,109 @@ jobs:
             - name: Publish to npm
               if: steps.version.outputs.should_release == 'true' && steps.version.outputs.npm_published == 'false'
               run: npm publish --access public
+
+            - name: Install MCP publisher
+              if: steps.version.outputs.should_release == 'true'
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: |
+                  set -euo pipefail
+                  DOWNLOAD_DIR="$RUNNER_TEMP/mcp-publisher-download"
+                  INSTALL_DIR="$RUNNER_TEMP/mcp-publisher-bin"
+                  mkdir -p "$DOWNLOAD_DIR" "$INSTALL_DIR"
+                  gh release download "$MCP_PUBLISHER_VERSION" \
+                    --repo modelcontextprotocol/registry \
+                    --pattern "mcp-publisher_linux_amd64.tar.gz" \
+                    --dir "$DOWNLOAD_DIR"
+                  echo "${MCP_PUBLISHER_LINUX_AMD64_SHA256}  ${DOWNLOAD_DIR}/mcp-publisher_linux_amd64.tar.gz" | sha256sum --check
+                  tar -xzf "${DOWNLOAD_DIR}/mcp-publisher_linux_amd64.tar.gz" -C "$INSTALL_DIR"
+                  chmod +x "$INSTALL_DIR/mcp-publisher"
+                  echo "$INSTALL_DIR" >> "$GITHUB_PATH"
+
+            - name: Prepare MCP registry manifest
+              if: steps.version.outputs.should_release == 'true'
+              id: mcp_manifest
+              run: |
+                  set -euo pipefail
+                  VERSION="${{ steps.version.outputs.version }}"
+                  MANIFEST="$RUNNER_TEMP/server.json"
+                  jq --arg version "$VERSION" '
+                    .version = $version
+                    | (.packages[]? | select(.registryType == "npm" and .identifier == "githits") | .version) = $version
+                  ' server.json > "$MANIFEST"
+                  echo "path=$MANIFEST" >> "$GITHUB_OUTPUT"
+
+            - name: Azure login
+              if: steps.version.outputs.should_release == 'true'
+              uses: azure/login@v2
+              with:
+                  client-id: ${{ secrets.AZURE_CLIENT_ID }}
+                  tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+                  subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+            - name: Authenticate MCP registry
+              if: steps.version.outputs.should_release == 'true'
+              env:
+                  MCP_REGISTRY_KEY_VAULT_NAME: ${{ secrets.MCP_REGISTRY_KEY_VAULT_NAME }}
+                  MCP_REGISTRY_SIGNING_KEY_NAME: ${{ secrets.MCP_REGISTRY_SIGNING_KEY_NAME }}
+              run: |
+                  set -euo pipefail
+                  mcp-publisher login http azure-key-vault \
+                    --domain githits.com \
+                    --vault "$MCP_REGISTRY_KEY_VAULT_NAME" \
+                    --key "$MCP_REGISTRY_SIGNING_KEY_NAME"
+
+            - name: Validate MCP registry manifest
+              if: steps.version.outputs.should_release == 'true'
+              env:
+                  MCP_SERVER_JSON: ${{ steps.mcp_manifest.outputs.path }}
+              run: |
+                  set -euo pipefail
+                  jq -e '
+                    .name == "com.githits/githits"
+                    and .version == "${{ steps.version.outputs.version }}"
+                    and any(.remotes[]?; .url == "https://mcp.githits.com")
+                    and any(.packages[]?; .registryType == "npm" and .identifier == "githits" and .version == "${{ steps.version.outputs.version }}")
+                  ' "$MCP_SERVER_JSON" >/dev/null
+
+                  set +e
+                  VALIDATE_OUTPUT="$(mcp-publisher validate "$MCP_SERVER_JSON" 2>&1)"
+                  VALIDATE_STATUS=$?
+                  set -e
+                  if [ "$VALIDATE_STATUS" -eq 0 ]; then
+                    echo "$VALIDATE_OUTPUT"
+                  elif grep -qi "Unknown command: validate" <<<"$VALIDATE_OUTPUT"; then
+                    echo "::warning::mcp-publisher $MCP_PUBLISHER_VERSION does not implement validate; publish will perform registry validation"
+                  else
+                    echo "$VALIDATE_OUTPUT"
+                    exit "$VALIDATE_STATUS"
+                  fi
+
+            - name: Publish to MCP registry
+              if: steps.version.outputs.should_release == 'true'
+              env:
+                  MCP_SERVER_JSON: ${{ steps.mcp_manifest.outputs.path }}
+              run: |
+                  set -euo pipefail
+                  PUBLISH_LOG="$RUNNER_TEMP/mcp-publisher-publish.log"
+
+                  set +e
+                  mcp-publisher publish "$MCP_SERVER_JSON" >"$PUBLISH_LOG" 2>&1
+                  PUBLISH_STATUS=$?
+                  set -e
+
+                  if [ "$PUBLISH_STATUS" -eq 0 ]; then
+                    cat "$PUBLISH_LOG"
+                    exit 0
+                  fi
+
+                  if grep -Eiq "already exists|409|conflict|duplicate" "$PUBLISH_LOG"; then
+                    echo "MCP registry version already exists; treating publish as complete."
+                    exit 0
+                  fi
+
+                  cat "$PUBLISH_LOG"
+                  exit "$PUBLISH_STATUS"
 
             - name: Create GitHub Release
               if: steps.version.outputs.should_release == 'true' && steps.version.outputs.release_exists == 'false'

--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Code examples from global open source for developers and AI assistants",
   "author": {
     "name": "GitHits"

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Code examples from global open source for developers and AI assistants.",
   "mcpServers": {
     "githits": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "githits",
   "description": "Version-aware open-source context for agentic software development",
-  "version": "0.6.1",
+  "version": "0.6.2",
+  "mcpName": "com.githits/githits",
   "type": "module",
   "workspaces": [
     "packages/*"
@@ -12,6 +13,7 @@
     ".plugin",
     ".claude-plugin",
     ".mcp.json",
+    "server.json",
     "gemini-extension.json",
     "GEMINI.md",
     "plugins",

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Code examples from global open source for developers and AI assistants",
   "author": {
     "name": "GitHits"

--- a/server.json
+++ b/server.json
@@ -63,7 +63,7 @@
         "code-examples",
         "code-navigation",
         "code-search",
-        "documentation-access",
+        "documentation-search",
         "package-inspection"
       ],
       "workflows": [

--- a/server.json
+++ b/server.json
@@ -75,11 +75,10 @@
         "maintenance"
       ],
       "useCases": [
-        "Plan and research unfamiliar APIs, SDKs, and implementation approaches before changing code",
-        "Inspect version-specific dependency behavior, undocumented APIs, and stack traces from third-party code",
-        "Compare package documentation with indexed source for configuration, migration notes, and docs-source disagreements",
-        "Debug failing tests or integration issues by searching package source, documentation, symbols, and error messages",
-        "Review dependency selection, upgrades, vulnerabilities, dependency graphs, changelogs, and upgrade evidence"
+        "Find prior art and implementation patterns from public open-source repositories, issues, discussions, and pull requests",
+        "Search indexed packages and repositories, grep source, list files, and read exact lines without cloning",
+        "Search hosted and repo-backed package documentation, then read targeted pages and line ranges",
+        "Inspect package metadata, vulnerabilities, dependency graphs, changelogs, upgrade evidence, and package documentation"
       ]
     }
   }

--- a/server.json
+++ b/server.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "com.githits/githits",
+  "title": "GitHits",
+  "description": "Version-aware open-source context for agentic software development.",
+  "websiteUrl": "https://githits.com",
+  "repository": {
+    "url": "https://github.com/githits-com/githits-cli",
+    "source": "github",
+    "id": "1165453165"
+  },
+  "version": "0.6.2",
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.githits.com"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "npm",
+      "registryBaseUrl": "https://registry.npmjs.org",
+      "identifier": "githits",
+      "version": "0.6.2",
+      "runtimeHint": "npx",
+      "transport": {
+        "type": "stdio"
+      },
+      "packageArguments": [
+        {
+          "type": "positional",
+          "value": "mcp"
+        },
+        {
+          "type": "positional",
+          "value": "start"
+        }
+      ]
+    }
+  ]
+}

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "com.githits/githits",
   "title": "GitHits",
-  "description": "Public open-source code, package documentation, metadata, vulnerabilities, changelogs, and examples.",
+  "description": "Search public open-source code, documentation, metadata, vulnerabilities, changelogs, and examples.",
   "websiteUrl": "https://githits.com",
   "icons": [
     {

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "com.githits/githits",
   "title": "GitHits",
-  "description": "Version-aware open-source code, documentation, and package context for AI agents.",
+  "description": "Indexed public open-source code, package docs, metadata, vulnerabilities, changelogs, and examples.",
   "websiteUrl": "https://githits.com",
   "icons": [
     {
@@ -49,23 +49,26 @@
     "io.modelcontextprotocol.registry/publisher-provided": {
       "keywords": [
         "githits",
-        "open source",
-        "open-source",
-        "code search",
+        "public open-source",
+        "open-source code",
         "package docs",
         "package metadata",
         "vulnerabilities",
-        "security advisories",
         "changelogs",
-        "dependency intelligence",
-        "examples",
-        "coding agents"
+        "dependency graphs",
+        "upgrade evidence",
+        "implementation examples"
       ],
-      "categories": ["developer-tools", "code-search", "package-intelligence"],
+      "categories": [
+        "code-examples",
+        "code-navigation",
+        "documentation-access",
+        "package-inspection"
+      ],
       "useCases": [
-        "Find version-aware OSS code examples",
-        "Inspect package docs and metadata",
-        "Review vulnerabilities, dependencies, and changelogs"
+        "Find prior art and implementation patterns",
+        "Search indexed packages and repositories without cloning",
+        "Inspect dependency metadata, vulnerabilities, changelogs, and upgrade context"
       ]
     }
   }

--- a/server.json
+++ b/server.json
@@ -1,9 +1,16 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "com.githits/githits",
-  "title": "GitHits",
-  "description": "Version-aware open-source context for agentic software development.",
+  "title": "GitHits OSS Context",
+  "description": "Search OSS code, package docs, vulnerabilities, changelogs, and examples for AI coding agents.",
   "websiteUrl": "https://githits.com",
+  "icons": [
+    {
+      "src": "https://githits.com/assets/brand/logos/GH-Favicon-Gradient_512x512.png",
+      "mimeType": "image/png",
+      "sizes": ["512x512"]
+    }
+  ],
   "repository": {
     "url": "https://github.com/githits-com/githits-cli",
     "source": "github",
@@ -37,5 +44,32 @@
         }
       ]
     }
-  ]
+  ],
+  "_meta": {
+    "io.modelcontextprotocol.registry/publisher-provided": {
+      "keywords": [
+        "githits",
+        "mcp",
+        "model context protocol",
+        "open source",
+        "oss",
+        "code search",
+        "package docs",
+        "package metadata",
+        "vulnerabilities",
+        "security advisories",
+        "changelogs",
+        "dependency intelligence",
+        "examples",
+        "coding agents",
+        "ai agents"
+      ],
+      "categories": ["developer-tools", "code-search", "package-intelligence"],
+      "useCases": [
+        "Find version-aware OSS code examples",
+        "Inspect package docs and metadata",
+        "Review vulnerabilities, dependencies, and changelogs"
+      ]
+    }
+  }
 }

--- a/server.json
+++ b/server.json
@@ -66,9 +66,10 @@
         "package-inspection"
       ],
       "useCases": [
-        "Find prior art and implementation patterns",
-        "Search indexed packages and repositories without cloning",
-        "Inspect dependency metadata, vulnerabilities, changelogs, and upgrade context"
+        "Find prior art and implementation patterns from public open-source repositories, issues, discussions, and pull requests",
+        "Search indexed packages and repositories, grep source, list files, and read exact lines without cloning",
+        "Search hosted and repo-backed package docs, then read targeted pages and line ranges",
+        "Inspect package metadata, vulnerabilities, dependency graphs, changelogs, upgrade evidence, and package docs"
       ]
     }
   }

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "com.githits/githits",
   "title": "GitHits",
-  "description": "Indexed public open-source code, package docs, metadata, vulnerabilities, changelogs, and examples.",
+  "description": "Public open-source code, package documentation, metadata, vulnerabilities, changelogs, and examples.",
   "websiteUrl": "https://githits.com",
   "icons": [
     {
@@ -51,7 +51,7 @@
         "githits",
         "public open-source",
         "open-source code",
-        "package docs",
+        "package documentation",
         "package metadata",
         "vulnerabilities",
         "changelogs",
@@ -62,14 +62,15 @@
       "categories": [
         "code-examples",
         "code-navigation",
+        "code-search",
         "documentation-access",
         "package-inspection"
       ],
       "useCases": [
         "Find prior art and implementation patterns from public open-source repositories, issues, discussions, and pull requests",
         "Search indexed packages and repositories, grep source, list files, and read exact lines without cloning",
-        "Search hosted and repo-backed package docs, then read targeted pages and line ranges",
-        "Inspect package metadata, vulnerabilities, dependency graphs, changelogs, upgrade evidence, and package docs"
+        "Search hosted and repo-backed package documentation, then read targeted pages and line ranges",
+        "Inspect package metadata, vulnerabilities, dependency graphs, changelogs, upgrade evidence, and package documentation"
       ]
     }
   }

--- a/server.json
+++ b/server.json
@@ -66,11 +66,20 @@
         "documentation-access",
         "package-inspection"
       ],
+      "workflows": [
+        "planning",
+        "research",
+        "implementation",
+        "debugging",
+        "dependency review",
+        "maintenance"
+      ],
       "useCases": [
-        "Find prior art and implementation patterns from public open-source repositories, issues, discussions, and pull requests",
-        "Search indexed packages and repositories, grep source, list files, and read exact lines without cloning",
-        "Search hosted and repo-backed package documentation, then read targeted pages and line ranges",
-        "Inspect package metadata, vulnerabilities, dependency graphs, changelogs, upgrade evidence, and package documentation"
+        "Plan and research unfamiliar APIs, SDKs, and implementation approaches before changing code",
+        "Inspect version-specific dependency behavior, undocumented APIs, and stack traces from third-party code",
+        "Compare package documentation with indexed source for configuration, migration notes, and docs-source disagreements",
+        "Debug failing tests or integration issues by searching package source, documentation, symbols, and error messages",
+        "Review dependency selection, upgrades, vulnerabilities, dependency graphs, changelogs, and upgrade evidence"
       ]
     }
   }

--- a/server.json
+++ b/server.json
@@ -50,7 +50,7 @@
       "keywords": [
         "githits",
         "open source",
-        "oss",
+        "open-source",
         "code search",
         "package docs",
         "package metadata",

--- a/server.json
+++ b/server.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "com.githits/githits",
-  "title": "GitHits OSS Context",
-  "description": "Search OSS code, package docs, vulnerabilities, changelogs, and examples for AI coding agents.",
+  "title": "GitHits",
+  "description": "Version-aware open-source code, documentation, and package context for AI agents.",
   "websiteUrl": "https://githits.com",
   "icons": [
     {
@@ -49,8 +49,6 @@
     "io.modelcontextprotocol.registry/publisher-provided": {
       "keywords": [
         "githits",
-        "mcp",
-        "model context protocol",
         "open source",
         "oss",
         "code search",
@@ -61,8 +59,7 @@
         "changelogs",
         "dependency intelligence",
         "examples",
-        "coding agents",
-        "ai agents"
+        "coding agents"
       ],
       "categories": ["developer-tools", "code-search", "package-intelligence"],
       "useCases": [


### PR DESCRIPTION
## Summary

- Add `server.json` for `com.githits/githits` with both remote `https://mcp.githits.com` and npm `githits` stdio transports.
- Bump root CLI/plugin release metadata to `0.6.2` and add `package.json#mcpName` plus `server.json` to npm package files.
- Extend the release workflow to publish to the MCP registry after npm trusted publishing using GitHub OIDC to Azure Key Vault, with no client secret or raw signing key material.

## Rollout note

The landing proof is deployed: `https://githits.com/.well-known/mcp-registry-auth` returns the generated MCP registry proof body.

## Validation

- `bun test`
- `bun run build`
- `bun run validate:packages`
- `bun run smoke:mcp`
- `npm pack --dry-run --json` confirms `server.json` is included
- `mcp-publisher validate server.json`
- `https://githits.com/.well-known/mcp-registry-auth` returns 200 and matches the generated proof body
- `https://mcp.githits.com/.well-known/oauth-protected-resource` returns 200
- unauthenticated remote MCP initialize returns 401 with OAuth resource metadata