### PR TITLE
Align skills and mcp instructions with tool schemas

### DIFF
--- a/packages/mcp/src/mcp/instructions.ts
+++ b/packages/mcp/src/mcp/instructions.ts
@@ -77,6 +77,17 @@ const STRATEGY_TIP =
   "Strategy — reference-first. Source, symbols, tests, and call sites beat docs prose. Enumerate paths with `code_files`; locate symbols/lines with `search` or `code_grep`; read focused windows with `code_read`.";
 
 /**
+ * Guidance to ensure correct mapping from camelCase returned fields in responses
+ * (e.g. search results or examples) to snake_case input parameters of the MCP tools.
+ */
+const INPUT_MAPPING_TIP =
+  "**Casing & Input Parameter Mapping:** MCP tool parameters are snake_case, but returned response keys may be camelCase. Always map returned fields to the correct tool inputs:\n" +
+  "- For `docs_read`: Pass the returned `pageId` value to the `page_id` parameter.\n" +
+  "- For `code_read`: Pass `filePath` to the `path` parameter, `startLine` to `start_line`, and `endLine` to `end_line`.\n" +
+  "- For `search_status`: Pass `searchRef` from search progress responses to the `search_ref` parameter.\n" +
+  "- For `feedback`: Pass `solutionId` (if present) to the `solution_id` parameter, and specify `accepted` (boolean).";
+
+/**
  * Build the server-level instructions string for the current session.
  *
  * Emits the core block plus the package/code-tools section.
@@ -126,6 +137,7 @@ export function buildMcpInstructions(
     MULTI_TURN_TIP,
     bullets.join("\n"),
     STRATEGY_TIP,
+    INPUT_MAPPING_TIP,
   ].join("\n\n");
 
   // External-content posture lands between the core orientation and the

--- a/skills/githits-mcp/SKILL.md
+++ b/skills/githits-mcp/SKILL.md
@@ -18,13 +18,24 @@ Scope boundaries:
 Use the most targeted GitHits MCP tool or combination of tools for the job:
 
 - Use `search` and `docs_*` for package documentation, repository docs, exact APIs, configuration, or setup behavior.
+- Use `search_status` with `search_ref` to follow up on a prior search that returned a `searchRef` or is still indexing.
 - Use `search`, `code_files`, `code_grep`, and `code_read` for version-specific package/repository source, tests, symbols, call sites, and implementation evidence.
 - Use `pkg_info`, `pkg_vulns`, `pkg_deps`, `pkg_changelog`, and `pkg_upgrade_review` for package metadata, versions, adoption, vulnerabilities, dependency graphs, changelogs, and upgrade-review evidence.
 - Use `get_example` as the broad OSS-first discovery, planning, and research path for vague issues, unfamiliar errors, "how do others do this" questions, multi-library/API combinations, global implementation-pattern scans, and rare needle-in-the-haystack examples that may appear in only one or a few repositories. When the dependency or repository is already known, default to `search`, `docs_*`, and `code_*` first; add `get_example` when you need broader cross-project evidence or a hard-to-find real-world example.
+- Use `search_language` to search for valid language names before calling `get_example` if you are unsure of the exact spelling of a programming language.
+- Use `feedback` to submit positive or negative ratings and comments about a specific solution (using `solution_id`) or general tool results (omitting `solution_id`).
 
 Prefer the default compact text output. Request JSON only when exact structured fields are necessary.
 
 When answering, ground claims in fetched GitHits evidence and cite the relevant package, repository, file, docs page, or version facts when available. If GitHits does not have enough evidence, say what is missing and then use the next best source.
+
+## Input Parameter Mapping & Casing
+
+MCP tool input parameters are strictly `snake_case`, but returned response keys may be `camelCase`. Always map returned fields to the correct tool parameters:
+- **`docs_read`**: The search or list hit returns `locator.pageId` (camelCase). You must pass this value to the `page_id` parameter (snake_case).
+- **`code_read`**: The search or grep hit returns `locator.filePath`, `locator.startLine`, and `locator.endLine`. You must map these to the `path`, `start_line`, and `end_line` parameters.
+- **`search_status`**: The search response returns `searchRef`. You must pass this value to the `search_ref` parameter.
+- **`feedback`**: The example response returns `solutionId`. You must pass this value to the `solution_id` parameter.
 
 ## External Content Posture
 

--- a/src/commands/mcp-instructions.test.ts
+++ b/src/commands/mcp-instructions.test.ts
@@ -71,6 +71,13 @@ describe("buildMcpInstructions", () => {
     expect(instructions).toContain(
       "request JSON only when exact structured fields are necessary",
     );
+    expect(instructions).toContain("Casing & Input Parameter Mapping");
+    expect(instructions).toContain("`pageId` value to the `page_id` parameter");
+    expect(instructions).toContain("`filePath` to the `path` parameter");
+    expect(instructions).toContain("`startLine` to `start_line`");
+    expect(instructions).toContain("`endLine` to `end_line`");
+    expect(instructions).toContain("`searchRef` from search progress responses to the `search_ref` parameter");
+    expect(instructions).toContain("`solutionId` (if present) to the `solution_id` parameter");
   });
 
   it("includes the external-content posture by default", () => {

--- a/src/commands/mcp-instructions.test.ts
+++ b/src/commands/mcp-instructions.test.ts
@@ -76,8 +76,12 @@ describe("buildMcpInstructions", () => {
     expect(instructions).toContain("`filePath` to the `path` parameter");
     expect(instructions).toContain("`startLine` to `start_line`");
     expect(instructions).toContain("`endLine` to `end_line`");
-    expect(instructions).toContain("`searchRef` from search progress responses to the `search_ref` parameter");
-    expect(instructions).toContain("`solutionId` (if present) to the `solution_id` parameter");
+    expect(instructions).toContain(
+      "`searchRef` from search progress responses to the `search_ref` parameter",
+    );
+    expect(instructions).toContain(
+      "`solutionId` (if present) to the `solution_id` parameter",
+    );
   });
 
   it("includes the external-content posture by default", () => {


### PR DESCRIPTION
Aligned GitHits MCP instructions and skills with tool schemas. Added explicit mapping documentation for camelCase response fields (like pageId or filePath) to snake_case tool inputs. Expanded the skill documentation to explicitly cover all 15 registered tools (specifically adding search_status, search_language, and feedback). Added tests to src/commands/mcp-instructions.test.ts to assert and maintain instruction quality going forward.

---
*PR created automatically by Jules for task [6368570097870907019](https://jules.google.com/task/6368570097870907019) started by @nathanBurg*