### PR TITLE
Clarify repository-wide CodeDiff behavior

### DIFF
--- a/changes/code-diff-repository-scope.fixed.md
+++ b/changes/code-diff-repository-scope.fixed.md
@@ -1,0 +1,9 @@
+---
+"githits": patch
+"@githits/mcp": patch
+---
+
+- **Clarify repository-wide code diffs** - CLI help, legacy-scope diagnostics,
+  and public client documentation now explain that package targets resolve
+  repository and commit identity while raw diffs remain repository-wide and
+  may include only sibling paths when results are bounded.

--- a/docs/implementation/cli-commands.md
+++ b/docs/implementation/cli-commands.md
@@ -32,7 +32,7 @@ The CLI exposes setup/auth commands, `doctor`, `example`, `languages`, `feedback
 | `pkg upgrade-review [spec]` | single package spec with current version plus `--to`, OR repeatable `--package` ranges | `--to`, repeatable `--package`, `--no-transitive-security`, `--dependency-issues`, `--min-severity`, `--verbose`, `--json` | Compare current and target versions for upgrade evidence: vulnerabilities, changelog entries, deprecation metadata, peer changes, dependency changes, and transitive security evidence by default. Reports facts only. |
 | `docs list <spec>` | package spec (optional `@version`) | `--limit`, `--after`, `--verbose`, `--json` | List hosted/crawled and repository-backed documentation pages for a package. Entries include page IDs for `docs read`; JSON includes exact repo-file follow-up metadata when available. |
 | `docs read <page-id>` | page ID from `docs list` or search results | `--lines`, `--verbose`, `--json` | Read a documentation page by page ID. Default output is content-only; `--lines` fetches a bounded range for long pages. |
-| `code diff <target> <from>..<to>` | unversioned package/repository target and exact range, or `--repo-url` and range | `--patch`, `--stat`, `--name-only`, `--name-status`, `--max-files`, `--max-patch-bytes`, `--verbose`, `--json`, one glob after `--` | Silently dogfood a bounded exact-tree diff; not exposed through MCP or agent guidance |
+| `code diff <target> <from>..<to>` | unversioned package/repository target and exact range, or `--repo-url` and range | `--patch`, `--stat`, `--name-only`, `--name-status`, `--max-files`, `--max-patch-bytes`, `--verbose`, `--json`, one glob after `--` | Silently dogfood bounded repository-wide tree diffs resolved from package versions or repository refs; not exposed through MCP or agent guidance |
 | `code files [spec] [path-prefix]` | package spec OR `--repo-url` with optional `--git-ref`; optional `[path-prefix]` | `--path`, repeatable `--glob`, repeatable `--ext`, repeatable `--file-type`, repeatable `--language`, repeatable `--file-intent`, repeatable `--exclude-intent`, `--exclude-docs`, `--exclude-tests`, `--hidden`, `--limit`, `--wait`, `--verbose`, `--json` | List files in an indexed dependency. Selectors (`[path-prefix]`, `--path`, `--glob`) are OR-ed; the other flags filter that scope down further. Plain output is one path per line; `--verbose` adds language / type / size annotations. Indexing errors include elapsed/expected duration when available plus retry via `--wait` or indexed refs/versions from the error detail. |
 | `code read <spec?> <path>` | package spec OR `--repo-url` with optional `--git-ref`; plus `<path>` | `--lines`, `--start`, `--end`, `--wait`, `--verbose`, `--json` | Read a file's contents. Plain output is the raw file bytes (pipe-friendly); `--verbose` adds a header and a line-number gutter. `--lines 10-40` concise form; `--start`/`--end` equivalent. Binary files show a sentinel line. |
 | `code grep [spec] <pattern> [path-prefix]` | package spec OR `--repo-url` with optional `--git-ref`; plus `<pattern>` and optional `[path-prefix]` | `--path`, repeatable `--glob`, repeatable `--ext`, `--regex`, `--case-sensitive`, `-C/-A/-B`, `--exclude-docs`, `--exclude-tests`, `--limit`, `--per-file-limit`, `--cursor`, `--symbol-field`, `--wait`, `--verbose`, `--json` | Deterministic text grep over indexed dependency or repository source. Defaults to whole-target, literal, ASCII case-insensitive matching; non-ASCII letters match case-sensitively. Narrow with `[path-prefix]`, `--path`, `--glob`, or `--ext`. Plain output is `file:line:text`; `--verbose` groups matches by file. |
@@ -512,22 +512,34 @@ githits code diff npm:express 4.18.1..4.18.2 --name-status -- 'lib/**/*.js'
 githits code diff --repo-url https://github.com/expressjs/express v4.18.1..v4.18.2 --name-only
 ```
 
-Compares two exact source trees left-to-right. Package targets must omit a
-version and repository targets must omit a ref because both endpoints belong
-in the required two-dot range. Three-dot merge-base syntax and `--git-ref` are
-rejected. The optional value after `--` is one repository-relative bounded
-glob, not a full Git pathspec. A backslash escapes one following non-slash
+Compares repository trees resolved from package versions or repository refs,
+left-to-right. Package targets must omit a version and repository targets must
+omit a ref because both endpoints belong in the required two-dot range.
+Package addressing resolves package, repository, version, and exact-commit
+identity, but every raw diff is repository-wide. It does not discover or filter
+to a package directory. Sibling package paths may therefore appear, and a
+bounded relevance-ranked result may contain no files from the addressed
+package. That absence does not prove the package is unchanged.
+
+Three-dot merge-base syntax and `--git-ref` are rejected. The optional value
+after `--` is one caller-supplied repository-relative bounded glob, not a full
+Git pathspec or verified package scope. It narrows repository paths without
+changing the effective scope. A backslash escapes one following non-slash
 character according to the backend grammar.
 
 Patch output is the default. `--stat`, `--name-only`, and `--name-status`
 select cheaper views and are mutually exclusive with `--patch` and each other.
-`--max-files` applies to every view; `--max-patch-bytes` is patch-only. The CLI
-does not send client defaults for either bound.
+`--max-files` applies to every view after deterministic repository-relative
+relevance ranking; `--max-patch-bytes` is patch-only. The CLI does not send
+client defaults for either bound.
 
-The selected Git-like view stays on stdout. Completeness, truncation, scope,
-content-safety, and display-only path warnings stay on stderr; `--verbose` adds
-exact resolutions and scope facts there. JSON keeps the same evidence as a
-lean selected-view envelope, including authoritative paths in normalized patch
+The selected Git-like view stays on stdout. Exceptional completeness,
+truncation, legacy-`UNKNOWN` scope, content-safety, and display-only path
+warnings stay on stderr; normal repository scope is not a warning.
+`--verbose` adds exact resolutions and `scope: repository` there. JSON keeps
+package target identity, exact resolutions, effective repository scope, caller
+filters, completeness, and truncation as separate facts in the lean
+selected-view envelope, including authoritative paths in normalized patch
 headers. Text paths use reversible Git-style quoting rather than deleting
 control characters. Stat columns use terminal-cell width, so wide Unicode and
 emoji filenames remain aligned. Interactive color-capable terminals use

--- a/docs/implementation/code-diff.md
+++ b/docs/implementation/code-diff.md
@@ -27,6 +27,15 @@ Repository requests send only `repoUrl`, `fromRef`, and `toRef`. Raw options are
 omitted when empty. The adapter does not infer refs, synthesize patches,
 detect renames, or fall back to a hosted compare endpoint.
 
+Both addressing forms return repository-wide raw results. Package addressing
+resolves package, repository, version, and exact-commit identity, but does not
+discover or filter to a package subpath. Caller-supplied `pathPrefix` and
+`pathGlob` narrow repository-relative paths without changing
+`scope.status: REPOSITORY` or proving package ownership. Sibling package paths
+may appear, and deterministic repository-relative relevance ranking plus
+`maxFiles` can produce a bounded result with no files from the addressed
+package. That absence does not prove the package is unchanged.
+
 Target selection uses own-key presence: an opposite target key is rejected even
 when its value is `undefined`.
 
@@ -39,11 +48,13 @@ network request.
 ## Response and error contract
 
 Successful responses require a non-null `raw` result. The normalized result
-preserves both exact resolutions, package identity when present, scoped
-summary, scope, content coverage/failure, file identity/status/content status,
-backend content-safety modifications, and `hasMoreFiles`. A non-null raw
-inventory remains successful even when it contains `contentFailure`; that is
-post-inventory partial content, not a transport failure.
+preserves both exact resolutions, package identity when present,
+repository-wide summary and scope, caller filters, content coverage/failure,
+file identity/status/content status, backend content-safety modifications, and
+`hasMoreFiles`. A non-null raw inventory remains successful even when it
+contains `contentFailure`; that is post-inventory partial content, not a
+transport failure. Current successful results use `REPOSITORY`; `PACKAGE` and
+`UNKNOWN` remain accepted only for compatibility with older backends.
 
 Raw field-local GraphQL failures are represented by `CodeDiffError`. Its
 `details` object retains only the bounded backend extension fields needed for
@@ -100,11 +111,16 @@ owns its defaults.
 Plain stdout contains only the selected Git-like projection. Resolution,
 scope, truncation, unprojectable-file, content-coverage, path-encoding, and
 content-safety diagnostics go to stderr. `--verbose` adds exact identity and
-scope diagnostics without changing the primary stream. `--json` emits a lean
-camel-case data envelope whose file objects include only fields relevant to the
-selected view, except that `pathEncoding` is always retained to distinguish
-display-only byte escapes. Text views use reversible Git-style quoting for
-control characters, quotes, and backslashes instead of changing path identity.
+scope diagnostics without changing the primary stream, including
+`scope: repository` for current results. Repository scope is normal and does
+not produce a warning; legacy `UNKNOWN` remains visibly repository-wide.
+`--json` emits a lean camel-case data envelope whose separate package target,
+exact resolutions, effective `scope: {status: "repository"}`, caller filters,
+and completeness fields preserve the contract without presentation prose. File
+objects include only fields relevant to the selected view, except that
+`pathEncoding` is always retained to distinguish display-only byte escapes.
+Text views use reversible Git-style quoting for control characters, quotes, and
+backslashes instead of changing path identity.
 Stat rows measure quoted paths in terminal cells rather than JavaScript string
 length, keeping dividers aligned for wide Unicode and emoji filenames. On an
 interactive color-capable terminal, patch additions/deletions, stat bars, and

--- a/packages/core-internal/src/services/code-navigation-service.ts
+++ b/packages/core-internal/src/services/code-navigation-service.ts
@@ -448,8 +448,10 @@ export interface ReadFileResult {
 }
 
 /**
- * A package target for CodeDiff. Version resolution belongs to the
- * comparison endpoints, so this target intentionally has no version field.
+ * A package-addressing target for a repository-wide CodeDiff. Version
+ * resolution belongs to the comparison endpoints, so this target
+ * intentionally has no version field. Package addressing resolves repository
+ * identity and commits; it does not narrow raw file results to a package path.
  * Target selection uses own-key presence; a `repoUrl` key rejects this shape
  * even when its value is `undefined`.
  */
@@ -491,6 +493,11 @@ export type CodeDiffRefKind = "SHA" | "TAG" | "BRANCH" | "HEAD" | "UNKNOWN";
 
 export type CodeDiffVersionSource = "REGISTRY" | "GIT_HEAD" | "TAG" | "RELEASE";
 
+/**
+ * Effective raw inventory scope. Current successful backends return
+ * `REPOSITORY`; `PACKAGE` and `UNKNOWN` remain accepted for compatibility with
+ * legacy responses.
+ */
 export type RawCodeDiffScopeStatus = "PACKAGE" | "REPOSITORY" | "UNKNOWN";
 
 export type RawCodeDiffFileStatus = "ADDED" | "DELETED" | "MODIFIED";
@@ -545,10 +552,15 @@ export interface RawCodeDiffSummary {
 }
 
 export interface RawCodeDiffScope {
+  /** Scope of returned paths and counts, independent of addressing form. */
   status: RawCodeDiffScopeStatus;
+  /** Legacy package-scope metadata; absent from current repository results. */
   fromSubpath?: string;
+  /** Legacy package-scope metadata; absent from current repository results. */
   toSubpath?: string;
+  /** Caller-supplied repository-relative filter, not verified package scope. */
   pathPrefix?: string;
+  /** Caller-supplied repository-relative filter, not verified package scope. */
   pathGlob?: string;
 }
 

--- a/packages/mcp/src/services/test-helpers.ts
+++ b/packages/mcp/src/services/test-helpers.ts
@@ -273,9 +273,7 @@ export const defaultCodeDiffResult: CodeDiffResult = {
       unprojectableFiles: 0,
     },
     scope: {
-      status: "PACKAGE",
-      fromSubpath: "",
-      toSubpath: "",
+      status: "REPOSITORY",
     },
     contentCoverage: "COMPLETE",
     files: [

--- a/packages/mcp/src/shared/code-diff-response.test.ts
+++ b/packages/mcp/src/shared/code-diff-response.test.ts
@@ -174,7 +174,7 @@ describe("buildCodeDiffSuccessPayload", () => {
     expect(Object.hasOwn(payload.to, "resolvedVersion")).toBe(false);
   });
 
-  it("preserves summary, root package scope, truncation, and coverage facts", () => {
+  it("preserves summary, legacy package scope, truncation, and coverage facts", () => {
     const payload = buildCodeDiffSuccessPayload(
       makeResult(),
       options(packageTarget, "name-only"),

--- a/packages/mcp/src/shared/code-diff-text.test.ts
+++ b/packages/mcp/src/shared/code-diff-text.test.ts
@@ -35,7 +35,7 @@ function envelope(
       inventoryComplete: true,
       unprojectableFiles: 0,
     },
-    scope: { status: "package", fromSubpath: "", toSubpath: "" },
+    scope: { status: "repository" },
     contentCoverage: "complete",
     files: [],
     hasMoreFiles: false,
@@ -652,10 +652,9 @@ describe("formatCodeDiffTerminal", () => {
       options,
     );
 
-    expect(result.stderr).toContain(
-      "Showing changes for the entire repository",
-    );
-    expect(result.stderr).toContain("Unrelated files may be included");
+    expect(result.stderr).toContain("legacy unknown scope metadata");
+    expect(result.stderr).toContain("Treat this diff as repository-wide");
+    expect(result.stderr).toContain("unrelated paths may be included");
     expect(result.stderr).toContain("inventory is incomplete");
     expect(result.stderr).toContain("More matching files");
     expect(result.stderr).toContain("Add a path glob after `--`");
@@ -667,7 +666,7 @@ describe("formatCodeDiffTerminal", () => {
     expect(result.stderr).toContain("modified for content safety");
   });
 
-  it("explains that an unknown package scope applies the glob repository-wide", () => {
+  it("explains that legacy unknown scope applies the glob repository-wide", () => {
     const result = formatCodeDiffTerminal(
       envelope({
         scope: { status: "unknown", pathGlob: "packages/**/*.ts" },
@@ -676,27 +675,45 @@ describe("formatCodeDiffTerminal", () => {
     );
 
     expect(result.stderr).toContain(
-      "the path glob was applied across the entire repository",
+      "the path glob was applied repository-wide",
     );
     expect(result.stderr).toContain(
-      "Matching files from other packages may be included",
+      "Matching paths from anywhere in the repository may be included",
     );
     expect(result.stderr).toContain("narrow the path glob if needed");
-    expect(result.stderr).not.toContain("add a path glob");
+    expect(result.stderr).not.toContain("Add a path glob");
   });
 
-  it("offers a path glob when unknown package scope is otherwise complete", () => {
+  it("offers a path glob when legacy unknown scope is otherwise complete", () => {
     const result = formatCodeDiffTerminal(
       envelope({ scope: { status: "unknown" } }),
       options,
     );
 
-    expect(result.stderr).toContain(
-      "Showing changes for the entire repository",
-    );
+    expect(result.stderr).toContain("Treat this diff as repository-wide");
     expect(result.stderr).toContain(
       "Add a path glob after `--` to narrow the diff",
     );
+  });
+
+  it("keeps normal repository scope quiet for package targets", () => {
+    const result = formatCodeDiffTerminal(
+      envelope({ scope: { status: "repository" } }),
+      options,
+    );
+
+    expect(result.stderr).toBeUndefined();
+  });
+
+  it("reports repository scope in verbose package diagnostics", () => {
+    const result = formatCodeDiffTerminal(envelope(), {
+      useColors: false,
+      verbose: true,
+    });
+
+    expect(result.stderr).toContain("target: npm:example");
+    expect(result.stderr).toContain("scope: repository");
+    expect(result.stderr).not.toContain("legacy unknown scope metadata");
   });
 
   it("adds full exact identity and scope facts only in verbose diagnostics", () => {

--- a/packages/mcp/src/shared/code-diff-text.ts
+++ b/packages/mcp/src/shared/code-diff-text.ts
@@ -258,10 +258,10 @@ function buildDiagnostics(
 
   if (envelope.scope.status === "unknown") {
     let message =
-      "Showing changes for the entire repository because GitHits could not identify this package's directory. Unrelated files may be included.";
+      "GitHits returned legacy unknown scope metadata. Treat this diff as repository-wide; unrelated paths may be included.";
     if (envelope.scope.pathGlob) {
       message =
-        "GitHits could not identify this package's directory, so the path glob was applied across the entire repository. Matching files from other packages may be included; narrow the path glob if needed.";
+        "GitHits returned legacy unknown scope metadata, so the path glob was applied repository-wide. Matching paths from anywhere in the repository may be included; narrow the path glob if needed.";
     } else if (!envelope.hasMoreFiles) {
       message += " Add a path glob after `--` to narrow the diff.";
     }

--- a/src/commands/code/diff.test.ts
+++ b/src/commands/code/diff.test.ts
@@ -96,6 +96,8 @@ describe("codeDiffAction", () => {
     const payload = JSON.parse(log.mock.calls[0]?.[0] as string);
     expect(payload.view).toBe("name-only");
     expect(payload.from.commitSha).toBe("from-sha");
+    expect(payload.to.commitSha).toBe("to-sha");
+    expect(payload.scope).toEqual({ status: "repository" });
     expect(payload.files).toEqual([
       { path: "lib/express.js", pathEncoding: "utf8" },
     ]);
@@ -451,6 +453,13 @@ describe("registerCodeDiffCommand", () => {
       "githits code diff [options] --repo-url <url> <from>..<to> [-- <path-glob>]",
     );
     expect(help).not.toContain("[target-or-range] [range-or-path-glob]");
+    expect(help).toContain(
+      "Compare repository trees resolved from package versions or repository refs",
+    );
+    expect(help).toContain("Diffs are always repository-wide");
+    expect(help).toContain("Sibling package paths");
+    expect(help).toContain("bounded relevance-ranked result may contain no");
+    expect(help).toContain("Maximum relevance-ranked returned files");
     expect(help).toContain("Target examples: `npm:express`");
     expect(help).toContain("suppressed patch output exits 1");
   });

--- a/src/commands/code/diff.ts
+++ b/src/commands/code/diff.ts
@@ -273,7 +273,13 @@ function formatRecoveryList(
   return omitted > 0 ? `${shown} (+${omitted} more)` : shown;
 }
 
-const CODE_DIFF_DESCRIPTION = `Compare two exact dependency source trees.
+const CODE_DIFF_DESCRIPTION = `Compare repository trees resolved from package versions or repository refs.
+
+Diffs are always repository-wide, subject only to an explicit caller-supplied
+path glob. Package targets resolve repository identity, versions, and exact
+commits; they do not narrow files to a package directory. Sibling package paths
+may appear, and a bounded relevance-ranked result may contain no files from the
+addressed package.
 
 The default output is a bounded patch, matching ordinary \`git diff\` where the
 backend contract permits it. Select --stat, --name-only, or --name-status for
@@ -298,7 +304,7 @@ export function registerCodeDiffCommand(
 ): Command {
   return codeCommand
     .command("diff")
-    .summary("Compare two dependency source trees")
+    .summary("Compare resolved repository trees")
     .description(CODE_DIFF_DESCRIPTION)
     .usage(
       "[options] <target> <from>..<to> [-- <path-glob>]\n       githits code diff [options] --repo-url <url> <from>..<to> [-- <path-glob>]",
@@ -320,7 +326,10 @@ export function registerCodeDiffCommand(
     .option("--stat", "Emit per-file line statistics")
     .option("--name-only", "Emit changed paths only")
     .option("--name-status", "Emit change status and path")
-    .option("--max-files <n>", "Maximum returned files (1-300)")
+    .option(
+      "--max-files <n>",
+      "Maximum relevance-ranked returned files (1-300)",
+    )
     .option(
       "--max-patch-bytes <bytes>",
       "Maximum aggregate patch bytes (1024-2097152; patch view only)",

--- a/src/services/test-helpers.ts
+++ b/src/services/test-helpers.ts
@@ -515,9 +515,7 @@ export const defaultCodeDiffResult: CodeDiffResult = {
       unprojectableFiles: 0,
     },
     scope: {
-      status: "PACKAGE",
-      fromSubpath: "",
-      toSubpath: "",
+      status: "REPOSITORY",
     },
     contentCoverage: "COMPLETE",
     files: [


### PR DESCRIPTION
## Summary

- explain that package targets resolve repository identity and commits while raw diffs remain repository-wide
- document sibling-path and bounded-result behavior across CLI help, implementation docs, and public client types
- keep normal repository scope quiet and make legacy UNKNOWN diagnostics target-neutral
- preserve the silent dogfood boundary with no MCP tool, skill, or agent-instruction exposure

## Validation

- `bun test` — 2913 passed, 0 failed
- `bun run build` — passed
- `bun run format:check` — passed
- `bun run plugins:generate` and `bun run plugins:check` — passed with no generated asset changes
- `bun run smoke:cli --mode unauthenticated` — 12/12 passed
- `bun run smoke:mcp` — passed unauthenticated
- targeted CodeDiff tests after review fixes — 63 passed, 0 failed
- internal Codex review and three-round Claude Opus review loop — final round clean

Authenticated live CLI smoke was not fully green because a later unrelated `example` request was rate-limited.