### PR TITLE
chore: prepare githits 0.9.2 and MCP 0.9.1 releases

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,12 +6,12 @@
   },
   "metadata": {
     "description": "The code context layer for AI coding agents",
-    "version": "0.9.1"
+    "version": "0.9.2"
   },
   "plugins": [
     {
       "name": "githits",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "description": "The code context layer for AI coding agents",
       "author": {
         "name": "GitHits"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,23 +12,38 @@ errors.
 
 | Public artifact | Current release | Pending bump | Reason |
 |---|---:|---:|---|
-| `githits` | 0.9.1 | patch | Fixes CLI-native exact-path recovery and Claude Code/Codex CLI init detection and verification |
-| `@githits/mcp` | 0.9.0 | patch | Fixes MCP-native exact-path read and grep recovery; later MCP-visible changes in the CLI 0.9 minor bump the MCP patch |
+| `githits` | 0.9.2 | none | No unreleased package-visible changes |
+| `@githits/mcp` | 0.9.1 | none | No unreleased package-visible changes |
+
+## [githits 0.9.2] - 2026-08-14
+
+Patch release: improves CLI exact-path recovery and makes Claude Code and Codex
+CLI initialization checks more reliable.
 
 ### Fixed
 
-- **Exact-path recovery (CLI/MCP)** - typed `FILE_NOT_FOUND` responses from
-  `code_read` and `code_grep` now add surface-native path-discovery guidance: MCP names
-  `code_files` / `code_grep`, while CLI JSON names `githits code files` /
-  `githits code grep`. Read recovery names `code_read` or `githits code read`
-  respectively, and extensionless exact files use their containing directory.
-  Generic `NOT_FOUND` errors that do not describe a missing file path no longer
-  receive path-discovery guidance.
+- **Exact-path recovery** - typed `FILE_NOT_FOUND` responses from CLI code read
+  and grep commands now name `githits code files`, `githits code grep`, and
+  `githits code read` in path-discovery guidance. Extensionless exact files use
+  their containing directory, and generic `NOT_FOUND` errors do not receive
+  file-path guidance.
 - **Claude Code and Codex CLI init setup** - user-scoped MCP checks now run
   outside project configuration, use targeted server probes with host-specific
   timeouts, distinguish missing, non-canonical, disabled, and failed checks,
   preserve enabled customized Codex entries, and avoid reporting cleanup no-ops
   as successful setup when a later command fails.
+
+## [@githits/mcp 0.9.1] - 2026-08-14
+
+Patch release: improves surface-native recovery from exact-path read and grep
+failures.
+
+### Fixed
+
+- **Exact-path recovery** - typed `FILE_NOT_FOUND` responses from `code_read`
+  and `code_grep` now name `code_files`, `code_grep`, and `code_read` in
+  path-discovery guidance. Extensionless exact files use their containing
+  directory, and generic `NOT_FOUND` errors do not receive file-path guidance.
 
 ## [githits 0.9.1] - 2026-08-13
 

--- a/bun.lock
+++ b/bun.lock
@@ -43,7 +43,7 @@
     },
     "packages/mcp": {
       "name": "@githits/mcp",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "^4.4.3",

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "The code context layer for AI coding agents",
   "mcpServers": {
     "githits": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "githits",
   "description": "The code context layer for AI coding agents",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "mcpName": "com.githits/githits",
   "type": "module",
   "workspaces": [

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@githits/mcp",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Reusable MCP server APIs and tools for GitHits",
   "type": "module",
   "files": [

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "githits",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/server.json
+++ b/server.json
@@ -16,7 +16,7 @@
     "source": "github",
     "id": "1165453165"
   },
-  "version": "0.9.1",
+  "version": "0.9.2",
   "remotes": [
     {
       "type": "streamable-http",
@@ -28,7 +28,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "githits",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Summary

- prepare `githits` 0.9.2 and align the root package, MCP registry manifest, lockfile, and generated plugin manifests
- prepare `@githits/mcp` 0.9.1 for the MCP-visible exact-path recovery changes
- finalize separate dated changelog sections and reset the Unreleased impact table

## Why

Since the previous releases, `main` gained CLI-native exact-path recovery, MCP-native `code_read` / `code_grep` recovery, and more reliable Claude Code and Codex CLI init detection and verification. The MCP response behavior is package-visible, so the independently versioned MCP artifact receives a patch release alongside the CLI patch.

## Impact

After merge, the successful Main workflow will publish `githits@0.9.2`, publish `@githits/mcp@0.9.1` if it is not already present on npm, and publish the aligned `com.githits/githits` MCP registry entry.

## Validation

- `bun install --frozen-lockfile`
- `bun run plugins:check`
- `bun run typecheck`
- `bun run validate:packages`
- `bun run validate:packages:mcp-publish`
- `bun test` — 2,759 passing
- root and `packages/mcp` builds
- `bun run smoke:cli`
- `bun run smoke:mcp`
- `bun run smoke:cli:built`
- `bun run smoke:mcp:built`
- pinned MCP Publisher v1.7.9: `server.json` valid
