### PR TITLE
docs: clarify search-status wait syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ errors.
 
 | Public artifact | Current release | Pending bump | Reason |
 |---|---:|---:|---|
-| `githits` | 0.9.0 | none | Repository-only release process documentation |
+| `githits` | 0.9.0 | patch | Clarify packaged Agent Skill syntax for search-status waits |
 | `@githits/mcp` | 0.9.0 | none | No MCP-package-visible changes |
 
 ### Changed
@@ -24,6 +24,9 @@ errors.
 
 ### Fixed
 
+- **Search-status skill syntax (`githits`)** - agent guidance now presents
+  `--wait <seconds>` as a placeholder with the valid 0-60 integer range instead
+  of resembling a literal `--wait 0-60` invocation.
 - **Cross-platform changelog validation (repository)** - release-boundary tests
   accept both LF and CRLF Markdown while enforcing identical package-version
   content.

--- a/skills/githits-code/SKILL.md
+++ b/skills/githits-code/SKILL.md
@@ -59,7 +59,7 @@ githits docs read <pageId> --lines 20-120
 - For multi-step code/docs investigations, keep raw CLI output out of the final answer unless it is the evidence the user needs.
 - If output says it used recent/stale indexed evidence, treat the displayed served target as provenance; if freshness matters, retry with a longer `--wait` or use one of the displayed `queryable now` versions/refs, or inspect JSON `targetResolution` for structured candidates.
 - Treat partial documentation coverage as incomplete evidence and retry later when advised. Capped coverage is terminal for the current crawl, so report the limitation instead of retrying.
-- If search returns a `searchRef`, continue with `githits search-status <searchRef>` instead of repeating the original search. Its bounded wait defaults to 20 seconds; use `--wait 0-60` to adjust it.
+- If search returns a `searchRef`, continue with `githits search-status <searchRef>` instead of repeating the original search. Its bounded wait defaults to 20 seconds; use `--wait <seconds>` with an integer from 0 to 60 to adjust it.
 - If grep returns no matches, do not repeat it unchanged. Follow the returned guidance by changing the pattern, broadening the file scope, or switching to `githits search` for conceptual discovery.
 - If a code-navigation command returns `INDEXING`, use the elapsed/expected duration in the message to decide whether to retry with `--wait`; prefer any displayed indexed refs/versions when you need an immediate follow-up.
 - After using GitHits results, send feedback when practical. Use `githits feedback <solution_id> --accept|--reject` for `githits example` results, or omit `<solution_id>` for generic session feedback such as `githits feedback --reject --tool search -m "missing kotlin support"`.

--- a/skills/githits-code/references/code-and-docs.md
+++ b/skills/githits-code/references/code-and-docs.md
@@ -8,7 +8,7 @@ Package target syntax requires an explicit registry: `registry:name[@version]`, 
 
 Useful filters: `--kind`, `--category`, `--path-prefix`, `--intent`, `--public`, `--name`, `--lang`, `--limit`, `--offset`, `--wait`, `--allow-partial`, `--json`.
 
-If search returns a `searchRef`, do not repeat the original search. Continue with `githits search-status <searchRef> [--wait 0-60]`; the bounded wait defaults to 20 seconds.
+If search returns a `searchRef`, do not repeat the original search. Continue with `githits search-status <searchRef> [--wait <seconds>]`; the bounded wait defaults to 20 seconds, and the explicit value must be an integer from 0 to 60.
 
 ## Code Files
 


### PR DESCRIPTION
## Summary

- clarify that `search-status --wait` accepts a single integer seconds value
- align the detailed code/docs reference with the canonical skill
- record the packaged Agent Skill patch impact in the changelog

## Root cause

The skill rendered `--wait 0-60` as inline command syntax. Agents could interpret that range as the literal option value even though the CLI accepts one integer from 0 through 60.

## Impact

Agents receive unambiguous `--wait <seconds>` guidance. Runtime CLI behavior is unchanged.

## Validation

- `bun run plugins:generate`
- `bun run plugins:check`
- `bun test` (2,676 passing)
- `bun run build`
- targeted Codex skills-surface `unified-search-investigation` evaluation (success, high confidence)