### PR TITLE
chore: prepare 0.6.7 release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "The code context layer for AI coding agents",
-    "version": "0.6.6"
+    "version": "0.6.7"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/bun.lock
+++ b/bun.lock
@@ -43,7 +43,7 @@
     },
     "packages/mcp": {
       "name": "@githits/mcp",
-      "version": "0.6.3",
+      "version": "0.6.4",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "^4.4.3",

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "The code context layer for AI coding agents",
   "mcpServers": {
     "githits": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "githits",
   "description": "The code context layer for AI coding agents",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "mcpName": "com.githits/githits",
   "type": "module",
   "workspaces": [

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@githits/mcp",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Reusable MCP server APIs and tools for GitHits",
   "type": "module",
   "files": [

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/server.json
+++ b/server.json
@@ -16,7 +16,7 @@
     "source": "github",
     "id": "1165453165"
   },
-  "version": "0.6.6",
+  "version": "0.6.7",
   "remotes": [
     {
       "type": "streamable-http",
@@ -28,7 +28,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "githits",
-      "version": "0.6.6",
+      "version": "0.6.7",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/skills/githits-code/SKILL.md
+++ b/skills/githits-code/SKILL.md
@@ -54,8 +54,10 @@ githits docs read <pageId> --lines 20-120
 - For `githits example` results, report the source repositories/citations shown in GitHits' generated references/provenance section; they are core evidence for the synthesized pattern.
 - Package targets inspect published artifacts and omitted versions resolve to the latest release; repository targets inspect repository trees. For source-layout questions, always pin and report the package version or Git ref.
 - For source work, locate symbols or matches first, then read a focused window with explicit `--lines`.
+- Documentation text reads return at most 150 lines per call. Continue with the reported returned range and `totalLines` when more context is needed.
 - For multi-step code/docs investigations, keep raw CLI output out of the final answer unless it is the evidence the user needs.
 - If output says it used recent/stale indexed evidence, treat the displayed served target as provenance; if freshness matters, retry with a longer `--wait` or use one of the displayed `queryable now` versions/refs, or inspect JSON `targetResolution` for structured candidates.
+- Treat partial documentation coverage as incomplete evidence and retry later when advised. Capped coverage is terminal for the current crawl, so report the limitation instead of retrying.
 - If a code-navigation command returns `INDEXING`, use the elapsed/expected duration in the message to decide whether to retry with `--wait`; prefer any displayed indexed refs/versions when you need an immediate follow-up.
 - After using GitHits results, send feedback when practical. Use `githits feedback <solution_id> --accept|--reject` for `githits example` results, or omit `<solution_id>` for generic session feedback such as `githits feedback --reject --tool search -m "missing kotlin support"`.
 

--- a/skills/githits-code/references/code-and-docs.md
+++ b/skills/githits-code/references/code-and-docs.md
@@ -32,9 +32,11 @@ Use `search` for discovery and `code grep` only when you know the pattern.
 
 `githits docs list <spec>` browses available documentation pages. It is not topic search.
 
-`githits docs read <pageId>` reads a page. Use `--lines` for bounded windows and `--json` when extracting `totalLines` or source metadata.
+`githits docs read <pageId>` reads a page. Text output returns at most 150 lines per call, including larger explicit ranges; continue from the reported returned range when more context is needed. Use `--lines` for bounded windows and `--json` when extracting `totalLines` or source metadata.
 
 For topic search, use `githits search "<topic>" --source docs --in <target>`, then pass the returned page ID to `docs read`.
+
+When search reports partial documentation coverage, treat the evidence as incomplete and retry later when advised. Capped coverage means the current crawl stopped at a limit; report that limitation instead of retrying.
 
 ## Command Name Mapping
 


### PR DESCRIPTION
## Summary

- bump the root `githits` CLI, plugin manifests, Gemini extension, and MCP registry manifest to `0.6.7`
- bump `@githits/mcp` and its workspace lock entry to `0.6.4` because this release includes MCP-visible schemas, instructions, search behavior, and response types
- refresh the public code skill for the 150-line docs-read cap and partial/capped documentation coverage handling

## User-visible changes since v0.6.6

- disclose outbound data flows and require install-review acknowledgement during interactive init
- configure Cursor through the hosted remote MCP path and preserve guidance-only remediation flows
- support explicit indexed documentation site targets in unified search and surface partial/capped crawl coverage
- improve MCP guidance for public-OSS scope, documentation discovery/read limits, and `code_grep` context schema
- add the Smithery listing badge

## Release impact

After merge, a successful `Main` workflow on `main` will trigger the independent root and MCP release workflows. The root workflow publishes `githits@0.6.7`, its GitHub release, and `com.githits/githits@0.6.7` to the MCP registry. The MCP workflow publishes `@githits/mcp@0.6.4` and its package release.

## Validation

- `bun test` — 2558 passed
- `bun run typecheck`
- `bun run lint`
- `bun run build`
- `bun run validate:packages`
- `bun run validate:packages:mcp-publish`
- `bun run smoke:cli`
- `bun run smoke:mcp`
- `bun run smoke:cli:built`
- `bun run smoke:mcp:built`
- pinned `mcp-publisher v1.7.9 validate server.json`
- production MCP registry domain proof, OAuth metadata, and unauthenticated 401 challenge checks
- targeted Codex skills-surface eval: `docs-search-followup` (success, high confidence, no tool or instruction issues)
- staged-file pre-commit formatting and `git diff --check`

## Local formatting note

Repository-wide `bun run format:check` reports whole-file CRLF differences across hundreds of untouched files in this Windows checkout. Only the explicitly staged release files were normalized and formatted; CI will run the repository-wide check on its LF checkout.