### PR TITLE
feat: add portable Agent Plugins support

### DIFF
--- a/docs/implementation/plugin-packaging.md
+++ b/docs/implementation/plugin-packaging.md
@@ -3,11 +3,12 @@
 ## Purpose
 
 GitHits publishes one canonical skill and guidance surface from this repository
-for Claude Code, Codex, Cursor, Gemini CLI, Google Antigravity, and
-VS Code/GitHub Copilot OpenPlugin hosts.
+as a portable Agent Plugin and through native adapters for Claude Code, Codex,
+Cursor, Gemini CLI, Google Antigravity, and VS Code/GitHub Copilot OpenPlugin
+hosts.
 
-Root `skills/` and `AGENTS.md` are authored inputs. Host manifests and MCP
-configuration are deterministic generated artifacts.
+Root `skills/` and `AGENTS.md` are authored inputs. Portable and host manifests
+and MCP configuration are deterministic generated artifacts.
 
 ## Canonical Inputs
 
@@ -39,6 +40,7 @@ The generator owns:
 - `.codex-plugin/plugin.json`
 - `.cursor-plugin/plugin.json`
 - `.mcp.json`
+- `mcp.json`
 - `gemini-extension.json`
 - `plugin.json`
 - `mcp_config.json`
@@ -63,10 +65,19 @@ content and reference parity with the root source.
 Plugin Markdown commands are intentionally absent. User-facing CLI commands are
 implemented under `src/commands/**` and are not plugin slash commands.
 
+## Portable Agent Plugins Contract
+
+Root `plugin.json` and `mcp.json` target Agent Plugins 1.0.0. The portable
+manifest reuses the same canonical product metadata as the generated host
+manifests. Portable MCP uses the explicit `streamable-http` transport while
+native adapters retain their host-specific field names and files. Do not remove
+native adapters until their consumers have migrated to the portable format.
+
 ## Transport Contract
 
 | Host | Generated configuration | Transport |
 |---|---|---|
+| Agent Plugins 1.0.0 | `plugin.json` + `mcp.json` | Hosted Streamable HTTP at `https://mcp.githits.com` |
 | Cursor | `.cursor-plugin/plugin.json` + `.mcp.json` | Hosted Streamable HTTP at `https://mcp.githits.com` |
 | Claude Code | `.mcp.json` | Hosted Streamable HTTP at `https://mcp.githits.com` |
 | Codex | `.codex-plugin/plugin.json` + `.mcp.json` | Hosted Streamable HTTP at `https://mcp.githits.com` |
@@ -82,12 +93,13 @@ local hosts, while Cursor remains remote-only. Claude and Gemini CLI setup
 remove obsolete plugin or extension state before installing the user-scoped
 stdio server so the remote package and local server are not registered together.
 
-The repository root is also a native Antigravity plugin directory:
-`plugin.json` is its marker, `mcp_config.json` supplies the hosted remote MCP
-using Antigravity's `serverUrl` field, and the root `skills/` tree supplies the
-same four canonical skills. Direct CLI setup remains local stdio and writes the
-current global `~/.gemini/config/mcp_config.json` or workspace
-`.agents/mcp_config.json` path.
+The repository root is the portable Agent Plugin root and also a native
+Antigravity plugin directory. `plugin.json` is the shared Agent Plugins manifest
+and Antigravity marker. Portable clients load the hosted remote MCP from
+`mcp.json`; Antigravity retains `mcp_config.json` with its native `serverUrl`
+field. Both formats discover the same four canonical root skills. Direct CLI
+setup remains local stdio and writes the current global
+`~/.gemini/config/mcp_config.json` or workspace `.agents/mcp_config.json` path.
 
 Generated plugin manifests use the publisher-provided `keywords` from
 `server.json`. `package.json` retains the same ordered list so npm and every
@@ -95,10 +107,10 @@ plugin marketplace describe the product consistently.
 
 ## Marketplace Layout
 
-The repository root is the plugin root for the Anthropic community marketplace,
-the first-party Claude marketplace, direct Codex installs, Cursor, the Gemini
-extension gallery, VS Code/GitHub Copilot OpenPlugin installs, and a manually
-installed Antigravity plugin.
+The repository root is the plugin root for Agent Plugins clients, the Anthropic
+community marketplace, the first-party Claude marketplace, direct Codex
+installs, Cursor, the Gemini extension gallery, VS Code/GitHub Copilot
+OpenPlugin installs, and a manually installed Antigravity plugin.
 
 The first-party Claude marketplace entry uses the public HTTPS Git URL for
 `githits-com/githits-cli`. Claude clones that repository as the plugin root and
@@ -127,8 +139,8 @@ bun run build
 
 Run CLI/MCP smoke suites when packaging or startup behavior changes. Run targeted
 agent evaluations when skills, instructions, or agent-facing setup behavior
-changes. Validate real Claude, Cursor, and Gemini installs before a release that
-changes their manifests.
+changes. Validate a real Agent Plugins client plus Antigravity, Claude, Cursor,
+and Gemini installs before a release that changes their manifests.
 
 Use the repository-internal `githits-plugin-maintenance` skill for every change
 in this area. It lives under `.agents/skills/` and is never part of the public

--- a/mcp.json
+++ b/mcp.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "mcpServers": {
+    "githits": {
+      "type": "streamable-http",
+      "url": "https://mcp.githits.com"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     ".codex-plugin",
     ".cursor-plugin",
     ".mcp.json",
+    "mcp.json",
     "server.json",
     "gemini-extension.json",
     "plugin.json",

--- a/plugin.json
+++ b/plugin.json
@@ -1,3 +1,27 @@
 {
-  "name": "githits"
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "githits",
+  "version": "0.7.0",
+  "description": "The code context layer for AI coding agents",
+  "author": {
+    "name": "GitHits"
+  },
+  "homepage": "https://githits.com",
+  "repository": "https://github.com/githits-com/githits-cli",
+  "license": "Apache-2.0",
+  "keywords": [
+    "githits",
+    "context layer",
+    "public open-source",
+    "open-source code",
+    "code search",
+    "package documentation",
+    "documentation search",
+    "package metadata",
+    "vulnerabilities",
+    "changelogs",
+    "dependency graphs",
+    "upgrade evidence",
+    "implementation examples"
+  ]
 }

--- a/scripts/generate-plugin-assets.test.ts
+++ b/scripts/generate-plugin-assets.test.ts
@@ -3,6 +3,8 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  AGENT_PLUGINS_MCP_SCHEMA_URL,
+  AGENT_PLUGINS_SCHEMA_URL,
   CANONICAL_SKILL_NAMES,
   createPluginAssetInputs,
   generatePluginAssets,
@@ -70,7 +72,16 @@ describe("plugin asset generation", () => {
       },
     });
     const assetPaths: string[] = [...assets.keys()];
-    expect(assetPaths).not.toContain("mcp.json");
+    expect(assetPaths).toContain("mcp.json");
+    expect(JSON.parse(assets.get("mcp.json") ?? "{}")).toEqual({
+      $schema: AGENT_PLUGINS_MCP_SCHEMA_URL,
+      mcpServers: {
+        githits: {
+          type: "streamable-http",
+          url: "https://mcp.githits.com",
+        },
+      },
+    });
     expect(
       JSON.parse(assets.get("gemini-extension.json") ?? "{}").mcpServers,
     ).toEqual({
@@ -79,7 +90,15 @@ describe("plugin asset generation", () => {
       },
     });
     expect(JSON.parse(assets.get("plugin.json") ?? "{}")).toEqual({
+      $schema: AGENT_PLUGINS_SCHEMA_URL,
       name: "githits",
+      version: "1.2.3",
+      description: "The code context layer for AI coding agents",
+      author: { name: "GitHits" },
+      homepage: "https://githits.com",
+      repository: "https://github.com/githits-com/githits-cli",
+      license: "Apache-2.0",
+      keywords: registryKeywords,
     });
     expect(JSON.parse(assets.get("mcp_config.json") ?? "{}")).toEqual(
       expect.objectContaining({
@@ -164,7 +183,7 @@ describe("plugin asset generation", () => {
       await generatePluginAssets({ root });
       await expect(
         generatePluginAssets({ root, check: true }),
-      ).resolves.toHaveLength(9);
+      ).resolves.toHaveLength(10);
 
       await writeFile(join(root, ".mcp.json"), "{}\n");
       await expect(generatePluginAssets({ root, check: true })).rejects.toThrow(

--- a/scripts/generate-plugin-assets.ts
+++ b/scripts/generate-plugin-assets.ts
@@ -9,6 +9,10 @@ export const CANONICAL_SKILL_NAMES = [
   "githits-package",
 ] as const;
 
+export const AGENT_PLUGINS_VERSION = "1.0.0";
+export const AGENT_PLUGINS_SCHEMA_URL = `https://agent-plugins.org/schemas/${AGENT_PLUGINS_VERSION}/plugin.schema.json`;
+export const AGENT_PLUGINS_MCP_SCHEMA_URL = `https://agent-plugins.org/schemas/${AGENT_PLUGINS_VERSION}/mcp.schema.json`;
+
 export const GENERATED_PLUGIN_ASSET_PATHS = [
   ".plugin/plugin.json",
   ".claude-plugin/plugin.json",
@@ -16,6 +20,7 @@ export const GENERATED_PLUGIN_ASSET_PATHS = [
   ".codex-plugin/plugin.json",
   ".cursor-plugin/plugin.json",
   ".mcp.json",
+  "mcp.json",
   "gemini-extension.json",
   "plugin.json",
   "mcp_config.json",
@@ -309,6 +314,18 @@ export function renderPluginAssets(
       }),
     },
     {
+      path: "mcp.json",
+      content: json({
+        $schema: AGENT_PLUGINS_MCP_SCHEMA_URL,
+        mcpServers: {
+          githits: {
+            type: "streamable-http",
+            url: inputs.remoteMcpUrl,
+          },
+        },
+      }),
+    },
+    {
       path: "gemini-extension.json",
       content: json({
         name: inputs.name,
@@ -324,7 +341,10 @@ export function renderPluginAssets(
     },
     {
       path: "plugin.json",
-      content: json({ name: inputs.name }),
+      content: json({
+        $schema: AGENT_PLUGINS_SCHEMA_URL,
+        ...sharedManifest,
+      }),
     },
     {
       path: "mcp_config.json",

--- a/src/plugin-config.test.ts
+++ b/src/plugin-config.test.ts
@@ -3,6 +3,27 @@ import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 
 describe("plugin MCP configuration", () => {
+  it("provides the portable Agent Plugins Streamable HTTP configuration", async () => {
+    const contents = await readFile(
+      join(import.meta.dir, "..", "mcp.json"),
+      "utf8",
+    );
+    const parsed = JSON.parse(contents) as {
+      $schema?: string;
+      mcpServers?: Record<string, { type?: string; url?: string }>;
+    };
+
+    expect(parsed).toEqual({
+      $schema: "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+      mcpServers: {
+        githits: {
+          type: "streamable-http",
+          url: "https://mcp.githits.com",
+        },
+      },
+    });
+  });
+
   it("uses the hosted remote MCP for root plugin packages", async () => {
     const rootMcpPath = join(import.meta.dir, "..", ".mcp.json");
     const contents = await readFile(rootMcpPath, "utf8");

--- a/src/plugin-manifest.test.ts
+++ b/src/plugin-manifest.test.ts
@@ -35,6 +35,7 @@ describe("plugin manifest wiring", () => {
       [".codex-plugin", "plugin.json"],
       [".cursor-plugin", "plugin.json"],
       ["gemini-extension.json"],
+      ["plugin.json"],
     ];
 
     for (const parts of manifestPaths) {
@@ -64,6 +65,7 @@ describe("plugin manifest wiring", () => {
       [".claude-plugin", "plugin.json"],
       [".codex-plugin", "plugin.json"],
       [".cursor-plugin", "plugin.json"],
+      ["plugin.json"],
     ]) {
       const manifest = JSON.parse(
         await readFile(join(root, ...parts), "utf8"),
@@ -91,12 +93,17 @@ describe("plugin manifest wiring", () => {
     expect(cursorManifest.mcpServers).toBe(".mcp.json");
   });
 
-  it("provides the native Antigravity plugin marker at the repository root", async () => {
+  it("provides the shared Agent Plugins and Antigravity manifest", async () => {
     const manifest = JSON.parse(
       await readFile(join(root, "plugin.json"), "utf8"),
     ) as { name?: string };
 
-    expect(manifest).toEqual({ name: "githits" });
+    expect(manifest).toEqual(
+      expect.objectContaining({
+        $schema: "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+        name: "githits",
+      }),
+    );
   });
 
   it("uses only the canonical root skill tree", async () => {

--- a/src/skills-packaging.test.ts
+++ b/src/skills-packaging.test.ts
@@ -251,6 +251,7 @@ describe("agent skills packaging", () => {
     expect(packageJson.files).toContain("skills");
     expect(packageJson.files).toContain(".codex-plugin");
     expect(packageJson.files).toContain("plugin.json");
+    expect(packageJson.files).toContain("mcp.json");
     expect(packageJson.files).toContain("mcp_config.json");
     expect(packageJson.files).not.toContain(".agents");
     expect(packageJson.files).not.toContain("plugins");


### PR DESCRIPTION
## Summary

- generate an Agent Plugins 1.0.0 root manifest from canonical GitHits metadata
- add portable Streamable HTTP MCP configuration at `mcp.json`
- retain every existing host-specific manifest and MCP adapter
- document and test portable/native packaging parity

## Why

Agent Plugins standardizes a portable root `plugin.json`, `skills/`, and `mcp.json` layout. GitHits already has the canonical skill tree and hosted MCP endpoint, so this adds the portable contract without removing Claude, Codex, Cursor, Gemini, Antigravity, or OpenPlugin compatibility.

## Validation

- `bun run plugins:generate`
- `bun run plugins:check`
- `bun test` (2574 passed)
- `bun run build`
- `bun run smoke:cli`
- `bun run smoke:mcp`
- `npm pack --dry-run --json`