### PR TITLE
fix: stop upgrading release workflows to broken npm 12

### DIFF
--- a/.github/workflows/mcp-release.yml
+++ b/.github/workflows/mcp-release.yml
@@ -51,11 +51,11 @@ jobs:
           node-version-file: ".node-version"
           registry-url: "https://registry.npmjs.org"
 
-      # Trusted publishing requires npm 11.5.1+. The dry-run path also uses npm
-      # publish so PRs exercise the same command shape without publishing.
-      - name: Update npm
-        run: npm install -g npm@latest
-
+      # Trusted publishing requires npm 11.5.1+; the npm bundled with the
+      # pinned .node-version satisfies this. Do not upgrade to npm@latest:
+      # npm 12.0.0 self-installs without sigstore and breaks npm publish
+      # (npm/cli#9722). The dry-run path also uses npm publish so PRs
+      # exercise the same command shape without publishing.
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
@@ -102,10 +102,9 @@ jobs:
           node-version-file: ".node-version"
           registry-url: "https://registry.npmjs.org"
 
-      # Trusted publishing requires npm 11.5.1+.
-      - name: Update npm
-        run: npm install -g npm@latest
-
+      # Trusted publishing requires npm 11.5.1+; the npm bundled with the
+      # pinned .node-version satisfies this. Do not upgrade to npm@latest
+      # (npm/cli#9722).
       - name: Install dependencies
         run: bun install --frozen-lockfile
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,10 +72,9 @@ jobs:
                   node-version-file: ".node-version"
                   registry-url: "https://registry.npmjs.org"
 
-            # Trusted publishing requires npm 11.5.1+
-            - name: Update npm
-              if: steps.version.outputs.should_release == 'true'
-              run: npm install -g npm@latest
+            # Trusted publishing requires npm 11.5.1+; the npm bundled with the
+            # pinned .node-version satisfies this. Do not upgrade to npm@latest
+            # (npm/cli#9722).
 
             - name: Install dependencies
               if: steps.version.outputs.should_release == 'true'


### PR DESCRIPTION
## Problem

The `MCP Package Release` validation job on `main` failed with:

```
npm error Cannot find module 'sigstore'
npm error Require stack:
npm error - .../libnpmpublish/lib/provenance.js
```

## Root cause

npm 12.0.0 (dist-tag `latest` since 2026-07-08) has a packaging bug ([npm/cli#9722](https://github.com/npm/cli/issues/9722)): its tarball ships `sigstore` under `node_modules/` but does not declare it in npm's own `dependencies`/`bundleDependencies`. `npm install -g npm@latest` therefore prunes it as extraneous ("removed 18 packages" in the run log), and every subsequent `npm publish` — including `--dry-run` — crashes loading `libnpmpublish/lib/provenance.js`. Reproduced locally with a temp-prefix install of npm 12.0.0.

It surfaced only now because earlier runs since July 8 skipped the publish/dry-run paths (versions already published). Both `release.yml` and `mcp-release.yml` publish steps were broken; the root workflow simply hadn't been exercised.

## Fix

Remove the `Update npm` (`npm install -g npm@latest`) steps from `release.yml` and both `mcp-release.yml` jobs. The step existed only because trusted publishing requires npm ≥ 11.5.1, but the pinned `.node-version` (24.15.0) bundles npm 11.12.1, which already satisfies it. Comments now document the requirement and warn against reintroducing `npm@latest`.

## Verification

- `bun run validate:packages:mcp-publish` passes locally on bundled npm 11.12.1 (same version CI will now use; `ci.yml` already runs this path without the npm upgrade and passes).
- This PR touches `mcp-release.yml`, so the `MCP package validation` job runs on the PR and exercises the exact `npm publish --dry-run` path with the bundled npm.
- The first post-merge release is the end-to-end confirmation for the real publish steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)