### PR TITLE
chore: add Glama maintainer metadata

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["skvark"]
+}


### PR DESCRIPTION
## Summary

- add the root-level `glama.json` ownership metadata
- register `skvark` as the Glama maintainer

## Why

Glama uses this repository metadata to verify maintainers for the GitHits MCP server listing. This change has no runtime impact.

## Validation

- parsed `glama.json` successfully
- passed the repository's staged JSON formatting check