### PR TITLE
Prepare 0.6.5 release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "The code context layer for AI coding agents",
-    "version": "0.6.4"
+    "version": "0.6.5"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "The code context layer for AI coding agents",
   "mcpServers": {
     "githits": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "githits",
   "description": "The code context layer for AI coding agents",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "mcpName": "com.githits/githits",
   "type": "module",
   "workspaces": [

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/server.json
+++ b/server.json
@@ -16,7 +16,7 @@
     "source": "github",
     "id": "1165453165"
   },
-  "version": "0.6.4",
+  "version": "0.6.5",
   "remotes": [
     {
       "type": "streamable-http",
@@ -28,7 +28,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "githits",
-      "version": "0.6.4",
+      "version": "0.6.5",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Release scope

Prepare the root `githits` 0.6.5 release across npm, Open Plugin, Claude, Gemini, and the official MCP registry manifest.

`@githits/mcp` remains at 0.6.3 because no `packages/mcp/**` source, package API, schema, tool behavior, instruction, or remote-server-facing type changed.

## User-visible changes since 0.6.4

- Fix automatic login refresh so normal access-token expiry remains noninteractive (#232).
- Preserve recoverable credentials across refresh transport, timeout, and server failures; later calls retry automatically (#232).
- Support fixed OAuth callback ports for SSH port-forwarding and constrained remote environments (#230).
- Refresh runtime and workflow dependencies (#231).

## Validation

- `bun test` — 2504 passed
- `bun run typecheck`
- `bun run lint` — no errors; one pre-existing non-null assertion warning
- `bun run build`
- `bun run validate:packages`
- source CLI unauthenticated smoke
- source MCP registration smoke
- built CLI unauthenticated smoke
- built MCP registration smoke
- authenticated live CLI/MCP smoke reached the backend; later example calls were rate-limited with HTTP 429, unrelated to authentication
- `mcp-publisher` v1.7.9 checksum verification and `server.json` registry validation
- MCP registry domain proof returned 200
- OAuth protected-resource metadata returned 200
- unauthenticated remote MCP initialize returned 401 with the expected `resource_metadata` challenge

Merging this PR triggers the root release workflow after the successful Main workflow on `main`. That workflow publishes `githits@0.6.5`, the `v0.6.5` GitHub release, and `com.githits/githits@0.6.5` in the MCP registry.
