### PR TITLE
Adopt conflict-free changelog fragments

### DIFF
--- a/.agents/skills/githits-release/SKILL.md
+++ b/.agents/skills/githits-release/SKILL.md
@@ -23,9 +23,9 @@ Use this skill for GitHits changelog maintenance, release work, version-bump PRs
 - Keep `server.json.version`, the npm package entry version in `server.json`, and root `package.json.version` aligned. The release workflow rewrites a temporary registry manifest from `package.json`, but the committed `server.json` should still reflect the intended next root release for review and local validation.
 - Keep root `package.json#mcpName` equal to `com.githits/githits`; npm registry ownership validation depends on the published package manifest matching `server.json.name`.
 - Run or rely on package-scoped version checks to verify root plugin versions stay aligned and MCP versions are intentionally independent.
-- Reconcile the complete package-specific tag-to-HEAD delta with `CHANGELOG.md`. Its `Unreleased` impact table must name every public artifact and an explicit pending bump, including `none` for unaffected packages.
+- Reconcile the complete package-specific tag-to-HEAD delta with the files in `changes/`. Every fragment must name every public artifact and an explicit pending bump, including `none` for unaffected packages.
 - Run `bun run plugins:generate`, inspect the generated diff, and run `bun run plugins:check` before release-readiness signoff. Do not release with manually edited or stale generated assets.
-- Finalize the continuously maintained changelog before release. Move shipped entries into a separate `## [<artifact> <version>] - YYYY-MM-DD` section for each released artifact, leave a fresh `Unreleased` section, and reset every pending bump to `none`.
+- Finalize the changelog before release. Group the fragments into a separate `## [<artifact> <version>] - YYYY-MM-DD` section for each released artifact, then delete every consumed fragment.
 - Review public skills before signoff whenever user-facing CLI/MCP behavior changed. After the behavior is released or included in the same release branch, update `skills/githits-code/SKILL.md`, `skills/githits-package/SKILL.md`, and their references so `skills.sh` users get instructions that match the released surface.
 - Keep PR titles and labels release-note friendly; GitHub release notes are generated from merged PRs and `.github/release.yml` categories.
 - Run `bun run build` before release-readiness signoff. Run targeted smoke/eval commands when MCP tools, CLI commands, shared formatters, auth/error envelopes, Agent Skills, or agent-facing instructions changed.
@@ -51,12 +51,12 @@ Use this skill for GitHits changelog maintenance, release work, version-bump PRs
 - After changing public skills or plugin-facing guidance, run `bun run plugins:generate` and `bun run plugins:check` so every host manifest remains aligned with the canonical root surface.
 - If a skill update is intentionally delayed until after release, note that in the release/change plan so it is not forgotten.
 
-## Continuous Changelog
+## Changelog Fragments
 
-- Follow `docs/implementation/release-process.md`; `CHANGELOG.md` is maintained with each notable change rather than reconstructed only at release time.
-- For every notable change, update the existing `Unreleased` entries and recompute the aggregate pending bump in the same change. Do not add a second unreleased section or choose a target version before release preparation.
-- Use `git log` and merged PRs since each package's previous tag to audit the maintained entries and find omissions.
-- Record the pending SemVer impact for `githits`, `@githits/mcp`, and every future independently versioned public artifact. Keep unaffected packages explicit as `none`.
+- Follow `docs/implementation/release-process.md` and `changes/README.md`; every notable change owns a new independent fragment under `changes/` rather than editing `CHANGELOG.md`.
+- Use `git log` and merged PRs since each package's previous tag to audit the fragments and find omissions before release; fragments do not replace range review.
+- Record the pending SemVer impact for `githits`, `@githits/mcp`, and every future independently versioned public artifact in each fragment. Keep unaffected packages explicit as `none`.
+- During release preparation, compute each artifact's aggregate bump from the highest impact in its fragments, group affected entries by category into that artifact's versioned section, and delete all consumed fragments. Never partially consume a cross-artifact fragment; leave unrelated fragments untouched. Consume all-`none` repository entries with the next root `githits` release.
 - Treat dated, versioned sections as immutable historical records. Change one only for a blatant, demonstrable factual error and make the smallest correction that restores accuracy; wording improvements and omitted minor details do not qualify.
 - Exclude purely internal refactors unless they affect users, agent behavior, performance, or reliability.
 - Call out changes that require users or agents to adjust commands, flags, config, auth setup, environment variables, MCP setup, or skill usage.
@@ -67,6 +67,6 @@ Use this skill for GitHits changelog maintenance, release work, version-bump PRs
 - Do not expose credentials while verifying release/auth flows.
 - Do not force-push, amend, or rewrite release history unless explicitly requested.
 - Refuse historical changelog cleanup or expansion unless the existing text is blatantly factually wrong.
-- If the changelog impact table, package manifests, or verified package-visible delta disagree, stop and reconcile them before release signoff.
+- If fragment impacts, package manifests, or the verified package-visible delta disagree, stop and reconcile them before release signoff.
 - If root package and plugin manifests disagree, stop and fix them before a root `githits` release.
 - If `@githits/mcp` changed but its package version did not, stop and either bump it or document why the change is not MCP-package-visible.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,14 +118,19 @@ See `docs/guidelines/TESTING.md` for comprehensive patterns.
 
 ## Release Boundaries
 
-- Keep `CHANGELOG.md` current during development. Every notable user-, agent-, operator-, or public-API-visible change must update `Unreleased` in the same change, including the explicit pending SemVer impact for every public artifact. Follow `docs/implementation/release-process.md`.
+- Every notable user-, agent-, operator-, or public-API-visible change must add
+  one independent `changes/<unique-name>.<category>.md` fragment with an
+  explicit pending SemVer impact for every public artifact. Do not edit
+  `CHANGELOG.md` outside release preparation. Follow
+  `docs/implementation/release-process.md` and `changes/README.md`.
 - Treat dated, versioned changelog sections as immutable historical records. Change them only to correct blatant, demonstrable factual errors, and keep any correction minimal.
 - `githits` and `@githits/mcp` have separate release flows. They may be bumped together when both surfaces changed, but CLI-only changes should not bump `@githits/mcp`.
 - Root `githits` release versions must stay aligned with generated plugin/assistant manifests: `.plugin/plugin.json`, `.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`, `.cursor-plugin/plugin.json`, `.claude-plugin/marketplace.json`, and `gemini-extension.json`. The versionless Antigravity `plugin.json` and `mcp_config.json` must also be regenerated and checked.
 - `@githits/mcp` release versions live in `packages/mcp/package.json` and should change only for MCP package API, tool behavior, MCP instructions, schemas, MCP auth/error behavior, or remote-server-facing public type changes.
 - For coordinated CLI and MCP releases, keep the MCP minor aligned with the CLI minor for discoverability. The first MCP release for a CLI minor starts at `X.Y.0`; later MCP-package-visible changes in that CLI minor bump the MCP patch.
 - Successful `Main` runs on `main` trigger both root and MCP release workflows. The MCP workflow publishes only when the package version is not already published; manual dispatch is for recovery or dry runs.
-- Release preparation moves shipped entries from `Unreleased` into separate versioned sections for each released artifact and leaves a fresh impact table with pending bumps reset to `none`.
+- Release preparation consumes all fragments into separate versioned sections
+  for each released artifact and deletes the consumed files.
 - Validate package behavior from outside root path aliases. Repo-local imports can hide package export-map or declaration problems.
 
 ### Common Pitfalls

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,26 +1,9 @@
 # Changelog
 
-All notable GitHits CLI and public package changes are recorded here. The
-`Unreleased` section is updated with each notable change so pending releases and
-package-version impact remain visible during development. Dated, versioned
-sections are historical records and change only to correct blatant factual
-errors.
-
-## [Unreleased]
-
-### Release impact
-
-| Public artifact | Current release | Pending bump | Reason |
-|---|---:|---:|---|
-| `githits` | 0.9.2 | patch | Fixes CLI-native code-validation guidance |
-| `@githits/mcp` | 0.9.1 | none | No unreleased package-visible changes |
-
-### Fixed
-
-- **Code validation guidance (`githits`)** - client-side `INVALID_ARGUMENT`
-  errors from shared code-read and grep request builders now name CLI commands,
-  positionals, and options on the CLI while MCP keeps MCP-native tool and
-  argument syntax.
+All notable GitHits CLI and public package changes are recorded here. Unreleased
+changes use independent files under [`changes/`](changes/README.md) and are
+consolidated here only during release preparation. Dated, versioned sections
+are historical records and change only to correct blatant factual errors.
 
 ## [githits 0.9.2] - 2026-08-14
 

--- a/changes/README.md
+++ b/changes/README.md
@@ -1,0 +1,38 @@
+# Unreleased Changelog Fragments
+
+Normal pull requests record each notable user-, agent-, operator-, or
+public-API-visible change in a new file instead of editing `CHANGELOG.md`. Use:
+
+```text
+changes/<pr-number-or-unique-slug>.<category>.md
+```
+
+Valid categories are `added`, `changed`, `deprecated`, `removed`, `fixed`, and
+`security`. Use a lowercase, hyphenated unique name and this exact structure:
+
+```markdown
+---
+"githits": patch
+"@githits/mcp": none
+---
+
+- **Short title** - Describe the user-visible behavior and important rollout or
+  compatibility impact.
+```
+
+Each public artifact must have an explicit `none`, `patch`, `minor`, or `major`
+impact. Add future independently versioned public artifacts to every fragment.
+Keep the body to one concise Markdown bullet. Never edit another change's
+fragment.
+
+A pull request that fully reverts an unreleased change removes that change's
+fragment instead of adding a release note for behavior that will not ship.
+
+A release PR verifies the fragments against the complete tag-to-HEAD ranges and
+computes the highest bump per artifact. A fragment with non-`none` impact on
+multiple artifacts must be released for all of them together; never consume it
+partially. Group entries by category into each affected artifact's versioned
+`CHANGELOG.md` section and delete only the consumed fragments. Leave fragments
+unrelated to that release untouched. A fragment with `none` for every artifact
+documents repository or release-operation impact; it does not trigger a release
+and is consumed into the next `githits` release.

--- a/changes/changelog-fragments.changed.md
+++ b/changes/changelog-fragments.changed.md
@@ -1,0 +1,8 @@
+---
+"githits": none
+"@githits/mcp": none
+---
+
+- **Independent changelog fragments** - Notable changes now record release notes
+  and per-artifact SemVer impact in independently owned files, avoiding conflicts
+  in `CHANGELOG.md` during normal development.

--- a/changes/cli-validation-guidance.fixed.md
+++ b/changes/cli-validation-guidance.fixed.md
@@ -1,0 +1,8 @@
+---
+"githits": patch
+"@githits/mcp": none
+---
+
+- **Code validation guidance** - Client-side `INVALID_ARGUMENT` errors from
+  shared code-read and grep request builders now name CLI commands, positionals,
+  and options on the CLI while MCP keeps MCP-native tool and argument syntax.

--- a/docs/guidelines/REVIEW_GUIDELINES.md
+++ b/docs/guidelines/REVIEW_GUIDELINES.md
@@ -31,7 +31,8 @@ Checklist for reviewing code changes in githits-cli.
 - [ ] Comments explain "why" not just "what"
 - [ ] Implementation docs updated if needed
 - [ ] `AGENTS.md` updated if agent-facing patterns change
-- [ ] Notable public changes update `CHANGELOG.md` and its per-artifact pending bumps
+- [ ] Notable changes add an independent valid `changes/` fragment with every public artifact's pending bump
+- [ ] Feature pull requests do not edit `CHANGELOG.md`
 - [ ] Historical changelog sections are unchanged unless a minimal edit corrects a blatant factual error
 
 ## Build & Lint

--- a/docs/implementation/release-process.md
+++ b/docs/implementation/release-process.md
@@ -10,30 +10,36 @@ artifacts:
 - `@githits/mcp`, the reusable transport-neutral MCP package
 
 Add future independently versioned public artifacts, including an SDK, to this
-document and the changelog impact table when their package manifests are added.
-Private workspace packages do not receive changelog rows or release versions.
+document and the changelog fragment schema when their package manifests are
+added. Private workspace packages do not receive changelog impact entries or
+release versions.
 
-## Continuous Changelog
+## Changelog Fragments
 
-`CHANGELOG.md` is the source of truth for curated release communication. Keep a
-single `## [Unreleased]` section at the top and update it in the same change as
-every notable user-, agent-, operator-, or public-API-visible change. Do not wait
-until release preparation to reconstruct the whole release from commit history.
+Every notable user-, agent-, operator-, or public-API-visible change owns one
+independent file under `changes/` following `changes/README.md`. Normal pull
+requests do not edit `CHANGELOG.md`; only release preparation consolidates the
+fragments into versioned release sections.
 
-The unreleased section contains:
+Each fragment contains:
 
-1. A release-impact table with every public artifact, its current published
-   version, its pending SemVer bump (`none`, `patch`, `minor`, or `major`), and a
-   short reason.
-2. `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, or `Security`
-   subsections as needed.
-3. Entries that identify the affected artifact when the scope is not obvious
-   and explain user impact, compatibility, migration, or operational action.
+1. YAML front matter naming every public artifact and its pending SemVer impact
+   (`none`, `patch`, `minor`, or `major`).
+2. One concise Markdown bullet whose category comes from the filename suffix:
+   `added`, `changed`, `deprecated`, `removed`, `fixed`, or `security`.
+3. User impact, compatibility, migration, or operational action, identifying
+   the affected artifact when the scope is not obvious.
 
-The highest required bump for an artifact wins. Keep `none` explicit for
-unaffected artifacts; that is the signal that an independent package release is
-not required. When another public package is added, add its row immediately so
-cross-package impact cannot remain implicit.
+Keep `none` explicit for unaffected artifacts; that is the signal that an
+independent package release is not required. When another public package is
+added, add it to `changes/README.md`, fragment validation, and every new
+fragment so cross-package impact cannot remain implicit. The highest impact
+across an artifact's fragments determines its release bump.
+
+A fragment with non-`none` impact on multiple artifacts is atomic: release all
+of those artifacts together or leave the fragment untouched. A fragment with
+`none` for every artifact records repository or release-operation impact; it
+does not trigger a release and is consumed into the next `githits` release.
 
 Exclude internal refactors, test-only changes, development-dependency updates,
 and generated-file churn unless they materially affect behavior, security,
@@ -52,8 +58,8 @@ Change a historical entry only when it contains a blatant, demonstrable factual
 error, such as the wrong artifact, version, release date, shipped behavior,
 compatibility statement, or migration requirement. Make the smallest correction
 that restores factual accuracy. If the error could mislead current users or
-operators, also describe the correction in `Unreleased`; do not silently rely on
-the historical edit to communicate new guidance.
+operators, also add a fragment for the correction; do not silently rely on the
+historical edit to communicate new guidance.
 
 ## Package Impact Rules
 
@@ -73,8 +79,8 @@ release impact:
   explicitly whether the next `githits` artifact must carry the same update.
 
 Before assigning `none`, compare the delta against every public consumer and
-package export. The release-impact table records the conclusion; it does not
-replace that review.
+package export. A fragment's impact records the conclusion; it does not replace
+that review.
 
 ## Release Preparation
 
@@ -82,19 +88,24 @@ For each artifact being released:
 
 1. Inspect the complete package-specific tag-to-HEAD delta (`vX.Y.Z` for
    `githits`, `mcp-vX.Y.Z` for `@githits/mcp`) and reconcile it with
-   `CHANGELOG.md`.
-2. Confirm the pending bump matches the actual public surface and that every
-   notable entry states required migration or compatibility effects.
+   all files in `changes/`; fragments do not replace range review.
+2. Confirm each fragment's impact matches the actual public surface, compute
+   the highest pending bump for each artifact, and verify every notable entry
+   states required migration or compatibility effects.
 3. Bump only the affected package manifests. For a root release, also update
    `server.json` and regenerate every plugin/assistant manifest.
-4. Move each shipped artifact's entries into its own
+4. Group each affected artifact's fragment entries by category into its own
    `## [<artifact> <version>] - YYYY-MM-DD` section. Keep separate sections for
-   coordinated releases so each package tag has unambiguous notes.
-5. Leave a fresh `## [Unreleased]` section with all current versions and
-   pending bumps reset to `none`.
+   coordinated releases so each package tag has unambiguous notes. Exclude an
+   entry from artifacts marked `none`; include all-`none` repository entries in
+   the root `githits` section.
+5. Delete every consumed fragment. Leave fragments unrelated to the artifacts
+   being released untouched, and never partially consume a cross-artifact
+   fragment.
 6. Run the release skill checklist, package validation, tests, build, and the
    smoke or agent evaluations required by the changed surfaces.
 
-The version-boundary test requires release sections for the versions currently
-declared in both public package manifests. A version bump without a matching
-changelog section must fail before release.
+The release-boundary tests validate fragment names, front matter, and body
+shape during development, and require release sections for the versions
+currently declared in both public package manifests. A version bump without a
+matching changelog section must fail before release.

--- a/docs/implementation/workspace-packages.md
+++ b/docs/implementation/workspace-packages.md
@@ -54,10 +54,10 @@ manifest move is complete.
 
 ## Release Boundaries
 
-- `CHANGELOG.md` continuously records pending changes and the required SemVer
-  impact for every public artifact. See
-  `docs/implementation/release-process.md` for entry and release-finalization
-  rules.
+- Independent files under `changes/` record pending changes and the required
+  SemVer impact for every public artifact. `CHANGELOG.md` is updated only during
+  release preparation. See `docs/implementation/release-process.md` for
+  fragment and release-finalization rules.
 - Root `githits` and public `@githits/mcp` releases are independent. Coordinated
   releases are allowed, but version equality is not required.
 - When both are released together, keep the MCP minor aligned with the CLI minor

--- a/docs/plans/terminal-text-sanitization.md
+++ b/docs/plans/terminal-text-sanitization.md
@@ -148,7 +148,7 @@ the root `githits` patch version in `package.json` and `server.json`, then run
 `mcp_config.json` assets. Bump the `@githits/mcp` patch version in
 `packages/mcp/package.json`; for a new root minor, follow the coordinated-release
 rule and start the MCP package at `X.Y.0`. Add the security hardening and explicit
-pending bumps to the `CHANGELOG.md` Unreleased section. Review public Agent Skills
+pending bumps in an independent `changes/` fragment. Review public Agent Skills
 for wording impact, but do not change them unless their documented output behavior
 is now inaccurate. Run `bun run plugins:check` after generation.
 

--- a/src/package-release-boundaries.test.ts
+++ b/src/package-release-boundaries.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
-import { readFile } from "node:fs/promises";
+import { readdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
+import { parse as parseYaml } from "yaml";
 
 async function readJson<T>(path: string): Promise<T> {
   return JSON.parse(await readFile(path, "utf8")) as T;
@@ -14,6 +15,26 @@ interface PackageJson {
   optionalDependencies?: Record<string, string>;
   peerDependencies?: Record<string, string>;
   version: string;
+}
+
+const changelogCategories = [
+  "added",
+  "changed",
+  "deprecated",
+  "removed",
+  "fixed",
+  "security",
+] as const;
+
+const semverImpacts = ["none", "patch", "minor", "major"] as const;
+
+function isSemverImpact(
+  value: unknown,
+): value is (typeof semverImpacts)[number] {
+  return (
+    typeof value === "string" &&
+    (semverImpacts as readonly string[]).includes(value)
+  );
 }
 
 function allDependencyNames(packageJson: PackageJson): Set<string> {
@@ -39,22 +60,50 @@ describe("package release boundaries", () => {
       lfChangelog,
       lfChangelog.replaceAll("\n", "\r\n"),
     ]) {
-      const unreleased = changelog.match(
-        /## \[Unreleased\]\r?\n([\s\S]*?)(?=\r?\n## \[)/,
-      )?.[1];
-
-      expect(unreleased).toBeDefined();
-      expect(unreleased).toContain(
-        `| \`${rootPackage.name}\` | ${rootPackage.version} |`,
-      );
-      expect(unreleased).toContain(
-        `| \`${mcpPackage.name}\` | ${mcpPackage.version} |`,
-      );
+      expect(changelog).not.toContain("## [Unreleased]");
       expect(changelog).toContain(
         `## [${rootPackage.name} ${rootPackage.version}]`,
       );
       expect(changelog).toContain(
         `## [${mcpPackage.name} ${mcpPackage.version}]`,
+      );
+    }
+  });
+
+  it("keeps independent changelog fragments well formed", async () => {
+    const root = join(import.meta.dir, "..");
+    const changesDirectory = join(root, "changes");
+    const fragmentNames = (await readdir(changesDirectory)).filter(
+      (name: string): boolean => name !== "README.md",
+    );
+    const fileNamePattern = new RegExp(
+      `^[a-z0-9][a-z0-9-]*\\.(${changelogCategories.join("|")})\\.md$`,
+    );
+
+    for (const fragmentName of fragmentNames) {
+      expect(fragmentName).toMatch(fileNamePattern);
+
+      const source = (
+        await readFile(join(changesDirectory, fragmentName), "utf8")
+      ).replaceAll("\r\n", "\n");
+      const fragment = source.match(/^---\n([\s\S]*?)\n---\n\n([\s\S]*\S)\n?$/);
+
+      expect(fragment).not.toBeNull();
+      const metadataSource = fragment?.[1];
+      const body = fragment?.[2];
+      if (metadataSource === undefined || body === undefined) {
+        throw new Error(
+          `Invalid changelog fragment structure: ${fragmentName}`,
+        );
+      }
+
+      const impact = parseYaml(metadataSource) as Record<string, unknown>;
+      expect(Object.keys(impact).sort()).toEqual(["@githits/mcp", "githits"]);
+      expect(isSemverImpact(impact.githits)).toBe(true);
+      expect(isSemverImpact(impact["@githits/mcp"])).toBe(true);
+
+      expect(body).toMatch(
+        /^- \*\*[^*\n]+\*\* - \S[^\n]*(?:\n {2,}\S[^\n]*)*$/,
       );
     }
   });


### PR DESCRIPTION
## Summary

- record each notable unreleased change in an independently owned `changes/<slug>.<category>.md` fragment
- preserve explicit `githits` and `@githits/mcp` SemVer impact in fragment front matter
- define atomic handling for cross-artifact changes and migrate the pending CLI validation note
- validate fragment names, metadata, and Markdown body shape in release-boundary tests

## Validation

- `bun test` (2,768 passed)
- `bun run typecheck`
- `bun run format:check`
- `bun run lint`
- `bun run build`
- `bun run validate:packages`
- `bun run plugins:generate`
- `bun run plugins:check`

Agentic evals were not run because the harness intentionally excludes repository `AGENTS.md` and internal release skills.