### PR TITLE
chore: prepare 0.7.0 release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,12 +6,12 @@
   },
   "metadata": {
     "description": "The code context layer for AI coding agents",
-    "version": "0.6.7"
+    "version": "0.7.0"
   },
   "plugins": [
     {
       "name": "githits",
-      "version": "0.6.7",
+      "version": "0.7.0",
       "description": "The code context layer for AI coding agents",
       "author": {
         "name": "GitHits"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.6.7",
+  "version": "0.7.0",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.6.7",
+  "version": "0.7.0",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.6.7",
+  "version": "0.7.0",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.6.7",
+  "version": "0.7.0",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.6.7",
+  "version": "0.7.0",
   "description": "The code context layer for AI coding agents",
   "mcpServers": {
     "githits": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "githits",
   "description": "The code context layer for AI coding agents",
-  "version": "0.6.7",
+  "version": "0.7.0",
   "mcpName": "com.githits/githits",
   "type": "module",
   "workspaces": [

--- a/server.json
+++ b/server.json
@@ -16,7 +16,7 @@
     "source": "github",
     "id": "1165453165"
   },
-  "version": "0.6.7",
+  "version": "0.7.0",
   "remotes": [
     {
       "type": "streamable-http",
@@ -28,7 +28,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "githits",
-      "version": "0.6.7",
+      "version": "0.7.0",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Summary

Prepare the root `githits` 0.7.0 release for the consolidated cross-host plugin surface.

- bump the root npm package and MCP registry manifest to 0.7.0
- regenerate and align Claude, Cursor, Codex, generic/OpenPlugin, and Gemini extension manifest versions
- keep `@githits/mcp` at 0.6.4 because its public package API and runtime behavior did not change

## User-visible release notes

- Consolidates GitHits plugin and skill packaging in this repository as the single source of truth.
- Aligns Claude, Cursor, Codex, Gemini CLI, Antigravity, and generic/OpenPlugin surfaces around the same four skills.
- Uses hosted remote MCP for plugin/extension installs while preserving local stdio MCP for direct CLI setup where supported.
- Removes the legacy Cursor command payload and duplicated standalone plugin repositories.
- Adds generated-manifest drift protection and updated marketplace metadata.

## Validation

- `bun test` — 2,573 passed
- `bun run typecheck`
- `bun run lint` — only the two pre-existing Biome notices
- `bun run build`
- `bun run validate:packages`
- `bun run validate:packages:mcp-publish`
- `bun run plugins:check`
- `npm pack --dry-run --json` — 27 expected entries
- `claude plugin validate .`
- `bun run smoke:cli`
- `bun run smoke:mcp`
- `bun run smoke:cli:built`
- `bun run smoke:mcp:built`
- pinned `mcp-publisher 1.7.9 validate server.json`
- verified MCP registry domain proof, OAuth resource metadata, and unauthenticated 401 challenge

Merging this PR allows the successful `Main` workflow to publish `githits@0.7.0`, `com.githits/githits@0.7.0`, and the GitHub `v0.7.0` release.