### PR TITLE
fix: prevent callback shutdown from blocking login

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.2/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.6/schema.json",
   "files": {
     "includes": [
       "**/*.ts",

--- a/docs/implementation/auth.md
+++ b/docs/implementation/auth.md
@@ -33,7 +33,7 @@ The login command (`src/commands/login.ts`) orchestrates a 9-step OAuth flow (ma
 8. **Exchange code for tokens** — POST to token endpoint with PKCE verifier
 9. **Save tokens** — Store to the configured auth store
 
-The flow has a 5-minute timeout. The callback server must start before the browser opens so it's ready to receive the redirect. After the callback response finishes, the CLI immediately stops the temporary listener and destroys its remaining connections. Token exchange and credential persistence continue without awaiting listener shutdown, so a proxy-held callback connection cannot block authentication completion.
+The flow has a 5-minute timeout. The callback server must start before the browser opens so it's ready to receive the redirect. After the callback response finishes or its connection closes, the CLI immediately stops the temporary listener and destroys its remaining connections. Token exchange, credential persistence, and callback error reporting continue without awaiting listener shutdown, so a proxy-held callback connection cannot block authentication completion.
 
 OAuth discovery, registration, exchange, and refresh validate endpoint schemes immediately before network use. Remote endpoints must use HTTPS; exact loopback HTTP endpoints remain available for local development. Registration and token responses are runtime-validated, positive numeric-string `expires_in` values are normalized to numbers for OAuth-provider compatibility, and HTTP failures surface only bounded JSON error details rather than raw HTML/plain-text response bodies.
 

--- a/docs/implementation/auth.md
+++ b/docs/implementation/auth.md
@@ -33,7 +33,7 @@ The login command (`src/commands/login.ts`) orchestrates a 9-step OAuth flow (ma
 8. **Exchange code for tokens** — POST to token endpoint with PKCE verifier
 9. **Save tokens** — Store to the configured auth store
 
-The flow has a 5-minute timeout. The callback server must start before the browser opens so it's ready to receive the redirect.
+The flow has a 5-minute timeout. The callback server must start before the browser opens so it's ready to receive the redirect. After the callback response finishes, the CLI immediately stops the temporary listener and destroys its remaining connections. Token exchange and credential persistence continue without awaiting listener shutdown, so a proxy-held callback connection cannot block authentication completion.
 
 OAuth discovery, registration, exchange, and refresh validate endpoint schemes immediately before network use. Remote endpoints must use HTTPS; exact loopback HTTP endpoints remain available for local development. Registration and token responses are runtime-validated, positive numeric-string `expires_in` values are normalized to numbers for OAuth-provider compatibility, and HTTP failures surface only bounded JSON error details rather than raw HTML/plain-text response bodies.
 

--- a/docs/implementation/remote-authentication.md
+++ b/docs/implementation/remote-authentication.md
@@ -18,11 +18,12 @@ one login flow:
 When no port is supplied, the login flow continues to reuse a stored client's
 redirect URI or select a port in its existing random range.
 
-After serving the callback response, the CLI immediately stops the temporary
-listener and destroys any remaining callback connections. Token exchange and
-credential persistence proceed without waiting for listener shutdown. This is
-required for remote environments whose port proxy may retain the callback
-connection after the browser has rendered the response.
+After the callback response finishes or its connection closes, the CLI
+immediately stops the temporary listener and destroys any remaining callback
+connections. Token exchange, credential persistence, and callback error
+reporting proceed without waiting for listener shutdown. This is required for
+remote environments whose port proxy may retain or terminate the callback
+connection independently of the browser.
 
 ## Documentation handoff
 

--- a/docs/implementation/remote-authentication.md
+++ b/docs/implementation/remote-authentication.md
@@ -18,6 +18,12 @@ one login flow:
 When no port is supplied, the login flow continues to reuse a stored client's
 redirect URI or select a port in its existing random range.
 
+After serving the callback response, the CLI immediately stops the temporary
+listener and destroys any remaining callback connections. Token exchange and
+credential persistence proceed without waiting for listener shutdown. This is
+required for remote environments whose port proxy may retain the callback
+connection after the browser has rendered the response.
+
 ## Documentation handoff
 
 Hosted authentication and command-reference content should distinguish three

--- a/src/commands/init/agent-definitions.ts
+++ b/src/commands/init/agent-definitions.ts
@@ -1169,7 +1169,7 @@ const amazonQCli: AgentDefinition = {
             "--name",
             "githits",
             "--command",
-            GITHITS_MCP_INVOCATION[0]!,
+            GITHITS_MCP_INVOCATION[0],
             "--args",
             JSON.stringify(GITHITS_MCP_INVOCATION.slice(1)),
           ],

--- a/src/commands/login.test.ts
+++ b/src/commands/login.test.ts
@@ -441,7 +441,6 @@ describe("loginFlow", () => {
     const authService = createMockAuthService({
       startCallbackServer: mock(() =>
         Promise.resolve({
-          port: 8080,
           result: Promise.resolve({
             type: "success",
             code: "test-code",
@@ -684,14 +683,14 @@ describe("loginFlow", () => {
   });
 
   it("continues authentication while the callback server is closing", async () => {
-    const close = mock(() => new Promise<void>(() => {}));
     let closeStarted = false;
-    close.mockImplementation(() => {
+    let exchangeStartedAfterClose = false;
+    const close = mock(() => {
       closeStarted = true;
       return new Promise<void>(() => {});
     });
     const exchangeCodeForTokens = mock(() => {
-      expect(closeStarted).toBe(true);
+      exchangeStartedAfterClose = closeStarted;
       return Promise.resolve({
         accessToken: "access-token",
         refreshToken: "refresh-token",
@@ -701,7 +700,6 @@ describe("loginFlow", () => {
     const authService = createMockAuthService({
       startCallbackServer: mock(() =>
         Promise.resolve({
-          port: 8080,
           result: Promise.resolve({
             type: "success" as const,
             code: "test-code",
@@ -731,6 +729,7 @@ describe("loginFlow", () => {
       message: "Logged in successfully.",
     });
     expect(close).toHaveBeenCalledTimes(1);
+    expect(exchangeStartedAfterClose).toBe(true);
   });
 
   it("prints manual URL when browser opening fails", async () => {
@@ -762,13 +761,12 @@ describe("loginFlow", () => {
     ).toBe(true);
   });
 
-  it("closes callback server and clears fresh client when authentication wait fails", async () => {
-    const close = mock(() => Promise.resolve());
+  it("reports callback failure without awaiting callback server shutdown", async () => {
+    const close = mock(() => new Promise<void>(() => {}));
     const authStorage = createMockAuthStorage();
     const authService = createMockAuthService({
       startCallbackServer: mock(() =>
         Promise.resolve({
-          port: 8080,
           result: Promise.reject(new Error("callback failed")),
           close,
         }),
@@ -793,12 +791,11 @@ describe("loginFlow", () => {
   });
 
   it("returns actionable timeout message and clears fresh client", async () => {
-    const close = mock(() => Promise.resolve());
+    const close = mock(() => new Promise<void>(() => {}));
     const authStorage = createMockAuthStorage();
     const authService = createMockAuthService({
       startCallbackServer: mock(() =>
         Promise.resolve({
-          port: 8080,
           result: new Promise<never>(() => {}),
           close,
         }),
@@ -854,7 +851,6 @@ describe("loginFlow", () => {
     const authService = createMockAuthService({
       startCallbackServer: mock(() =>
         Promise.resolve({
-          port: 8080,
           result: Promise.reject(new Error("callback failed")),
           close,
         }),
@@ -895,7 +891,6 @@ describe("loginFlow", () => {
     const authService = createMockAuthService({
       startCallbackServer: mock(() =>
         Promise.resolve({
-          port: 9090,
           result: Promise.reject(new Error("callback failed")),
           close,
         }),

--- a/src/commands/login.test.ts
+++ b/src/commands/login.test.ts
@@ -441,6 +441,7 @@ describe("loginFlow", () => {
     const authService = createMockAuthService({
       startCallbackServer: mock(() =>
         Promise.resolve({
+          port: 8080,
           result: Promise.resolve({
             type: "success",
             code: "test-code",
@@ -675,8 +676,61 @@ describe("loginFlow", () => {
       ),
     ).toBe(true);
     expect(writes).toContain("Waiting for sign-in to finish...\n");
+    expect(writes).toContain(
+      "Sign-in callback received. Completing authentication...\n",
+    );
     expect(consoleSpy).not.toHaveBeenCalled();
     consoleSpy.mockRestore();
+  });
+
+  it("continues authentication while the callback server is closing", async () => {
+    const close = mock(() => new Promise<void>(() => {}));
+    let closeStarted = false;
+    close.mockImplementation(() => {
+      closeStarted = true;
+      return new Promise<void>(() => {});
+    });
+    const exchangeCodeForTokens = mock(() => {
+      expect(closeStarted).toBe(true);
+      return Promise.resolve({
+        accessToken: "access-token",
+        refreshToken: "refresh-token",
+        expiresIn: 3600,
+      });
+    });
+    const authService = createMockAuthService({
+      startCallbackServer: mock(() =>
+        Promise.resolve({
+          port: 8080,
+          result: Promise.resolve({
+            type: "success" as const,
+            code: "test-code",
+            state: "test-state",
+          }),
+          close,
+        }),
+      ),
+      exchangeCodeForTokens,
+    });
+
+    const loginPromise = loginFlow(
+      { port: 8080 },
+      {
+        authService,
+        authStorage: createMockAuthStorage(),
+        browserService: createMockBrowserService(),
+        mcpUrl,
+      },
+      silentLoginOutput,
+    );
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(exchangeCodeForTokens).toHaveBeenCalledTimes(1);
+    expect(await loginPromise).toEqual({
+      status: "success",
+      message: "Logged in successfully.",
+    });
+    expect(close).toHaveBeenCalledTimes(1);
   });
 
   it("prints manual URL when browser opening fails", async () => {
@@ -714,6 +768,7 @@ describe("loginFlow", () => {
     const authService = createMockAuthService({
       startCallbackServer: mock(() =>
         Promise.resolve({
+          port: 8080,
           result: Promise.reject(new Error("callback failed")),
           close,
         }),
@@ -743,6 +798,7 @@ describe("loginFlow", () => {
     const authService = createMockAuthService({
       startCallbackServer: mock(() =>
         Promise.resolve({
+          port: 8080,
           result: new Promise<never>(() => {}),
           close,
         }),
@@ -798,6 +854,7 @@ describe("loginFlow", () => {
     const authService = createMockAuthService({
       startCallbackServer: mock(() =>
         Promise.resolve({
+          port: 8080,
           result: Promise.reject(new Error("callback failed")),
           close,
         }),
@@ -838,6 +895,7 @@ describe("loginFlow", () => {
     const authService = createMockAuthService({
       startCallbackServer: mock(() =>
         Promise.resolve({
+          port: 9090,
           result: Promise.reject(new Error("callback failed")),
           close,
         }),

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -275,7 +275,7 @@ export async function loginFlow(
     void callbackServer.close().catch(() => {});
   } catch (error) {
     if (timeoutId) clearTimeout(timeoutId);
-    await callbackServer.close().catch(() => {});
+    void callbackServer.close().catch(() => {});
     if (shouldClearClientOnFailedAttempt) {
       await authStorage.clearActiveClient(mcpUrl).catch(() => {});
     }

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -272,7 +272,7 @@ export async function loginFlow(
   try {
     callback = await Promise.race([callbackServer.result, timeoutPromise]);
     if (timeoutId) clearTimeout(timeoutId);
-    await callbackServer.close().catch(() => {});
+    void callbackServer.close().catch(() => {});
   } catch (error) {
     if (timeoutId) clearTimeout(timeoutId);
     await callbackServer.close().catch(() => {});
@@ -284,10 +284,10 @@ export async function loginFlow(
     return { status: "failed", message: ensureTerminalPeriod(msg) };
   }
 
+  output.write("Sign-in callback received. Completing authentication...\n");
+
   // Step 7: Handle callback outcome
   if (callback.type !== "success") {
-    // Let the callback server finish sending the error page to the browser
-    await new Promise((r) => setTimeout(r, 2000));
     if (shouldClearClientOnFailedAttempt) {
       await authStorage.clearActiveClient(mcpUrl).catch(() => {});
     }

--- a/src/services/auth-service.test.ts
+++ b/src/services/auth-service.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, it, mock } from "bun:test";
+import { once } from "node:events";
 import { createServer } from "node:http";
+import { connect } from "node:net";
 import { FetchTimeoutError } from "@githits/core-internal";
 import {
   AuthServiceImpl,
@@ -383,6 +385,49 @@ describe("AuthServiceImpl", () => {
             else resolve();
           });
         });
+      }
+    });
+
+    it("serves the callback before force closing its kept-alive connection", async () => {
+      const handle = await service.startCallbackServer(0, "expected-state");
+      const socket = connect(handle.port, "127.0.0.1");
+      socket.setEncoding("utf8");
+      await once(socket, "connect");
+
+      let response = "";
+      const responseReceived = new Promise<void>((resolve) => {
+        socket.on("data", (chunk: string) => {
+          response += chunk;
+          if (response.includes("</html>")) resolve();
+        });
+      });
+      const socketClosed = once(socket, "close");
+      socket.write(
+        [
+          "GET /callback?code=test-code&state=expected-state HTTP/1.1",
+          `Host: 127.0.0.1:${handle.port}`,
+          "Connection: keep-alive",
+          "",
+          "",
+        ].join("\r\n"),
+      );
+
+      try {
+        await responseReceived;
+        expect(response).toContain("HTTP/1.1 200 OK");
+        expect(response).toContain("signed in");
+        expect(await handle.result).toEqual({
+          type: "success",
+          code: "test-code",
+          state: "expected-state",
+        });
+
+        await handle.close();
+        await socketClosed;
+        expect(socket.destroyed).toBe(true);
+      } finally {
+        socket.destroy();
+        await handle.close().catch(() => {});
       }
     });
   });

--- a/src/services/auth-service.test.ts
+++ b/src/services/auth-service.test.ts
@@ -1,6 +1,6 @@
-import { afterEach, describe, expect, it, mock } from "bun:test";
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test";
 import { once } from "node:events";
-import { createServer } from "node:http";
+import { createServer, ServerResponse } from "node:http";
 import { connect } from "node:net";
 import { FetchTimeoutError } from "@githits/core-internal";
 import {
@@ -14,6 +14,22 @@ function asFetchFn<T extends (...args: never[]) => unknown>(
   fn: T,
 ): typeof fetch {
   return fn as unknown as typeof fetch;
+}
+
+async function getAvailablePort(): Promise<number> {
+  const server = createServer();
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  const port =
+    typeof address === "object" && address !== null ? address.port : 0;
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+  if (port === 0) throw new Error("Failed to allocate a callback test port");
+  return port;
 }
 
 describe("AuthServiceImpl", () => {
@@ -389,8 +405,9 @@ describe("AuthServiceImpl", () => {
     });
 
     it("serves the callback before force closing its kept-alive connection", async () => {
-      const handle = await service.startCallbackServer(0, "expected-state");
-      const socket = connect(handle.port, "127.0.0.1");
+      const port = await getAvailablePort();
+      const handle = await service.startCallbackServer(port, "expected-state");
+      const socket = connect(port, "127.0.0.1");
       socket.setEncoding("utf8");
       await once(socket, "connect");
 
@@ -405,7 +422,7 @@ describe("AuthServiceImpl", () => {
       socket.write(
         [
           "GET /callback?code=test-code&state=expected-state HTTP/1.1",
-          `Host: 127.0.0.1:${handle.port}`,
+          `Host: 127.0.0.1:${port}`,
           "Connection: keep-alive",
           "",
           "",
@@ -428,6 +445,49 @@ describe("AuthServiceImpl", () => {
       } finally {
         socket.destroy();
         await handle.close().catch(() => {});
+      }
+    });
+
+    it("settles a valid callback when the response closes before finish", async () => {
+      const endSpy = spyOn(ServerResponse.prototype, "end").mockImplementation(
+        function (this: ServerResponse): ServerResponse {
+          this.destroy();
+          return this;
+        },
+      );
+      try {
+        const port = await getAvailablePort();
+        const handle = await service.startCallbackServer(
+          port,
+          "expected-state",
+        );
+        const socket = connect(port, "127.0.0.1");
+        await once(socket, "connect");
+        const socketClosed = once(socket, "close");
+
+        socket.write(
+          [
+            "GET /callback?code=test-code&state=expected-state HTTP/1.1",
+            `Host: 127.0.0.1:${port}`,
+            "Connection: keep-alive",
+            "",
+            "",
+          ].join("\r\n"),
+        );
+
+        try {
+          await socketClosed;
+          expect(await handle.result).toEqual({
+            type: "success",
+            code: "test-code",
+            state: "expected-state",
+          });
+        } finally {
+          socket.destroy();
+          await handle.close().catch(() => {});
+        }
+      } finally {
+        endSpy.mockRestore();
       }
     });
   });

--- a/src/services/auth-service.test.ts
+++ b/src/services/auth-service.test.ts
@@ -5,6 +5,7 @@ import { connect } from "node:net";
 import { FetchTimeoutError } from "@githits/core-internal";
 import {
   AuthServiceImpl,
+  type CallbackServerHandle,
   classifyTerminalRefreshError,
   evaluateCallback,
   TokenRefreshError,
@@ -30,6 +31,32 @@ async function getAvailablePort(): Promise<number> {
   });
   if (port === 0) throw new Error("Failed to allocate a callback test port");
   return port;
+}
+
+interface CallbackTestServer {
+  handle: CallbackServerHandle;
+  port: number;
+}
+
+async function startCallbackTestServer(
+  service: AuthServiceImpl,
+  expectedState: string,
+): Promise<CallbackTestServer> {
+  const maxAttempts = 3;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const port = await getAvailablePort();
+    try {
+      return {
+        handle: await service.startCallbackServer(port, expectedState),
+        port,
+      };
+    } catch (error) {
+      const portWasReallocated =
+        error instanceof Error && error.message.includes("EADDRINUSE");
+      if (!portWasReallocated || attempt === maxAttempts) throw error;
+    }
+  }
+  throw new Error("Failed to start callback test server");
 }
 
 describe("AuthServiceImpl", () => {
@@ -405,8 +432,10 @@ describe("AuthServiceImpl", () => {
     });
 
     it("serves the callback before force closing its kept-alive connection", async () => {
-      const port = await getAvailablePort();
-      const handle = await service.startCallbackServer(port, "expected-state");
+      const { handle, port } = await startCallbackTestServer(
+        service,
+        "expected-state",
+      );
       const socket = connect(port, "127.0.0.1");
       socket.setEncoding("utf8");
       await once(socket, "connect");
@@ -449,6 +478,16 @@ describe("AuthServiceImpl", () => {
     });
 
     it("settles a valid callback when the response closes before finish", async () => {
+      const { handle, port } = await startCallbackTestServer(
+        service,
+        "expected-state",
+      );
+      const socket = connect(port, "127.0.0.1");
+      await once(socket, "connect");
+      const socketClosed = once(socket, "close");
+
+      // A client-side destroy races the kernel flush and may still emit finish.
+      // Destroying in end deterministically exercises the close-only path.
       const endSpy = spyOn(ServerResponse.prototype, "end").mockImplementation(
         function (this: ServerResponse): ServerResponse {
           this.destroy();
@@ -456,15 +495,6 @@ describe("AuthServiceImpl", () => {
         },
       );
       try {
-        const port = await getAvailablePort();
-        const handle = await service.startCallbackServer(
-          port,
-          "expected-state",
-        );
-        const socket = connect(port, "127.0.0.1");
-        await once(socket, "connect");
-        const socketClosed = once(socket, "close");
-
         socket.write(
           [
             "GET /callback?code=test-code&state=expected-state HTTP/1.1",
@@ -475,19 +505,16 @@ describe("AuthServiceImpl", () => {
           ].join("\r\n"),
         );
 
-        try {
-          await socketClosed;
-          expect(await handle.result).toEqual({
-            type: "success",
-            code: "test-code",
-            state: "expected-state",
-          });
-        } finally {
-          socket.destroy();
-          await handle.close().catch(() => {});
-        }
+        await socketClosed;
+        expect(await handle.result).toEqual({
+          type: "success",
+          code: "test-code",
+          state: "expected-state",
+        });
       } finally {
         endSpy.mockRestore();
+        socket.destroy();
+        await handle.close().catch(() => {});
       }
     });
   });

--- a/src/services/auth-service.ts
+++ b/src/services/auth-service.ts
@@ -176,8 +176,6 @@ export interface AuthService {
 }
 
 export interface CallbackServerHandle {
-  /** Effective listener port, including when the service receives port 0. */
-  port: number;
   result: Promise<CallbackResult>;
   close(): Promise<void>;
 }
@@ -355,12 +353,14 @@ export class AuthServiceImpl implements AuthService {
           expectedState,
         });
         callbackHandled = true;
-        res.once("finish", () => {
+        const settle = (): void => {
           if (!resolved) {
             resolved = true;
             resolve(evaluation.result);
           }
-        });
+        };
+        res.once("finish", settle);
+        res.once("close", settle);
         sendHtmlResponse(res, evaluation.statusCode, evaluation.html);
       });
     });
@@ -373,11 +373,7 @@ export class AuthServiceImpl implements AuthService {
       server.listen(port, "127.0.0.1", () => {
         server.off("error", onError);
         server.on("error", () => {});
-        const address = server.address();
-        const actualPort =
-          typeof address === "object" && address !== null ? address.port : port;
         resolve({
-          port: actualPort,
           result,
           close: () => closeCallbackServerConnections(server, connections),
         });

--- a/src/services/auth-service.ts
+++ b/src/services/auth-service.ts
@@ -1,4 +1,5 @@
 import { createServer, type Server, type ServerResponse } from "node:http";
+import type { Socket } from "node:net";
 import {
   DEFAULT_FETCH_TIMEOUT_MS,
   fetchWithTimeout,
@@ -175,6 +176,8 @@ export interface AuthService {
 }
 
 export interface CallbackServerHandle {
+  /** Effective listener port, including when the service receives port 0. */
+  port: number;
   result: Promise<CallbackResult>;
   close(): Promise<void>;
 }
@@ -294,10 +297,15 @@ export class AuthServiceImpl implements AuthService {
     port: number,
     expectedState: string,
   ): Promise<CallbackServerHandle> {
-    let closeTimer: ReturnType<typeof setTimeout> | undefined;
     const server = createServer();
+    const connections = new Set<Socket>();
     let callbackHandled = false;
     let resolved = false;
+
+    server.on("connection", (socket) => {
+      connections.add(socket);
+      socket.once("close", () => connections.delete(socket));
+    });
 
     const result = new Promise<CallbackResult>((resolve) => {
       server.on("request", (req, res) => {
@@ -347,13 +355,13 @@ export class AuthServiceImpl implements AuthService {
           expectedState,
         });
         callbackHandled = true;
+        res.once("finish", () => {
+          if (!resolved) {
+            resolved = true;
+            resolve(evaluation.result);
+          }
+        });
         sendHtmlResponse(res, evaluation.statusCode, evaluation.html);
-        if (!resolved) {
-          resolved = true;
-          resolve(evaluation.result);
-        }
-        if (closeTimer) clearTimeout(closeTimer);
-        closeTimer = setTimeout(() => closeServer(server), 1500);
       });
     });
 
@@ -365,12 +373,13 @@ export class AuthServiceImpl implements AuthService {
       server.listen(port, "127.0.0.1", () => {
         server.off("error", onError);
         server.on("error", () => {});
+        const address = server.address();
+        const actualPort =
+          typeof address === "object" && address !== null ? address.port : port;
         resolve({
+          port: actualPort,
           result,
-          close: async () => {
-            if (closeTimer) clearTimeout(closeTimer);
-            await closeServer(server);
-          },
+          close: () => closeCallbackServerConnections(server, connections),
         });
       });
     });
@@ -943,10 +952,17 @@ function sendHtmlResponse(
   res.end(html);
 }
 
-/** Close server gracefully */
-function closeServer(server: Server): Promise<void> {
+/** Stop accepting callbacks and destroy every temporary callback connection. */
+function closeCallbackServerConnections(
+  server: Server,
+  connections: Set<Socket>,
+): Promise<void> {
   return new Promise((resolve, reject) => {
+    const destroyConnections = (): void => {
+      for (const socket of connections) socket.destroy();
+    };
     if (!server.listening) {
+      destroyConnections();
       resolve();
       return;
     }
@@ -954,6 +970,7 @@ function closeServer(server: Server): Promise<void> {
       if (error) reject(error);
       else resolve();
     });
+    destroyConnections();
   });
 }
 

--- a/src/services/test-helpers.ts
+++ b/src/services/test-helpers.ts
@@ -104,6 +104,7 @@ export function createMockAuthService(
     }),
     startCallbackServer: mock(() =>
       Promise.resolve({
+        port: 8080,
         result: Promise.resolve(defaultCallbackResult),
         close: mock(() => Promise.resolve()),
       }),

--- a/src/services/test-helpers.ts
+++ b/src/services/test-helpers.ts
@@ -104,7 +104,6 @@ export function createMockAuthService(
     }),
     startCallbackServer: mock(() =>
       Promise.resolve({
-        port: 8080,
         result: Promise.resolve(defaultCallbackResult),
         close: mock(() => Promise.resolve()),
       }),


### PR DESCRIPTION
## Summary

- force-close temporary OAuth callback connections after the browser response finishes or closes
- continue token exchange, credential persistence, timeout reporting, and callback-error reporting without awaiting listener teardown
- cover proxied keep-alive callbacks, close-before-finish responses, and non-resolving shutdown with regressions
- document callback shutdown behavior for remote environments

## Root cause

The login flow awaited HTTP server close before exchanging the authorization code. A sandbox port proxy could keep the callback connection alive after rendering the success page, leaving init blocked indefinitely. The callback result also depended only on the response finish event, so an early connection close could leave a valid callback unsettled.

## Review follow-up

- settle callback results on both response finish and close
- make listener cleanup non-blocking on success, callback error, and timeout paths
- remove the test-only CallbackServerHandle port field
- make shutdown-order assertions explicit and add real listener regressions
- harden callback socket tests against probe/rebind collisions and limit the response prototype spy to the request window

The Biome schema alignment and removal of a forbidden non-null assertion are validation-only cleanup surfaced by this change; they do not affect callback behavior.

## Validation

- bun run format:check
- bun run lint
- bun run typecheck
- bun test (2579 passing)
- callback socket regressions repeated 20 times (40 passing)
- bun run build
- bun run plugins:generate
- bun run plugins:check
- bun run smoke:cli (70 steps, authenticated live smoke passed)
- bun run smoke:mcp (38 steps, authenticated live smoke passed)
- bun run smoke:cli:built
- bun run smoke:mcp:built