### PR TITLE
fix: gate resolve target next actions by confidence

### DIFF
--- a/changes/resolve-target-actionability.fixed.md
+++ b/changes/resolve-target-actionability.fixed.md
@@ -1,0 +1,8 @@
+---
+"githits": patch
+"@githits/mcp": patch
+---
+
+- **Require confident target resolution** - Resolve guidance now emits direct
+  canonical next actions only for non-ambiguous exact or high-confidence
+  matches; weaker and empty results require explicit correction or selection.

--- a/changes/resolve-target-actionability.fixed.md
+++ b/changes/resolve-target-actionability.fixed.md
@@ -1,6 +1,6 @@
 ---
 "githits": patch
-"@githits/mcp": patch
+"@githits/mcp": none
 ---
 
 - **Require confident target resolution** - Resolve guidance now emits direct

--- a/docs/implementation/cli-commands.md
+++ b/docs/implementation/cli-commands.md
@@ -309,12 +309,18 @@ stars, the terminal shows its linked repository as compact
 `github:owner/repo` when possible and otherwise preserves the repository URL.
 Missing evidence is omitted rather than shown as zero.
 
-The copyable `githits search --in` follow-up uses the resolved target only for
-non-ambiguous results. Ambiguous results use the literal `<target>` placeholder
-so the terminal does not imply that candidate 1 was selected. No candidates is
-a valid JSON/text result but exits 1 because the command did not resolve a
-target. The backend guarantees that `best` is absent only when there are no
-candidates, so the terminal no-result message and exit status key off `best`.
+Terminal and MCP compact text share one actionability rule. A best result is a
+copyable/direct canonical next action only when it is non-ambiguous and has
+`EXACT` or `HIGH` confidence. Non-ambiguous `MEDIUM` and `LOW` results are
+labeled as unconfirmed ranked candidates and require the caller to narrow the
+name or filters, or choose a canonical candidate explicitly. Ambiguous results
+retain their existing choose-or-narrow guidance and literal `<target>`
+placeholder. Empty results ask for corrected spelling or adjusted
+registry filters; query, preferred-kind, and intent hints are ranking-only and
+cannot create candidates. No candidates is a valid JSON/text result but exits 1
+because the command did not resolve a target. The backend guarantees that
+`best` is absent only when there are no candidates, so the terminal no-result
+message and exit status key off `best`.
 
 `--registry` accepts a comma-separated package-registry list and the command
 help enumerates every accepted value; repository candidates remain eligible.
@@ -332,8 +338,9 @@ objects occur once; `best` and `protectedMatches` use canonical-key references.
 Reference-only best/protected targets outside the ranked list produce minimal
 candidate objects with `target`, `kind`, and `confidence`, because no redundant
 detail fields are requested for those lists. Detailed ranking fields are fetched
-only for JSON. Null fields are omitted and enum values are lowercase. Errors use
-the standard JSON envelope on stderr with clean stdout.
+only for JSON. The actionability rule does not add or remove JSON fields. Null
+fields are omitted and enum values are lowercase. Errors use the standard JSON
+envelope on stderr with clean stdout.
 
 The command and local experimental MCP adapter use an internal service and do
 not change the public `@githits/mcp` service interface. Its GraphQL selection keeps `best` and

--- a/docs/implementation/cli-commands.md
+++ b/docs/implementation/cli-commands.md
@@ -297,7 +297,7 @@ githits resolve "pi agent" --query "coding agent CLI" --json
 
 Resolves a human-provided package or GitHub repository name to ranked canonical
 targets such as `npm:express` or `github:openai/codex`. The default output is a
-compact numbered `Candidates` list with ambiguity guidance when needed and
+compact numbered candidate list with ambiguity guidance when needed and
 protected exact-name matches annotated inline. It does not label any terminal
 candidate as best or top. Ranked candidates include their available normalized
 description, capped at 240 characters, and cheap trust evidence: repository

--- a/docs/implementation/mcp-cli-parity.md
+++ b/docs/implementation/mcp-cli-parity.md
@@ -163,8 +163,12 @@ test suite anchors the doc.
   names a command/flag and MCP names a tool/argument.
 - Text rendering, agent-specific descriptions, and the deliberate default
   view divergence are not parity targets. The MCP default is compact
-  `text-v1`; `code_diff` patch previews are bounded at 320 UTF-8 bytes, label
-  each affected file, and emit one aggregate `Next:` recovery, while
+  `text-v1`. Both resolve text renderers nevertheless use the same pure
+  actionability rule: only a non-ambiguous `EXACT`/`HIGH` best result can emit a
+  direct canonical next action; `MEDIUM`/`LOW` results remain unconfirmed and
+  empty results point to spelling or filters rather than ranking-only context.
+  `code_diff` patch previews are bounded at 320 UTF-8 bytes, label each affected
+  file, and emit one aggregate `Next:` recovery, while
   `format: "json"` returns the full patch returned by the backend subject to
   backend limits and content coverage. Parity uses `format: "json"`
   explicitly.

--- a/docs/implementation/tools.md
+++ b/docs/implementation/tools.md
@@ -282,8 +282,11 @@ The MCP server advertises a short, cross-tool orientation via the protocol's ser
 - **Local experimental block** — appended only by the workspace-internal local
   composer when the host policy enables experimental tools. It names only the
   registered local `resolve_target`/`code_diff` subset, routes fuzzy identity
-  before canonical diff evidence, states public-OSS/privacy limits, and adds
-  opt-in negative-feedback guidance only for the configured reporting scope.
+  before canonical diff evidence, and permits direct reuse of a resolved target
+  only for a non-ambiguous `EXACT` or `HIGH` best result. `MEDIUM`, `LOW`, and
+  ambiguous results require narrowing or an explicit choice. The block also
+  states public-OSS/privacy limits and adds opt-in negative-feedback guidance
+  only for the configured reporting scope.
   Disabled or dormant reporting returns the public builder's exact baseline;
   public and remote servers never receive this block.
 

--- a/docs/plans/experimental-tools.md
+++ b/docs/plans/experimental-tools.md
@@ -246,12 +246,16 @@ does not change.
   deliberately by the shared builder; raw Zod errors do not escape.
 - The service request selects detailed ranking fields only for JSON. Compact
   text shows ranked candidates, ambiguity, protected exact-name matches, cheap
-  evidence, and an MCP-native follow-up. An ambiguous result never tells the
-  agent to select candidate one automatically.
+  evidence, and confidence-appropriate MCP follow-up guidance. Only a
+  non-ambiguous `EXACT` or `HIGH` best result is directly actionable;
+  `MEDIUM`, `LOW`, and ambiguous results require narrowing or an explicit
+  choice.
 - Descriptions state that query and intent hints leave the machine and must not
   contain credentials, personal data, private code, or proprietary content.
-- No-candidate and ambiguous results remain successful evidence envelopes; the
-  text tells the agent whether human judgment or a changed query is required.
+- No-candidate and ambiguous results remain successful evidence envelopes.
+  No-candidate text asks for corrected spelling or adjusted registry filters;
+  query, preferred-kind, and intent hints only rank existing candidates.
+  Ambiguous text preserves human-judgment and narrowing guidance.
   Transport/auth/service failures use the established structured MCP errors.
 
 ### `code_diff` agent contract

--- a/docs/plans/experimental-tools.md
+++ b/docs/plans/experimental-tools.md
@@ -493,6 +493,12 @@ as helped with high confidence and reported no tool or instruction issues. The
 retained Opus implementation reviewer then returned a clean verdict on the
 final delta with no actionable findings.
 
+A later consumer-actionability review found that non-ambiguous `MEDIUM` and
+`LOW` best results were still presented as direct next actions. Shared CLI/MCP
+formatter gating now keeps those results unconfirmed and requires narrowing or
+an explicit choice, while preserving direct actions for non-ambiguous `EXACT`
+and `HIGH` results.
+
 ### Likely files and components
 
 - `src/services/` config parser/loader modules and focused tests, refactoring

--- a/packages/mcp/src/mcp/instructions.test.ts
+++ b/packages/mcp/src/mcp/instructions.test.ts
@@ -37,7 +37,9 @@ describe("buildLocalMcpInstructions", () => {
     expect(instructions).toContain("`resolve_target`");
     expect(instructions).toContain("`code_diff`");
     expect(instructions).toContain("canonical `registry:name`");
-    expect(instructions).toContain("never guess");
+    expect(instructions).toContain("EXACT/HIGH");
+    expect(instructions).toContain("MEDIUM/LOW");
+    expect(instructions).toContain("never auto-select");
     expect(instructions).toContain("`pkg_upgrade_review`");
     expect(instructions).toContain("public GitHub refs repository-wide");
     expect(instructions).toContain("name-status");
@@ -46,7 +48,7 @@ describe("buildLocalMcpInstructions", () => {
     expect(instructions).toContain("credentials");
     expect(instructions).toContain("private or proprietary content");
     expect(instructions).toContain("targets.\n\n- `resolve_target`");
-    expect(instructions).toContain("directly.\n- `code_diff`");
+    expect(instructions).toContain("auto-select.\n- `code_diff`");
     expect(instructions.length - buildMcpInstructions().length).toBeLessThan(
       900,
     );

--- a/packages/mcp/src/mcp/instructions.ts
+++ b/packages/mcp/src/mcp/instructions.ts
@@ -152,7 +152,7 @@ const LOCAL_EXPERIMENTAL_PRIVACY =
   "Inputs are sent to GitHits. Never send credentials, personal data, private or proprietary content, local paths, or private targets.";
 
 const LOCAL_RESOLVE_TARGET_GUIDANCE =
-  "- `resolve_target` — resolve only fuzzy, misspelled, ambiguous, or otherwise noncanonical names. Skip canonical `registry:name` and `github:owner/repo` targets. If ambiguous, narrow or ask; never guess. Reuse the chosen canonical target directly.";
+  "- `resolve_target` — resolve fuzzy, misspelled, or noncanonical names; skip canonical `registry:name` and `github:owner/repo`. Reuse only a non-ambiguous EXACT/HIGH best target. For MEDIUM/LOW or ambiguity, narrow or explicitly choose; never auto-select.";
 
 const LOCAL_CODE_DIFF_GUIDANCE =
   "- `code_diff` — compare exact package versions or public GitHub refs repository-wide after canonicalization. Prefer `pkg_changelog` or `pkg_upgrade_review` for upgrade summaries. Start with default `name-status`; use `stat` for magnitude or a scoped `patch` for content. Keep `text-v1` unless exact fields or the full returned patch are needed. Treat truncation, coverage, and safety warnings as evidence limits; diffs do not prove compatibility.";

--- a/packages/mcp/src/shared/resolve-target-response.test.ts
+++ b/packages/mcp/src/shared/resolve-target-response.test.ts
@@ -280,6 +280,30 @@ describe("formatResolveTargetTerminal", () => {
     }
   });
 
+  it("preserves ambiguous guidance when the best result has LOW confidence", () => {
+    const best = candidate({ confidence: "LOW" });
+    const output = formatResolveTargetTerminal(
+      result({
+        best,
+        candidates: [best],
+        protectedMatches: [],
+        ambiguous: true,
+        ambiguousReason: "LOW_CONFIDENCE",
+      }),
+      { name: "express", useColors: false },
+    );
+
+    expect(output).toContain(
+      "Ambiguous: only low-confidence matches were found",
+    );
+    expect(output).toContain("Candidates:\n  1. npm:express [low]");
+    expect(output).toContain(
+      "Next after choosing: githits search '<query>' --in '<target>'",
+    );
+    expect(output).not.toContain("Unconfirmed ranked candidates:");
+    expect(output).not.toContain("--in 'npm:express'");
+  });
+
   it("emits direct canonical next actions for EXACT and HIGH results", () => {
     for (const confidence of ["EXACT", "HIGH"] as const) {
       const best = candidate({ confidence });

--- a/packages/mcp/src/shared/resolve-target-response.test.ts
+++ b/packages/mcp/src/shared/resolve-target-response.test.ts
@@ -142,6 +142,15 @@ describe("isResolveTargetActionable", () => {
       ).toBe(false);
     }
 
+    for (const confidence of ["exact", "high", "VERY_HIGH"] as const) {
+      const best = candidate({ confidence });
+      expect(
+        isResolveTargetActionable(
+          result({ best, candidates: [best], protectedMatches: [] }),
+        ),
+      ).toBe(false);
+    }
+
     expect(isResolveTargetActionable(result({ ambiguous: true }))).toBe(false);
     expect(
       isResolveTargetActionable(
@@ -386,7 +395,7 @@ describe("formatResolveTargetTerminal", () => {
         { name: "\u001b]0;owned\u0007missing", useColors: false },
       ),
     ).toBe(
-      "No targets found for 'missing'.\nCheck the spelling or loosen --registry filters; --query, --prefer-kind, and --intent-hint only rank existing candidates.\n",
+      "No targets found for 'missing'.\nCheck the spelling or adjust --registry filters; --query, --prefer-kind, and --intent-hint only rank existing candidates.\n",
     );
   });
 
@@ -397,7 +406,7 @@ describe("formatResolveTargetTerminal", () => {
         { name: "missing", useColors: false },
       ),
     ).toBe(
-      "No targets found for 'missing'.\nCheck the spelling or loosen --registry filters; --query, --prefer-kind, and --intent-hint only rank existing candidates.\n",
+      "No targets found for 'missing'.\nCheck the spelling or adjust --registry filters; --query, --prefer-kind, and --intent-hint only rank existing candidates.\n",
     );
   });
 

--- a/packages/mcp/src/shared/resolve-target-response.test.ts
+++ b/packages/mcp/src/shared/resolve-target-response.test.ts
@@ -6,6 +6,7 @@ import type {
 import {
   buildResolveTargetSuccessPayload,
   formatResolveTargetTerminal,
+  isResolveTargetActionable,
 } from "./resolve-target-response.js";
 
 function candidate(
@@ -118,6 +119,35 @@ describe("buildResolveTargetSuccessPayload", () => {
       candidates: [],
       protectedMatches: [],
     });
+  });
+});
+
+describe("isResolveTargetActionable", () => {
+  it("accepts only non-ambiguous EXACT and HIGH best results", () => {
+    for (const confidence of ["EXACT", "HIGH"] as const) {
+      const best = candidate({ confidence });
+      expect(
+        isResolveTargetActionable(
+          result({ best, candidates: [best], protectedMatches: [] }),
+        ),
+      ).toBe(true);
+    }
+
+    for (const confidence of ["MEDIUM", "LOW"] as const) {
+      const best = candidate({ confidence });
+      expect(
+        isResolveTargetActionable(
+          result({ best, candidates: [best], protectedMatches: [] }),
+        ),
+      ).toBe(false);
+    }
+
+    expect(isResolveTargetActionable(result({ ambiguous: true }))).toBe(false);
+    expect(
+      isResolveTargetActionable(
+        result({ best: undefined, candidates: [], protectedMatches: [] }),
+      ),
+    ).toBe(false);
   });
 });
 
@@ -250,14 +280,38 @@ describe("formatResolveTargetTerminal", () => {
     }
   });
 
-  it("does not add recommendation wording for a medium result", () => {
-    const medium = candidate({ confidence: "MEDIUM" });
-    expect(
-      formatResolveTargetTerminal(
-        result({ best: medium, candidates: [medium], protectedMatches: [] }),
-        { name: "express", useColors: false },
-      ),
-    ).toContain("Candidates:\n  1. npm:express");
+  it("emits direct canonical next actions for EXACT and HIGH results", () => {
+    for (const confidence of ["EXACT", "HIGH"] as const) {
+      const best = candidate({ confidence });
+      const output = formatResolveTargetTerminal(
+        result({ best, candidates: [best], protectedMatches: [] }),
+        { name: "express", query: "middleware", useColors: false },
+      );
+
+      expect(output).toContain("Candidates:\n  1. npm:express");
+      expect(output).toContain(
+        "Next: githits search 'middleware' --in 'npm:express'",
+      );
+      expect(output).not.toContain("Unconfirmed ranked candidates:");
+    }
+  });
+
+  it("requires narrowing or an explicit choice for MEDIUM and LOW results", () => {
+    for (const confidence of ["MEDIUM", "LOW"] as const) {
+      const best = candidate({ confidence });
+      const output = formatResolveTargetTerminal(
+        result({ best, candidates: [best], protectedMatches: [] }),
+        { name: "express", query: "middleware", useColors: false },
+      );
+
+      expect(output).toContain(
+        "Unconfirmed ranked candidates:\n  1. npm:express",
+      );
+      expect(output).toContain("narrow the name or filters");
+      expect(output).toContain("explicitly choose a candidate");
+      expect(output).toContain("--in '<target>'");
+      expect(output).not.toContain("--in 'npm:express'");
+    }
   });
 
   it("normalizes and caps candidate descriptions at 240 characters", () => {
@@ -307,16 +361,23 @@ describe("formatResolveTargetTerminal", () => {
         result({ best: undefined, candidates: [], protectedMatches: [] }),
         { name: "\u001b]0;owned\u0007missing", useColors: false },
       ),
-    ).toBe("No targets found for 'missing'.\n");
+    ).toBe(
+      "No targets found for 'missing'.\nCheck the spelling or loosen --registry filters; --query, --prefer-kind, and --intent-hint only rank existing candidates.\n",
+    );
   });
 
-  it("renders no-result text and optional ANSI colors", () => {
+  it("renders corrected-spelling and filter guidance for empty results", () => {
     expect(
       formatResolveTargetTerminal(
         result({ best: undefined, candidates: [], protectedMatches: [] }),
         { name: "missing", useColors: false },
       ),
-    ).toBe("No targets found for 'missing'.\n");
+    ).toBe(
+      "No targets found for 'missing'.\nCheck the spelling or loosen --registry filters; --query, --prefer-kind, and --intent-hint only rank existing candidates.\n",
+    );
+  });
+
+  it("renders optional ANSI colors", () => {
     expect(
       formatResolveTargetTerminal(result(), {
         name: "express",

--- a/packages/mcp/src/shared/resolve-target-response.ts
+++ b/packages/mcp/src/shared/resolve-target-response.ts
@@ -102,7 +102,8 @@ export interface FormatResolveTargetTerminalOptions {
 
 /**
  * Decide whether consumers may offer the best target as a direct next action.
- * Lower-confidence results remain evidence for an explicit caller choice.
+ * Only canonical uppercase EXACT/HIGH values are actionable; unexpected values
+ * fail closed as evidence for an explicit caller choice.
  */
 export function isResolveTargetActionable(
   result: Pick<ResolveTargetResult, "ambiguous" | "best">,
@@ -120,7 +121,7 @@ export function formatResolveTargetTerminal(
   options: FormatResolveTargetTerminalOptions,
 ): string {
   if (!result.best) {
-    return `No targets found for '${sanitizeTerminalText(options.name)}'.\nCheck the spelling or loosen --registry filters; --query, --prefer-kind, and --intent-hint only rank existing candidates.\n`;
+    return `No targets found for '${sanitizeTerminalText(options.name)}'.\nCheck the spelling or adjust --registry filters; --query, --prefer-kind, and --intent-hint only rank existing candidates.\n`;
   }
   const useColors = options.useColors ?? false;
   const actionable = isResolveTargetActionable(result);
@@ -164,7 +165,7 @@ export function formatResolveTargetTerminal(
   } else {
     lines.push(
       "",
-      `Next: narrow the name or filters, or explicitly choose a candidate before running githits search ${shellQuote(query)} --in ${shellQuote("<target>")}.`,
+      `Next: narrow the name or filters, or explicitly choose a candidate before running githits search ${shellQuote(query)} --in ${shellQuote("<target>")}`,
     );
   }
   return `${lines.join("\n")}\n`;

--- a/packages/mcp/src/shared/resolve-target-response.ts
+++ b/packages/mcp/src/shared/resolve-target-response.ts
@@ -100,15 +100,30 @@ export interface FormatResolveTargetTerminalOptions {
   useColors?: boolean;
 }
 
-/** Render a compact result with explicit confidence and a copyable follow-up. */
+/**
+ * Decide whether consumers may offer the best target as a direct next action.
+ * Lower-confidence results remain evidence for an explicit caller choice.
+ */
+export function isResolveTargetActionable(
+  result: Pick<ResolveTargetResult, "ambiguous" | "best">,
+): boolean {
+  return (
+    !result.ambiguous &&
+    result.best !== undefined &&
+    (result.best.confidence === "EXACT" || result.best.confidence === "HIGH")
+  );
+}
+
+/** Render a compact result with confidence-appropriate follow-up guidance. */
 export function formatResolveTargetTerminal(
   result: ResolveTargetResult,
   options: FormatResolveTargetTerminalOptions,
 ): string {
   if (!result.best) {
-    return `No targets found for '${sanitizeTerminalText(options.name)}'.\n`;
+    return `No targets found for '${sanitizeTerminalText(options.name)}'.\nCheck the spelling or loosen --registry filters; --query, --prefer-kind, and --intent-hint only rank existing candidates.\n`;
   }
   const useColors = options.useColors ?? false;
+  const actionable = isResolveTargetActionable(result);
   const lines: string[] = [];
   if (result.ambiguous) lines.push(ambiguityMessage(result.ambiguousReason));
   const protectedKeys = new Set(
@@ -119,7 +134,11 @@ export function formatResolveTargetTerminal(
     ...result.protectedMatches,
     result.best,
   ]);
-  lines.push("Candidates:");
+  lines.push(
+    !result.ambiguous && !actionable
+      ? "Unconfirmed ranked candidates:"
+      : "Candidates:",
+  );
   lines.push(
     ...candidates.flatMap((candidate, index) =>
       formatCandidateLines(
@@ -132,13 +151,22 @@ export function formatResolveTargetTerminal(
   );
 
   const query = sanitizeTerminalText(options.query?.trim() || "<query>");
-  const target = result.ambiguous
-    ? "<target>"
-    : sanitizeTerminalText(result.best.canonicalKey);
-  lines.push(
-    "",
-    `${result.ambiguous ? "Next after choosing" : "Next"}: githits search ${shellQuote(query)} --in ${shellQuote(target)}`,
-  );
+  if (result.ambiguous) {
+    lines.push(
+      "",
+      `Next after choosing: githits search ${shellQuote(query)} --in ${shellQuote("<target>")}`,
+    );
+  } else if (actionable) {
+    lines.push(
+      "",
+      `Next: githits search ${shellQuote(query)} --in ${shellQuote(sanitizeTerminalText(result.best.canonicalKey))}`,
+    );
+  } else {
+    lines.push(
+      "",
+      `Next: narrow the name or filters, or explicitly choose a candidate before running githits search ${shellQuote(query)} --in ${shellQuote("<target>")}.`,
+    );
+  }
   return `${lines.join("\n")}\n`;
 }
 

--- a/packages/mcp/src/tools/resolve-target.test.ts
+++ b/packages/mcp/src/tools/resolve-target.test.ts
@@ -253,6 +253,34 @@ describe("resolve_target MCP adapter", () => {
     expect(ambiguousText).not.toContain("candidate 1");
   });
 
+  it("preserves ambiguous guidance when the best result has LOW confidence", () => {
+    const best = {
+      kind: "PACKAGE",
+      canonicalKey: "npm:express",
+      confidence: "LOW",
+    };
+    const text = formatResolveTargetMcpText(
+      result({
+        best,
+        candidates: [],
+        protectedMatches: [],
+        ambiguous: true,
+        ambiguousReason: "LOW_CONFIDENCE",
+      }),
+      { name: "express" },
+    );
+
+    expect(text).toContain(
+      "Ambiguous: low confidence; multiple candidates remain.",
+    );
+    expect(text).toContain("Candidates:\n  1. npm:express [low; package]");
+    expect(text).toContain("do not auto-select a candidate");
+    expect(text).not.toContain("Unconfirmed ranked candidates:");
+    expect(text).not.toContain(
+      'pass the canonical target "npm:express" to the next MCP tool',
+    );
+  });
+
   it("corrects spelling or filters for empty resolution without adding ranking context", async () => {
     const tool = createResolveTargetTool(
       createService(() =>

--- a/packages/mcp/src/tools/resolve-target.test.ts
+++ b/packages/mcp/src/tools/resolve-target.test.ts
@@ -187,13 +187,40 @@ describe("resolve_target MCP adapter", () => {
         confidence,
       };
       const text = formatResolveTargetMcpText(
-        result({ best, candidates: [], protectedMatches: [] }),
+        result({
+          best,
+          candidates: [
+            {
+              ...best,
+              docsAvailable: false,
+              codeAvailable: false,
+            },
+            {
+              kind: "REPOSITORY",
+              canonicalKey: "github:expressjs/express",
+              confidence,
+              docsAvailable: false,
+              codeAvailable: false,
+            },
+          ],
+          protectedMatches: [
+            {
+              kind: "PACKAGE",
+              canonicalKey: "jsr:@express/core",
+              confidence: "EXACT",
+            },
+          ],
+        }),
         { name: "express" },
       );
 
       expect(text).toContain(
-        `Unconfirmed ranked candidates: the best result is ${confidence.toLowerCase()} confidence.`,
+        `Unconfirmed ranked candidates: the best result is ${confidence.toLowerCase()} confidence.\n  1. npm:express`,
       );
+      expect(text).toContain(
+        "jsr:@express/core [exact; package] · protected exact-name match",
+      );
+      expect(text).not.toContain("\nCandidates:\n");
       expect(text).toContain("narrow the name or filters");
       expect(text).toContain("explicitly choose a candidate");
       expect(text).toContain("do not pass the best result automatically");
@@ -297,7 +324,7 @@ describe("resolve_target MCP adapter", () => {
     expect(response.isError).toBeUndefined();
     expect(response.content[0]?.text).toContain("No targets found");
     expect(response.content[0]?.text).toContain(
-      "Check the spelling or loosen registry filters",
+      "Check the spelling or adjust registry filters",
     );
     expect(response.content[0]?.text).toContain(
       "query, preferred kind, and intent hints only rank existing candidates",

--- a/packages/mcp/src/tools/resolve-target.test.ts
+++ b/packages/mcp/src/tools/resolve-target.test.ts
@@ -108,6 +108,11 @@ describe("resolve_target MCP adapter", () => {
       "proprietary content",
       "text-v1",
       "json",
+      "EXACT",
+      "HIGH",
+      "MEDIUM",
+      "LOW",
+      "explicit choice",
     ]) {
       expect(DESCRIPTION).toContain(phrase);
     }
@@ -152,6 +157,52 @@ describe("resolve_target MCP adapter", () => {
     });
   });
 
+  it("emits direct canonical next actions only for EXACT and HIGH results", () => {
+    for (const confidence of ["EXACT", "HIGH"] as const) {
+      const best = {
+        kind: "PACKAGE",
+        canonicalKey: "npm:express",
+        confidence,
+      };
+      const text = formatResolveTargetMcpText(
+        result({ best, candidates: [], protectedMatches: [] }),
+        { name: "express" },
+      );
+
+      expect(text).toContain(
+        `Best match: npm:express [${confidence.toLowerCase()}; package].`,
+      );
+      expect(text).toContain(
+        'Next: pass the canonical target "npm:express" to the next MCP tool.',
+      );
+      expect(text).not.toContain("Unconfirmed ranked candidates:");
+    }
+  });
+
+  it("requires narrowing or an explicit choice for MEDIUM and LOW results", () => {
+    for (const confidence of ["MEDIUM", "LOW"] as const) {
+      const best = {
+        kind: "PACKAGE",
+        canonicalKey: "npm:express",
+        confidence,
+      };
+      const text = formatResolveTargetMcpText(
+        result({ best, candidates: [], protectedMatches: [] }),
+        { name: "express" },
+      );
+
+      expect(text).toContain(
+        `Unconfirmed ranked candidates: the best result is ${confidence.toLowerCase()} confidence.`,
+      );
+      expect(text).toContain("narrow the name or filters");
+      expect(text).toContain("explicitly choose a candidate");
+      expect(text).toContain("do not pass the best result automatically");
+      expect(text).not.toContain(
+        'pass the canonical target "npm:express" to the next MCP tool',
+      );
+    }
+  });
+
   it("requests detailed fields only for JSON and reuses the stable payload", async () => {
     const service: ResolveTargetService = {
       resolveTarget: mock(() => Promise.resolve(result())),
@@ -170,7 +221,7 @@ describe("resolve_target MCP adapter", () => {
     );
   });
 
-  it("keeps ambiguous and empty resolution successful without guessing", async () => {
+  it("preserves ambiguous resolution guidance without guessing", () => {
     const ambiguous = result({
       best: undefined,
       candidates: [
@@ -200,7 +251,9 @@ describe("resolve_target MCP adapter", () => {
     expect(ambiguousText).toContain("choose the canonical target");
     expect(ambiguousText).not.toContain("Best match:");
     expect(ambiguousText).not.toContain("candidate 1");
+  });
 
+  it("corrects spelling or filters for empty resolution without adding ranking context", async () => {
     const tool = createResolveTargetTool(
       createService(() =>
         Promise.resolve(
@@ -215,6 +268,13 @@ describe("resolve_target MCP adapter", () => {
     const response = await invoke(tool, { name: "missing" });
     expect(response.isError).toBeUndefined();
     expect(response.content[0]?.text).toContain("No targets found");
+    expect(response.content[0]?.text).toContain(
+      "Check the spelling or loosen registry filters",
+    );
+    expect(response.content[0]?.text).toContain(
+      "query, preferred kind, and intent hints only rank existing candidates",
+    );
+    expect(response.content[0]?.text).not.toContain("include more context");
     expect(response.content[0]?.text).toContain("no target was invented");
   });
 

--- a/packages/mcp/src/tools/resolve-target.ts
+++ b/packages/mcp/src/tools/resolve-target.ts
@@ -149,7 +149,7 @@ export function formatResolveTargetMcpText(
     );
   } else {
     lines.push(
-      `No targets found for "${sanitizeTerminalText(options.name)}". Check the spelling or loosen registry filters; query, preferred kind, and intent hints only rank existing candidates.`,
+      `No targets found for "${sanitizeTerminalText(options.name)}". Check the spelling or adjust registry filters; query, preferred kind, and intent hints only rank existing candidates.`,
     );
   }
 

--- a/packages/mcp/src/tools/resolve-target.ts
+++ b/packages/mcp/src/tools/resolve-target.ts
@@ -11,6 +11,7 @@ import { mapPackageIntelligenceError } from "../shared/package-intelligence-erro
 import { buildResolveTargetParams } from "../shared/resolve-target-request.js";
 import {
   buildResolveTargetSuccessPayload,
+  isResolveTargetActionable,
   sanitizeTerminalText,
 } from "../shared/resolve-target-response.js";
 import { mcpMappedErrorResult } from "./shared.js";
@@ -74,7 +75,7 @@ const schema: ZodRawShape = {
 };
 
 export const DESCRIPTION =
-  "Use for fuzzy, ambiguous, misspelled, or human-friendly package and repository names when a canonical target is not known. Do not call for canonical `registry:name` or `github:owner/repo` targets; use those directly with the next MCP tool. The optional `query` and `intent_hints` values leave this machine and must not contain credentials, personal data, private code, or proprietary content. Default `text-v1` (also available as `text`) gives bounded ranked candidates and a precise MCP follow-up; use `json` for the structured result.";
+  "Use for fuzzy, ambiguous, misspelled, or human-friendly package and repository names when a canonical target is not known. Do not call for canonical `registry:name` or `github:owner/repo` targets; use those directly with the next MCP tool. The optional `query` and `intent_hints` values leave this machine and must not contain credentials, personal data, private code, or proprietary content. Default `text-v1` (also available as `text`) gives bounded ranked candidates; only a non-ambiguous EXACT or HIGH best result gets a direct MCP follow-up, while MEDIUM or LOW requires narrowing or an explicit choice. Use `json` for the structured result.";
 
 export function createResolveTargetTool(
   service: ResolveTargetService,
@@ -123,6 +124,7 @@ export function formatResolveTargetMcpText(
   result: ResolveTargetResult,
   options: FormatResolveTargetMcpTextOptions,
 ): string {
+  const actionable = isResolveTargetActionable(result);
   const protectedKeys = new Set(
     result.protectedMatches.map((target) => targetKey(target)),
   );
@@ -139,16 +141,20 @@ export function formatResolveTargetMcpText(
     lines.push(
       `Ambiguous: ${formatAmbiguousReason(result.ambiguousReason)} Choose a candidate or narrow the name, query, registry, or preferred kind before continuing.`,
     );
-  } else if (result.best) {
+  } else if (actionable && result.best) {
     lines.push(`Best match: ${formatReference(result.best)}.`);
+  } else if (result.best) {
+    lines.push(
+      `Unconfirmed ranked candidates: the best result is ${sanitizeTerminalText(result.best.confidence.toLowerCase())} confidence.`,
+    );
   } else {
     lines.push(
-      `No targets found for "${sanitizeTerminalText(options.name)}". Try a changed name, query, registry filter, or intent hint; include more context if the name is human-friendly.`,
+      `No targets found for "${sanitizeTerminalText(options.name)}". Check the spelling or loosen registry filters; query, preferred kind, and intent hints only rank existing candidates.`,
     );
   }
 
   if (references.length > 0) {
-    lines.push("Candidates:");
+    if (result.ambiguous || actionable) lines.push("Candidates:");
     references.forEach((target, index) => {
       lines.push(
         `  ${index + 1}. ${formatReference(target)}${
@@ -180,13 +186,17 @@ export function formatResolveTargetMcpText(
     lines.push(
       "Next: choose the canonical target that matches the user's intent, then pass that exact target to the next MCP tool; do not auto-select a candidate.",
     );
-  } else if (result.best) {
+  } else if (actionable && result.best) {
     lines.push(
       `Next: pass the canonical target "${sanitizeTerminalText(result.best.canonicalKey)}" to the next MCP tool.`,
     );
+  } else if (result.best) {
+    lines.push(
+      "Next: narrow the name or filters, or explicitly choose a candidate that matches the user's intent; do not pass the best result automatically.",
+    );
   } else {
     lines.push(
-      "Next: revise the name or add narrow context before requesting another resolution; no target was invented.",
+      "Next: correct the spelling or adjust filters before requesting another resolution; no target was invented.",
     );
   }
   return `${lines.join("\n")}\n`;

--- a/scripts/cli-smoke.ts
+++ b/scripts/cli-smoke.ts
@@ -821,13 +821,26 @@ async function runExperimentalLiveSmoke(
       /\n\s+\d+\. (?:npm|github):\S+/.test(resolveText),
     "experimental resolve text should include ranked canonical candidates",
   );
-  assert(
-    /Next: githits search .+ --in '(?:npm|github):[^']+'/.test(resolveText) ||
-      resolveText.includes("Next after choosing:") ||
-      (resolveText.includes("explicitly choose a candidate") &&
-        resolveText.includes("--in '<target>'")),
-    "experimental resolve text should gate its canonical next action on confidence and ambiguity",
-  );
+  const hasDirectResolveAction =
+    /Next: githits search .+ --in '(?:npm|github):[^']+'/.test(resolveText);
+  if (resolveText.includes("Unconfirmed ranked candidates:")) {
+    assert(
+      !hasDirectResolveAction &&
+        resolveText.includes("explicitly choose a candidate") &&
+        resolveText.includes("--in '<target>'"),
+      "experimental unconfirmed resolve text should require an explicit choice",
+    );
+  } else if (resolveText.includes("Ambiguous:")) {
+    assert(
+      !hasDirectResolveAction && resolveText.includes("Next after choosing:"),
+      "experimental ambiguous resolve text should require an explicit choice",
+    );
+  } else {
+    assert(
+      hasDirectResolveAction,
+      "experimental actionable resolve text should include a canonical next action",
+    );
+  }
 
   const resolveJson = assertJsonOutput(
     await runCliWithEnv(

--- a/scripts/cli-smoke.ts
+++ b/scripts/cli-smoke.ts
@@ -816,9 +816,17 @@ async function runExperimentalLiveSmoke(
     "experimental resolve terminal",
   );
   assert(
-    resolveText.includes("Candidates:") &&
+    (resolveText.includes("Candidates:") ||
+      resolveText.includes("Unconfirmed ranked candidates:")) &&
       /\n\s+\d+\. (?:npm|github):\S+/.test(resolveText),
     "experimental resolve text should include ranked canonical candidates",
+  );
+  assert(
+    /Next: githits search .+ --in '(?:npm|github):[^']+'/.test(resolveText) ||
+      resolveText.includes("Next after choosing:") ||
+      (resolveText.includes("explicitly choose a candidate") &&
+        resolveText.includes("--in '<target>'")),
+    "experimental resolve text should gate its canonical next action on confidence and ambiguity",
   );
 
   const resolveJson = assertJsonOutput(

--- a/scripts/mcp-smoke.ts
+++ b/scripts/mcp-smoke.ts
@@ -319,6 +319,14 @@ async function runExperimentalLiveSmoke(
             !resolveTextBody.includes("--"),
           "experimental resolve text should use MCP-native follow-up guidance",
         );
+        assert(
+          /Next: pass the canonical target "[^"]+"/.test(resolveTextBody) ||
+            resolveTextBody.includes("do not auto-select a candidate") ||
+            resolveTextBody.includes(
+              "do not pass the best result automatically",
+            ),
+          "experimental resolve text should gate its canonical next action on confidence and ambiguity",
+        );
 
         const resolveJson = (await trackSmokeStep(
           "mcp resolve_target JSON experimental live",

--- a/scripts/mcp-smoke.ts
+++ b/scripts/mcp-smoke.ts
@@ -319,14 +319,28 @@ async function runExperimentalLiveSmoke(
             !resolveTextBody.includes("--"),
           "experimental resolve text should use MCP-native follow-up guidance",
         );
-        assert(
-          /Next: pass the canonical target "[^"]+"/.test(resolveTextBody) ||
-            resolveTextBody.includes("do not auto-select a candidate") ||
-            resolveTextBody.includes(
-              "do not pass the best result automatically",
-            ),
-          "experimental resolve text should gate its canonical next action on confidence and ambiguity",
-        );
+        const hasDirectResolveAction =
+          /Next: pass the canonical target "[^"]+"/.test(resolveTextBody);
+        if (resolveTextBody.includes("Unconfirmed ranked candidates:")) {
+          assert(
+            !hasDirectResolveAction &&
+              resolveTextBody.includes(
+                "do not pass the best result automatically",
+              ),
+            "experimental unconfirmed resolve text should require an explicit choice",
+          );
+        } else if (resolveTextBody.includes("Ambiguous:")) {
+          assert(
+            !hasDirectResolveAction &&
+              resolveTextBody.includes("do not auto-select a candidate"),
+            "experimental ambiguous resolve text should require an explicit choice",
+          );
+        } else {
+          assert(
+            hasDirectResolveAction,
+            "experimental actionable resolve text should include a canonical next action",
+          );
+        }
 
         const resolveJson = (await trackSmokeStep(
           "mcp resolve_target JSON experimental live",

--- a/src/commands/resolve.test.ts
+++ b/src/commands/resolve.test.ts
@@ -174,7 +174,7 @@ describe("resolveAction", () => {
     );
 
     expect(String(writeSpy.mock.calls[0]?.[0])).toBe(
-      "No targets found for 'missing'.\n",
+      "No targets found for 'missing'.\nCheck the spelling or loosen --registry filters; --query, --prefer-kind, and --intent-hint only rank existing candidates.\n",
     );
     expect(process.exitCode).toBe(1);
   });

--- a/src/commands/resolve.test.ts
+++ b/src/commands/resolve.test.ts
@@ -174,7 +174,7 @@ describe("resolveAction", () => {
     );
 
     expect(String(writeSpy.mock.calls[0]?.[0])).toBe(
-      "No targets found for 'missing'.\nCheck the spelling or loosen --registry filters; --query, --prefer-kind, and --intent-hint only rank existing candidates.\n",
+      "No targets found for 'missing'.\nCheck the spelling or adjust --registry filters; --query, --prefer-kind, and --intent-hint only rank existing candidates.\n",
     );
     expect(process.exitCode).toBe(1);
   });


### PR DESCRIPTION
## Summary

- gate direct canonical next actions behind one shared non-ambiguous EXACT/HIGH actionability rule
- present MEDIUM/LOW results as unconfirmed ranked candidates and preserve ambiguous behavior
- correct empty-result guidance without changing structured JSON or backend/API selections
- add behavior-focused MCP/CLI tests, durable experimental-tool documentation, smoke assertions, and a release fragment

## Validation

- `bun test packages/mcp/src/shared/resolve-target-response.test.ts packages/mcp/src/tools/resolve-target.test.ts scripts/smoke-scripts.test.ts src/commands/resolve.test.ts` — 57 passed
- focused resolver/parity/service/instruction suite — 60 passed
- `bun run format:check`
- `bun run lint`
- `bun run build`
- `bun run validate:packages`
- `bun run plugins:generate && bun run plugins:check`
- `bun run smoke:cli` — stable and experimental live cohorts passed
- `bun run smoke:mcp` — passed on retry; the first run timed out on the unchanged `get_example` JSON call before experimental tools
- full `bun test` — 3,066 passed; two aggregate timing failures passed when rerun in isolation
- agent evals intentionally not rerun; release evaluation is already pending this change

## Review

- internal changed-delta review: clean
- fresh Claude Opus review loop: clean after closure, no remaining findings