### PR TITLE
fix: use remote MCP for root Open Plugin installs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "The code context layer for AI coding agents",
-    "version": "0.6.7"
+    "version": "0.6.8"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,7 @@
 {
   "mcpServers": {
     "githits": {
-      "command": "npx",
-      "args": ["-y", "githits@latest", "mcp", "start"]
+      "url": "https://mcp.githits.com"
     }
   }
 }

--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/README.md
+++ b/README.md
@@ -263,6 +263,12 @@ compatible hosts:
 - `skills/`
 - `commands/`
 
+The root `.mcp.json` registers the hosted GitHits MCP server for Open Plugin
+hosts, which manage OAuth for that remote connection. The Claude marketplace
+payload under `plugins/claude/` intentionally continues to launch the local
+GitHits MCP server over stdio and uses CLI-managed authentication. The Gemini
+extension also continues to use stdio.
+
 For Claude Code marketplace installs:
 
 ```sh

--- a/commands/help.md
+++ b/commands/help.md
@@ -5,22 +5,15 @@ disable-model-invocation: true
 
 # GitHits Help
 
-Run the GitHits CLI help command in the terminal:
-
-```
-npx -y githits help
-```
-
-Then display the command output clearly to the user, followed by this plugin
-context summary:
+Display this plugin help directly to the user:
 
 ## Slash Commands
 
 - `/githits:example <query>` — Search for canonical code examples from open source.
 - `/githits:search <query>` — Legacy alias for `/githits:example`.
-- `/githits:login` — Authenticate with your GitHits account.
-- `/githits:status` — Show your current authentication status.
-- `/githits:logout` — Remove stored credentials.
+- `/githits:login` — Authenticate the GitHits remote server through Cursor.
+- `/githits:status` — Verify Cursor's GitHits connection and tools.
+- `/githits:logout` — Disconnect the remote session through Cursor's MCP settings.
 - `/githits:help` — Show this help message.
 
 ## MCP Tools
@@ -40,13 +33,27 @@ Additional indexed dependency/package tools are available by default:
 
 ## Authentication
 
-Run `npx -y githits login` to authenticate via browser, or set the
-`GITHITS_API_TOKEN` environment variable for headless environments.
+This plugin uses the hosted GitHits MCP server, and Cursor owns its OAuth
+session. When `cursor-agent` is available, use:
+
+```text
+cursor-agent mcp login githits
+cursor-agent mcp list
+cursor-agent mcp list-tools githits
+```
+
+If connection status remains uncertain, call the `search_language` MCP tool
+with the query `python`. Cursor has no supported `cursor-agent mcp logout githits`
+command, so logout uses Cursor's MCP settings.
+
+If `cursor-agent` is unavailable, use a new Cursor Agent chat and Cursor's MCP
+tools UI to authenticate and confirm that GitHits tools are listed.
+
+The `githits login`, `githits logout`, and `githits auth status` CLI commands,
+as well as `GITHITS_API_TOKEN`, apply to local CLI and stdio integrations. They
+do not control Cursor's remote session.
 
 If users want to verify MCP tools loaded, suggest `/mcp`.
 
-If the command fails, report the error and suggest running:
-
-```
-npx -y githits login
-```
+If an MCP tool fails because authentication is required, report the error and
+suggest `/githits:login`.

--- a/commands/help.md
+++ b/commands/help.md
@@ -11,9 +11,9 @@ Display this plugin help directly to the user:
 
 - `/githits:example <query>` — Search for canonical code examples from open source.
 - `/githits:search <query>` — Legacy alias for `/githits:example`.
-- `/githits:login` — Authenticate the GitHits remote server through Cursor.
-- `/githits:status` — Verify Cursor's GitHits connection and tools.
-- `/githits:logout` — Disconnect the remote session through Cursor's MCP settings.
+- `/githits:login` — Authenticate the current host's GitHits remote server.
+- `/githits:status` — Verify the current host's GitHits connection.
+- `/githits:logout` — Disconnect GitHits through the current host's settings.
 - `/githits:help` — Show this help message.
 
 ## MCP Tools
@@ -33,27 +33,17 @@ Additional indexed dependency/package tools are available by default:
 
 ## Authentication
 
-This plugin uses the hosted GitHits MCP server, and Cursor owns its OAuth
-session. When `cursor-agent` is available, use:
+This plugin uses the hosted GitHits MCP server, and the current host owns its
+OAuth session. Login and status use the `search_language` MCP tool with the
+query `python` to start or verify authentication. Complete the host's OAuth flow
+if prompted, then retry the tool call.
 
-```text
-cursor-agent mcp login githits
-cursor-agent mcp list
-cursor-agent mcp list-tools githits
-```
-
-If connection status remains uncertain, call the `search_language` MCP tool
-with the query `python`. Cursor has no supported `cursor-agent mcp logout githits`
-command, so logout uses Cursor's MCP settings.
-
-If `cursor-agent` is unavailable, use a new Cursor Agent chat and Cursor's MCP
-tools UI to authenticate and confirm that GitHits tools are listed.
+MCP provides no portable logout operation. Disconnect or revoke GitHits through
+the current host's MCP, connection, or account settings.
 
 The `githits login`, `githits logout`, and `githits auth status` CLI commands,
 as well as `GITHITS_API_TOKEN`, apply to local CLI and stdio integrations. They
-do not control Cursor's remote session.
-
-If users want to verify MCP tools loaded, suggest `/mcp`.
+do not control the current host's remote session.
 
 If an MCP tool fails because authentication is required, report the error and
 suggest `/githits:login`.

--- a/commands/login.md
+++ b/commands/login.md
@@ -1,36 +1,31 @@
 ---
-description: Log in to your GitHits account
+description: Connect GitHits using your host's remote MCP authentication
 ---
 
 # Login
 
-Authenticate the user with GitHits by running the CLI login command in the
-terminal:
+GitHits uses a hosted remote MCP server for this plugin. If `cursor-agent` is
+available, authenticate through Cursor by running:
 
-```
-npx -y githits login
-```
-
-This opens the user's browser for secure OAuth authentication. Tokens are stored
-locally and refreshed automatically.
-
-If the environment has no display (SSH, CI, containers), use the `--no-browser`
-flag instead:
-
-```
-npx -y githits login --no-browser
+```text
+cursor-agent mcp login githits
 ```
 
-This prints a URL the user can open on another device.
+Let the user complete browser OAuth. Do not ask them to paste OAuth data into
+chat. Then verify the connection by running:
 
-Other useful flags:
+```text
+cursor-agent mcp list
+cursor-agent mcp list-tools githits
+```
 
-- `--force` — re-authenticate even if already logged in.
-- `--port <port>` — use a specific port for the local callback server.
+If those checks do not prove the authenticated connection is usable, call the
+`search_language` MCP tool with the query `python`.
 
-After running the command, inform the user of the result. If login succeeds,
-confirm they are authenticated. If it fails, provide the error and suggest they
-try again.
+If `cursor-agent` is unavailable, tell the user to open a new Cursor Agent chat.
+In Cursor's MCP tools UI, confirm that GitHits is enabled, complete OAuth if
+prompted, and confirm its tools are listed. Require the user's confirmation or
+a successful `search_language` call before reporting success.
 
-Alternative: the user can set the `GITHITS_API_TOKEN` environment variable
-instead of using browser login.
+The `githits login` CLI command and `GITHITS_API_TOKEN` authenticate local CLI
+and stdio integrations. They do not authenticate Cursor's remote MCP session.

--- a/commands/login.md
+++ b/commands/login.md
@@ -4,28 +4,18 @@ description: Connect GitHits using your host's remote MCP authentication
 
 # Login
 
-GitHits uses a hosted remote MCP server for this plugin. If `cursor-agent` is
-available, authenticate through Cursor by running:
+GitHits uses a hosted remote MCP server for this plugin, and the current host
+owns its OAuth session. Call the `search_language` MCP tool with the query
+`python` to start or verify authentication.
 
-```text
-cursor-agent mcp login githits
-```
+If the call requires authentication, let the current host present its OAuth
+flow. Ask the user to complete it without pasting OAuth data into chat, then
+retry `search_language`.
 
-Let the user complete browser OAuth. Do not ask them to paste OAuth data into
-chat. Then verify the connection by running:
-
-```text
-cursor-agent mcp list
-cursor-agent mcp list-tools githits
-```
-
-If those checks do not prove the authenticated connection is usable, call the
-`search_language` MCP tool with the query `python`.
-
-If `cursor-agent` is unavailable, tell the user to open a new Cursor Agent chat.
-In Cursor's MCP tools UI, confirm that GitHits is enabled, complete OAuth if
-prompted, and confirm its tools are listed. Require the user's confirmation or
-a successful `search_language` call before reporting success.
+If the tool is unavailable or disabled, direct the user to the current host's
+MCP or server settings to enable or reconnect GitHits, then retry. For any other
+error, report the error without claiming authentication succeeded.
 
 The `githits login` CLI command and `GITHITS_API_TOKEN` authenticate local CLI
-and stdio integrations. They do not authenticate Cursor's remote MCP session.
+and stdio integrations. They do not authenticate the current host's remote MCP
+session.

--- a/commands/logout.md
+++ b/commands/logout.md
@@ -4,14 +4,14 @@ description: Disconnect GitHits from your host-managed remote session
 
 # Logout
 
-Cursor does not have a supported `cursor-agent mcp logout githits` command. Open
-Cursor's MCP settings, select GitHits, and use the available disconnect,
-sign-out, or account-removal action.
+The current host owns the remote OAuth session, and MCP provides no portable
+logout operation. Open the current host's MCP, connection, or account settings,
+select GitHits, and use the available disconnect, sign-out, or account-removal
+action.
 
-Ask the user to confirm that Cursor no longer shows an authenticated GitHits
-connection. If `cursor-agent` is available, `cursor-agent mcp list` may be used
-to inspect the server afterward, but the server can remain registered after its
-OAuth session is cleared.
+Ask the user to confirm that the host no longer reports an authenticated GitHits
+connection. Do not call a GitHits MCP tool afterward because that could trigger
+authentication again.
 
 The `githits logout` CLI command removes credentials for local CLI and stdio
-integrations. It does not clear Cursor's remote OAuth session.
+integrations. It does not clear the current host's remote OAuth session.

--- a/commands/logout.md
+++ b/commands/logout.md
@@ -1,16 +1,17 @@
 ---
-description: Log out of your GitHits account
+description: Disconnect GitHits from your host-managed remote session
 ---
 
 # Logout
 
-Sign the user out of GitHits by running the CLI logout command in the terminal:
+Cursor does not have a supported `cursor-agent mcp logout githits` command. Open
+Cursor's MCP settings, select GitHits, and use the available disconnect,
+sign-out, or account-removal action.
 
-```
-npx -y githits logout
-```
+Ask the user to confirm that Cursor no longer shows an authenticated GitHits
+connection. If `cursor-agent` is available, `cursor-agent mcp list` may be used
+to inspect the server afterward, but the server can remain registered after its
+OAuth session is cleared.
 
-This removes the locally stored authentication tokens.
-
-Confirm to the user that they have been logged out successfully. If the logout
-fails, provide the error details.
+The `githits logout` CLI command removes credentials for local CLI and stdio
+integrations. It does not clear Cursor's remote OAuth session.

--- a/commands/status.md
+++ b/commands/status.md
@@ -1,22 +1,27 @@
 ---
-description: Show your GitHits authentication status
+description: Show the host-managed GitHits connection status
 ---
 
 # Status
 
-Check the user's current GitHits authentication status by running the CLI
-command in the terminal:
+If `cursor-agent` is available, inspect the GitHits connection by running:
 
-```
-npx -y githits auth status
+```text
+cursor-agent mcp list
+cursor-agent mcp list-tools githits
 ```
 
-This shows whether the user is authenticated, where credentials are sourced
-from, and token expiry details when available.
+Report whether GitHits is missing or disabled, requires authentication, is
+connected without tools, or has discovered tools. If authentication is
+required, suggest `/githits:login`.
 
-After running the command, report the status clearly. If the user is not
-authenticated, suggest running:
+If the CLI output does not prove that the authenticated connection is usable,
+call the `search_language` MCP tool with the query `python`. Do not report
+GitHits as ready until Cursor shows its tools or that call succeeds.
 
-```
-npx -y githits login
-```
+If `cursor-agent` is unavailable, tell the user to open a new Cursor Agent chat
+and inspect Cursor's MCP tools UI. Confirm that GitHits is enabled and its tools
+are listed, and complete OAuth if prompted.
+
+The `githits auth status` CLI command reports credentials for local CLI and
+stdio integrations. It cannot inspect Cursor's remote OAuth session.

--- a/commands/status.md
+++ b/commands/status.md
@@ -4,24 +4,17 @@ description: Show the host-managed GitHits connection status
 
 # Status
 
-If `cursor-agent` is available, inspect the GitHits connection by running:
+Call the `search_language` MCP tool with the query `python` to check whether the
+current host's GitHits remote connection is usable.
 
-```text
-cursor-agent mcp list
-cursor-agent mcp list-tools githits
-```
+Report only what the result establishes:
 
-Report whether GitHits is missing or disabled, requires authentication, is
-connected without tools, or has discovered tools. If authentication is
-required, suggest `/githits:login`.
-
-If the CLI output does not prove that the authenticated connection is usable,
-call the `search_language` MCP tool with the query `python`. Do not report
-GitHits as ready until Cursor shows its tools or that call succeeds.
-
-If `cursor-agent` is unavailable, tell the user to open a new Cursor Agent chat
-and inspect Cursor's MCP tools UI. Confirm that GitHits is enabled and its tools
-are listed, and complete OAuth if prompted.
+- A successful call means the remote MCP connection is usable.
+- An authentication-required error means the current host needs OAuth; suggest
+  `/githits:login`.
+- An unavailable tool means GitHits may be disabled, disconnected, or not yet
+  discovered. Direct the user to the current host's MCP or server settings.
+- For any other failure, report the exact error without guessing its cause.
 
 The `githits auth status` CLI command reports credentials for local CLI and
-stdio integrations. It cannot inspect Cursor's remote OAuth session.
+stdio integrations. It cannot inspect the current host's remote OAuth session.

--- a/docs/implementation/plugin-packaging.md
+++ b/docs/implementation/plugin-packaging.md
@@ -31,10 +31,9 @@ Required components at repo root:
 - `skills/`
 - `commands/`
 
-Root `.mcp.json` is intentional and required for Open Plugin hosts.
-Both root and Claude payload MCP configs launch with
-`npx -y githits@latest mcp start` so plugin installs track the latest published
-GitHits CLI by default.
+Root `.mcp.json` is intentional and required for Open Plugin hosts. It registers
+the hosted remote MCP server at `https://mcp.githits.com`. The host owns OAuth
+for this connection; local GitHits CLI credentials do not control it.
 
 ### Claude marketplace package
 
@@ -48,6 +47,10 @@ Marketplace plugin source is `./plugins/claude`, which contains:
 
 This keeps Claude runtime payload explicit and marketplace-scoped.
 
+The Claude payload intentionally launches
+`npx -y githits@latest mcp start` over stdio. It therefore uses the local CLI
+authentication flow rather than the Open Plugin host's remote OAuth session.
+
 `plugins/claude/skills/githits-mcp/SKILL.md` is generated from the canonical
 `skills/githits-mcp/SKILL.md` during package creation. The root `prepack`
 script materializes the Claude payload copy and `postpack` removes it so the
@@ -57,8 +60,9 @@ skill content is authored in one place.
 
 When running Claude from this repository directory:
 
-- plugin server appears as `plugin:githits:githits`
-- root project `.mcp.json` can also register `githits`
+- Claude's stdio plugin server appears as `plugin:githits:githits`
+- root project `.mcp.json` can also register the hosted remote server as
+  `githits`
 
 This dual visibility is a local testing artifact, not an `init` behavior bug.
 For plugin-only attribution tests, run Claude from a different working
@@ -68,7 +72,8 @@ directory.
 
 Automated checks:
 
-- `src/plugin-config.test.ts` asserts root and Claude payload MCP server config
+- `src/plugin-config.test.ts` asserts that root uses remote MCP while the Claude
+  payload uses stdio
 - `src/plugin-manifest.test.ts` asserts Claude marketplace source points to
   `./plugins/claude`
 - `src/skills-packaging.test.ts` asserts the GitHits MCP skill is packaged from
@@ -76,8 +81,8 @@ Automated checks:
 
 Manual checks:
 
-- Open Plugin host install reads root package MCP config
-- Claude marketplace install loads `plugin:githits:githits`
+- Open Plugin host install reads the root remote MCP config and manages its OAuth
+- Claude marketplace install loads the stdio server as `plugin:githits:githits`
 - `npm pack --dry-run --json` includes
   `plugins/claude/skills/githits-mcp/SKILL.md`
 
@@ -85,9 +90,9 @@ Manual checks:
 
 | File | Purpose |
 |---|---|
-| `.mcp.json` | Root Open Plugin MCP server registration |
+| `.mcp.json` | Root hosted remote MCP server registration |
 | `.plugin/plugin.json` | Open Plugin manifest |
 | `.claude-plugin/marketplace.json` | Claude marketplace catalog and source path |
-| `plugins/claude/.mcp.json` | Claude payload MCP server registration |
+| `plugins/claude/.mcp.json` | Claude payload stdio MCP server registration |
 | `src/plugin-config.test.ts` | MCP packaging regression checks |
 | `src/plugin-manifest.test.ts` | Marketplace source path regression check |

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "description": "The code context layer for AI coding agents",
   "mcpServers": {
     "githits": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "githits",
   "description": "The code context layer for AI coding agents",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "mcpName": "com.githits/githits",
   "type": "module",
   "workspaces": [

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/server.json
+++ b/server.json
@@ -16,7 +16,7 @@
     "source": "github",
     "id": "1165453165"
   },
-  "version": "0.6.7",
+  "version": "0.6.8",
   "remotes": [
     {
       "type": "streamable-http",
@@ -28,7 +28,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "githits",
-      "version": "0.6.7",
+      "version": "0.6.8",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/src/plugin-auth-commands.test.ts
+++ b/src/plugin-auth-commands.test.ts
@@ -4,17 +4,6 @@ import { join } from "node:path";
 
 const root = join(import.meta.dir, "..");
 
-async function readMarketplaceServerName(): Promise<string> {
-  const contents = await readFile(join(root, ".mcp.json"), "utf8");
-  const parsed = JSON.parse(contents) as {
-    mcpServers?: Record<string, unknown>;
-  };
-  const serverNames = Object.keys(parsed.mcpServers ?? {});
-
-  expect(serverNames).toEqual(["githits"]);
-  return serverNames[0] as string;
-}
-
 async function readCommand(basePath: string, name: string): Promise<string> {
   return readFile(join(root, basePath, "commands", `${name}.md`), "utf8");
 }
@@ -26,43 +15,31 @@ function codeBlocks(markdown: string): string {
 }
 
 describe("plugin authentication commands", () => {
-  it("uses executable Cursor authentication and verification in root commands", async () => {
-    const [serverName, help, login, logout, status] = await Promise.all([
-      readMarketplaceServerName(),
+  it("uses host-neutral authentication and verification in root commands", async () => {
+    const [help, login, logout, status] = await Promise.all([
       readCommand(".", "help"),
       readCommand(".", "login"),
       readCommand(".", "logout"),
       readCommand(".", "status"),
     ]);
-    const loginCommand = `cursor-agent mcp login ${serverName}`;
-    const listToolsCommand = `cursor-agent mcp list-tools ${serverName}`;
 
-    expect(login).toContain(loginCommand);
-    expect(help).toContain(loginCommand);
     for (const command of [help, login, status]) {
-      expect(command).toContain("cursor-agent mcp list");
-      expect(command).toContain(listToolsCommand);
       expect(command).toContain("search_language");
-      expect(command).toContain("new Cursor Agent chat");
+      expect(command).toContain("current host");
     }
     for (const command of [help, login, logout, status]) {
-      expect(command).not.toMatch(
-        /cursor-agent mcp (?:login|list-tools|logout) GitHits/,
-      );
+      expect(command).not.toContain("Cursor");
+      expect(command).not.toContain("cursor-agent");
+      expect(command).not.toContain("/mcp");
     }
   });
 
-  it("keeps root logout manual without inventing a Cursor command", async () => {
-    const [serverName, logout] = await Promise.all([
-      readMarketplaceServerName(),
-      readCommand(".", "logout"),
-    ]);
-    const logoutCommand = `cursor-agent mcp logout ${serverName}`;
+  it("keeps root logout host-managed without triggering authentication", async () => {
+    const logout = await readCommand(".", "logout");
 
-    expect(logout).toMatch(/Cursor's\s+MCP settings/);
-    expect(logout).toContain("does not have a supported");
-    expect(logout).toContain(logoutCommand);
-    expect(codeBlocks(logout)).not.toContain(logoutCommand);
+    expect(logout).toContain("no portable");
+    expect(logout).toContain("current host");
+    expect(logout).not.toContain("search_language");
   });
 
   it("does not prescribe local CLI authentication for root remote sessions", async () => {

--- a/src/plugin-auth-commands.test.ts
+++ b/src/plugin-auth-commands.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const root = join(import.meta.dir, "..");
+
+async function readMarketplaceServerName(): Promise<string> {
+  const contents = await readFile(join(root, ".mcp.json"), "utf8");
+  const parsed = JSON.parse(contents) as {
+    mcpServers?: Record<string, unknown>;
+  };
+  const serverNames = Object.keys(parsed.mcpServers ?? {});
+
+  expect(serverNames).toEqual(["githits"]);
+  return serverNames[0] as string;
+}
+
+async function readCommand(basePath: string, name: string): Promise<string> {
+  return readFile(join(root, basePath, "commands", `${name}.md`), "utf8");
+}
+
+function codeBlocks(markdown: string): string {
+  return [...markdown.matchAll(/```[^\n]*\n([\s\S]*?)```/g)]
+    .map((match) => match[1])
+    .join("\n");
+}
+
+describe("plugin authentication commands", () => {
+  it("uses executable Cursor authentication and verification in root commands", async () => {
+    const [serverName, help, login, logout, status] = await Promise.all([
+      readMarketplaceServerName(),
+      readCommand(".", "help"),
+      readCommand(".", "login"),
+      readCommand(".", "logout"),
+      readCommand(".", "status"),
+    ]);
+    const loginCommand = `cursor-agent mcp login ${serverName}`;
+    const listToolsCommand = `cursor-agent mcp list-tools ${serverName}`;
+
+    expect(login).toContain(loginCommand);
+    expect(help).toContain(loginCommand);
+    for (const command of [help, login, status]) {
+      expect(command).toContain("cursor-agent mcp list");
+      expect(command).toContain(listToolsCommand);
+      expect(command).toContain("search_language");
+      expect(command).toContain("new Cursor Agent chat");
+    }
+    for (const command of [help, login, logout, status]) {
+      expect(command).not.toMatch(
+        /cursor-agent mcp (?:login|list-tools|logout) GitHits/,
+      );
+    }
+  });
+
+  it("keeps root logout manual without inventing a Cursor command", async () => {
+    const [serverName, logout] = await Promise.all([
+      readMarketplaceServerName(),
+      readCommand(".", "logout"),
+    ]);
+    const logoutCommand = `cursor-agent mcp logout ${serverName}`;
+
+    expect(logout).toMatch(/Cursor's\s+MCP settings/);
+    expect(logout).toContain("does not have a supported");
+    expect(logout).toContain(logoutCommand);
+    expect(codeBlocks(logout)).not.toContain(logoutCommand);
+  });
+
+  it("does not prescribe local CLI authentication for root remote sessions", async () => {
+    const commands = await Promise.all(
+      ["login", "logout", "status"].map((name) => readCommand(".", name)),
+    );
+
+    expect(codeBlocks(commands.join("\n"))).not.toMatch(
+      /githits (?:login|logout|auth status)/,
+    );
+  });
+
+  it("keeps Claude payload authentication on local stdio commands", async () => {
+    const [login, logout, status] = await Promise.all([
+      readCommand("plugins/claude", "login"),
+      readCommand("plugins/claude", "logout"),
+      readCommand("plugins/claude", "status"),
+    ]);
+
+    expect(login).toContain("npx -y githits login");
+    expect(login).toContain("npx -y githits login --no-browser");
+    expect(logout).toContain("npx -y githits logout");
+    expect(status).toContain("npx -y githits auth status");
+
+    for (const command of [login, logout, status]) {
+      expect(command).not.toContain("cursor-agent mcp");
+    }
+  });
+
+  it("keeps root help static and Claude help executable over stdio", async () => {
+    const [rootHelp, claudeHelp] = await Promise.all([
+      readCommand(".", "help"),
+      readCommand("plugins/claude", "help"),
+    ]);
+    const npxGitHitsCommand = /\bnpx\b[^\n]*\bgithits(?:@latest)?(?=\s|$)/;
+
+    expect(rootHelp).not.toMatch(npxGitHitsCommand);
+    expect(codeBlocks(rootHelp)).not.toMatch(npxGitHitsCommand);
+    expect(codeBlocks(claudeHelp)).toContain("npx -y githits help");
+  });
+});

--- a/src/plugin-config.test.ts
+++ b/src/plugin-config.test.ts
@@ -2,26 +2,45 @@ import { describe, expect, it } from "bun:test";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 
+interface McpServerConfig {
+  url?: string;
+  command?: string;
+  args?: string[];
+}
+
+interface RegistryManifest {
+  remotes?: Array<{
+    type?: string;
+    url?: string;
+  }>;
+}
+
 describe("plugin MCP configuration", () => {
-  it("defines githits MCP server in root Open Plugin package", async () => {
+  it("uses hosted remote MCP in the root Open Plugin package", async () => {
     const rootMcpPath = join(import.meta.dir, "..", ".mcp.json");
-    const contents = await readFile(rootMcpPath, "utf8");
-    const parsed = JSON.parse(contents) as {
-      mcpServers?: Record<string, { command?: string; args?: string[] }>;
+    const registryPath = join(import.meta.dir, "..", "server.json");
+    const [rootMcpContents, registryContents] = await Promise.all([
+      readFile(rootMcpPath, "utf8"),
+      readFile(registryPath, "utf8"),
+    ]);
+    const parsed = JSON.parse(rootMcpContents) as {
+      mcpServers?: Record<string, McpServerConfig>;
     };
+    const registry = JSON.parse(registryContents) as RegistryManifest;
+    const streamableHttpRemotes =
+      registry.remotes?.filter((remote) => remote.type === "streamable-http") ??
+      [];
 
     expect(parsed.mcpServers).toBeDefined();
     expect(parsed.mcpServers?.githits).toBeDefined();
-    expect(parsed.mcpServers?.githits?.command).toBe("npx");
-    expect(parsed.mcpServers?.githits?.args).toEqual([
-      "-y",
-      "githits@latest",
-      "mcp",
-      "start",
-    ]);
+    expect(streamableHttpRemotes).toHaveLength(1);
+    expect(streamableHttpRemotes[0]?.url).toBeDefined();
+    expect(parsed.mcpServers?.githits?.url).toBe(streamableHttpRemotes[0]?.url);
+    expect(parsed.mcpServers?.githits?.command).toBeUndefined();
+    expect(parsed.mcpServers?.githits?.args).toBeUndefined();
   });
 
-  it("defines githits MCP server in Claude plugin payload", async () => {
+  it("uses local stdio MCP in the Claude plugin payload", async () => {
     const pluginMcpPath = join(
       import.meta.dir,
       "..",
@@ -31,7 +50,7 @@ describe("plugin MCP configuration", () => {
     );
     const contents = await readFile(pluginMcpPath, "utf8");
     const parsed = JSON.parse(contents) as {
-      mcpServers?: Record<string, { command?: string; args?: string[] }>;
+      mcpServers?: Record<string, McpServerConfig>;
     };
 
     expect(parsed.mcpServers).toBeDefined();
@@ -43,5 +62,6 @@ describe("plugin MCP configuration", () => {
       "mcp",
       "start",
     ]);
+    expect(parsed.mcpServers?.githits?.url).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

- switch the root Open Plugin MCP registration from local stdio to the hosted remote endpoint
- keep the Claude marketplace payload on stdio with separate CLI authentication guidance
- make root auth/help commands use Cursor-managed OAuth and static remote help
- add transport, auth-command, help, endpoint consistency, and packaging regression coverage
- prepare the synchronized root/plugin 0.6.8 patch release without bumping `@githits/mcp`

## Validation

- `bun test` (2,563 passed)
- `bun run typecheck`
- `bun run format:check`
- `bun run build`
- CLI unauthenticated smoke
- MCP registration smoke
- `git diff --check`

## Known Existing Issues

- lint reports the existing non-null assertion warning in `src/commands/init/agent-definitions.ts:1142`
- built Node smoke/package validation remains blocked by the existing duplicate `createContainer` export in the generated bundle