### PR TITLE
chore: prepare 0.9.0 release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,12 +6,12 @@
   },
   "metadata": {
     "description": "The code context layer for AI coding agents",
-    "version": "0.8.0"
+    "version": "0.9.0"
   },
   "plugins": [
     {
       "name": "githits",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "description": "The code context layer for AI coding agents",
       "author": {
         "name": "GitHits"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/bun.lock
+++ b/bun.lock
@@ -43,7 +43,7 @@
     },
     "packages/mcp": {
       "name": "@githits/mcp",
-      "version": "0.6.4",
+      "version": "0.9.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "^4.4.3",

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "The code context layer for AI coding agents",
   "mcpServers": {
     "githits": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "githits",
   "description": "The code context layer for AI coding agents",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "mcpName": "com.githits/githits",
   "type": "module",
   "workspaces": [

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@githits/mcp",
-  "version": "0.6.4",
+  "version": "0.9.0",
   "description": "Reusable MCP server APIs and tools for GitHits",
   "type": "module",
   "files": [

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "githits",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/server.json
+++ b/server.json
@@ -16,7 +16,7 @@
     "source": "github",
     "id": "1165453165"
   },
-  "version": "0.8.0",
+  "version": "0.9.0",
   "remotes": [
     {
       "type": "streamable-http",
@@ -28,7 +28,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "githits",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/skills/githits-code/SKILL.md
+++ b/skills/githits-code/SKILL.md
@@ -16,6 +16,7 @@ Use GitHits for evidence from real open-source code instead of guessing from mod
 - If `githits` is not found, retry the same command as `npx -y githits@latest ...`.
 - Use `--json` when you need stable fields to parse or chain into another command.
 - Do not expose credentials. If auth is required interactively, run `githits login`; use `githits login --no-browser` only when the user can complete the printed URL flow. In noninteractive eval/CI, do not start OAuth; report that `GITHITS_API_TOKEN` or prior login is required.
+- If a command returns `TERMS_ACCEPTANCE_REQUIRED`, run `githits settings terms accept` or use the returned authenticated acceptance URL, then retry once.
 
 ## Decision Flow
 
@@ -58,6 +59,8 @@ githits docs read <pageId> --lines 20-120
 - For multi-step code/docs investigations, keep raw CLI output out of the final answer unless it is the evidence the user needs.
 - If output says it used recent/stale indexed evidence, treat the displayed served target as provenance; if freshness matters, retry with a longer `--wait` or use one of the displayed `queryable now` versions/refs, or inspect JSON `targetResolution` for structured candidates.
 - Treat partial documentation coverage as incomplete evidence and retry later when advised. Capped coverage is terminal for the current crawl, so report the limitation instead of retrying.
+- If search returns a `searchRef`, continue with `githits search-status <searchRef>` instead of repeating the original search. Its bounded wait defaults to 20 seconds; use `--wait 0-60` to adjust it.
+- If grep returns no matches, do not repeat it unchanged. Follow the returned guidance by changing the pattern, broadening the file scope, or switching to `githits search` for conceptual discovery.
 - If a code-navigation command returns `INDEXING`, use the elapsed/expected duration in the message to decide whether to retry with `--wait`; prefer any displayed indexed refs/versions when you need an immediate follow-up.
 - After using GitHits results, send feedback when practical. Use `githits feedback <solution_id> --accept|--reject` for `githits example` results, or omit `<solution_id>` for generic session feedback such as `githits feedback --reject --tool search -m "missing kotlin support"`.
 

--- a/skills/githits-code/references/code-and-docs.md
+++ b/skills/githits-code/references/code-and-docs.md
@@ -8,7 +8,7 @@ Package target syntax requires an explicit registry: `registry:name[@version]`, 
 
 Useful filters: `--kind`, `--category`, `--path-prefix`, `--intent`, `--public`, `--name`, `--lang`, `--limit`, `--offset`, `--wait`, `--allow-partial`, `--json`.
 
-If search returns a `searchRef`, continue with `githits search-status <searchRef>`.
+If search returns a `searchRef`, do not repeat the original search. Continue with `githits search-status <searchRef> [--wait 0-60]`; the bounded wait defaults to 20 seconds.
 
 ## Code Files
 
@@ -27,6 +27,7 @@ For repository addressing: `githits code read --repo-url <url> [--git-ref <ref>]
 `githits code grep <spec> <pattern> [path-prefix]` runs deterministic text grep. Use `--regex` for RE2 regex, `--case-sensitive`, `-C`, `-A`, `-B`, `--path`, repeatable `--glob`, repeatable `--ext`, `--exclude-docs`, `--exclude-tests`, `--limit`, `--per-file-limit`, `--cursor`, `--symbol-field`, `--wait`, `--verbose`, `--json`.
 
 Use `search` for discovery and `code grep` only when you know the pattern.
+When grep returns no matches, do not repeat it unchanged. Change or shorten the pattern, broaden the path/filter scope, or switch to `search` for conceptual intent.
 
 ## Docs
 

--- a/skills/githits-package/SKILL.md
+++ b/skills/githits-package/SKILL.md
@@ -17,6 +17,7 @@ Use GitHits package intelligence before making dependency claims from memory.
 - If `githits` is not found, retry the same command as `npx -y githits@latest ...`.
 - Use `--json` when comparing versions, counting vulnerabilities, or extracting fields.
 - Do not expose credentials. If auth is required interactively, run `githits login`; use `githits login --no-browser` only when the user can complete the printed URL flow. In noninteractive eval/CI, do not start OAuth; report that `GITHITS_API_TOKEN` or prior login is required.
+- If a command returns `TERMS_ACCEPTANCE_REQUIRED`, run `githits settings terms accept` or use the returned authenticated acceptance URL, then retry once.
 
 ## Package Spec
 


### PR DESCRIPTION
## Summary

- bump the root `githits` CLI from 0.8.0 to 0.9.0
- bump `@githits/mcp` from 0.6.4 to 0.9.0 for the public MCP behavior shipped since its last release
- align the MCP registry package reference and all generated plugin/extension manifests
- update the public code and package skills for Terms of Service remediation and bounded search/grep recovery

## Release highlights

GitHits 0.9.0 adds canonical account settings and Terms of Service workflows:

- `githits settings show|get|set|clear`
- `githits settings terms` and `githits settings terms accept`
- typed, selective settings updates with stable JSON output
- one bounded OAuth refresh/retry for stale terms claims, without refresh loops for opaque `ghi-*` credentials
- shared CLI/MCP `TERMS_ACCEPTANCE_REQUIRED` remediation with legal and authenticated acceptance URLs

The coordinated MCP release also includes:

- bounded `search_status` waiting and explicit unchanged-search retry prevention
- actionable empty-grep recovery and human-readable truncation diagnostics
- preserved backend hints, alternatives, estimates, freshness, and not-found metadata
- consistent terminal-state handling across CLI, MCP text, and JSON output

Other user-visible fixes since 0.8.0 include non-blocking OAuth callback shutdown in proxied/sandboxed environments and the Undici 7.29.0 security update.

## Validation

- `bun run plugins:generate`
- `bun run plugins:check`
- `bun test` — 2,675 passed
- `bun run lint`
- `bun run typecheck`
- `bun run build`
- `bun run validate:packages:mcp-publish`
- `bun run smoke:cli` — 70 authenticated/live steps passed
- `bun run smoke:mcp` — 38 authenticated/live steps passed
- `bun run smoke:cli:built`
- `bun run smoke:mcp:built`
- Codex and Claude skills-surface agent evals — both succeeded with high confidence and no tool or instruction issues
- `npm pack --dry-run --json` — confirmed `githits@0.9.0`
- `mcp-publisher v1.7.9 validate server.json` — checksum verified and manifest valid
- registry domain proof and OAuth metadata returned 200; unauthenticated MCP returned the expected 401 resource-metadata challenge
- `git diff --check`

The repository-wide Biome format check is affected by CRLF conversion across unchanged files in this Windows checkout; the commit hook formatted every staged release file, and Linux CI remains the canonical full-tree format gate.

## Publishing behavior

After merge, a successful `Main` workflow will:

- publish `githits@0.9.0`, tag `v0.9.0`, create its GitHub release, and publish `com.githits/githits@0.9.0` to the MCP registry
- publish `@githits/mcp@0.9.0`, tag `mcp-v0.9.0`, and create its GitHub release

The hosted remote MCP must then bump to `@githits/mcp@0.9.0` and be redeployed before remote users receive the new package behavior.