### PR TITLE
chore: prepare githits 0.9.1 release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,12 +6,12 @@
   },
   "metadata": {
     "description": "The code context layer for AI coding agents",
-    "version": "0.9.0"
+    "version": "0.9.1"
   },
   "plugins": [
     {
       "name": "githits",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "description": "The code context layer for AI coding agents",
       "author": {
         "name": "GitHits"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,14 +12,23 @@ errors.
 
 | Public artifact | Current release | Pending bump | Reason |
 |---|---:|---:|---|
-| `githits` | 0.9.0 | minor | Adds `githits resolve` and clarifies packaged Agent Skill syntax for search-status waits; hold release until the gates in `docs/implementation/cli-commands.md` clear |
+| `githits` | 0.9.1 | none | No unreleased package-visible changes |
 | `@githits/mcp` | 0.9.0 | none | No MCP-package-visible changes |
+
+## [githits 0.9.1] - 2026-08-13
+
+Patch release: silently launches a CLI-only target-resolution dogfood surface,
+corrects packaged Agent Skill syntax, and improves release visibility.
+`@githits/mcp` remains at 0.9.0 because this release adds no MCP tool or public
+MCP package surface.
 
 ### Added
 
 - **Target resolution CLI dogfood surface** - `githits resolve` ranks canonical
   package and GitHub repository targets with compact terminal and diagnostic
-  JSON output, discoverable registry help, and terminal-safe text errors.
+  JSON output, discoverable registry help, and terminal-safe text errors. This
+  silent launch is CLI-only and is not promoted through Agent Skills or an MCP
+  tool.
 
 ### Changed
 

--- a/docs/implementation/cli-commands.md
+++ b/docs/implementation/cli-commands.md
@@ -311,13 +311,15 @@ and one explicit family ambiguity were recorded in the backend relevance
 corpus. Those findings do not block landing the CLI dogfood surface. The earlier
 `guava` and `symfony/framework-bundle` mismatches now resolve correctly on dev.
 
-Do not publish the command until the expanded production corpus has no known
-wrong exact-package result, ambiguity wording is accepted, fuzzy latency and
-rate limiting are validated for expected CLI/MCP volume, and shipping without
-linked-repository popularity evidence is explicitly accepted or that evidence
-is exposed cheaply. The reduced query has been validated below production's
-GraphQL complexity limit; roughly 50 dogfood calls completed without protocol,
-schema, complexity, or rate-limit errors, but that is not a volume test.
+The command ships as a silent CLI-only dogfood surface. Do not promote it
+through Agent Skills or add an MCP tool until the expanded production corpus
+has no known wrong exact-package result, ambiguity wording is accepted, fuzzy
+latency and rate limiting are validated for expected CLI/MCP volume, and
+shipping without linked-repository popularity evidence is explicitly accepted
+or that evidence is exposed cheaply. The reduced query has been validated
+below production's GraphQL complexity limit; roughly 50 dogfood calls completed
+without protocol, schema, complexity, or rate-limit errors, but that is not a
+volume test.
 
 After CLI dogfooding, add an MCP `resolve_target` tool using the stable request
 and JSON contracts, promote only the smallest required API through

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "The code context layer for AI coding agents",
   "mcpServers": {
     "githits": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "githits",
   "description": "The code context layer for AI coding agents",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "mcpName": "com.githits/githits",
   "type": "module",
   "workspaces": [

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "githits",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/server.json
+++ b/server.json
@@ -16,7 +16,7 @@
     "source": "github",
     "id": "1165453165"
   },
-  "version": "0.9.0",
+  "version": "0.9.1",
   "remotes": [
     {
       "type": "streamable-http",
@@ -28,7 +28,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "githits",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Summary

- bump the root `githits` package, MCP registry manifest, and generated plugin manifests to `0.9.1`
- finalize the `githits 0.9.1` changelog and reset unreleased impact to `none`
- document `githits resolve` as a silent CLI-only dogfood launch without Agent Skill or MCP promotion
- keep `@githits/mcp` at `0.9.0` because its public surface is unchanged

## Why

Prepare the root patch release with the intended product posture for `resolve`. The previous changelog incorrectly classified the silent CLI dogfood launch as a minor release and blocked publication on gates that apply to Agent Skill and MCP promotion.

## Impact

After merge, the successful `Main` workflow can publish `githits@0.9.1` and the aligned `com.githits/githits` registry metadata. No `@githits/mcp` release is expected.

## Validation

- `bun run plugins:check`
- `bun run typecheck`
- `bun run format:check`
- `bun run lint`
- `bun test` — 2,721 passing
- `bun run build`
- `bun run validate:packages`
- `bun run smoke:cli`
- `bun run smoke:mcp`
- `bun run smoke:cli:built`
- `bun run smoke:mcp:built`