### PR TITLE
fix: harden credential persistence

### DIFF
--- a/docs/implementation/auth.md
+++ b/docs/implementation/auth.md
@@ -50,6 +50,7 @@ Tokens are JWTs with a configurable expiration (typically 1 hour). The CLI handl
 - **Shared retry helper** — GitHits REST calls and package/source service calls both use the same token-refresh/retry flow, so auth drift is handled consistently across both service families.
 - **Concurrent coalescing** — Soft refreshes from `getToken()` coalesce with each other, and strict refreshes from `forceRefresh()` coalesce with each other. A strict refresh waits for any in-flight soft refresh to finish, then refreshes the latest stored token instead of reusing a soft result that may not have hit the token endpoint. Once a strict refresh is active, later `getToken()` calls join it instead of serving cached credentials, even if the cached token still looks time-valid. Refresh attempts run inside the auth storage lock, covering storage reload, token endpoint refresh, and token save/clear as one cross-process transaction. The lock is per OS user, not per active config directory, because keychain credentials are shared even when `APPDATA` or `XDG_CONFIG_HOME` differs between agents. This prevents parallel agents from spending the same rotating refresh token at the same time. Storage writes still use compare-and-swap helpers as a defensive guard. Before refreshing a cached token, the manager reloads storage so long-running MCP servers use credentials written by a separate login/refresh.
 - **Terminal refresh failures** — Supabase OAuth refresh failures such as `invalid_client`, deleted client registrations, revoked sessions, or refresh-token reuse (`Invalid Refresh Token: Already Used`) are not retried as transient errors. The CLI clears stale token state immediately, and clears the stored client registration for invalid-client failures so the next login performs fresh dynamic client registration.
+- **Transient refresh failures** — Transport, timeout, and 5xx failures never clear refresh credentials. If the access token is expired, the current call returns no token, leaves the expired candidate cached and persisted, and the next `getToken()` call attempts refresh again. A later successful refresh persists token rotation normally; the expired access token is never served.
 - **Active-backend-scoped automatic clears** — Automatic refresh-failure cleanup (`TokenManager`) and login's client re-registration cleanup clear only the **active storage backend class**, never the inactive one. The active class is everything the active-mode load reads: keychain in keychain mode; the file store plus all legacy plaintext stores in file mode (a leftover legacy copy would otherwise be re-migrated on the next load and resurrect the just-cleared credential). This prevents a stale credential in an inactive backend — e.g. a keychain token left over from a launch without `GITHITS_AUTH_STORAGE=file` — from wiping the good credential in the mode the user actually runs. Only explicit `logout` (`clearAuthSession`) clears every backend. The composite methods are `clearActiveTokensIfUnchanged` / `clearActiveClient` on `AuthStorage`; single-backend stores delegate them to the unscoped clear.
 - **At login** (`src/commands/login.ts`) — Checks if existing token is still valid before starting the OAuth flow. Respects `--force` flag to re-authenticate regardless.
 - **At init** (`src/commands/init/init.ts`) — Resolves auth through `createContainer()` at the login step so standard token refresh runs before falling back to browser login.
@@ -103,7 +104,7 @@ When `auth.storage = "file"`, auth data is stored under the platform config auth
 | `auth.json` | OAuth tokens | `{ version: 1, tokens: { [mcpUrl]: { accessToken, refreshToken, expiresAt (string\|null), createdAt } } }` |
 | `client.json` | DCR client registration | `{ version: 1, clients: { [mcpUrl]: { clientId, clientSecret, redirectUri, registeredAt } } }` |
 
-Both files use 0600 permissions. The directory uses 0700. Rewrites use `FileSystemService.atomicWriteFile()` so a crash does not leave half-written JSON. This protects against other local users but does not encrypt credentials at rest.
+On POSIX, new files and successful rewrites are capped at 0600 permissions; an existing more-restrictive mode such as 0400 is preserved. The directory is requested with 0700 when created. Rewrites use `FileSystemService.atomicWriteFile()` so readers do not observe half-written JSON, but no power-loss durability is claimed. POSIX mode bits are not a Windows ACL guarantee. File storage protects against other local users where those modes apply, but does not encrypt credentials at rest.
 
 Typical Linux layout:
 
@@ -129,11 +130,12 @@ Keychain mode:
 
 File mode:
 
-1. Check new file path — if found, return it
-2. Check legacy `~/.githits` — if found, write to new file path, delete legacy entry, return it
-3. Do not inspect or export keychain credentials
+1. Read canonical and legacy plaintext candidates without inspecting keychain credentials.
+2. Select the unique newest valid timestamp when one exists.
+3. For tied or invalid timestamps, prefer the canonical candidate when present, re-persist it, then clear all legacy copies best-effort.
+4. If ambiguity exists only between legacy stores, return no candidate, leave every legacy entry intact, and warn instead of guessing.
 
-The file-mode legacy target write must succeed before the legacy source entry is deleted. Tokens and client registrations migrate independently. If both plaintext paths contain entries, the newer timestamp wins; ambiguous ties prefer the new file path and leave the other entry intact with a warning.
+The canonical target write must succeed before any legacy source entry is deleted. Tokens and client registrations migrate independently, and cleanup across independent stores is not transactionally atomic.
 
 ### Architecture
 
@@ -151,7 +153,7 @@ Container (createAuthStorage)
 
 All credential types are keyed by normalized MCP base URL (trailing slashes stripped), supporting multiple environments simultaneously.
 
-`LockedAuthStorage` serializes mutating auth operations and token refresh transactions across CLI processes and long-running MCP servers with an `auth.lock` directory under the platform config path. The lock records PID and process start time so dead-owner locks can be reclaimed without stealing live locks. Token refresh holds this lock while it reloads stored credentials, calls the token endpoint, and saves or clears the result.
+`LockedAuthStorage` serializes mutations and file-mode migration loads across CLI processes and long-running MCP servers with an `auth.lock` directory under the platform config path. File-mode loads participate because migration can reconcile ambiguous plaintext candidates by writing the canonical record and clearing legacy copies; ordinary keychain loads remain read-only and avoid this lock. The lock records PID and process start time so dead-owner locks can be reclaimed without stealing live locks. Token refresh holds this lock while it reloads stored credentials, calls the token endpoint, and saves or clears the result.
 
 ## How Auth Flows Through the System
 
@@ -164,8 +166,9 @@ CLI startup / MCP server start
                  ├─ stored token valid? → use it
                  ├─ stored token near-expiry (≥90% lifetime)? → proactive refresh
                  ├─ stored token expired? → reactive refresh
-                 │    ├─ refresh success → save new tokens, use them
-                  │    └─ refresh fail → reload storage; use externally updated tokens or clear the active backend only if unchanged and expired
+                  │    ├─ refresh success → save new tokens, use them
+                  │    ├─ transient failure → reload storage; retain unchanged refresh credentials and return no expired access token
+                  │    └─ terminal failure → reload storage; clear the active backend only if unchanged
                   └─ no stored token → hasValidToken=false
 
 Per API call (via RefreshingGitHitsService):
@@ -181,7 +184,7 @@ The MCP server starts without a synchronous auth gate. Tool calls resolve tokens
 - **Different auth behavior across terminals or agents** — Run `githits doctor` or `githits doctor --json` to compare redacted runtime, environment, config, and auth-storage diagnostics without exposing token values.
 - **"Already logged in."** — Token is still valid. Use `githits login --force` to re-authenticate.
 - **Port conflicts on login** — The callback server uses the port from the stored client registration. On first login, a random port (8000–9999) is chosen and saved. Use `--port <port>` to change it (triggers re-registration).
-- **Token refresh fails silently** — By design. The token manager first reloads storage in case another process refreshed credentials. If the expired token is still unchanged, it clears that stale token (active backend only — see "Active-backend-scoped automatic clears") and later calls prompt re-login.
+- **Token refresh fails silently** — The token manager first reloads storage in case another process refreshed credentials. Transient failures retain unchanged refresh credentials and later calls retry. Only classified terminal failures clear the stale token from the active backend and require login again.
 - **Logged out after running in a different storage mode** — Credentials saved under one `auth.storage` mode are invisible to the other (keychain and file modes do not cross-inspect). An inconsistent `GITHITS_AUTH_STORAGE` across contexts (e.g. set for the MCP server but not the interactive shell) looks like a logout. Automatic clears no longer compound this by wiping the other mode's credentials, but the fix for the phantom logout is to make the mode consistent everywhere (prefer `auth.storage` in `config.toml` over the env var) and `githits login --force` once.
 - **Clearing auth** — Run `githits logout` to remove stored tokens and client registration for the current environment.
 - **System keychain unavailable** — In default keychain mode, OAuth login/refresh fails rather than writing plaintext credentials. Use `GITHITS_API_TOKEN`, fix/unlock the keychain, or explicitly configure `auth.storage = "file"` if plaintext local storage is acceptable.
@@ -190,7 +193,7 @@ The MCP server starts without a synchronous auth gate. Tool calls resolve tokens
 ## Diagnostics
 
 - **Telemetry (opt-in, local repro only)** — When `GITHITS_TELEMETRY` is enabled, auth spans carry diagnostic attributes: `auth.fingerprint` records the resolved storage `mode`, platform, and which scope-determining env vars are set (booleans only, never values); token/client clear spans carry a `reason` (`terminal_invalid_refresh_token`, `terminal_invalid_client`, `logout`). This flushes to stderr and is invisible to external users running the MCP server, so it only helps when we reproduce locally with the flag on.
-- **Persisted auth-clear breadcrumb (doctor-visible)** — Because the only diagnostic channel that reaches an external user is persisted state surfaced by `githits doctor`, the last auth-clear `{ reason, at }` is persisted to `auth/diagnostics.json` and rendered by `doctor` as `last clear: ...`. When the active token is missing, `doctor` adds a recommendation explaining the cause (refresh-token reuse/expiry, rejected client registration, or explicit logout). Writes happen at the clear sites — `logout` and `TokenManager` terminal refresh failures — and are best-effort, so a diagnostics write can never break the path it observes. The file lives separately from `metadata.json` because credential clears wipe metadata and a breadcrumb stored there would erase itself; it is only ever overwritten by the next event, never cleared, and holds no secrets (a reason enum and timestamp keyed by MCP URL).
+- **Persisted auth-clear breadcrumb (doctor-visible)** — Because the only diagnostic channel that reaches an external user is persisted state surfaced by `githits doctor`, the last auth-clear `{ reason, at }` is persisted to `auth/diagnostics.json` and rendered by `doctor` as `last clear: ...`. When the active token is missing, `doctor` adds a recommendation explaining the cause (refresh-token reuse/expiry, rejected client registration, or explicit logout). Writes happen at the clear sites — `logout` and `TokenManager` terminal refresh failures — and are best-effort, so a diagnostics write can never break the path it observes. The file lives separately from `metadata.json` because credential clears wipe metadata and a breadcrumb stored there would erase itself; it is only ever overwritten by the next event, never cleared, and holds no secrets (a reason enum and timestamp keyed by MCP URL). Like other auth-associated files, successful POSIX rewrites are capped at 0600.
 
 ## Key Reference Files
 

--- a/docs/implementation/config.md
+++ b/docs/implementation/config.md
@@ -30,7 +30,7 @@ The container (`src/container.ts`) resolves authentication in priority order:
 
 1. **`GITHITS_API_TOKEN`** — If set, uses this token directly. No OAuth flow needed. Quick to set up for CI and automation environments.
 
-2. **Stored OAuth JWT** — Loaded from the configured auth store. If expired, the container automatically attempts a refresh using the stored refresh token. If refresh fails, auth is cleared silently.
+2. **Stored OAuth JWT** — Loaded from the configured auth store. If expired, the container automatically attempts a refresh using the stored refresh token. Transient failures retain credentials for a later retry; classified terminal failures clear the active credential state.
 
 3. **Unauthenticated** — No token available. Auth-required CLI commands fail on use, and the MCP server can start but every authenticated tool call will fail. Commands like `auth status` and `doctor` still work to help the user diagnose the issue.
 
@@ -75,7 +75,7 @@ Invalid `GITHITS_AUTH_STORAGE` or `auth.storage` values fail fast with a message
 
 Auto-login startup checks use non-secret metadata before touching the credential store. This avoids keychain reads during ordinary command startup when the local metadata was updated recently and says an unexpired session exists. Missing, stale, expired, or malformed metadata falls back to the credential store so existing users recover after the next successful keychain/file read.
 
-When file mode is enabled, storage uses secure file permissions but is not encrypted:
+When file mode is enabled, storage uses restrictive POSIX file modes but is not encrypted:
 
 ```text
 ~/.config/githits/          (0700 on Unix-like platforms)
@@ -84,7 +84,10 @@ When file mode is enabled, storage uses secure file permissions but is not encry
     auth.json              (0600) — OAuth tokens keyed by MCP URL
     client.json            (0600) — DCR client registrations keyed by MCP URL
     metadata.json          (0600) — non-secret session expiry metadata keyed by MCP URL
+    diagnostics.json       (0600) — non-secret last-clear breadcrumb keyed by MCP URL
 ```
+
+The four files under `auth/` are capped at the listed mode for new files and successful rewrites on POSIX; existing more-restrictive files are not broadened. A new `config.toml` uses 0600, while later config rewrites preserve its existing mode. Directory modes apply when GitHits creates the directory and do not repair a pre-existing permissive directory. Windows mode bits are not an ACL guarantee.
 
 Platform roots:
 
@@ -96,7 +99,7 @@ Platform roots:
 
 Legacy `~/.githits/auth.json`, `~/.githits/client.json`, and the old macOS `~/Library/Application Support/githits` auth/config paths are still read for migration and cleared by logout where applicable, but new plaintext writes use the canonical config auth path.
 
-When writing config or auth files, use `FileSystemService` rather than `node:fs` directly — this enables testing via mock implementations from `src/services/test-helpers.ts`. Auth credential rewrites should use `atomicWriteFile()` to avoid truncated JSON on crashes.
+When writing config or auth files, use `FileSystemService` rather than `node:fs` directly — this enables testing via mock implementations from `src/services/test-helpers.ts`. Auth-associated rewrites must pass a 0600 maximum to `atomicWriteFile()` to avoid preserving permissive modes and to prevent readers from observing truncated JSON.
 
 Non-secret update-check state uses the XDG config location:
 

--- a/docs/implementation/update-check.md
+++ b/docs/implementation/update-check.md
@@ -113,8 +113,9 @@ When `XDG_CONFIG_HOME` is set, the path is:
 $XDG_CONFIG_HOME/githits/update-check.json
 ```
 
-The directory is created with mode `0o700`; the cache file is written with mode
-`0o600`. The cache contains no credentials.
+The directory is requested with mode `0o700` when created. A new cache file uses
+mode `0o600`; atomic rewrites preserve an existing cache file's mode because the
+cache contains no credentials.
 
 Cache shape:
 

--- a/docs/plans/quality-review-p0-p1.md
+++ b/docs/plans/quality-review-p0-p1.md
@@ -12,8 +12,9 @@ migration, config, and command suites.
 
 ## Status
 
-- PR 1 implemented and fully verified in the worktree; pending review/landing.
-- PR 2 and PR 3 remain pending.
+- PR 1 landed in PR #224.
+- PR 2 is implemented and fully verified in the worktree; pending review/landing.
+- PR 3 remains pending.
 
 ## PR Decision
 
@@ -67,11 +68,12 @@ collapse everything into one PR.
   `127.0.0.1`, and `[::1]`/`::1` after URL parsing.
 - `PKGSEER_URL` remains a supported legacy fallback and receives the same URL
   validation as `GITHITS_CODE_NAV_URL`.
-- Existing OAuth terminal classification remains authoritative:
-  `invalid_grant` and `invalid_client` may clear credentials; transport,
-  timeout, and 5xx failures may not.
+- Existing OAuth terminal classification remains authoritative: classified 4xx
+  `invalid_grant` and `invalid_client` responses may clear credentials;
+  transport, timeout, and 5xx failures may not.
 - Existing token refresh locking, compare-and-swap behavior, and storage
-  decorator structure are not redesigned.
+  decorator structure remain. Auth loads acquire the same re-entrant lock
+  because file-mode migration loads can persist and clear ambiguous candidates.
 - Smoke CI remains unauthenticated and must not require secrets or a live
   backend.
 - Release version changes are handled by the normal release process. PRs that

--- a/src/services/auth-diagnostics-storage.test.ts
+++ b/src/services/auth-diagnostics-storage.test.ts
@@ -28,6 +28,7 @@ describe("AuthDiagnosticsStorage", () => {
     expect(fs.atomicWriteFile).toHaveBeenCalledWith(
       "/test/auth/diagnostics.json",
       expect.any(String),
+      0o600,
     );
     const calls = (fs.atomicWriteFile as ReturnType<typeof mock>).mock.calls;
     const written = JSON.parse(calls[0]?.[1] as string);

--- a/src/services/auth-diagnostics-storage.ts
+++ b/src/services/auth-diagnostics-storage.ts
@@ -29,6 +29,7 @@ interface StoredAuthDiagnostics {
 
 const DIAGNOSTICS_FILE = "diagnostics.json";
 const DIR_MODE = 0o700;
+const FILE_MODE = 0o600;
 const CLEAR_REASONS: ReadonlySet<string> = new Set<AuthClearReason>([
   "logout",
   "terminal_invalid_refresh_token",
@@ -77,6 +78,7 @@ export class AuthDiagnosticsStorage implements AuthDiagnosticsStore {
       await this.fs.atomicWriteFile(
         this.diagnosticsPath,
         JSON.stringify(stored, null, 2),
+        FILE_MODE,
       );
     } catch {
       // Diagnostic side-channel; never propagate into the observed clear path.

--- a/src/services/auth-service.test.ts
+++ b/src/services/auth-service.test.ts
@@ -509,6 +509,30 @@ describe("AuthServiceImpl", () => {
       }
     });
 
+    it("does not classify terminal-shaped 5xx refresh errors as terminal", () => {
+      const error = new TokenRefreshError(
+        503,
+        JSON.stringify({
+          error: "invalid_client",
+          error_description: "OAuth client not found",
+        }),
+      );
+
+      expect(classifyTerminalRefreshError(error)).toBeUndefined();
+    });
+
+    it("does not classify terminal-shaped 3xx refresh errors as terminal", () => {
+      const error = new TokenRefreshError(
+        302,
+        JSON.stringify({
+          error: "invalid_client",
+          error_description: "OAuth client not found",
+        }),
+      );
+
+      expect(classifyTerminalRefreshError(error)).toBeUndefined();
+    });
+
     it("normalizes and bounds JSON refresh error details", async () => {
       const description = `Invalid Refresh Token: Already Used\nsecond line ${"x".repeat(600)}`;
       const body = JSON.stringify({

--- a/src/services/auth-service.ts
+++ b/src/services/auth-service.ts
@@ -467,7 +467,13 @@ export class AuthServiceImpl implements AuthService {
 export function classifyTerminalRefreshError(
   error: unknown,
 ): TerminalRefreshFailureReason | undefined {
-  if (!(error instanceof TokenRefreshError)) return undefined;
+  if (
+    !(error instanceof TokenRefreshError) ||
+    error.status < 400 ||
+    error.status >= 500
+  ) {
+    return undefined;
+  }
 
   const oauthError = error.oauthError?.toLowerCase();
   const text = [

--- a/src/services/auth-session-metadata-storage.test.ts
+++ b/src/services/auth-session-metadata-storage.test.ts
@@ -39,6 +39,7 @@ describe("AuthSessionMetadataStorage", () => {
     expect(fs.atomicWriteFile).toHaveBeenCalledWith(
       "/test/auth/metadata.json",
       expect.any(String),
+      0o600,
     );
     const calls = (fs.atomicWriteFile as ReturnType<typeof mock>).mock.calls;
     const written = JSON.parse(calls[0]?.[1] as string);
@@ -115,5 +116,43 @@ describe("AuthSessionMetadataStorage", () => {
     await storage.clear(BASE_URL);
 
     expect(fs.deleteFile).toHaveBeenCalledWith("/test/auth/metadata.json");
+  });
+
+  it("securely rewrites metadata when another session remains", async () => {
+    const otherUrl = "https://other.githits.com";
+    const metadata = {
+      version: 1,
+      sessions: {
+        [BASE_URL]: {
+          createdAt: "2026-01-01T00:00:00Z",
+          expiresAt: null,
+          updatedAt: "2026-01-01T00:00:00Z",
+        },
+        [otherUrl]: {
+          createdAt: "2026-01-02T00:00:00Z",
+          expiresAt: null,
+          updatedAt: "2026-01-02T00:00:00Z",
+        },
+      },
+    };
+    const fs = createMockFileSystemService({
+      exists: mock(() => Promise.resolve(true)),
+      readFile: mock(() => Promise.resolve(JSON.stringify(metadata))),
+    });
+    const storage = new AuthSessionMetadataStorage(fs, "/test/auth");
+
+    await storage.clear(BASE_URL);
+
+    expect(fs.atomicWriteFile).toHaveBeenCalledWith(
+      "/test/auth/metadata.json",
+      expect.any(String),
+      0o600,
+    );
+    const written = JSON.parse(
+      (fs.atomicWriteFile as ReturnType<typeof mock>).mock
+        .calls[0]?.[1] as string,
+    );
+    expect(written.sessions[BASE_URL]).toBeUndefined();
+    expect(written.sessions[otherUrl]).toBeDefined();
   });
 });

--- a/src/services/auth-session-metadata-storage.ts
+++ b/src/services/auth-session-metadata-storage.ts
@@ -22,6 +22,7 @@ interface StoredAuthSessionMetadata {
 
 const METADATA_FILE = "metadata.json";
 const DIR_MODE = 0o700;
+const FILE_MODE = 0o600;
 
 /**
  * Stores non-secret auth metadata used for startup decisions without touching
@@ -61,6 +62,7 @@ export class AuthSessionMetadataStorage implements AuthSessionMetadataStore {
     await this.fs.atomicWriteFile(
       this.metadataPath,
       JSON.stringify(stored, null, 2),
+      FILE_MODE,
     );
   }
 
@@ -78,6 +80,7 @@ export class AuthSessionMetadataStorage implements AuthSessionMetadataStore {
     await this.fs.atomicWriteFile(
       this.metadataPath,
       JSON.stringify(stored, null, 2),
+      FILE_MODE,
     );
   }
 

--- a/src/services/auth-storage.test.ts
+++ b/src/services/auth-storage.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, mock } from "bun:test";
+import { chmod, mkdtemp, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { AuthStorageImpl, normalizeBaseUrl } from "./auth-storage.js";
+import { FileSystemServiceImpl } from "./filesystem-service.js";
 import { createMockFileSystemService } from "./test-helpers.js";
 
 describe("AuthStorageImpl", () => {
@@ -130,6 +134,7 @@ describe("AuthStorageImpl", () => {
       expect(fs.atomicWriteFile).toHaveBeenCalledWith(
         "/test/.githits/auth.json",
         expect.any(String),
+        0o600,
       );
 
       // Verify the written content
@@ -171,6 +176,35 @@ describe("AuthStorageImpl", () => {
       expect(
         writtenContent.tokens["https://other.example.com"].accessToken,
       ).toBe("eyJ-other");
+    });
+
+    it("tightens an existing permissive auth file after save", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "githits-auth-storage-"));
+      const authPath = join(dir, "auth.json");
+      try {
+        await writeFile(authPath, JSON.stringify({ version: 1, tokens: {} }), {
+          mode: 0o644,
+        });
+        if (process.platform !== "win32") await chmod(authPath, 0o644);
+        const storage = new AuthStorageImpl(new FileSystemServiceImpl(), dir);
+
+        await storage.saveTokens(BASE_URL, {
+          accessToken: "eyJ-new",
+          refreshToken: "refresh-new",
+          expiresAt: null,
+          createdAt: "2025-01-15T10:00:00Z",
+        });
+
+        expect(await storage.loadTokens(BASE_URL)).toMatchObject({
+          accessToken: "eyJ-new",
+          refreshToken: "refresh-new",
+        });
+        if (process.platform !== "win32") {
+          expect((await stat(authPath)).mode & 0o777).toBe(0o600);
+        }
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
     });
   });
 
@@ -228,6 +262,11 @@ describe("AuthStorageImpl", () => {
       const writtenContent = JSON.parse(calls[0]?.[1] as string);
       expect(Object.keys(writtenContent.tokens)).toHaveLength(1);
       expect(writtenContent.tokens[BASE_URL]).toBeUndefined();
+      expect(fs.atomicWriteFile).toHaveBeenCalledWith(
+        "/test/.githits/auth.json",
+        expect.any(String),
+        0o600,
+      );
     });
 
     it("does nothing when no auth file exists", async () => {
@@ -370,6 +409,7 @@ describe("AuthStorageImpl", () => {
       expect(fs.atomicWriteFile).toHaveBeenCalledWith(
         "/test/.githits/client.json",
         expect.any(String),
+        0o600,
       );
     });
   });
@@ -428,6 +468,11 @@ describe("AuthStorageImpl", () => {
       const writtenContent = JSON.parse(calls[0]?.[1] as string);
       expect(Object.keys(writtenContent.clients)).toHaveLength(1);
       expect(writtenContent.clients[BASE_URL]).toBeUndefined();
+      expect(fs.atomicWriteFile).toHaveBeenCalledWith(
+        "/test/.githits/client.json",
+        expect.any(String),
+        0o600,
+      );
     });
 
     it("does nothing when no client file exists", async () => {

--- a/src/services/auth-storage.ts
+++ b/src/services/auth-storage.ts
@@ -44,6 +44,9 @@ export interface StoredClients {
  * Abstraction allows for easy testing with mock implementations.
  */
 export interface AuthStorage {
+  /** Whether loads may reconcile storage and therefore require mutation locking. */
+  readonly requiresLoadLock?: boolean;
+
   /** Load tokens for a specific base URL, returns null if not found */
   loadTokens(baseUrl: string): Promise<TokenData | null>;
 
@@ -113,6 +116,7 @@ export interface AuthStorage {
 const AUTH_FILE = "auth.json";
 const CLIENT_FILE = "client.json";
 const DIR_MODE = 0o700;
+const FILE_MODE = 0o600;
 
 /**
  * File-based auth storage implementation.
@@ -153,6 +157,7 @@ export class AuthStorageImpl implements AuthStorage {
     await this.fs.atomicWriteFile(
       this.authPath,
       JSON.stringify(stored, null, 2),
+      FILE_MODE,
     );
   }
 
@@ -179,6 +184,7 @@ export class AuthStorageImpl implements AuthStorage {
       await this.fs.atomicWriteFile(
         this.authPath,
         JSON.stringify(stored, null, 2),
+        FILE_MODE,
       );
     }
   }
@@ -219,6 +225,7 @@ export class AuthStorageImpl implements AuthStorage {
       await this.fs.atomicWriteFile(
         this.clientPath,
         JSON.stringify(stored, null, 2),
+        FILE_MODE,
       );
     }
   }
@@ -234,6 +241,7 @@ export class AuthStorageImpl implements AuthStorage {
     await this.fs.atomicWriteFile(
       this.clientPath,
       JSON.stringify(stored, null, 2),
+      FILE_MODE,
     );
   }
 

--- a/src/services/filesystem-service.test.ts
+++ b/src/services/filesystem-service.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import {
+  chmod,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { FileSystemServiceImpl } from "./filesystem-service.js";
+
+describe("FileSystemServiceImpl.atomicWriteFile", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs
+        .splice(0)
+        .map((dir) => rm(dir, { recursive: true, force: true })),
+    );
+  });
+
+  it("caps an existing file at the requested maximum mode", async () => {
+    const path = await createExistingFile(0o644);
+
+    await new FileSystemServiceImpl().atomicWriteFile(path, "updated", 0o600);
+
+    expect(await readFile(path, "utf8")).toBe("updated");
+    await expectMode(path, 0o600);
+  });
+
+  it("does not broaden an existing restrictive mode", async () => {
+    const path = await createExistingFile(0o400);
+
+    await new FileSystemServiceImpl().atomicWriteFile(path, "updated", 0o600);
+
+    expect(await readFile(path, "utf8")).toBe("updated");
+    await expectMode(path, 0o400);
+  });
+
+  it("uses the maximum mode for a new file", async () => {
+    const dir = await createTempDir();
+    const path = join(dir, "new.json");
+
+    await new FileSystemServiceImpl().atomicWriteFile(path, "created", 0o600);
+
+    expect(await readFile(path, "utf8")).toBe("created");
+    await expectMode(path, 0o600);
+  });
+
+  it("preserves an existing mode when no maximum is provided", async () => {
+    const path = await createExistingFile(0o644);
+
+    await new FileSystemServiceImpl().atomicWriteFile(path, "updated");
+
+    expect(await readFile(path, "utf8")).toBe("updated");
+    await expectMode(path, 0o644);
+  });
+
+  async function createTempDir(): Promise<string> {
+    const dir = await mkdtemp(join(tmpdir(), "githits-filesystem-"));
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  async function createExistingFile(mode: number): Promise<string> {
+    const dir = await createTempDir();
+    const path = join(dir, "existing.json");
+    await writeFile(path, "original", { mode });
+    if (process.platform !== "win32") await chmod(path, mode);
+    return path;
+  }
+
+  async function expectMode(path: string, expected: number): Promise<void> {
+    if (process.platform === "win32") return;
+    expect((await stat(path)).mode & 0o777).toBe(expected);
+  }
+});

--- a/src/services/filesystem-service.test.ts
+++ b/src/services/filesystem-service.test.ts
@@ -32,7 +32,11 @@ describe("FileSystemServiceImpl.atomicWriteFile", () => {
   });
 
   it("does not broaden an existing restrictive mode", async () => {
-    const path = await createExistingFile(0o400);
+    // Windows maps 0400 to a read-only attribute that prevents rename-based
+    // replacement; POSIX permission-bit narrowing is not meaningful there.
+    const path = await createExistingFile(
+      process.platform === "win32" ? 0o600 : 0o400,
+    );
 
     await new FileSystemServiceImpl().atomicWriteFile(path, "updated", 0o600);
 

--- a/src/services/filesystem-service.ts
+++ b/src/services/filesystem-service.ts
@@ -58,8 +58,13 @@ export interface FileSystemService {
    * Ensures the target file is never left in a half-written state.
    * The temp file is created in the same directory as the target
    * so rename() is atomic on the same filesystem.
+   * An optional maximum mode intersects with an existing file's permissions.
    */
-  atomicWriteFile(path: string, contents: string): Promise<void>;
+  atomicWriteFile(
+    path: string,
+    contents: string,
+    maximumMode?: number,
+  ): Promise<void>;
 }
 
 /**
@@ -142,14 +147,25 @@ export class FileSystemServiceImpl implements FileSystemService {
     }
   }
 
-  async atomicWriteFile(path: string, contents: string): Promise<void> {
+  async atomicWriteFile(
+    path: string,
+    contents: string,
+    maximumMode?: number,
+  ): Promise<void> {
     const tmpPath = `${path}.${process.pid}.${randomUUID()}.tmp`;
-    // Preserve existing file permissions; default to 0o600 for new files
-    // (config files may contain sensitive data from other MCP servers)
-    let mode = 0o600;
+    const normalizedMaximum =
+      maximumMode === undefined ? undefined : maximumMode & 0o777;
+    // Existing modes are preserved unless a caller supplies a cap. New files
+    // use that cap or default to 0600. Rename is atomic at filesystem rename
+    // granularity; this does not claim power-loss durability.
+    let mode = normalizedMaximum ?? 0o600;
     try {
       const existing = await stat(path);
-      mode = existing.mode & 0o777;
+      const existingMode = existing.mode & 0o777;
+      mode =
+        normalizedMaximum === undefined
+          ? existingMode
+          : existingMode & normalizedMaximum;
     } catch {
       // File doesn't exist yet — use default
     }

--- a/src/services/locked-auth-storage.test.ts
+++ b/src/services/locked-auth-storage.test.ts
@@ -1,9 +1,13 @@
-import { afterEach, describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it, mock } from "bun:test";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { getAppConfigDir, getAuthLockDir } from "./app-config-paths.js";
-import { AuthStorageImpl } from "./auth-storage.js";
+import {
+  AuthStorageImpl,
+  type ClientRegistration,
+  type TokenData,
+} from "./auth-storage.js";
 import { FileSystemServiceImpl } from "./filesystem-service.js";
 import { LockedAuthStorage } from "./locked-auth-storage.js";
 import {
@@ -54,6 +58,134 @@ describe("LockedAuthStorage", () => {
     const finalToken = await first.loadTokens(baseUrl);
     expect(finalToken).not.toBeNull();
     expect(["first", "second"]).toContain(finalToken?.accessToken ?? "");
+  });
+
+  it("serializes token loads with external writes", async () => {
+    const { fsWithHome } = await createStoragePaths();
+    let releaseLoad!: () => void;
+    let loadStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      loadStarted = resolve;
+    });
+    let contentionStarted!: () => void;
+    const contention = new Promise<"contention">((resolve) => {
+      contentionStarted = () => resolve("contention");
+    });
+    let saveStarted!: () => void;
+    const innerSave = new Promise<"save">((resolve) => {
+      saveStarted = () => resolve("save");
+    });
+    const firstInner = createMockAuthStorage({
+      requiresLoadLock: true,
+      loadTokens: mock<(_baseUrl: string) => Promise<TokenData | null>>(
+        () =>
+          new Promise<TokenData | null>((resolve) => {
+            loadStarted();
+            releaseLoad = () => resolve(createValidTokenData());
+          }),
+      ),
+    });
+    const secondInner = createMockAuthStorage({
+      saveTokens: mock(() => {
+        saveStarted();
+        return Promise.resolve();
+      }),
+    });
+    const first = new LockedAuthStorage(firstInner, fsWithHome);
+    const second = new LockedAuthStorage(secondInner, fsWithHome, {
+      isOwnerAlive: async () => {
+        contentionStarted();
+        return true;
+      },
+    });
+
+    const load = first.loadTokens(baseUrl);
+    await started;
+    const save = second.saveTokens(baseUrl, createValidTokenData());
+    expect(await Promise.race([contention, innerSave])).toBe("contention");
+    expect(secondInner.saveTokens).not.toHaveBeenCalled();
+
+    releaseLoad();
+    await Promise.all([load, save]);
+    expect(secondInner.saveTokens).toHaveBeenCalledTimes(1);
+  });
+
+  it("serializes client loads with external writes", async () => {
+    const { fsWithHome } = await createStoragePaths();
+    let releaseLoad!: () => void;
+    let loadStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      loadStarted = resolve;
+    });
+    let contentionStarted!: () => void;
+    const contention = new Promise<"contention">((resolve) => {
+      contentionStarted = () => resolve("contention");
+    });
+    let saveStarted!: () => void;
+    const innerSave = new Promise<"save">((resolve) => {
+      saveStarted = () => resolve("save");
+    });
+    const firstInner = createMockAuthStorage({
+      requiresLoadLock: true,
+      loadClient: mock<
+        (_baseUrl: string) => Promise<ClientRegistration | null>
+      >(
+        () =>
+          new Promise<ClientRegistration | null>((resolve) => {
+            loadStarted();
+            releaseLoad = () => resolve(null);
+          }),
+      ),
+    });
+    const secondInner = createMockAuthStorage({
+      saveClient: mock(() => {
+        saveStarted();
+        return Promise.resolve();
+      }),
+    });
+    const first = new LockedAuthStorage(firstInner, fsWithHome);
+    const second = new LockedAuthStorage(secondInner, fsWithHome, {
+      isOwnerAlive: async () => {
+        contentionStarted();
+        return true;
+      },
+    });
+
+    const load = first.loadClient(baseUrl);
+    await started;
+    const save = second.saveClient(baseUrl, {
+      clientId: "client-id",
+      clientSecret: "client-secret",
+      redirectUri: "http://127.0.0.1/callback",
+      registeredAt: "2026-01-01T00:00:00Z",
+    });
+    expect(await Promise.race([contention, innerSave])).toBe("contention");
+    expect(secondInner.saveClient).not.toHaveBeenCalled();
+
+    releaseLoad();
+    await Promise.all([load, save]);
+    expect(secondInner.saveClient).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps read-only storage loads outside the mutation lock", async () => {
+    const { fsWithHome, lockPath } = await createStoragePaths();
+    await mkdir(lockPath, { recursive: true, mode: 0o700 });
+    await writeFile(
+      join(lockPath, "owner.json"),
+      JSON.stringify({
+        id: "live-owner",
+        pid: process.pid,
+        createdAt: new Date().toISOString(),
+        processStartedAt: "test-start-time",
+      }),
+    );
+    const storage = new LockedAuthStorage(createMockAuthStorage(), fsWithHome, {
+      isOwnerAlive: async () => true,
+      lockTimeoutMs: 10,
+    });
+
+    await expect(storage.loadTokens(baseUrl)).resolves.toBeNull();
+    await expect(storage.loadClient(baseUrl)).resolves.toBeNull();
   });
 
   it("clearActiveTokensIfUnchanged delegates through the lock", async () => {

--- a/src/services/locked-auth-storage.ts
+++ b/src/services/locked-auth-storage.ts
@@ -56,6 +56,7 @@ export class LockedAuthStorage implements AuthStorage, AuthStorageLockProvider {
   ) => Promise<boolean>;
   private readonly lockContext = new AsyncLocalStorage<string>();
   private currentOwner: LockOwner | null = null;
+  private readonly lockLoads: boolean;
 
   constructor(
     private readonly storage: AuthStorage,
@@ -70,6 +71,7 @@ export class LockedAuthStorage implements AuthStorage, AuthStorageLockProvider {
   ) {
     this.lockTimeoutMs = options.lockTimeoutMs ?? LOCK_TIMEOUT_MS;
     this.isOwnerAlive = options.isOwnerAlive ?? isOriginalProcessAlive;
+    this.lockLoads = storage.requiresLoadLock === true;
     this.lockPath = fileSystemService.joinPath(
       getAuthLockDir(fileSystemService),
       LOCK_DIR,
@@ -77,7 +79,9 @@ export class LockedAuthStorage implements AuthStorage, AuthStorageLockProvider {
   }
 
   loadTokens(baseUrl: string): Promise<TokenData | null> {
-    return this.storage.loadTokens(baseUrl);
+    return this.lockLoads
+      ? this.withAuthStorageLock(() => this.storage.loadTokens(baseUrl))
+      : this.storage.loadTokens(baseUrl);
   }
 
   saveTokens(baseUrl: string, data: TokenData): Promise<void> {
@@ -119,7 +123,9 @@ export class LockedAuthStorage implements AuthStorage, AuthStorageLockProvider {
   }
 
   loadClient(baseUrl: string): Promise<ClientRegistration | null> {
-    return this.storage.loadClient(baseUrl);
+    return this.lockLoads
+      ? this.withAuthStorageLock(() => this.storage.loadClient(baseUrl))
+      : this.storage.loadClient(baseUrl);
   }
 
   saveClient(baseUrl: string, data: ClientRegistration): Promise<void> {

--- a/src/services/migrating-auth-storage.test.ts
+++ b/src/services/migrating-auth-storage.test.ts
@@ -11,6 +11,20 @@ import {
 describe("MigratingAuthStorage", () => {
   const BASE_URL = "https://mcp.githits.com";
 
+  it("requires load locking only when file-mode migration can mutate", () => {
+    const primary = createMockAuthStorage();
+    const file = createMockAuthStorage();
+    const legacy = createMockAuthStorage();
+
+    expect(
+      new MigratingAuthStorage(primary, file, legacy, "keychain")
+        .requiresLoadLock,
+    ).toBe(false);
+    expect(
+      new MigratingAuthStorage(primary, file, legacy, "file").requiresLoadLock,
+    ).toBe(true);
+  });
+
   it("keychain mode returns from keychain first", async () => {
     const token = createValidTokenData();
     const primary = createMockAuthStorage({
@@ -257,6 +271,125 @@ describe("MigratingAuthStorage", () => {
     expect(legacy.clearTokens).not.toHaveBeenCalled();
   });
 
+  it("re-persists tied canonical tokens before clearing all legacy copies", async () => {
+    const events: string[] = [];
+    const canonical = createValidTokenData({
+      accessToken: "canonical-token",
+      createdAt: "2025-01-01T00:00:00Z",
+    });
+    const file = createMockAuthStorage({
+      loadTokens: mock(() => Promise.resolve(canonical)),
+      saveTokens: mock(() => {
+        events.push("canonical-save");
+        return Promise.resolve();
+      }),
+    });
+    const additionalLegacy = createMockAuthStorage({
+      loadTokens: mock(() =>
+        Promise.resolve(
+          createValidTokenData({
+            accessToken: "additional-legacy-token",
+            createdAt: canonical.createdAt,
+          }),
+        ),
+      ),
+      clearTokens: mock(() => {
+        events.push("additional-legacy-clear");
+        return Promise.reject(new Error("cleanup failed"));
+      }),
+    });
+    const legacy = createMockAuthStorage({
+      loadTokens: mock(() =>
+        Promise.resolve(
+          createValidTokenData({
+            accessToken: "legacy-token",
+            createdAt: canonical.createdAt,
+          }),
+        ),
+      ),
+      clearTokens: mock(() => {
+        events.push("legacy-clear");
+        return Promise.resolve();
+      }),
+    });
+    const warning = mock(() => {});
+    const storage = new MigratingAuthStorage(
+      createMockAuthStorage(),
+      file,
+      legacy,
+      "file",
+      "test-config.toml",
+      warning,
+      undefined,
+      [additionalLegacy],
+    );
+
+    await expect(storage.loadTokens(BASE_URL)).resolves.toEqual(canonical);
+    expect(events).toEqual([
+      "canonical-save",
+      "additional-legacy-clear",
+      "legacy-clear",
+    ]);
+    expect(file.saveTokens).toHaveBeenCalledWith(BASE_URL, canonical);
+    expect(warning).not.toHaveBeenCalled();
+  });
+
+  it("reconciles invalid token timestamps through the canonical file", async () => {
+    const canonical = createValidTokenData({
+      accessToken: "canonical-token",
+      createdAt: "not-a-date",
+    });
+    const file = createMockAuthStorage({
+      loadTokens: mock(() => Promise.resolve(canonical)),
+    });
+    const legacy = createMockAuthStorage({
+      loadTokens: mock(() =>
+        Promise.resolve(
+          createValidTokenData({
+            accessToken: "legacy-token",
+            createdAt: "also-not-a-date",
+          }),
+        ),
+      ),
+    });
+    const storage = new MigratingAuthStorage(
+      createMockAuthStorage(),
+      file,
+      legacy,
+      "file",
+    );
+
+    await expect(storage.loadTokens(BASE_URL)).resolves.toEqual(canonical);
+    expect(file.saveTokens).toHaveBeenCalledWith(BASE_URL, canonical);
+    expect(legacy.clearTokens).toHaveBeenCalledWith(BASE_URL);
+  });
+
+  it("leaves legacy tokens untouched when canonical reconciliation fails", async () => {
+    const canonical = createValidTokenData({
+      createdAt: "2025-01-01T00:00:00Z",
+    });
+    const file = createMockAuthStorage({
+      loadTokens: mock(() => Promise.resolve(canonical)),
+      saveTokens: mock(() => Promise.reject(new Error("save failed"))),
+    });
+    const legacy = createMockAuthStorage({
+      loadTokens: mock(() =>
+        Promise.resolve(
+          createValidTokenData({ createdAt: canonical.createdAt }),
+        ),
+      ),
+    });
+    const storage = new MigratingAuthStorage(
+      createMockAuthStorage(),
+      file,
+      legacy,
+      "file",
+    );
+
+    await expect(storage.loadTokens(BASE_URL)).rejects.toThrow("save failed");
+    expect(legacy.clearTokens).not.toHaveBeenCalled();
+  });
+
   it("file mode ignores keychain tokens instead of exporting across storage modes", async () => {
     const token = createValidTokenData();
     const primary = createMockAuthStorage({
@@ -345,11 +478,12 @@ describe("MigratingAuthStorage", () => {
       ),
     });
     const warning = mock(() => {});
+    const file = createMockAuthStorage();
     const storage = new MigratingAuthStorage(
       createMockAuthStorage(),
-      createMockAuthStorage(),
+      file,
       legacy,
-      "keychain",
+      "file",
       "test-config.toml",
       warning,
       undefined,
@@ -357,9 +491,10 @@ describe("MigratingAuthStorage", () => {
     );
 
     await expect(storage.loadTokens(BASE_URL)).resolves.toBeNull();
+    expect(file.saveTokens).not.toHaveBeenCalled();
     expect(additionalLegacy.clearTokens).not.toHaveBeenCalled();
     expect(legacy.clearTokens).not.toHaveBeenCalled();
-    expect(warning).not.toHaveBeenCalled();
+    expect(warning).toHaveBeenCalledTimes(1);
   });
 
   it("clears all legacy stores during logout", async () => {
@@ -453,6 +588,126 @@ describe("MigratingAuthStorage", () => {
     await expect(storage.loadClient(BASE_URL)).resolves.toEqual(newer);
     expect(file.saveClient).toHaveBeenCalledWith(BASE_URL, newer);
     expect(legacy.clearClient).toHaveBeenCalledWith(BASE_URL);
+  });
+
+  it("re-persists tied canonical clients before clearing all legacy copies", async () => {
+    const events: string[] = [];
+    const canonical = {
+      ...defaultClientRegistration,
+      clientId: "canonical-client",
+      registeredAt: "2025-01-01T00:00:00Z",
+    };
+    const file = createMockAuthStorage({
+      loadClient: mock(() => Promise.resolve(canonical)),
+      saveClient: mock(() => {
+        events.push("canonical-save");
+        return Promise.resolve();
+      }),
+    });
+    const additionalLegacy = createMockAuthStorage({
+      loadClient: mock(() =>
+        Promise.resolve({
+          ...defaultClientRegistration,
+          clientId: "additional-legacy-client",
+          registeredAt: canonical.registeredAt,
+        }),
+      ),
+      clearClient: mock(() => {
+        events.push("additional-legacy-clear");
+        return Promise.reject(new Error("cleanup failed"));
+      }),
+    });
+    const legacy = createMockAuthStorage({
+      loadClient: mock(() =>
+        Promise.resolve({
+          ...defaultClientRegistration,
+          clientId: "legacy-client",
+          registeredAt: canonical.registeredAt,
+        }),
+      ),
+      clearClient: mock(() => {
+        events.push("legacy-clear");
+        return Promise.resolve();
+      }),
+    });
+    const storage = new MigratingAuthStorage(
+      createMockAuthStorage(),
+      file,
+      legacy,
+      "file",
+      "test-config.toml",
+      () => {},
+      undefined,
+      [additionalLegacy],
+    );
+
+    await expect(storage.loadClient(BASE_URL)).resolves.toEqual(canonical);
+    expect(events).toEqual([
+      "canonical-save",
+      "additional-legacy-clear",
+      "legacy-clear",
+    ]);
+    expect(file.saveClient).toHaveBeenCalledWith(BASE_URL, canonical);
+  });
+
+  it("reconciles invalid client timestamps through the canonical file", async () => {
+    const canonical = {
+      ...defaultClientRegistration,
+      clientId: "canonical-client",
+      registeredAt: "not-a-date",
+    };
+    const file = createMockAuthStorage({
+      loadClient: mock(() => Promise.resolve(canonical)),
+    });
+    const legacy = createMockAuthStorage({
+      loadClient: mock(() =>
+        Promise.resolve({
+          ...defaultClientRegistration,
+          clientId: "legacy-client",
+          registeredAt: "also-not-a-date",
+        }),
+      ),
+    });
+    const storage = new MigratingAuthStorage(
+      createMockAuthStorage(),
+      file,
+      legacy,
+      "file",
+    );
+
+    await expect(storage.loadClient(BASE_URL)).resolves.toEqual(canonical);
+    expect(file.saveClient).toHaveBeenCalledWith(BASE_URL, canonical);
+    expect(legacy.clearClient).toHaveBeenCalledWith(BASE_URL);
+  });
+
+  it("leaves legacy clients untouched when canonical reconciliation fails", async () => {
+    const canonical = {
+      ...defaultClientRegistration,
+      clientId: "canonical-client",
+      registeredAt: "2025-01-01T00:00:00Z",
+    };
+    const file = createMockAuthStorage({
+      loadClient: mock(() => Promise.resolve(canonical)),
+      saveClient: mock(() => Promise.reject(new Error("save failed"))),
+    });
+    const legacy = createMockAuthStorage({
+      loadClient: mock(() =>
+        Promise.resolve({
+          ...defaultClientRegistration,
+          clientId: "legacy-client",
+          registeredAt: canonical.registeredAt,
+        }),
+      ),
+    });
+    const storage = new MigratingAuthStorage(
+      createMockAuthStorage(),
+      file,
+      legacy,
+      "file",
+    );
+
+    await expect(storage.loadClient(BASE_URL)).rejects.toThrow("save failed");
+    expect(legacy.clearClient).not.toHaveBeenCalled();
   });
 
   it("clears keychain, file, and legacy stores best-effort", async () => {

--- a/src/services/migrating-auth-storage.ts
+++ b/src/services/migrating-auth-storage.ts
@@ -26,6 +26,7 @@ interface Candidate<T> {
  */
 export class MigratingAuthStorage implements AuthStorage {
   private warnedAmbiguousPlaintext = false;
+  readonly requiresLoadLock: boolean;
 
   constructor(
     private readonly primary: AuthStorage,
@@ -36,7 +37,9 @@ export class MigratingAuthStorage implements AuthStorage {
     private readonly onWarning: (message: string) => void = () => {},
     private readonly metadata?: AuthSessionMetadataStore,
     private readonly additionalLegacyStores: AuthStorage[] = [],
-  ) {}
+  ) {
+    this.requiresLoadLock = mode === "file";
+  }
 
   async loadTokens(baseUrl: string): Promise<TokenData | null> {
     if (this.mode === "file") {
@@ -248,7 +251,12 @@ export class MigratingAuthStorage implements AuthStorage {
   private async loadTokensFileMode(baseUrl: string): Promise<TokenData | null> {
     const candidate = await this.selectPlaintextTokenCandidate(baseUrl);
     if (candidate) {
-      if (candidate.source === "legacy") {
+      if (candidate.ambiguous) {
+        await this.file.saveTokens(baseUrl, candidate.data);
+        for (const legacy of this.getLegacyStores()) {
+          await this.clearBestEffort(() => legacy.clearTokens(baseUrl));
+        }
+      } else if (candidate.source === "legacy") {
         await this.file.saveTokens(baseUrl, candidate.data);
         await this.clearBestEffort(() =>
           candidate.storage.clearTokens(baseUrl),
@@ -278,7 +286,12 @@ export class MigratingAuthStorage implements AuthStorage {
   ): Promise<ClientRegistration | null> {
     const candidate = await this.selectPlaintextClientCandidate(baseUrl);
     if (candidate) {
-      if (candidate.source === "legacy") {
+      if (candidate.ambiguous) {
+        await this.file.saveClient(baseUrl, candidate.data);
+        for (const legacy of this.getLegacyStores()) {
+          await this.clearBestEffort(() => legacy.clearClient(baseUrl));
+        }
+      } else if (candidate.source === "legacy") {
         await this.file.saveClient(baseUrl, candidate.data);
         await this.clearBestEffort(() =>
           candidate.storage.clearClient(baseUrl),
@@ -359,11 +372,7 @@ export class MigratingAuthStorage implements AuthStorage {
       timestampMs: Date.parse(candidate.timestamp),
     }));
     if (parsed.some((entry) => Number.isNaN(entry.timestampMs))) {
-      this.warnAmbiguousPlaintext();
-      const selected =
-        candidates.find((candidate) => candidate.source === "file") ?? null;
-      if (selected) selected.ambiguous = true;
-      return selected;
+      return this.selectCanonicalAmbiguousCandidate(candidates);
     }
 
     const sorted = [...parsed].sort((a, b) => b.timestampMs - a.timestampMs);
@@ -371,14 +380,22 @@ export class MigratingAuthStorage implements AuthStorage {
     const second = sorted[1];
     if (!first) return candidates[0] ?? null;
     if (second && first.timestampMs === second.timestampMs) {
-      this.warnAmbiguousPlaintext();
-      const selected =
-        candidates.find((candidate) => candidate.source === "file") ?? null;
-      if (!selected) return null;
-      selected.ambiguous = true;
-      return selected;
+      return this.selectCanonicalAmbiguousCandidate(candidates);
     }
     return first.candidate;
+  }
+
+  private selectCanonicalAmbiguousCandidate<T>(
+    candidates: Array<Candidate<T>>,
+  ): Candidate<T> | null {
+    const selected =
+      candidates.find((candidate) => candidate.source === "file") ?? null;
+    if (!selected) {
+      this.warnAmbiguousPlaintext();
+      return null;
+    }
+    selected.ambiguous = true;
+    return selected;
   }
 
   private getLegacyStores(): AuthStorage[] {
@@ -445,7 +462,7 @@ export class MigratingAuthStorage implements AuthStorage {
     if (this.warnedAmbiguousPlaintext) return;
     this.warnedAmbiguousPlaintext = true;
     this.onWarning(
-      "Warning: multiple plaintext auth entries exist with ambiguous timestamps; using the new config auth path and leaving the other entry intact.",
+      "Warning: multiple legacy plaintext auth entries exist with ambiguous timestamps; no canonical config-path entry was found, so the legacy entries were left intact.",
     );
   }
 

--- a/src/services/test-helpers.ts
+++ b/src/services/test-helpers.ts
@@ -242,7 +242,10 @@ export function createMockFileSystemService(
     ),
     readdir: mock(() => Promise.resolve([])),
     isDirectory: mock(() => Promise.resolve(false)),
-    atomicWriteFile: mock(() => Promise.resolve()),
+    atomicWriteFile: mock(
+      (_path: string, _contents: string, _maximumMode?: number) =>
+        Promise.resolve(),
+    ),
     ...impl,
   };
 }

--- a/src/services/token-manager.integration.test.ts
+++ b/src/services/token-manager.integration.test.ts
@@ -2,7 +2,10 @@ import { afterEach, describe, expect, it, mock } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { RefreshTokenResponse } from "./auth-service.js";
+import {
+  type RefreshTokenResponse,
+  TokenRefreshError,
+} from "./auth-service.js";
 import { AuthSessionMetadataStorage } from "./auth-session-metadata-storage.js";
 import { AuthStorageImpl } from "./auth-storage.js";
 import { FileSystemServiceImpl } from "./filesystem-service.js";
@@ -85,6 +88,53 @@ describe("TokenManager file-backed integration", () => {
     expect(firstStorage.getStorageLocation()).toContain(
       join("githits", "auth"),
     );
+  });
+
+  it("retains a refresh token after a transient failure for the next invocation", async () => {
+    const { firstStorage, secondStorage } = await createRealStorages();
+    const initial = createExpiredToken({
+      accessToken: "initial-access-token",
+      refreshToken: "initial-refresh-token",
+    });
+    await firstStorage.saveAuthSession(
+      baseUrl,
+      defaultClientRegistration,
+      initial,
+    );
+    const firstManager = new TokenManager({
+      authService: createMockAuthService({
+        refreshAccessToken: mock(() =>
+          Promise.reject(new Error("network unavailable")),
+        ),
+      }),
+      authStorage: firstStorage,
+      mcpUrl: baseUrl,
+    });
+
+    expect(await firstManager.getToken()).toBeUndefined();
+    expect(await secondStorage.loadTokens(baseUrl)).toEqual(initial);
+
+    const refreshAccessToken = mock((_request: { refreshToken: string }) =>
+      Promise.resolve({
+        accessToken: "rotated-access-token",
+        refreshToken: "rotated-refresh-token",
+        expiresIn: 3600,
+      }),
+    );
+    const secondManager = new TokenManager({
+      authService: createMockAuthService({ refreshAccessToken }),
+      authStorage: secondStorage,
+      mcpUrl: baseUrl,
+    });
+
+    expect(await secondManager.getToken()).toBe("rotated-access-token");
+    expect(refreshAccessToken).toHaveBeenCalledWith(
+      expect.objectContaining({ refreshToken: "initial-refresh-token" }),
+    );
+    expect(await firstStorage.loadTokens(baseUrl)).toMatchObject({
+      accessToken: "rotated-access-token",
+      refreshToken: "rotated-refresh-token",
+    });
   });
 
   it("serializes endpoint refresh when rotation invalidates concurrent refreshes", async () => {
@@ -353,7 +403,7 @@ describe("TokenManager file-backed integration", () => {
     expect(refreshAccessToken).toHaveBeenCalledTimes(1);
   });
 
-  it("keychain-mode refresh failure does not wipe the good file-mode token", async () => {
+  it("keychain-mode terminal refresh failure does not wipe the good file-mode token", async () => {
     // The reported bug: a stale keychain token (from a launch without
     // GITHITS_AUTH_STORAGE) fails refresh and must not destroy the user's good
     // file-mode credentials.
@@ -378,7 +428,17 @@ describe("TokenManager file-backed integration", () => {
 
     const manager = new TokenManager({
       authService: createMockAuthService({
-        refreshAccessToken: mock(() => Promise.reject(new Error("boom"))),
+        refreshAccessToken: mock(() =>
+          Promise.reject(
+            new TokenRefreshError(
+              400,
+              JSON.stringify({
+                error: "invalid_grant",
+                error_description: "Invalid Refresh Token: Already Used",
+              }),
+            ),
+          ),
+        ),
       }),
       authStorage: storage,
       mcpUrl: baseUrl,
@@ -391,7 +451,7 @@ describe("TokenManager file-backed integration", () => {
     expect(await file.loadClient(baseUrl)).toEqual(defaultClientRegistration);
   });
 
-  it("file-mode refresh failure clears legacy too so it cannot resurrect", async () => {
+  it("file-mode terminal refresh failure clears legacy so it cannot resurrect", async () => {
     const { storage, file, legacy } = await createCompositeStorage("file");
     await legacy.saveAuthSession(
       baseUrl,
@@ -414,7 +474,17 @@ describe("TokenManager file-backed integration", () => {
 
     const manager = new TokenManager({
       authService: createMockAuthService({
-        refreshAccessToken: mock(() => Promise.reject(new Error("boom"))),
+        refreshAccessToken: mock(() =>
+          Promise.reject(
+            new TokenRefreshError(
+              400,
+              JSON.stringify({
+                error: "invalid_grant",
+                error_description: "Invalid Refresh Token: Already Used",
+              }),
+            ),
+          ),
+        ),
       }),
       authStorage: storage,
       mcpUrl: baseUrl,

--- a/src/services/token-manager.test.ts
+++ b/src/services/token-manager.test.ts
@@ -150,7 +150,7 @@ describe("refreshExpiredToken", () => {
     );
   });
 
-  it("clears tokens and returns undefined on refresh failure", async () => {
+  it("retains expired credentials on transient refresh failure", async () => {
     const expiredToken = createValidTokenData({
       createdAt: new Date(Date.now() - 7200_000).toISOString(),
       expiresAt: new Date(Date.now() - 60_000).toISOString(),
@@ -168,10 +168,7 @@ describe("refreshExpiredToken", () => {
     const result = await refreshExpiredToken(authService, authStorage, MCP_URL);
 
     expect(result).toBeUndefined();
-    expect(authStorage.clearActiveTokensIfUnchanged).toHaveBeenCalledWith(
-      MCP_URL,
-      expiredToken,
-    );
+    expect(authStorage.clearActiveTokensIfUnchanged).not.toHaveBeenCalled();
   });
 });
 
@@ -453,32 +450,56 @@ describe("TokenManager", () => {
       expect(authStorage.clearActiveTokensIfUnchanged).not.toHaveBeenCalled();
     });
 
-    it("returns undefined when expired token refresh fails", async () => {
+    it("retries and rotates retained credentials after a transient refresh failure", async () => {
       const tokenData = createValidTokenData({
         createdAt: new Date(Date.now() - 7200_000).toISOString(),
         expiresAt: new Date(Date.now() - 60_000).toISOString(),
+        refreshToken: "initial-refresh-token",
       });
-      const { manager, authStorage } = createTokenManager({
-        authService: createMockAuthService({
-          refreshAccessToken: mock(() =>
-            Promise.reject(new Error("refresh failed")),
-          ),
-        }),
-        authStorage: createMockAuthStorage({
-          loadTokens: mock(() => Promise.resolve(tokenData)),
-          loadClient: mock(() => Promise.resolve(defaultClientRegistration)),
-        }),
+      let storedToken: TokenData | null = tokenData;
+      let refreshCalls = 0;
+      const refreshAccessToken = mock(async () => {
+        refreshCalls++;
+        if (refreshCalls === 1) throw new Error("network unavailable");
+        return {
+          accessToken: "rotated-access-token",
+          refreshToken: "rotated-refresh-token",
+          expiresIn: 3600,
+        };
+      });
+      const authStorage = createMockAuthStorage({
+        loadTokens: mock(() => Promise.resolve(storedToken)),
+        loadClient: mock(() => Promise.resolve(defaultClientRegistration)),
+        saveTokensIfUnchanged: mock(
+          (_baseUrl: string, _expected: TokenData | null, data: TokenData) => {
+            storedToken = data;
+            return Promise.resolve(true);
+          },
+        ),
+      });
+      const { manager } = createTokenManager({
+        authService: createMockAuthService({ refreshAccessToken }),
+        authStorage,
       });
 
-      const result = await manager.getToken();
-      expect(result).toBeUndefined();
-      expect(authStorage.clearActiveTokensIfUnchanged).toHaveBeenCalledWith(
+      expect(await manager.getToken()).toBeUndefined();
+      expect(storedToken).toEqual(tokenData);
+      expect(authStorage.clearActiveTokensIfUnchanged).not.toHaveBeenCalled();
+
+      expect(await manager.getToken()).toBe("rotated-access-token");
+      expect(refreshAccessToken).toHaveBeenCalledTimes(2);
+      expect(authStorage.saveTokensIfUnchanged).toHaveBeenCalledWith(
         MCP_URL,
         tokenData,
+        expect.objectContaining({
+          accessToken: "rotated-access-token",
+          refreshToken: "rotated-refresh-token",
+        }),
       );
+      expect(storedToken?.refreshToken).toBe("rotated-refresh-token");
     });
 
-    it("clears expired tokens when forced refresh times out", async () => {
+    it("retains expired credentials when forced refresh times out", async () => {
       const tokenData = createValidTokenData({
         createdAt: new Date(Date.now() - 7200_000).toISOString(),
         expiresAt: new Date(Date.now() - 60_000).toISOString(),
@@ -498,10 +519,37 @@ describe("TokenManager", () => {
       const result = await manager.forceRefresh();
 
       expect(result).toBeUndefined();
-      expect(authStorage.clearActiveTokensIfUnchanged).toHaveBeenCalledWith(
-        MCP_URL,
-        tokenData,
-      );
+      expect(authStorage.clearActiveTokensIfUnchanged).not.toHaveBeenCalled();
+    });
+
+    it("retains expired credentials on terminal-shaped 5xx failures", async () => {
+      const tokenData = createValidTokenData({
+        createdAt: new Date(Date.now() - 7200_000).toISOString(),
+        expiresAt: new Date(Date.now() - 60_000).toISOString(),
+      });
+      const { manager, authStorage } = createTokenManager({
+        authService: createMockAuthService({
+          refreshAccessToken: mock(() =>
+            Promise.reject(
+              new TokenRefreshError(
+                503,
+                JSON.stringify({
+                  error: "invalid_client",
+                  error_description: "OAuth client not found",
+                }),
+              ),
+            ),
+          ),
+        }),
+        authStorage: createMockAuthStorage({
+          loadTokens: mock(() => Promise.resolve(tokenData)),
+          loadClient: mock(() => Promise.resolve(defaultClientRegistration)),
+        }),
+      });
+
+      expect(await manager.getToken()).toBeUndefined();
+      expect(authStorage.clearActiveTokensIfUnchanged).not.toHaveBeenCalled();
+      expect(authStorage.clearActiveClient).not.toHaveBeenCalled();
     });
 
     it("coalesces concurrent refresh requests", async () => {
@@ -597,7 +645,7 @@ describe("TokenManager", () => {
       expect(authStorage.clearActiveTokensIfUnchanged).not.toHaveBeenCalled();
     });
 
-    it("clears tokens when refresh fails with expired token", async () => {
+    it("clears expired tokens on terminal refresh-token failure", async () => {
       const tokenData = createValidTokenData({
         createdAt: new Date(Date.now() - 7200_000).toISOString(),
         expiresAt: new Date(Date.now() - 60_000).toISOString(),
@@ -605,7 +653,15 @@ describe("TokenManager", () => {
       const { manager, authStorage } = createTokenManager({
         authService: createMockAuthService({
           refreshAccessToken: mock(() =>
-            Promise.reject(new Error("refresh failed")),
+            Promise.reject(
+              new TokenRefreshError(
+                400,
+                JSON.stringify({
+                  error: "invalid_grant",
+                  error_description: "Invalid Refresh Token: Already Used",
+                }),
+              ),
+            ),
           ),
         }),
         authStorage: createMockAuthStorage({
@@ -614,11 +670,7 @@ describe("TokenManager", () => {
         }),
       });
 
-      // getToken will attempt refresh since token is expired
-      await manager.getToken();
-
-      // forceRefresh should also clear since token is expired
-      const result = await manager.forceRefresh();
+      const result = await manager.getToken();
       expect(result).toBeUndefined();
       expect(authStorage.clearActiveTokensIfUnchanged).toHaveBeenCalledWith(
         MCP_URL,

--- a/src/services/token-manager.ts
+++ b/src/services/token-manager.ts
@@ -263,32 +263,15 @@ export class TokenManager implements TokenProvider {
             return refreshResult(tokens.accessToken, false);
           }
 
-          // Only clear tokens if they are actually expired and still match the
-          // failed in-memory refresh token. A separate `githits login` may have
-          // already written fresh tokens for long-running MCP servers.
+          // Reload once more in case another writer landed after the first
+          // post-failure check. Otherwise retain the expired candidate so the
+          // next call retries without serving its access token.
           if (isExpired) {
             const currentStoredTokens =
               await this.loadExternallyUpdatedToken(tokens);
             if (currentStoredTokens) {
               return refreshResult(currentStoredTokens.accessToken, false);
             }
-
-            const cleared = await withTelemetrySpan(
-              "token-manager.clear-tokens-if-unchanged",
-              () =>
-                this.authStorage.clearActiveTokensIfUnchanged(
-                  this.mcpUrl,
-                  tokens,
-                ),
-            );
-            if (!cleared) {
-              const currentToken = await this.authStorage.loadTokens(
-                this.mcpUrl,
-              );
-              this.cachedToken = currentToken;
-              return refreshResult(currentToken?.accessToken, false);
-            }
-            this.cachedToken = null;
           }
           return refreshResult(undefined, false);
         }


### PR DESCRIPTION
## Summary

- retain OAuth refresh credentials after transient transport, timeout, and 5xx failures while keeping terminal cleanup restricted to classified 4xx responses
- cap auth-associated file rewrites at POSIX `0600` without broadening more-restrictive modes
- reconcile ambiguous canonical token and client records before clearing legacy plaintext copies, serialized with external writers in file mode
- document the resulting refresh, migration, locking, and permission guarantees

This is PR 2 of the P0/P1 quality-review plan and addresses P0.2 and P1.4. PR 3 remains scoped to built-artifact smoke coverage in CI.

## Verification

- `bun test` (2,462 passed)
- `bun run typecheck`
- `bun run format:check`
- `bun run lint` (one pre-existing warning in `src/commands/init/agent-definitions.ts`)
- `bun run build`
- `bun run build` in `packages/mcp`
- `bun run validate:packages`
- authenticated `bun run smoke:cli` (65 steps)
- authenticated `bun run smoke:mcp` (38 steps)
- `bun run smoke:proxy-node`

## Review

An independent final review reported no findings.