### PR TITLE
feat: carry CLI attribution through OAuth callbacks

### DIFF
--- a/docs/implementation/auth.md
+++ b/docs/implementation/auth.md
@@ -24,9 +24,9 @@ The two methods exist because OAuth provides full access but requires a browser,
 The login command (`src/commands/login.ts`) orchestrates a 9-step OAuth flow (matching the `// Step N:` comments in the code):
 
 1. **Discover endpoints** — Fetch `.well-known/oauth-authorization-server` from the MCP URL. Production OAuth endpoints are served by the GitHits Supabase account host at `https://accounts.githits.com`.
-2. **Load or register client via DCR** — Reuse stored client from `client.json`, or register a new one. Re-registers if `--port` changes the redirect URI.
+2. **Load or register client via DCR** — Reuse stored client from `client.json`, or register a new one. Re-registers if `--port` changes the redirect URI. New registrations include both the base callback URI and its stable CLI-attributed variant.
 3. **Generate PKCE params** — Create `code_verifier`, `code_challenge` (S256), and `state`
-4. **Build auth URL** — Construct the authorization URL with PKCE challenge
+4. **Build auth URL** — Construct the authorization URL with PKCE challenge. The exact callback URI carries stable CLI attribution parameters; the same URI is used for the later token exchange.
 5. **Start callback server** — Bind local HTTP server to `127.0.0.1:{port}/callback` before opening the browser
 6. **Open browser or print URL** — Navigate user to auth URL, or print it if `--no-browser` is set
 7. **Verify state** — CSRF protection check on the callback

--- a/src/commands/login.test.ts
+++ b/src/commands/login.test.ts
@@ -162,6 +162,18 @@ describe("loginAction", () => {
     );
 
     expect(authService.registerClient).not.toHaveBeenCalled();
+    expect(authService.buildAuthUrl).toHaveBeenCalledWith(
+      expect.objectContaining({
+        redirectUri:
+          "http://127.0.0.1:8080/callback?utm_source=githits-cli&utm_medium=cli&utm_campaign=cli-auth",
+      }),
+    );
+    expect(authService.exchangeCodeForTokens).toHaveBeenCalledWith(
+      expect.objectContaining({
+        redirectUri:
+          "http://127.0.0.1:8080/callback?utm_source=githits-cli&utm_medium=cli&utm_campaign=cli-auth",
+      }),
+    );
     consoleSpy.mockRestore();
   });
 
@@ -181,6 +193,13 @@ describe("loginAction", () => {
     );
 
     expect(authService.registerClient).toHaveBeenCalled();
+    expect(authService.registerClient).toHaveBeenCalledWith({
+      registrationEndpoint: "https://accounts.githits.com/oauth/register",
+      redirectUris: [
+        "http://127.0.0.1:8080/callback",
+        "http://127.0.0.1:8080/callback?utm_source=githits-cli&utm_medium=cli&utm_campaign=cli-auth",
+      ],
+    });
     expect(authStorage.saveAuthSession).toHaveBeenCalledWith(
       mcpUrl,
       expect.any(Object),

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -7,6 +7,7 @@ import { createAuthCommandDependencies } from "../container.js";
 import type { AuthService } from "../services/auth-service.js";
 import type { AuthStorage } from "../services/auth-storage.js";
 import type { BrowserService } from "../services/browser-service.js";
+import { withCliAuthAttribution } from "../shared/oauth-attribution.js";
 import {
   addOAuthCallbackOptions,
   CALLBACK_PORT_REQUIREMENT,
@@ -173,7 +174,7 @@ export async function loginFlow(
         try {
           registration = await authService.registerClient({
             registrationEndpoint: metadata.registrationEndpoint,
-            redirectUri,
+            redirectUris: [redirectUri, withCliAuthAttribution(redirectUri)],
           });
         } catch (error) {
           return signInStartFailure(error);
@@ -200,7 +201,7 @@ export async function loginFlow(
     try {
       registration = await authService.registerClient({
         registrationEndpoint: metadata.registrationEndpoint,
-        redirectUri,
+        redirectUris: [redirectUri, withCliAuthAttribution(redirectUri)],
       });
     } catch (error) {
       return signInStartFailure(error);
@@ -214,6 +215,8 @@ export async function loginFlow(
     shouldClearClientOnFailedAttempt = !hadStoredClient;
   }
 
+  const authRedirectUri = withCliAuthAttribution(redirectUri);
+
   // Step 3: Generate PKCE parameters
   const { verifier, challenge, state } = authService.generatePkceParams();
 
@@ -221,7 +224,7 @@ export async function loginFlow(
   const authUrl = authService.buildAuthUrl({
     authorizationEndpoint: metadata.authorizationEndpoint,
     clientId: client.clientId,
-    redirectUri,
+    redirectUri: authRedirectUri,
     state,
     codeChallenge: challenge,
   });
@@ -305,7 +308,7 @@ export async function loginFlow(
       clientSecret: client.clientSecret,
       code: callback.code,
       codeVerifier: verifier,
-      redirectUri,
+      redirectUri: authRedirectUri,
     });
   } catch (error) {
     // Best-effort: clear potentially stale client so next login starts fresh.

--- a/src/services/auth-service.test.ts
+++ b/src/services/auth-service.test.ts
@@ -134,7 +134,10 @@ describe("AuthServiceImpl", () => {
       await expect(
         injectedService.registerClient({
           registrationEndpoint: "https://auth.example.com/register",
-          redirectUri: "http://127.0.0.1:8080/callback",
+          redirectUris: [
+            "http://127.0.0.1:8080/callback",
+            "http://127.0.0.1:8080/callback?utm_source=githits-cli",
+          ],
         }),
       ).resolves.toEqual({ clientId: "client-id", clientSecret: "secret" });
 
@@ -147,7 +150,10 @@ describe("AuthServiceImpl", () => {
       expect(init.headers).toEqual({ "Content-Type": "application/json" });
       expect(JSON.parse(String(init.body))).toEqual({
         client_name: "GitHits CLI",
-        redirect_uris: ["http://127.0.0.1:8080/callback"],
+        redirect_uris: [
+          "http://127.0.0.1:8080/callback",
+          "http://127.0.0.1:8080/callback?utm_source=githits-cli",
+        ],
         grant_types: ["authorization_code", "refresh_token"],
         response_types: ["code"],
         token_endpoint_auth_method: "client_secret_post",
@@ -169,7 +175,7 @@ describe("AuthServiceImpl", () => {
       await expect(
         new AuthServiceImpl(asFetchFn(jsonFetch)).registerClient({
           registrationEndpoint: "https://auth.example.com/register",
-          redirectUri: "http://127.0.0.1:8080/callback",
+          redirectUris: ["http://127.0.0.1:8080/callback"],
         }),
       ).rejects.toThrow(
         "Client registration failed with HTTP 503. Registration unavailable",
@@ -177,7 +183,7 @@ describe("AuthServiceImpl", () => {
       try {
         await new AuthServiceImpl(asFetchFn(htmlFetch)).registerClient({
           registrationEndpoint: "https://auth.example.com/register",
-          redirectUri: "http://127.0.0.1:8080/callback",
+          redirectUris: ["http://127.0.0.1:8080/callback"],
         });
         throw new Error("Expected registration to fail");
       } catch (error) {
@@ -197,7 +203,7 @@ describe("AuthServiceImpl", () => {
       await expect(
         new AuthServiceImpl(asFetchFn(malformedFetch)).registerClient({
           registrationEndpoint: "https://auth.example.com/register",
-          redirectUri: "http://127.0.0.1:8080/callback",
+          redirectUris: ["http://127.0.0.1:8080/callback"],
         }),
       ).rejects.toThrow("missing required fields");
 
@@ -205,7 +211,7 @@ describe("AuthServiceImpl", () => {
       await expect(
         new AuthServiceImpl(asFetchFn(unusedFetch)).registerClient({
           registrationEndpoint: "http://attacker.test/register",
-          redirectUri: "http://127.0.0.1:8080/callback",
+          redirectUris: ["http://127.0.0.1:8080/callback"],
         }),
       ).rejects.toThrow("OAuth registration endpoint");
       expect(unusedFetch).not.toHaveBeenCalled();

--- a/src/services/auth-service.ts
+++ b/src/services/auth-service.ts
@@ -140,7 +140,7 @@ export class TokenRefreshError extends Error {
  */
 export interface RegisterClientParams {
   registrationEndpoint: string;
-  redirectUri: string;
+  redirectUris: readonly string[];
 }
 
 /**
@@ -238,7 +238,7 @@ export class AuthServiceImpl implements AuthService {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           client_name: "GitHits CLI",
-          redirect_uris: [params.redirectUri],
+          redirect_uris: params.redirectUris,
           grant_types: ["authorization_code", "refresh_token"],
           response_types: ["code"],
           token_endpoint_auth_method: "client_secret_post",

--- a/src/shared/oauth-attribution.test.ts
+++ b/src/shared/oauth-attribution.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "bun:test";
+import { withCliAuthAttribution } from "./oauth-attribution.js";
+
+describe("withCliAuthAttribution", () => {
+  it("adds stable attribution to the callback URI", () => {
+    expect(withCliAuthAttribution("http://127.0.0.1:8080/callback")).toBe(
+      "http://127.0.0.1:8080/callback?utm_source=githits-cli&utm_medium=cli&utm_campaign=cli-auth",
+    );
+  });
+
+  it("preserves unrelated query parameters", () => {
+    expect(
+      withCliAuthAttribution("http://127.0.0.1:8080/callback?existing=value"),
+    ).toBe(
+      "http://127.0.0.1:8080/callback?existing=value&utm_source=githits-cli&utm_medium=cli&utm_campaign=cli-auth",
+    );
+  });
+
+  it("replaces attribution values without duplicating them", () => {
+    const uri =
+      "http://127.0.0.1:8080/callback?utm_source=old&utm_campaign=old";
+
+    expect(withCliAuthAttribution(withCliAuthAttribution(uri))).toBe(
+      "http://127.0.0.1:8080/callback?utm_source=githits-cli&utm_campaign=cli-auth&utm_medium=cli",
+    );
+  });
+});

--- a/src/shared/oauth-attribution.ts
+++ b/src/shared/oauth-attribution.ts
@@ -1,0 +1,21 @@
+const CLI_AUTH_UTM_PARAMS = {
+  utm_source: "githits-cli",
+  utm_medium: "cli",
+  utm_campaign: "cli-auth",
+} as const;
+
+/**
+ * Add stable CLI attribution to the OAuth callback URI.
+ *
+ * The callback URI is registered and matched as an exact OAuth redirect URI,
+ * so these values must remain stable across CLI versions and auth entrypoints.
+ */
+export function withCliAuthAttribution(callbackUri: string): string {
+  const attributedUri = new URL(callbackUri);
+
+  for (const [name, value] of Object.entries(CLI_AUTH_UTM_PARAMS)) {
+    attributedUri.searchParams.set(name, value);
+  }
+
+  return attributedUri.toString();
+}


### PR DESCRIPTION
## Summary

- carry stable CLI attribution in the OAuth callback URI
- register both the base and attributed callback URIs for new dynamic clients
- use the same attributed callback URI for authorization and token exchange

## Why

OAuth authorization servers are not required to preserve unrelated query parameters placed on the authorization endpoint. Putting the attribution parameters inside the registered `redirect_uri` makes them part of the OAuth flow instead.

The callback uses one stable set of values:

| Parameter | Value |
| --- | --- |
| `utm_source` | `githits-cli` |
| `utm_medium` | `cli` |
| `utm_campaign` | `cli-auth` |

The values do not vary by command or CLI version, avoiding registration churn. The CLI itself does not emit analytics events.

## Compatibility

New registrations allow both callback forms:

- the existing untagged loopback callback
- the attributed loopback callback

Keeping both forms lets older CLI versions continue using the same registration. Existing registrations must allow the attributed callback before this CLI change is released.

## Testing

- `bun test` — 2,507 tests passed
- `bun run typecheck`
- `bun run build`
- `bun run smoke:cli`
