### PR TITLE
Prepare 0.6.6 release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "The code context layer for AI coding agents",
-    "version": "0.6.5"
+    "version": "0.6.6"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "The code context layer for AI coding agents",
   "mcpServers": {
     "githits": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "githits",
   "description": "The code context layer for AI coding agents",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "mcpName": "com.githits/githits",
   "type": "module",
   "workspaces": [

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/server.json
+++ b/server.json
@@ -16,7 +16,7 @@
     "source": "github",
     "id": "1165453165"
   },
-  "version": "0.6.5",
+  "version": "0.6.6",
   "remotes": [
     {
       "type": "streamable-http",
@@ -28,7 +28,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "githits",
-      "version": "0.6.5",
+      "version": "0.6.6",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Release scope

Prepare the root `githits` 0.6.6 release across npm, Open Plugin, Claude, Gemini, and the official MCP registry manifest.

`@githits/mcp` remains at 0.6.3 because no published MCP package API, tool behavior, instruction, schema, or remote-server-facing type changed.

## User-visible changes since 0.6.5

- Carry GitHits CLI attribution through the OAuth authorization flow so CLI-originated signups and logins can be measured correctly (#234).
- Refresh compatible runtime and development dependencies (#235, #236, #237, #238).

The keyring change in #240 is preparatory only and is excluded from the generated release notes. This release still uses `@napi-rs/keyring@1.3.0`; the upstream release and dependency bump remain tracked in #241.

## Validation

- `bun test` — 2508 passed
- `bun run typecheck`
- `bun run lint` — no errors; one pre-existing warning and one schema-version informational diagnostic
- `bun run build`
- `bun run validate:packages`
- source CLI smoke — 70 steps passed
- source MCP smoke — 38 steps passed
- built CLI unauthenticated smoke passed
- built MCP registration smoke passed
- `mcp-publisher` 1.7.9 checksum verification and `server.json` registry validation passed
- MCP registry domain proof returned 200
- OAuth protected-resource metadata returned 200
- unauthenticated remote MCP initialization returned 401 with the expected `resource_metadata` challenge

Merging this PR triggers the root release workflow after the successful Main workflow on `main`. That workflow publishes `githits@0.6.6`, the `v0.6.6` GitHub release, and `com.githits/githits@0.6.6` in the MCP registry.