### PR TITLE
chore: prepare 0.8.0 release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,12 +6,12 @@
   },
   "metadata": {
     "description": "The code context layer for AI coding agents",
-    "version": "0.7.0"
+    "version": "0.8.0"
   },
   "plugins": [
     {
       "name": "githits",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "description": "The code context layer for AI coding agents",
       "author": {
         "name": "GitHits"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "The code context layer for AI coding agents",
   "mcpServers": {
     "githits": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "githits",
   "description": "The code context layer for AI coding agents",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "mcpName": "com.githits/githits",
   "type": "module",
   "workspaces": [

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "githits",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/server.json
+++ b/server.json
@@ -16,7 +16,7 @@
     "source": "github",
     "id": "1165453165"
   },
-  "version": "0.7.0",
+  "version": "0.8.0",
   "remotes": [
     {
       "type": "streamable-http",
@@ -28,7 +28,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "githits",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/src/services/locked-auth-storage.test.ts
+++ b/src/services/locked-auth-storage.test.ts
@@ -18,6 +18,8 @@ import {
 
 describe("LockedAuthStorage", () => {
   const baseUrl = "https://mcp.githits.com";
+  const testProcessStartedAt = async (): Promise<string> =>
+    "test-process-started-at";
   const tempDirs: string[] = [];
 
   afterEach(async () => {
@@ -33,10 +35,12 @@ describe("LockedAuthStorage", () => {
     const first = new LockedAuthStorage(
       new AuthStorageImpl(fs, configDir),
       fsWithHome,
+      { getProcessStartedAt: testProcessStartedAt },
     );
     const second = new LockedAuthStorage(
       new AuthStorageImpl(fs, configDir),
       fsWithHome,
+      { getProcessStartedAt: testProcessStartedAt },
     );
     const initial = createValidTokenData({ accessToken: "initial" });
     await first.saveTokens(baseUrl, initial);
@@ -58,6 +62,39 @@ describe("LockedAuthStorage", () => {
     const finalToken = await first.loadTokens(baseUrl);
     expect(finalToken).not.toBeNull();
     expect(["first", "second"]).toContain(finalToken?.accessToken ?? "");
+  });
+
+  it("reuses the current process identity across lock acquisitions", async () => {
+    const { fsWithHome } = await createStoragePaths();
+    const getProcessStartedAt = mock(async (_pid: number) =>
+      Promise.resolve("test-process-started-at"),
+    );
+    const storage = new LockedAuthStorage(createMockAuthStorage(), fsWithHome, {
+      getProcessStartedAt,
+    });
+
+    await storage.saveTokens(baseUrl, createValidTokenData());
+    await storage.clearTokens(baseUrl);
+
+    expect(getProcessStartedAt).toHaveBeenCalledTimes(1);
+    expect(getProcessStartedAt).toHaveBeenCalledWith(process.pid);
+  });
+
+  it("retries an unavailable current process identity", async () => {
+    const { fsWithHome } = await createStoragePaths();
+    let lookupCount = 0;
+    const getProcessStartedAt = mock(async (_pid: number) => {
+      lookupCount += 1;
+      return lookupCount === 1 ? null : "test-process-started-at";
+    });
+    const storage = new LockedAuthStorage(createMockAuthStorage(), fsWithHome, {
+      getProcessStartedAt,
+    });
+
+    await storage.saveTokens(baseUrl, createValidTokenData());
+    await storage.clearTokens(baseUrl);
+
+    expect(getProcessStartedAt).toHaveBeenCalledTimes(2);
   });
 
   it("serializes token loads with external writes", async () => {
@@ -91,8 +128,11 @@ describe("LockedAuthStorage", () => {
         return Promise.resolve();
       }),
     });
-    const first = new LockedAuthStorage(firstInner, fsWithHome);
+    const first = new LockedAuthStorage(firstInner, fsWithHome, {
+      getProcessStartedAt: testProcessStartedAt,
+    });
     const second = new LockedAuthStorage(secondInner, fsWithHome, {
+      getProcessStartedAt: testProcessStartedAt,
       isOwnerAlive: async () => {
         contentionStarted();
         return true;
@@ -143,8 +183,11 @@ describe("LockedAuthStorage", () => {
         return Promise.resolve();
       }),
     });
-    const first = new LockedAuthStorage(firstInner, fsWithHome);
+    const first = new LockedAuthStorage(firstInner, fsWithHome, {
+      getProcessStartedAt: testProcessStartedAt,
+    });
     const second = new LockedAuthStorage(secondInner, fsWithHome, {
+      getProcessStartedAt: testProcessStartedAt,
       isOwnerAlive: async () => {
         contentionStarted();
         return true;

--- a/src/services/locked-auth-storage.ts
+++ b/src/services/locked-auth-storage.ts
@@ -54,6 +54,10 @@ export class LockedAuthStorage implements AuthStorage, AuthStorageLockProvider {
     pid: number,
     processStartedAt: string | null,
   ) => Promise<boolean>;
+  private readonly processStartedAtLookup: (
+    pid: number,
+  ) => Promise<string | null>;
+  private currentProcessStartedAtPromise: Promise<string | null> | undefined;
   private readonly lockContext = new AsyncLocalStorage<string>();
   private currentOwner: LockOwner | null = null;
   private readonly lockLoads: boolean;
@@ -67,10 +71,22 @@ export class LockedAuthStorage implements AuthStorage, AuthStorageLockProvider {
         pid: number,
         processStartedAt: string | null,
       ) => Promise<boolean>;
+      getProcessStartedAt?: (pid: number) => Promise<string | null>;
     } = {},
   ) {
     this.lockTimeoutMs = options.lockTimeoutMs ?? LOCK_TIMEOUT_MS;
-    this.isOwnerAlive = options.isOwnerAlive ?? isOriginalProcessAlive;
+    this.processStartedAtLookup =
+      options.getProcessStartedAt ?? getProcessStartedAt;
+    this.isOwnerAlive =
+      options.isOwnerAlive ??
+      ((pid, processStartedAt) =>
+        isOriginalProcessAlive(
+          pid,
+          processStartedAt,
+          pid === process.pid
+            ? () => this.getCurrentProcessStartedAt()
+            : this.processStartedAtLookup,
+        ));
     this.lockLoads = storage.requiresLoadLock === true;
     this.lockPath = fileSystemService.joinPath(
       getAuthLockDir(fileSystemService),
@@ -180,7 +196,7 @@ export class LockedAuthStorage implements AuthStorage, AuthStorageLockProvider {
   }
 
   private async acquireLock(): Promise<void> {
-    const processStartedAt = await getProcessStartedAt(process.pid);
+    const processStartedAt = await this.getCurrentProcessStartedAt();
     const startedAt = Date.now();
     await mkdir(dirname(this.lockPath), { recursive: true, mode: 0o700 });
     while (true) {
@@ -221,6 +237,29 @@ export class LockedAuthStorage implements AuthStorage, AuthStorageLockProvider {
     return new AuthStorageLockTimeoutError(
       `Timed out waiting for GitHits auth storage lock at ${this.lockPath}. If no githits process is running, remove this directory and retry.`,
     );
+  }
+
+  private getCurrentProcessStartedAt(): Promise<string | null> {
+    if (!this.currentProcessStartedAtPromise) {
+      const lookup = this.processStartedAtLookup(process.pid);
+      this.currentProcessStartedAtPromise = lookup;
+      void lookup.then(
+        (startedAt) => {
+          if (
+            startedAt === null &&
+            this.currentProcessStartedAtPromise === lookup
+          ) {
+            this.currentProcessStartedAtPromise = undefined;
+          }
+        },
+        () => {
+          if (this.currentProcessStartedAtPromise === lookup) {
+            this.currentProcessStartedAtPromise = undefined;
+          }
+        },
+      );
+    }
+    return this.currentProcessStartedAtPromise;
   }
 
   private async writeOwner(processStartedAt: string | null): Promise<void> {
@@ -314,10 +353,11 @@ function sleep(ms: number): Promise<void> {
 async function isOriginalProcessAlive(
   pid: number,
   processStartedAt: string | null,
+  getStartedAt: (pid: number) => Promise<string | null>,
 ): Promise<boolean> {
   if (!isProcessAlive(pid)) return false;
   if (!processStartedAt) return true;
-  return (await getProcessStartedAt(pid)) === processStartedAt;
+  return (await getStartedAt(pid)) === processStartedAt;
 }
 
 function isProcessAlive(pid: number): boolean {


### PR DESCRIPTION
## Summary

- bump the root `githits` package from 0.7.0 to 0.8.0
- align the portable Agent Plugin, native plugin manifests, and MCP registry metadata
- cache the auth-lock identity of the current process to avoid repeated Windows subprocess lookups
- keep `@githits/mcp` at 0.6.4 because its public package surface is unchanged

## Release highlights

GitHits 0.8.0 adds the Agent Plugins 1.0.0 portable package contract introduced in #259:

- root `plugin.json` with portable metadata
- root `mcp.json` using the hosted Streamable HTTP endpoint
- existing Claude, Codex, Cursor, Gemini, Antigravity, and OpenPlugin adapters retained

The release also makes auth-lock process identity lookup deterministic and reusable. Unavailable identity lookups are retried so PID-reuse protection is preserved.

The generated GitHub release notes will also include the documentation correction merged in #258.

## Validation

- `bun run plugins:generate`
- `bun run plugins:check`
- `bun test` — 2,576 passed
- `bun run build`
- `bun run validate:packages:mcp-publish`
- `bun run smoke:cli` — 70 steps passed
- `bun run smoke:mcp` — 38 steps passed
- `bun run smoke:cli:built`
- `bun run smoke:mcp:built`
- `npm pack --dry-run --json` — confirmed `githits@0.8.0` with portable and native plugin assets
- `mcp-publisher v1.7.9 validate server.json` — passed with verified publisher checksum
- registry domain proof, OAuth metadata, and unauthenticated MCP challenge checks — passed

## Publishing behavior

After merge, a successful `Main` workflow will publish `githits@0.8.0`, update `com.githits/githits@0.8.0` in the MCP registry, tag `v0.8.0`, and generate the GitHub release notes.