### PR TITLE
Fix CLI-native code validation errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,15 @@ errors.
 
 | Public artifact | Current release | Pending bump | Reason |
 |---|---:|---:|---|
-| `githits` | 0.9.2 | none | No unreleased package-visible changes |
+| `githits` | 0.9.2 | patch | Fixes CLI-native code-validation guidance |
 | `@githits/mcp` | 0.9.1 | none | No unreleased package-visible changes |
+
+### Fixed
+
+- **Code validation guidance (`githits`)** - client-side `INVALID_ARGUMENT`
+  errors from shared code-read and grep request builders now name CLI commands,
+  positionals, and options on the CLI while MCP keeps MCP-native tool and
+  argument syntax.
 
 ## [githits 0.9.2] - 2026-08-14
 
@@ -32,7 +39,6 @@ CLI initialization checks more reliable.
   timeouts, distinguish missing, non-canonical, disabled, and failed checks,
   preserve enabled customized Codex entries, and avoid reporting cleanup no-ops
   as successful setup when a later command fails.
-
 ## [@githits/mcp 0.9.1] - 2026-08-14
 
 Patch release: improves surface-native recovery from exact-path read and grep

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ CLI initialization checks more reliable.
   timeouts, distinguish missing, non-canonical, disabled, and failed checks,
   preserve enabled customized Codex entries, and avoid reporting cleanup no-ops
   as successful setup when a later command fails.
+
 ## [@githits/mcp 0.9.1] - 2026-08-14
 
 Patch release: improves surface-native recovery from exact-path read and grep

--- a/docs/implementation/cli-commands.md
+++ b/docs/implementation/cli-commands.md
@@ -543,7 +543,7 @@ Reads a file from an indexed dependency. `<path>` is package-relative in spec mo
 
 **Binary files.** Plain mode writes `Binary file — cannot display as text.` to stdout (consistent with `grep`'s binary-file convention). `--verbose` adds the header above the sentinel. `--json` exposes the classification via `isBinary: true` with `content` omitted — agents branch on the flag, not a null check.
 
-**Exit codes.** `0` on success. `1` on error — `FILE_NOT_FOUND` (path doesn't resolve) carries a "Use `code files` to list available paths" hint in terminal output. With `--json`, `FILE_NOT_FOUND` and legacy `NOT_FOUND` messages that specifically describe a missing file path add a structured `details.action`. It names `githits code files`, the applicable positional path-prefix narrowing (or its omission at repository root), and `githits code read` so callers can retry without translating MCP tool names.
+**Exit codes.** `0` on success. `1` on error — `FILE_NOT_FOUND` (path doesn't resolve) carries a "Use `code files` to list available paths" hint in terminal output. With `--json`, `FILE_NOT_FOUND` and legacy `NOT_FOUND` messages that specifically describe a missing file path add a structured `details.action`. It names `githits code files`, the applicable positional path-prefix narrowing (or its omission at repository root), and `githits code read` so callers can retry without translating MCP tool names. Client-side `INVALID_ARGUMENT` errors likewise name the CLI positional and option syntax; for example, a directory-shaped read path points to `githits code files` and `githits code read` rather than MCP tools.
 
 ### `githits code grep`
 
@@ -572,6 +572,7 @@ Deterministic text grep over indexed dependency or repository source. Defaults t
 This is still the standard `grep(1)` contract even though the output includes file paths by default.
 
 With `--json`, a structured missing-file error names `githits code files`, the applicable positional path-prefix narrowing (or its omission at repository root), and `githits code grep --path` in `details.action`.
+Client-side `INVALID_ARGUMENT` errors use CLI positionals/options and name `githits code files` when file listing is the recovery.
 
 **Pattern note.** The `GREP_REPO_PATTERN_NOTE` string is shared verbatim across the CLI help text, the MCP tool description, and the MCP `pattern` argument's `describe` so the three surfaces never disagree about literal-vs-regex semantics.
 

--- a/docs/implementation/mcp-cli-parity.md
+++ b/docs/implementation/mcp-cli-parity.md
@@ -138,8 +138,9 @@ test suite anchors the doc.
   mechanism, not a convention.
 - MCP error text is always valid JSON. A client that parses
   `content[0].text` on error gets the same envelope shape and structured data as
-  CLI `--json`. Path-recovery `details.action` is deliberately surface-native:
-  MCP names MCP tools/arguments, while CLI JSON names CLI commands/options.
+  CLI `--json`. Client-owned validation messages and path-recovery
+  `details.action` are deliberately surface-native: MCP names MCP
+  tools/arguments, while CLI JSON names CLI commands/options.
   Cross-surface account actions such as `githits settings terms accept` remain
   identical because they name one shared external remediation.
 - Backend error messages, hints, indexing estimates, available versions/refs,

--- a/docs/implementation/mcp-cli-parity.md
+++ b/docs/implementation/mcp-cli-parity.md
@@ -140,7 +140,10 @@ test suite anchors the doc.
   `content[0].text` on error gets the same envelope shape and structured data as
   CLI `--json`. Client-owned validation messages and path-recovery
   `details.action` are deliberately surface-native: MCP names MCP
-  tools/arguments, while CLI JSON names CLI commands/options.
+  tools/arguments, while CLI JSON names CLI commands/options. The CLI request
+  wrappers translate MCP validation identifiers from the shared builders, normally
+  using their backtick delimiters and explicitly handling raw reversed-range labels;
+  changes to those identifiers must update the CLI mappings and parity tests.
   Cross-surface account actions such as `githits settings terms accept` remain
   identical because they name one shared external remediation.
 - Backend error messages, hints, indexing estimates, available versions/refs,

--- a/packages/mcp/src/shared/grep-repo-request.ts
+++ b/packages/mcp/src/shared/grep-repo-request.ts
@@ -89,6 +89,8 @@ export interface GrepRepoRequestBuildResult {
   };
 }
 
+// CLI rewrites MCP identifiers from these errors; keep their spelling stable with
+// src/commands/code/grep.ts or update its mapping and tests.
 export function buildGrepRepoParams(
   input: GrepRepoRequestInput,
 ): GrepRepoRequestBuildResult {

--- a/packages/mcp/src/shared/grep-repo-request.ts
+++ b/packages/mcp/src/shared/grep-repo-request.ts
@@ -89,8 +89,8 @@ export interface GrepRepoRequestBuildResult {
   };
 }
 
-// CLI rewrites MCP identifiers from these errors; keep their spelling stable with
-// src/commands/code/grep.ts or update its mapping and tests.
+// CLI rewrites pattern, code_files, globs, extensions, and symbol_fields from
+// these errors; keep them stable with src/commands/code/grep.ts or update its tests.
 export function buildGrepRepoParams(
   input: GrepRepoRequestInput,
 ): GrepRepoRequestBuildResult {

--- a/packages/mcp/src/shared/list-files-request.ts
+++ b/packages/mcp/src/shared/list-files-request.ts
@@ -17,7 +17,10 @@ import {
   knownFileIntentList,
   toFileIntent,
 } from "./code-navigation.js";
-import { DEFAULT_WAIT_TIMEOUT_MS } from "./code-navigation-defaults.js";
+import {
+  DEFAULT_WAIT_TIMEOUT_MS,
+  MAX_WAIT_TIMEOUT_MS,
+} from "./code-navigation-defaults.js";
 import { InvalidPackageSpecError } from "./package-spec.js";
 
 /** Mirrors the backend input bounds; callers stay below these. */
@@ -26,7 +29,6 @@ const LIMIT_MAX = 1000;
 const LIMIT_DEFAULT = 200;
 
 const WAIT_MIN = 0;
-const WAIT_MAX = 60_000;
 
 export interface ListFilesRequestInput {
   target: CodeNavigationTarget;
@@ -286,9 +288,9 @@ function normaliseLimit(raw: number | undefined): number {
 
 function normaliseWaitTimeoutMs(raw: number | undefined): number {
   if (raw === undefined) return DEFAULT_WAIT_TIMEOUT_MS;
-  if (!Number.isInteger(raw) || raw < WAIT_MIN || raw > WAIT_MAX) {
+  if (!Number.isInteger(raw) || raw < WAIT_MIN || raw > MAX_WAIT_TIMEOUT_MS) {
     throw new InvalidPackageSpecError(
-      `\`wait_timeout_ms\` must be an integer between ${WAIT_MIN} and ${WAIT_MAX}. Got ${raw}.`,
+      `\`wait_timeout_ms\` must be an integer between ${WAIT_MIN} and ${MAX_WAIT_TIMEOUT_MS}. Got ${raw}.`,
     );
   }
   return raw;

--- a/packages/mcp/src/shared/read-file-request.ts
+++ b/packages/mcp/src/shared/read-file-request.ts
@@ -26,6 +26,8 @@ export interface ReadFileRequestBuildResult {
   params: ReadFileParams;
 }
 
+// CLI rewrites MCP identifiers from these errors, including the raw reversed-range
+// labels; keep them stable with src/commands/code/read.ts or update its tests.
 export function buildReadFileParams(
   input: ReadFileRequestInput,
 ): ReadFileRequestBuildResult {

--- a/packages/mcp/src/shared/read-file-request.ts
+++ b/packages/mcp/src/shared/read-file-request.ts
@@ -8,11 +8,13 @@ import type {
   CodeNavigationTarget,
   ReadFileParams,
 } from "@githits/core-internal";
-import { DEFAULT_WAIT_TIMEOUT_MS } from "./code-navigation-defaults.js";
+import {
+  DEFAULT_WAIT_TIMEOUT_MS,
+  MAX_WAIT_TIMEOUT_MS,
+} from "./code-navigation-defaults.js";
 import { InvalidPackageSpecError } from "./package-spec.js";
 
 const WAIT_MIN = 0;
-const WAIT_MAX = 60_000;
 
 export interface ReadFileRequestInput {
   target: CodeNavigationTarget;
@@ -79,9 +81,9 @@ function normaliseLine(
 
 function normaliseWaitTimeoutMs(raw: number | undefined): number {
   if (raw === undefined) return DEFAULT_WAIT_TIMEOUT_MS;
-  if (!Number.isInteger(raw) || raw < WAIT_MIN || raw > WAIT_MAX) {
+  if (!Number.isInteger(raw) || raw < WAIT_MIN || raw > MAX_WAIT_TIMEOUT_MS) {
     throw new InvalidPackageSpecError(
-      `\`wait_timeout_ms\` must be an integer between ${WAIT_MIN} and ${WAIT_MAX}. Got ${raw}.`,
+      `\`wait_timeout_ms\` must be an integer between ${WAIT_MIN} and ${MAX_WAIT_TIMEOUT_MS}. Got ${raw}.`,
     );
   }
   return raw;

--- a/scripts/cli-smoke.ts
+++ b/scripts/cli-smoke.ts
@@ -1089,6 +1089,26 @@ async function runLiveSmoke(): Promise<void> {
     "code read json missing content",
   );
 
+  const codeReadInvalid = await runCli([
+    "code",
+    "read",
+    SMOKE_PACKAGE_SPEC,
+    "lib/",
+    "--json",
+  ]);
+  const codeReadInvalidEnvelope = assertCleanErrorEnvelope(
+    codeReadInvalid.stderr,
+    "code read invalid json",
+  );
+  assert(
+    codeReadInvalid.exitCode !== 0 &&
+      codeReadInvalidEnvelope.code === "INVALID_ARGUMENT" &&
+      codeReadInvalidEnvelope.error.includes("githits code files") &&
+      codeReadInvalidEnvelope.error.includes("githits code read") &&
+      !codeReadInvalidEnvelope.error.includes("code_files"),
+    "code read invalid json missing CLI-native recovery",
+  );
+
   const codeGrepText = assertTerminalOutput(
     await runCli([
       "code",
@@ -1123,6 +1143,26 @@ async function runLiveSmoke(): Promise<void> {
   assert(
     "matches" in codeGrepJson || "totalMatches" in codeGrepJson,
     "code grep json missing matches",
+  );
+
+  const codeGrepInvalid = await runCli([
+    "code",
+    "grep",
+    SMOKE_PACKAGE_SPEC,
+    " ",
+    "--json",
+  ]);
+  const codeGrepInvalidEnvelope = assertCleanErrorEnvelope(
+    codeGrepInvalid.stderr,
+    "code grep invalid json",
+  );
+  assert(
+    codeGrepInvalid.exitCode !== 0 &&
+      codeGrepInvalidEnvelope.code === "INVALID_ARGUMENT" &&
+      codeGrepInvalidEnvelope.error.includes("<pattern>") &&
+      codeGrepInvalidEnvelope.error.includes("githits code files") &&
+      !codeGrepInvalidEnvelope.error.includes("code_files"),
+    "code grep invalid json missing CLI-native recovery",
   );
 
   const searchText = assertTerminalOutput(

--- a/src/commands/code/grep.test.ts
+++ b/src/commands/code/grep.test.ts
@@ -568,6 +568,39 @@ describe("pkgGrepAction", () => {
     }
   });
 
+  it("does not rewrite MCP-like text echoed from a symbol-field value", async () => {
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+
+    try {
+      try {
+        await pkgGrepAction(
+          "npm:express",
+          "middleware",
+          undefined,
+          { symbolField: ["`symbol_fields`"], json: true },
+          createDeps(),
+        );
+      } catch {
+        /* expected */
+      }
+
+      const payload = JSON.parse(errorSpy.mock.calls[0]?.[0] as string) as {
+        code: string;
+        error: string;
+      };
+      expect(payload.code).toBe("INVALID_ARGUMENT");
+      expect(payload.error).toContain("`--symbol-field` value must be one of:");
+      expect(payload.error).toContain("Got: `symbol_fields`.");
+      expect(payload.error).not.toContain("Got: `--symbol-field`.");
+    } finally {
+      errorSpy.mockRestore();
+      exitSpy.mockRestore();
+    }
+  });
+
   it("sets exit code 1 on zero-match JSON while preserving output", async () => {
     const originalExitCode = process.exitCode;
     const logSpy = spyOn(console, "log").mockImplementation(() => {});

--- a/src/commands/code/grep.test.ts
+++ b/src/commands/code/grep.test.ts
@@ -533,6 +533,38 @@ describe("pkgGrepAction", () => {
     }
   });
 
+  it("uses --glob for empty shared glob validation", async () => {
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+
+    try {
+      try {
+        await pkgGrepAction(
+          "npm:express",
+          "middleware",
+          undefined,
+          { glob: [" "], json: true },
+          createDeps(),
+        );
+      } catch {
+        /* expected */
+      }
+
+      const payload = JSON.parse(errorSpy.mock.calls[0]?.[0] as string) as {
+        code: string;
+        error: string;
+      };
+      expect(payload.code).toBe("INVALID_ARGUMENT");
+      expect(payload.error).toContain("`--glob` entries cannot be empty");
+      expect(payload.error).not.toContain("`globs`");
+    } finally {
+      errorSpy.mockRestore();
+      exitSpy.mockRestore();
+    }
+  });
+
   it("keeps API field names in the --symbol-field validation message", async () => {
     const errorSpy = spyOn(console, "error").mockImplementation(() => {});
     const exitSpy = spyOn(process, "exit").mockImplementation(() => {

--- a/src/commands/code/grep.test.ts
+++ b/src/commands/code/grep.test.ts
@@ -533,6 +533,41 @@ describe("pkgGrepAction", () => {
     }
   });
 
+  it("keeps API field names in the --symbol-field validation message", async () => {
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+
+    try {
+      try {
+        await pkgGrepAction(
+          "npm:express",
+          "middleware",
+          undefined,
+          { symbolField: ["invalid"], json: true },
+          createDeps(),
+        );
+      } catch {
+        /* expected */
+      }
+
+      const payload = JSON.parse(errorSpy.mock.calls[0]?.[0] as string) as {
+        code: string;
+        error: string;
+      };
+      expect(payload.code).toBe("INVALID_ARGUMENT");
+      expect(payload.error).toContain("`--symbol-field` value must be one of:");
+      expect(payload.error).toContain("file_path");
+      expect(payload.error).toContain("start_line");
+      expect(payload.error).toContain("end_line");
+      expect(payload.error).not.toContain("`symbol_fields`");
+    } finally {
+      errorSpy.mockRestore();
+      exitSpy.mockRestore();
+    }
+  });
+
   it("sets exit code 1 on zero-match JSON while preserving output", async () => {
     const originalExitCode = process.exitCode;
     const logSpy = spyOn(console, "log").mockImplementation(() => {});

--- a/src/commands/code/grep.test.ts
+++ b/src/commands/code/grep.test.ts
@@ -468,6 +468,71 @@ describe("pkgGrepAction", () => {
     exitSpy.mockRestore();
   });
 
+  it("uses CLI syntax when a blank pattern suggests listing files", async () => {
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+
+    try {
+      try {
+        await pkgGrepAction(
+          "npm:express",
+          "   ",
+          undefined,
+          { json: true },
+          createDeps(),
+        );
+      } catch {
+        /* expected */
+      }
+
+      const payload = JSON.parse(errorSpy.mock.calls[0]?.[0] as string) as {
+        code: string;
+        error: string;
+      };
+      expect(payload.code).toBe("INVALID_ARGUMENT");
+      expect(payload.error).toContain("`<pattern>` is required");
+      expect(payload.error).toContain("`githits code files`");
+      expect(payload.error).not.toContain("code_files");
+    } finally {
+      errorSpy.mockRestore();
+      exitSpy.mockRestore();
+    }
+  });
+
+  it("uses CLI option names for shared grep validation", async () => {
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+
+    try {
+      try {
+        await pkgGrepAction(
+          "npm:express",
+          "middleware",
+          undefined,
+          { ext: [".js"], json: true },
+          createDeps(),
+        );
+      } catch {
+        /* expected */
+      }
+
+      const payload = JSON.parse(errorSpy.mock.calls[0]?.[0] as string) as {
+        code: string;
+        error: string;
+      };
+      expect(payload.code).toBe("INVALID_ARGUMENT");
+      expect(payload.error).toContain("`--ext` values");
+      expect(payload.error).not.toContain("`extensions`");
+    } finally {
+      errorSpy.mockRestore();
+      exitSpy.mockRestore();
+    }
+  });
+
   it("sets exit code 1 on zero-match JSON while preserving output", async () => {
     const originalExitCode = process.exitCode;
     const logSpy = spyOn(console, "log").mockImplementation(() => {});

--- a/src/commands/code/grep.ts
+++ b/src/commands/code/grep.ts
@@ -236,8 +236,20 @@ function buildCliGrepParams(
   } catch (error) {
     if (!(error instanceof InvalidPackageSpecError)) throw error;
     const rewritten = error.message
+      .replace(/^`pattern`/, "`<pattern>`")
+      .replace(/`path`/g, "`--path`")
+      .replace(/`path_prefix`/g, "`[path-prefix]`")
+      .replace(/`globs`/g, "`--glob`")
+      .replace(/`extensions`/g, "`--ext`")
+      .replace(/`context_lines`/g, "`--context`")
+      .replace(/`context_lines_before`/g, "`--before-context`")
+      .replace(/`context_lines_after`/g, "`--after-context`")
+      .replace(/`max_matches`/g, "`--limit`")
+      .replace(/`max_matches_per_file`/g, "`--per-file-limit`")
+      .replace(/`wait_timeout_ms`/g, "`--wait`")
       .replace(/^`symbol_fields`/, "`--symbol-field`")
-      .replace(/`symbol_fields` value/g, "`--symbol-field` value");
+      .replace(/`symbol_fields` value/g, "`--symbol-field` value")
+      .replace(/`code_files`/g, "`githits code files`");
     if (rewritten === error.message) throw error;
     throw new InvalidPackageSpecError(rewritten);
   }

--- a/src/commands/code/grep.ts
+++ b/src/commands/code/grep.ts
@@ -228,6 +228,10 @@ function collectRepeatable(value: string, previous: string[] = []): string[] {
   return [...previous, value];
 }
 
+/**
+ * Translate CLI-reachable, backtick-delimited MCP validation tokens. Anchored
+ * rules preserve API field names embedded in the `symbol_fields` value list.
+ */
 function buildCliGrepParams(
   input: GrepRepoRequestInput,
 ): GrepRepoRequestBuildResult {
@@ -237,18 +241,9 @@ function buildCliGrepParams(
     if (!(error instanceof InvalidPackageSpecError)) throw error;
     const rewritten = error.message
       .replace(/^`pattern`/, "`<pattern>`")
-      .replace(/`path`/g, "`--path`")
-      .replace(/`path_prefix`/g, "`[path-prefix]`")
       .replace(/`globs`/g, "`--glob`")
       .replace(/`extensions`/g, "`--ext`")
-      .replace(/`context_lines`/g, "`--context`")
-      .replace(/`context_lines_before`/g, "`--before-context`")
-      .replace(/`context_lines_after`/g, "`--after-context`")
-      .replace(/`max_matches`/g, "`--limit`")
-      .replace(/`max_matches_per_file`/g, "`--per-file-limit`")
-      .replace(/`wait_timeout_ms`/g, "`--wait`")
       .replace(/^`symbol_fields`/, "`--symbol-field`")
-      .replace(/`symbol_fields` value/g, "`--symbol-field` value")
       .replace(/`code_files`/g, "`githits code files`");
     if (rewritten === error.message) throw error;
     throw new InvalidPackageSpecError(rewritten);

--- a/src/commands/code/grep.ts
+++ b/src/commands/code/grep.ts
@@ -230,7 +230,7 @@ function collectRepeatable(value: string, previous: string[] = []): string[] {
 
 /**
  * Translate CLI-reachable, backtick-delimited MCP validation tokens. Anchored
- * rules preserve API field names embedded in the `symbol_fields` value list.
+ * rules prevent replacements inside user values echoed after `Got:`.
  */
 function buildCliGrepParams(
   input: GrepRepoRequestInput,

--- a/src/commands/code/read.test.ts
+++ b/src/commands/code/read.test.ts
@@ -365,6 +365,37 @@ describe("pkgReadAction", () => {
     }
   });
 
+  it("preserves backticks in a directory path suggestion", async () => {
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+
+    try {
+      try {
+        await pkgReadAction(
+          "npm:express",
+          "li`b/",
+          { json: true },
+          createDeps(),
+        );
+      } catch {
+        /* expected */
+      }
+
+      const payload = JSON.parse(errorSpy.mock.calls[0]?.[0] as string) as {
+        code: string;
+        error: string;
+      };
+      expect(payload.code).toBe("INVALID_ARGUMENT");
+      expect(payload.error).toContain('path prefix "li`b/"');
+      expect(payload.error).not.toContain('path prefix "lib/"');
+    } finally {
+      errorSpy.mockRestore();
+      exitSpy.mockRestore();
+    }
+  });
+
   it("uses CLI option names for a reversed explicit line range", async () => {
     const errorSpy = spyOn(console, "error").mockImplementation(() => {});
     const exitSpy = spyOn(process, "exit").mockImplementation(() => {

--- a/src/commands/code/read.test.ts
+++ b/src/commands/code/read.test.ts
@@ -353,9 +353,12 @@ describe("pkgReadAction", () => {
         error: string;
       };
       expect(payload.code).toBe("INVALID_ARGUMENT");
+      expect(payload.error).toContain("`<path>` must be an exact file path");
       expect(payload.error).toContain("`githits code files`");
       expect(payload.error).toContain('path prefix "lib/"');
       expect(payload.error).toContain("`githits code read`");
+      expect(payload.error).not.toContain("emitted `path`");
+      expect(payload.error).not.toContain("`file_path`");
       expect(payload.error).not.toContain("code_files");
       expect(payload.error).not.toContain("code_read");
       expect(payload.error).not.toContain("path_prefix");

--- a/src/commands/code/read.test.ts
+++ b/src/commands/code/read.test.ts
@@ -330,6 +330,74 @@ describe("pkgReadAction", () => {
     exitSpy.mockRestore();
   });
 
+  it("uses CLI syntax when a directory is passed to code read", async () => {
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+
+    try {
+      try {
+        await pkgReadAction(
+          "npm:express",
+          "lib/",
+          { json: true },
+          createDeps(),
+        );
+      } catch {
+        /* expected */
+      }
+
+      const payload = JSON.parse(errorSpy.mock.calls[0]?.[0] as string) as {
+        code: string;
+        error: string;
+      };
+      expect(payload.code).toBe("INVALID_ARGUMENT");
+      expect(payload.error).toContain("`githits code files`");
+      expect(payload.error).toContain('path prefix "lib/"');
+      expect(payload.error).toContain("`githits code read`");
+      expect(payload.error).not.toContain("code_files");
+      expect(payload.error).not.toContain("code_read");
+      expect(payload.error).not.toContain("path_prefix");
+    } finally {
+      errorSpy.mockRestore();
+      exitSpy.mockRestore();
+    }
+  });
+
+  it("uses CLI option names for a reversed explicit line range", async () => {
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+
+    try {
+      try {
+        await pkgReadAction(
+          "npm:express",
+          "src/index.js",
+          { start: "40", end: "10", json: true },
+          createDeps(),
+        );
+      } catch {
+        /* expected */
+      }
+
+      const payload = JSON.parse(errorSpy.mock.calls[0]?.[0] as string) as {
+        code: string;
+        error: string;
+      };
+      expect(payload.code).toBe("INVALID_ARGUMENT");
+      expect(payload.error).toContain("--start (40)");
+      expect(payload.error).toContain("--end (10)");
+      expect(payload.error).not.toContain("start_line");
+      expect(payload.error).not.toContain("end_line");
+    } finally {
+      errorSpy.mockRestore();
+      exitSpy.mockRestore();
+    }
+  });
+
   it("renders the binary sentinel via stdout.write", async () => {
     const writes: string[] = [];
     const writeSpy = spyOn(process.stdout, "write").mockImplementation(((

--- a/src/commands/code/read.ts
+++ b/src/commands/code/read.ts
@@ -103,7 +103,7 @@ export async function pkgReadAction(
       MAX_WAIT_TIMEOUT_MS,
     );
 
-    const build = buildReadFileParams({
+    const build = buildCliReadFileParams({
       target,
       filePath: pathWithRange.filePath,
       startLine: range.startLine,
@@ -144,6 +144,29 @@ export async function pkgReadAction(
       1,
       (mapped) => withCliReadFileRecovery(mapped, requestedFilePath),
     );
+  }
+}
+
+function buildCliReadFileParams(
+  input: Parameters<typeof buildReadFileParams>[0],
+): ReturnType<typeof buildReadFileParams> {
+  try {
+    return buildReadFileParams(input);
+  } catch (error) {
+    if (!(error instanceof InvalidPackageSpecError)) throw error;
+    const rewritten = error.message
+      .replace(/`file_path`/g, "`<path>`")
+      .replace(/`start_line`/g, "`--start`")
+      .replace(/`end_line`/g, "`--end`")
+      .replace("start_line (", "--start (")
+      .replace("end_line (", "--end (")
+      .replace(/`wait_timeout_ms`/g, "`--wait`")
+      .replace(/`code_files`/g, "`githits code files`")
+      .replace(/`path_prefix: ([^`]+)`/g, "path prefix $1")
+      .replace(/emitted `path`/g, "emitted path")
+      .replace(/`code_read`/g, "`githits code read`");
+    if (rewritten === error.message) throw error;
+    throw new InvalidPackageSpecError(rewritten);
   }
 }
 

--- a/src/commands/code/read.ts
+++ b/src/commands/code/read.ts
@@ -7,6 +7,8 @@ import {
   formatReadFileTerminal,
   InvalidPackageSpecError,
   MAX_WAIT_TIMEOUT_MS,
+  type ReadFileRequestBuildResult,
+  type ReadFileRequestInput,
   requireAuth,
   shouldUseColors,
 } from "@githits/mcp/internal";
@@ -147,22 +149,26 @@ export async function pkgReadAction(
   }
 }
 
+/**
+ * Translate CLI-reachable MCP validation tokens. Unchanged errors are rethrown
+ * so this boundary does not mask unrelated shared validation failures.
+ */
 function buildCliReadFileParams(
-  input: Parameters<typeof buildReadFileParams>[0],
-): ReturnType<typeof buildReadFileParams> {
+  input: ReadFileRequestInput,
+): ReadFileRequestBuildResult {
   try {
     return buildReadFileParams(input);
   } catch (error) {
     if (!(error instanceof InvalidPackageSpecError)) throw error;
     const rewritten = error.message
       .replace(/`file_path`/g, "`<path>`")
-      .replace(/`start_line`/g, "`--start`")
-      .replace(/`end_line`/g, "`--end`")
       .replace("start_line (", "--start (")
       .replace("end_line (", "--end (")
-      .replace(/`wait_timeout_ms`/g, "`--wait`")
       .replace(/`code_files`/g, "`githits code files`")
-      .replace(/`path_prefix: ([^`]+)`/g, "path prefix $1")
+      .replace(
+        /`path_prefix: ([\s\S]+)` to list files/g,
+        "path prefix $1 to list files",
+      )
       .replace(/emitted `path`/g, "emitted path")
       .replace(/`code_read`/g, "`githits code read`");
     if (rewritten === error.message) throw error;

--- a/src/services/exec-service.test.ts
+++ b/src/services/exec-service.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, realpath, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { join } from "node:path";
 import {
   ExecServiceImpl,
   ExecTimeoutError,
@@ -46,8 +46,8 @@ describe("ExecServiceImpl", () => {
         ["-e", "process.stdout.write(process.cwd())"],
         { cwd },
       );
-      expect(resolve(result.stdout).toLowerCase()).toBe(
-        resolve(cwd).toLowerCase(),
+      expect((await realpath(result.stdout)).toLowerCase()).toBe(
+        (await realpath(cwd)).toLowerCase(),
       );
     } finally {
       await rm(cwd, { recursive: true, force: true });

--- a/src/tools/grep-repo-parity.test.ts
+++ b/src/tools/grep-repo-parity.test.ts
@@ -237,13 +237,24 @@ describe("grep_repo parity", () => {
     expect(mcpAction).toContain("`code_grep`");
   });
 
-  it("PARITY-ERROR-ENVELOPE: whitespace-only pattern is INVALID_ARGUMENT on both surfaces", async () => {
-    const cli = await cliJson("npm:express", "   ", undefined);
-    const mcp = await mcpJson({
+  it("PARITY-ERROR-ENVELOPE: whitespace-only pattern shares data with surface-native messages", async () => {
+    const cli = (await cliJson("npm:express", "   ", undefined)) as {
+      code: string;
+      error: string;
+      retryable: boolean;
+    };
+    const mcp = (await mcpJson({
       target: { registry: "npm", package_name: "express" },
       pattern: "   ",
-    });
-    expect(cli).toEqual(mcp);
-    expect((cli as { code: string }).code).toBe("INVALID_ARGUMENT");
+    })) as { code: string; error: string; retryable: boolean };
+    const { error: cliError, ...cliData } = cli;
+    const { error: mcpError, ...mcpData } = mcp;
+
+    expect(cliData).toEqual(mcpData);
+    expect(cli.code).toBe("INVALID_ARGUMENT");
+    expect(cliError).toContain("`<pattern>`");
+    expect(cliError).toContain("`githits code files`");
+    expect(mcpError).toContain("`pattern`");
+    expect(mcpError).toContain("`code_files`");
   });
 });

--- a/src/tools/read-file-parity.test.ts
+++ b/src/tools/read-file-parity.test.ts
@@ -303,17 +303,24 @@ describe("read_file parity", () => {
   });
 
   it("PARITY-ERROR-ENVELOPE: INVALID_ARGUMENT on reversed range", async () => {
-    const cli = await cliJson("npm:express", "src/index.js", {
+    const cli = (await cliJson("npm:express", "src/index.js", {
       start: "40",
       end: "10",
-    });
-    const mcp = await mcpJson({
+    })) as { code: string; error: string; retryable: boolean };
+    const mcp = (await mcpJson({
       target: { registry: "npm", package_name: "express" },
       path: "src/index.js",
       start_line: 40,
       end_line: 10,
-    });
-    expect(cli).toMatchObject({ code: "INVALID_ARGUMENT" });
-    expect(mcp).toMatchObject({ code: "INVALID_ARGUMENT" });
+    })) as { code: string; error: string; retryable: boolean };
+    const { error: cliError, ...cliData } = cli;
+    const { error: mcpError, ...mcpData } = mcp;
+
+    expect(cliData).toEqual(mcpData);
+    expect(cli.code).toBe("INVALID_ARGUMENT");
+    expect(cliError).toContain("--start (40)");
+    expect(cliError).toContain("--end (10)");
+    expect(mcpError).toContain("start_line (40)");
+    expect(mcpError).toContain("end_line (10)");
   });
 });


### PR DESCRIPTION
## Summary

- rewrite shared code-read and grep `INVALID_ARGUMENT` messages at the CLI boundary so they use CLI commands, positionals, and options
- preserve MCP-native tool and argument names in the shared builders used by local and remote MCP
- align code-navigation wait validation on the shared ceiling and document the formatter coupling
- add parity, mutation-resistant unit, live smoke, implementation-doc, and changelog coverage
- canonicalize the newly merged exec-service cwd assertion so macOS `/var` and `/private/var` aliases compare correctly

## Root cause

The CLI and MCP share request builders. Their validation errors were written with MCP tool and argument names, so locally generated CLI errors could expose names such as `code_files`, `file_path`, and `symbol_fields`. The backend's structured error data cannot correct errors raised before a backend request.

During the rebase, the new base's cwd test exposed a separate lexical-path assumption on macOS. The spawned process canonicalizes `/var` to `/private/var`; comparing both paths through `realpath` verifies the intended working directory without depending on the alias spelling.

## Validation

- `bun test`: 2,767 passed, 0 failed
- isolated `src/services/exec-service.test.ts`: 10 passed, 0 failed
- `bun run build`
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run validate:packages`
- `bun run smoke:cli`: 78 live steps
- `bun run smoke:cli:built`: 10 built steps
- `bun run smoke:mcp`: 38 live steps
- `bun run smoke:mcp:built`: registration passed
- targeted Codex agent evaluation: high confidence, no tool or instruction issues
- four-round Claude Opus review loop: final verdict clean; mutation review confirmed all 12 live CLI translation rules are pinned by repository tests

## Release impact

- `githits`: patch
- `@githits/mcp`: no additional behavior change in this increment; MCP-native validation wording is preserved