### PR TITLE
Fail closed on malicious resolve targets

### DIFF
--- a/changes/resolve-target-malicious-status.security.md
+++ b/changes/resolve-target-malicious-status.security.md
@@ -1,0 +1,6 @@
+---
+"githits": patch
+"@githits/mcp": none
+---
+
+- **Fail closed on malicious package candidates** - Resolve output now preserves latest-version malicious-content decisions and bounded OSV evidence, links affected or uncertain advisories in warnings, and withholds normal CLI/MCP continuation for affected, unknown, or unrecognized states.

--- a/docs/experimental-tools.md
+++ b/docs/experimental-tools.md
@@ -78,6 +78,16 @@ githits resolve requests --registry pypi --prefer-kind package --json
 Canonical targets such as `npm:express` or `github:expressjs/express` do not
 need resolution.
 
+Structured output preserves each candidate's latest-version malicious-content
+decision. Text stays silent for `clear` and `not_applicable`; affected, uncertain,
+or unsupported decisions produce a concise warning, red in the terminal.
+Affected and uncertain warnings link the bounded, status-relevant `MAL-*`
+advisories returned by the resolver and explain uncertain classification reasons.
+Ordinary continuation is offered only for a non-ambiguous `EXACT`/`HIGH`
+identity with `clear` or `not_applicable` status. Other or missing decisions are
+non-actionable and suppress the normal next-tool handoff. `clear` is not a
+vulnerability-free claim.
+
 Compare exact package versions or public repository refs:
 
 ```sh

--- a/docs/implementation/cli-commands.md
+++ b/docs/implementation/cli-commands.md
@@ -340,14 +340,40 @@ objects occur once; `best` and `protectedMatches` use canonical-key references.
 Reference-only best/protected targets outside the ranked list produce minimal
 candidate objects with `target`, `kind`, and `confidence`, because no redundant
 detail fields are requested for those lists. Detailed ranking fields are fetched
-only for JSON. The actionability rule does not add or remove JSON fields. Null
-fields are omitted and enum values are lowercase. Errors use the standard JSON
-envelope on stderr with clean stdout.
+only for JSON. The always-selected non-null
+`latestVersionMaliciousStatus` candidate field is preserved in JSON as lowercase
+`latestVersionMaliciousStatus`. Nullable `latestVersionMaliciousEvidence` is
+preserved for affected and uncertain candidates with exact `osvId` values,
+lowercase `classificationReasons`, `totalCount`, and `truncated`. Null fields are
+omitted and enum values are lowercase. Errors use the standard JSON envelope on
+stderr with clean stdout.
+
+Terminal and local MCP text omit `CLEAR` and `NOT_APPLICABLE` decisions. They
+render concise warnings only for affected, uncertain, unsupported, or blocking
+unavailable evidence; terminal warnings are red. Reference-only entries remain
+non-actionable when they are not backed by a full candidate.
+Affected and uncertain warnings link every returned status-relevant advisory at
+`https://osv.dev/vulnerability/<percent-encoded-osv-id>`. Uncertain warnings also
+summarize the backend classification reasons; truncated evidence reports the
+number of omitted advisories. The warning never restores a normal cross-tool
+handoff.
+`CLEAR` means only that no persisted active MAL evidence affects the displayed
+latest version; it is not a vulnerability-free claim. `AFFECTED` means active
+malicious evidence affects that version. `UNKNOWN` means active malicious
+evidence exists but the displayed version or ranges cannot be classified
+reliably. `NOT_APPLICABLE` is the non-package state. Direct continuation requires
+the existing non-ambiguous `EXACT`/`HIGH` identity decision and a matching full
+candidate whose status is exactly `CLEAR` or `NOT_APPLICABLE`. Affected, unknown,
+missing, and unrecognized future values fail closed and emit no normal cross-tool
+next action. Ranking and filtering remain backend-owned.
 
 The command and local experimental MCP adapter use an internal service and do
 not change the public `@githits/mcp` service interface. Its GraphQL selection keeps `best` and
 `protectedMatches` to `kind`, `canonicalKey`, and `confidence`; full compact and
-conditional JSON fields are selected only for ranked `candidates`. This keeps
+conditional JSON fields are selected only for ranked `candidates`; the
+malicious-content decision is part of the compact candidate fields because every
+text surface consumes it. Its bounded advisory evidence is selected alongside the
+decision for the same reason. This keeps
 the operation below production's GraphQL complexity limit while preserving all
 fields consumed by each output mode. The CLI deliberately does not select
 expensive per-candidate `inspection` metadata. HTTP, transport, GraphQL, auth

--- a/docs/implementation/code-diff.md
+++ b/docs/implementation/code-diff.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-The transport-neutral adapter exposes PkgSeer's exact-tree `codeDiff` GraphQL
+The transport-neutral adapter exposes the backend's exact-tree `codeDiff` GraphQL
 operation to the public `@githits/mcp/client` runtime. The root package also
 registers `githits code diff` as an intentionally unpromoted CLI dogfood
 surface. The local MCP composer also exposes a config-gated `code_diff` adapter
@@ -45,7 +45,7 @@ package. That absence does not prove the package is unchanged.
 Target selection uses own-key presence: an opposite target key is rejected even
 when its value is `undefined`.
 
-The adapter rejects client values outside PkgSeer's raw bounds instead of
+The adapter rejects client values outside the backend's raw bounds instead of
 silently clamping them: `maxFiles` is `1..300`, `maxPatchBytes` is
 `1024..2097152`, and each path prefix/glob is non-empty and at most 1024 UTF-8
 bytes. Unknown raw option keys are rejected before token acquisition or a
@@ -109,7 +109,7 @@ The default is bounded patch output. `--patch`, `--stat`, `--name-only`, and
 requesting stats or patches. One optional repository-relative glob follows
 `--`. It is the backend's bounded `*`/`?`/exact-`**` grammar, not a Git
 pathspec. A backslash escapes exactly one following non-slash character; this
-mirrors PkgSeer's `CodeDiff.Raw.PathGlob` compiler rather than shell or Git
+mirrors the backend's `CodeDiff.Raw.PathGlob` compiler rather than shell or Git
 escaping. `--max-files` applies to every view and `--max-patch-bytes` applies
 only to patch output. Omitted bounds remain absent on the wire so the backend
 owns its defaults.
@@ -172,7 +172,7 @@ inventories, Agent Skills, and plugin guidance remain stable-only; any future
 promotion requires separate graduation evidence and release review.
 
 Typed changelog steering is a separate later stage, blocked on both a stable
-public CodeDiff invocation and a committed/deployed PkgSeer changelog-action
+public CodeDiff invocation and a committed/deployed backend changelog-action
 contract. Its discriminator, field names, result placement, and fallback
 behavior must come from that future backend contract rather than inferred
 prose. Package range outcomes may then steer to valid CLI and MCP calls;

--- a/docs/implementation/mcp-cli-parity.md
+++ b/docs/implementation/mcp-cli-parity.md
@@ -177,9 +177,14 @@ test suite anchors the doc.
 - Text rendering, agent-specific descriptions, and the deliberate default
   view divergence are not parity targets. The MCP default is compact
   `text-v1`. Both resolve text renderers nevertheless use the same pure
-  actionability rule: only a non-ambiguous `EXACT`/`HIGH` best result can emit a
-  direct canonical next action; `MEDIUM`/`LOW` results remain unconfirmed and
-  empty results point to spelling or filters rather than ranking-only context.
+  actionability rule: only a non-ambiguous `EXACT`/`HIGH` best result whose
+  matching candidate has `CLEAR` or `NOT_APPLICABLE` latest-version
+  malicious-content status can emit a direct canonical next action. `AFFECTED`,
+  `UNKNOWN`, missing, and future statuses fail closed. `MEDIUM`/`LOW` results
+  remain unconfirmed and empty results point to spelling or filters rather than
+  ranking-only context. Text omits actionable status lines and renders concise
+  warnings only for non-actionable evidence; CLI warnings are red while MCP text
+  remains ANSI-free.
   `code_diff` patch previews are bounded at 320 UTF-8 bytes, label each affected
   file, and emit one aggregate `Next:` recovery, while
   `format: "json"` returns the full patch returned by the backend subject to

--- a/docs/implementation/tools.md
+++ b/docs/implementation/tools.md
@@ -8,10 +8,10 @@ The CLI exposes MCP tools that mirror the backend's MCP server. This document ex
 
 GitHits has two MCP server implementations:
 
-- **Backend** (`githits-backend` / PkgSeer MCP) — Python/FastMCP, runs as hosted MCP services. Production exposes both the core example-search workflow (`get_example`, `search_language`, `feedback`) and indexed package/source tooling.
+- **Backend** (`githits-backend`) — Python/FastMCP, runs as hosted MCP services. Production exposes both the core example-search workflow (`get_example`, `search_language`, `feedback`) and indexed package/source tooling.
 - **CLI** (`githits-cli`) — TypeScript/MCP SDK, runs locally via `githits mcp start`. Surfaces the same public tool families, including unified `search`, package intelligence (`pkg_*`), docs (`docs_*`), and code navigation (`code_*`).
 
-The CLI mirrors the production MCP tool contract where equivalent tools exist. Core example-search tool descriptions are kept aligned with GitHits backend wording; indexed package/source tool descriptions are kept aligned with the PkgSeer/GitHits indexed-service contract.
+The CLI mirrors the production MCP tool contract where equivalent tools exist. Core example-search tool descriptions are kept aligned with GitHits backend wording; indexed package/source tool descriptions are kept aligned with the backend contract.
 
 ## Current Tools
 
@@ -283,10 +283,12 @@ The MCP server advertises a short, cross-tool orientation via the protocol's ser
   composer when the host policy enables experimental tools. It names only the
   registered local `resolve_target`/`code_diff` subset, routes fuzzy identity
   before canonical diff evidence, and permits direct reuse of a resolved target
-  only for a non-ambiguous `EXACT` or `HIGH` best result. `MEDIUM`, `LOW`, and
-  ambiguous results require narrowing or an explicit choice. The block also
-  states public-OSS/privacy limits and adds opt-in negative-feedback guidance
-  only for the configured reporting scope.
+  only for a non-ambiguous `EXACT` or `HIGH` best result with `CLEAR` or
+  `NOT_APPLICABLE` malicious-content status. `CLEAR` is not a vulnerability-free
+  claim. Other or missing statuses are non-actionable; `MEDIUM`, `LOW`, and
+  ambiguous results require narrowing or an explicit actionable choice. The
+  block also states public-OSS/privacy limits and adds opt-in negative-feedback
+  guidance only for the configured reporting scope.
   Disabled or dormant reporting returns the public builder's exact baseline;
   public and remote servers never receive this block.
 

--- a/packages/core-internal/src/services/resolve-target-service.test.ts
+++ b/packages/core-internal/src/services/resolve-target-service.test.ts
@@ -19,6 +19,7 @@ const LIST_CANDIDATE = {
   kind: "PACKAGE",
   canonicalKey: "npm:express",
   confidence: "EXACT",
+  latestVersionMaliciousStatus: "CLEAR",
 };
 
 const COMPACT_CANDIDATE = {
@@ -27,6 +28,7 @@ const COMPACT_CANDIDATE = {
   description: "Fast web framework",
   registry: "NPM",
   latestVersion: "5.1.0",
+  latestVersionMaliciousEvidence: null,
   repositoryUrl: "https://github.com/expressjs/express",
   stars: 66_000,
   downloadsLastMonth: 89_000_000,
@@ -45,6 +47,17 @@ const DETAILED_CANDIDATE = {
   matchTier: 0,
   score: 100,
   reason: "Exact package identity match",
+};
+
+const MALICIOUS_EVIDENCE = {
+  advisories: [
+    {
+      osvId: "MAL-2026-1234",
+      classificationReasons: ["AFFECTED_VERSION_RANGE_MATCH"],
+    },
+  ],
+  totalCount: 1,
+  truncated: false,
 };
 
 function resultBody(candidate: Record<string, unknown>) {
@@ -126,6 +139,7 @@ describe("ResolveTargetServiceImpl", () => {
       "kind",
       "canonicalKey",
       "confidence",
+      "latestVersionMaliciousStatus",
       "description",
       "repositoryUrl",
       "stars",
@@ -156,6 +170,14 @@ describe("ResolveTargetServiceImpl", () => {
     }
     expect(request.query).not.toContain("\n  protected\n");
     expect(request.query).not.toContain("inspection");
+    expect(request.query).toContain(`latestVersionMaliciousEvidence {
+    advisories {
+      osvId
+      classificationReasons
+    }
+    totalCount
+    truncated
+  }`);
     const compactResult = {
       ...LIST_CANDIDATE,
       description: "Fast web framework",
@@ -217,11 +239,65 @@ describe("ResolveTargetServiceImpl", () => {
       canonicalKey: "npm:express",
       confidence: "EXACT",
     });
-    expect(result.candidates[0]).toEqual({
-      ...DETAILED_CANDIDATE,
-      downloadsTotal: undefined,
-    });
+    const {
+      latestVersionMaliciousEvidence: _evidence,
+      downloadsTotal: _downloadsTotal,
+      ...detailedResult
+    } = DETAILED_CANDIDATE;
+    expect(result.candidates[0]).toEqual(detailedResult);
     expect(result.candidates[0]).not.toHaveProperty("downloadsTotal");
+  });
+
+  it("parses bounded malicious advisory evidence in compact mode", async () => {
+    const affected = {
+      ...COMPACT_CANDIDATE,
+      latestVersionMaliciousStatus: "AFFECTED",
+      latestVersionMaliciousEvidence: MALICIOUS_EVIDENCE,
+    };
+    const service = new ResolveTargetServiceImpl(
+      ENDPOINT,
+      createMockTokenProvider(),
+      asFetchFn(
+        mock(() => Promise.resolve(jsonResponse(resultBody(affected)))),
+      ),
+    );
+
+    const result = await service.resolveTarget({
+      name: "express",
+      limit: 8,
+      includeDetailedFields: false,
+    });
+
+    expect(result.candidates[0]?.latestVersionMaliciousEvidence).toEqual(
+      MALICIOUS_EVIDENCE,
+    );
+  });
+
+  it("rejects malformed malicious advisory evidence", async () => {
+    const malformed = {
+      ...COMPACT_CANDIDATE,
+      latestVersionMaliciousStatus: "UNKNOWN",
+      latestVersionMaliciousEvidence: {
+        advisories: [{ osvId: "MAL-2026-1234" }],
+        totalCount: 1,
+        truncated: false,
+      },
+    };
+    const service = new ResolveTargetServiceImpl(
+      ENDPOINT,
+      createMockTokenProvider(),
+      asFetchFn(
+        mock(() => Promise.resolve(jsonResponse(resultBody(malformed)))),
+      ),
+    );
+
+    await expect(
+      service.resolveTarget({
+        name: "express",
+        limit: 8,
+        includeDetailedFields: false,
+      }),
+    ).rejects.toBeInstanceOf(MalformedPackageIntelligenceResponseError);
   });
 
   it("requires detailed non-null fields only in detailed mode", async () => {
@@ -261,22 +337,74 @@ describe("ResolveTargetServiceImpl", () => {
   });
 
   it("rejects compact responses missing always-selected fields", async () => {
-    const { confidence: _confidence, ...malformed } = COMPACT_CANDIDATE;
+    const { confidence: _confidence, ...missingConfidence } = COMPACT_CANDIDATE;
+    const {
+      latestVersionMaliciousEvidence: _evidence,
+      ...missingMaliciousEvidence
+    } = COMPACT_CANDIDATE;
+
+    for (const malformed of [missingConfidence, missingMaliciousEvidence]) {
+      const service = new ResolveTargetServiceImpl(
+        ENDPOINT,
+        createMockTokenProvider(),
+        asFetchFn(
+          mock(() => Promise.resolve(jsonResponse(resultBody(malformed)))),
+        ),
+      );
+
+      await expect(
+        service.resolveTarget({
+          name: "express",
+          limit: 8,
+          includeDetailedFields: false,
+        }),
+      ).rejects.toBeInstanceOf(MalformedPackageIntelligenceResponseError);
+    }
+  });
+
+  it("requires a non-null malicious status and preserves future values", async () => {
+    for (const invalidStatus of [undefined, null]) {
+      const malformed = {
+        ...COMPACT_CANDIDATE,
+        latestVersionMaliciousStatus: invalidStatus,
+      };
+      const service = new ResolveTargetServiceImpl(
+        ENDPOINT,
+        createMockTokenProvider(),
+        asFetchFn(
+          mock(() => Promise.resolve(jsonResponse(resultBody(malformed)))),
+        ),
+      );
+
+      await expect(
+        service.resolveTarget({
+          name: "express",
+          limit: 8,
+          includeDetailedFields: false,
+        }),
+      ).rejects.toBeInstanceOf(MalformedPackageIntelligenceResponseError);
+    }
+
+    const futureStatus = {
+      ...COMPACT_CANDIDATE,
+      latestVersionMaliciousStatus: "REVIEW_REQUIRED",
+    };
     const service = new ResolveTargetServiceImpl(
       ENDPOINT,
       createMockTokenProvider(),
       asFetchFn(
-        mock(() => Promise.resolve(jsonResponse(resultBody(malformed)))),
+        mock(() => Promise.resolve(jsonResponse(resultBody(futureStatus)))),
       ),
     );
 
-    await expect(
-      service.resolveTarget({
-        name: "express",
-        limit: 8,
-        includeDetailedFields: false,
-      }),
-    ).rejects.toBeInstanceOf(MalformedPackageIntelligenceResponseError);
+    const result = await service.resolveTarget({
+      name: "express",
+      limit: 8,
+      includeDetailedFields: false,
+    });
+    expect(result.candidates[0]?.latestVersionMaliciousStatus).toBe(
+      "REVIEW_REQUIRED",
+    );
   });
 
   it("refreshes after a GraphQL authentication failure", async () => {

--- a/packages/core-internal/src/services/resolve-target-service.ts
+++ b/packages/core-internal/src/services/resolve-target-service.ts
@@ -19,6 +19,43 @@ import type { TokenProvider } from "./token-provider.js";
 
 export type ResolveTargetKind = "PACKAGE" | "REPOSITORY";
 
+export type KnownLatestVersionMaliciousStatus =
+  | "NOT_APPLICABLE"
+  | "CLEAR"
+  | "AFFECTED"
+  | "UNKNOWN";
+
+/**
+ * Backend-owned malicious-content decision for the displayed latest version.
+ * Future values remain readable and are interpreted conservatively by clients.
+ */
+export type LatestVersionMaliciousStatus =
+  | KnownLatestVersionMaliciousStatus
+  | (string & {});
+
+export type KnownMaliciousAdvisoryClassificationReason =
+  | "AFFECTED_VERSION_RANGE_MATCH"
+  | "MISSING_DISPLAYED_VERSION"
+  | "INVALID_DISPLAYED_VERSION"
+  | "MISSING_AFFECTED_RANGES"
+  | "EMPTY_AFFECTED_RANGES"
+  | "INVALID_AFFECTED_RANGE";
+
+export type MaliciousAdvisoryClassificationReason =
+  | KnownMaliciousAdvisoryClassificationReason
+  | (string & {});
+
+export interface ResolveTargetLatestVersionMaliciousAdvisory {
+  osvId: string;
+  classificationReasons: MaliciousAdvisoryClassificationReason[];
+}
+
+export interface ResolveTargetLatestVersionMaliciousEvidence {
+  advisories: ResolveTargetLatestVersionMaliciousAdvisory[];
+  totalCount: number;
+  truncated: boolean;
+}
+
 export interface ResolveTargetParams {
   name: string;
   query?: string;
@@ -41,6 +78,8 @@ export interface ResolveTargetCandidate extends ResolveTargetReference {
   registry?: string;
   packageName?: string;
   latestVersion?: string;
+  latestVersionMaliciousStatus: LatestVersionMaliciousStatus;
+  latestVersionMaliciousEvidence?: ResolveTargetLatestVersionMaliciousEvidence;
   repositoryUrl?: string;
   repositoryOwner?: string;
   repositoryName?: string;
@@ -68,10 +107,27 @@ export interface ResolveTargetService {
   resolveTarget(params: ResolveTargetParams): Promise<ResolveTargetResult>;
 }
 
+const latestVersionMaliciousEvidenceSchema = z
+  .object({
+    advisories: z
+      .array(
+        z.object({
+          osvId: z.string(),
+          classificationReasons: z.array(z.string()),
+        }),
+      )
+      .max(5),
+    totalCount: z.number().int().nonnegative(),
+    truncated: z.boolean(),
+  })
+  .nullable();
+
 const listCandidateSchema = z.object({
   kind: z.string(),
   canonicalKey: z.string(),
   confidence: z.string(),
+  latestVersionMaliciousStatus: z.string(),
+  latestVersionMaliciousEvidence: latestVersionMaliciousEvidenceSchema,
   description: z.string().nullable().optional(),
   repositoryUrl: z.string().nullable().optional(),
   stars: z.number().int().nullable().optional(),
@@ -169,6 +225,15 @@ fragment ResolveTargetListFields on TargetResolutionCandidate {
   kind
   canonicalKey
   confidence
+  latestVersionMaliciousStatus
+  latestVersionMaliciousEvidence {
+    advisories {
+      osvId
+      classificationReasons
+    }
+    totalCount
+    truncated
+  }
   description
   repositoryUrl
   stars
@@ -313,11 +378,17 @@ function normaliseCandidate(
     kind: candidate.kind,
     canonicalKey: candidate.canonicalKey,
     confidence: candidate.confidence,
+    latestVersionMaliciousStatus: candidate.latestVersionMaliciousStatus,
     docsAvailable: candidate.docsAvailable,
     codeAvailable: candidate.codeAvailable,
   };
 
   assignDefined(result, "description", candidate.description);
+  assignDefined(
+    result,
+    "latestVersionMaliciousEvidence",
+    candidate.latestVersionMaliciousEvidence,
+  );
   assignDefined(result, "repositoryUrl", candidate.repositoryUrl);
   assignDefined(result, "stars", candidate.stars);
   assignDefined(result, "downloadsLastMonth", candidate.downloadsLastMonth);

--- a/packages/mcp/src/mcp/instructions.test.ts
+++ b/packages/mcp/src/mcp/instructions.test.ts
@@ -38,6 +38,11 @@ describe("buildLocalMcpInstructions", () => {
     expect(instructions).toContain("`code_diff`");
     expect(instructions).toContain("canonical `registry:name`");
     expect(instructions).toContain("EXACT/HIGH");
+    expect(instructions).toContain("CLEAR or NOT_APPLICABLE");
+    expect(instructions).toContain(
+      "Other or missing statuses are non-actionable",
+    );
+    expect(instructions).toContain("CLEAR is not a vulnerability-free claim");
     expect(instructions).toContain("MEDIUM/LOW");
     expect(instructions).toContain("never auto-select");
     expect(instructions).toContain("`pkg_upgrade_review`");
@@ -50,7 +55,7 @@ describe("buildLocalMcpInstructions", () => {
     expect(instructions).toContain("targets.\n\n- `resolve_target`");
     expect(instructions).toContain("auto-select.\n- `code_diff`");
     expect(instructions.length - buildMcpInstructions().length).toBeLessThan(
-      900,
+      1_200,
     );
     expect(instructions).not.toContain("Issue reporting");
     expect(instructions).not.toContain("accepted: false");

--- a/packages/mcp/src/mcp/instructions.ts
+++ b/packages/mcp/src/mcp/instructions.ts
@@ -152,7 +152,7 @@ const LOCAL_EXPERIMENTAL_PRIVACY =
   "Inputs are sent to GitHits. Never send credentials, personal data, private or proprietary content, local paths, or private targets.";
 
 const LOCAL_RESOLVE_TARGET_GUIDANCE =
-  "- `resolve_target` — resolve fuzzy, misspelled, or noncanonical names; skip canonical `registry:name` and `github:owner/repo`. Reuse only a non-ambiguous EXACT/HIGH best target. For MEDIUM/LOW or ambiguity, narrow or explicitly choose; never auto-select.";
+  "- `resolve_target` — resolve fuzzy, misspelled, or noncanonical names; skip canonical `registry:name` and `github:owner/repo`. Reuse only a non-ambiguous EXACT/HIGH best target with CLEAR or NOT_APPLICABLE malicious-content status; CLEAR is not a vulnerability-free claim. Other or missing statuses are non-actionable. For MEDIUM/LOW or ambiguity, narrow or explicitly choose an actionable candidate; never auto-select.";
 
 const LOCAL_CODE_DIFF_GUIDANCE =
   "- `code_diff` — compare exact package versions or public GitHub refs repository-wide after canonicalization. Prefer `pkg_changelog` or `pkg_upgrade_review` for upgrade summaries. Start with default `name-status`; use `stat` for magnitude or a scoped `patch` for content. Keep `text-v1` unless exact fields or the full returned patch are needed. Treat truncation, coverage, and safety warnings as evidence limits; diffs do not prove compatibility.";

--- a/packages/mcp/src/shared/resolve-target-response.test.ts
+++ b/packages/mcp/src/shared/resolve-target-response.test.ts
@@ -29,6 +29,8 @@ function candidate(
     confidence: "EXACT",
     reason: "Exact package identity match",
     ...overrides,
+    latestVersionMaliciousStatus:
+      overrides.latestVersionMaliciousStatus ?? "CLEAR",
   };
 }
 
@@ -60,6 +62,7 @@ describe("buildResolveTargetSuccessPayload", () => {
           description: "Fast web framework",
           registry: "npm",
           latestVersion: "5.1.0",
+          latestVersionMaliciousStatus: "clear",
           stars: 66_000,
           downloadsLastMonth: 89_000_000,
           matchedAliases: ["express"],
@@ -97,12 +100,56 @@ describe("buildResolveTargetSuccessPayload", () => {
   });
 
   it("uses safe lowercase strings for unknown enum values", () => {
-    const unknown = candidate({ kind: "WORKSPACE", confidence: "VERY_HIGH" });
+    const unknown = candidate({
+      kind: "WORKSPACE",
+      confidence: "VERY_HIGH",
+      latestVersionMaliciousStatus: "REVIEW_REQUIRED",
+    });
     const payload = buildResolveTargetSuccessPayload(
       result({ best: unknown, candidates: [unknown], protectedMatches: [] }),
     );
     expect(payload.candidates[0]?.kind).toBe("workspace");
     expect(payload.candidates[0]?.confidence).toBe("very_high");
+    expect(payload.candidates[0]?.latestVersionMaliciousStatus).toBe(
+      "review_required",
+    );
+  });
+
+  it("preserves bounded malicious advisory evidence in JSON", () => {
+    const affected = candidate({
+      latestVersionMaliciousStatus: "AFFECTED",
+      latestVersionMaliciousEvidence: {
+        advisories: [
+          {
+            osvId: "MAL-2026-1234",
+            classificationReasons: [
+              "AFFECTED_VERSION_RANGE_MATCH",
+              "FUTURE_REASON",
+            ],
+          },
+        ],
+        totalCount: 3,
+        truncated: true,
+      },
+    });
+
+    expect(
+      buildResolveTargetSuccessPayload(
+        result({ best: affected, candidates: [affected] }),
+      ).candidates[0]?.latestVersionMaliciousEvidence,
+    ).toEqual({
+      advisories: [
+        {
+          osvId: "MAL-2026-1234",
+          classificationReasons: [
+            "affected_version_range_match",
+            "future_reason",
+          ],
+        },
+      ],
+      totalCount: 3,
+      truncated: true,
+    });
   });
 
   it("emits the compact empty envelope", () => {
@@ -158,6 +205,40 @@ describe("isResolveTargetActionable", () => {
       ),
     ).toBe(false);
   });
+
+  it("accepts only CLEAR and NOT_APPLICABLE malicious statuses", () => {
+    for (const latestVersionMaliciousStatus of [
+      "CLEAR",
+      "NOT_APPLICABLE",
+    ] as const) {
+      const best = candidate({ latestVersionMaliciousStatus });
+      expect(
+        isResolveTargetActionable(
+          result({ best, candidates: [best], protectedMatches: [] }),
+        ),
+      ).toBe(true);
+    }
+
+    for (const latestVersionMaliciousStatus of [
+      "AFFECTED",
+      "UNKNOWN",
+      "REVIEW_REQUIRED",
+      "clear",
+    ] as const) {
+      const best = candidate({ latestVersionMaliciousStatus });
+      expect(
+        isResolveTargetActionable(
+          result({ best, candidates: [best], protectedMatches: [] }),
+        ),
+      ).toBe(false);
+    }
+
+    expect(
+      isResolveTargetActionable(
+        result({ best: candidate(), candidates: [], protectedMatches: [] }),
+      ),
+    ).toBe(false);
+  });
 });
 
 describe("formatResolveTargetTerminal", () => {
@@ -172,6 +253,8 @@ describe("formatResolveTargetTerminal", () => {
       "Candidates:\n  1. npm:express [exact] · package · 66k stars · 89M downloads/mo · docs · code · protected exact-name match",
     );
     expect(output).toContain("     Fast web framework");
+    expect(output).not.toContain("Warning:");
+    expect(output).not.toContain("malicious");
     expect(output).toContain(
       `Next: githits search 'router'"'"'s middleware' --in 'npm:express'`,
     );
@@ -238,6 +321,10 @@ describe("formatResolveTargetTerminal", () => {
     ]);
     expect(output).toContain("2. pypi:express [exact] · package");
     expect(output).toContain("3. github:expressjs/express [high] · repository");
+    expect(output).toContain(
+      "Warning: Malicious-content status is unavailable for the best match. Do not use this target.",
+    );
+    expect(output.match(/Warning:/g)).toHaveLength(1);
   });
 
   it("shows total downloads or a linked repository when monthly downloads are unavailable", () => {
@@ -326,7 +413,192 @@ describe("formatResolveTargetTerminal", () => {
         "Next: githits search 'middleware' --in 'npm:express'",
       );
       expect(output).not.toContain("Unconfirmed ranked candidates:");
+      expect(output).not.toContain("Warning:");
+      expect(output).not.toContain("malicious");
     }
+  });
+
+  it("renders NOT_APPLICABLE repositories as actionable", () => {
+    const repository = candidate({
+      kind: "REPOSITORY",
+      canonicalKey: "github:expressjs/express",
+      latestVersionMaliciousStatus: "NOT_APPLICABLE",
+    });
+    const output = formatResolveTargetTerminal(
+      result({
+        best: repository,
+        candidates: [repository],
+        protectedMatches: [],
+      }),
+      { name: "express", query: "middleware", useColors: false },
+    );
+
+    expect(output).not.toContain("Warning:");
+    expect(output).not.toContain("malicious");
+    expect(output).toContain(
+      "Next: githits search 'middleware' --in 'github:expressjs/express'",
+    );
+  });
+
+  it("fails closed for affected, unknown, and future malicious statuses", () => {
+    const expectedEvidence = new Map([
+      [
+        "AFFECTED",
+        "Malicious content affects the latest version. Do not use the latest version. Verify another version against the linked evidence.",
+      ],
+      [
+        "UNKNOWN",
+        "Malicious-content status is uncertain. Verify the advisory details before using this version.",
+      ],
+      [
+        "REVIEW_REQUIRED",
+        "Unrecognized malicious-content status: REVIEW_REQUIRED. Do not use this target.",
+      ],
+    ]);
+
+    for (const [latestVersionMaliciousStatus, evidence] of expectedEvidence) {
+      const best = candidate({ latestVersionMaliciousStatus });
+      const output = formatResolveTargetTerminal(
+        result({ best, candidates: [best], protectedMatches: [] }),
+        { name: "express", query: "middleware", useColors: false },
+      );
+
+      expect(output).toContain(evidence);
+      expect(output).toContain("Warning:");
+      expect(output).not.toContain("Next:");
+      expect(output).not.toContain("Next after choosing:");
+      expect(output).not.toContain("githits search");
+    }
+  });
+
+  it("renders malicious-content findings as red warnings", () => {
+    const affected = candidate({
+      latestVersionMaliciousStatus: "AFFECTED",
+      latestVersionMaliciousEvidence: {
+        advisories: [
+          {
+            osvId: "MAL-2026-1234",
+            classificationReasons: ["AFFECTED_VERSION_RANGE_MATCH"],
+          },
+        ],
+        totalCount: 1,
+        truncated: false,
+      },
+    });
+    const output = formatResolveTargetTerminal(
+      result({ best: affected, candidates: [affected], protectedMatches: [] }),
+      { name: "express", useColors: true },
+    );
+
+    expect(output).toContain(
+      "\u001b[31mWarning: Malicious content affects the latest version — MAL-2026-1234: https://osv.dev/vulnerability/MAL-2026-1234. Do not use the latest version. Verify another version against the linked evidence.\u001b[0m",
+    );
+  });
+
+  it("explains unknown malicious evidence and reports truncation", () => {
+    const unknown = candidate({
+      latestVersionMaliciousStatus: "UNKNOWN",
+      latestVersionMaliciousEvidence: {
+        advisories: [
+          {
+            osvId: "MAL-2026/unsafe id",
+            classificationReasons: ["INVALID_AFFECTED_RANGE", "FUTURE_REASON"],
+          },
+        ],
+        totalCount: 3,
+        truncated: true,
+      },
+    });
+    const output = formatResolveTargetTerminal(
+      result({ best: unknown, candidates: [unknown], protectedMatches: [] }),
+      { name: "express", useColors: false },
+    );
+
+    expect(output).toContain(
+      "Warning: Malicious-content status is uncertain — MAL-2026/unsafe id (affected range invalid, unrecognized reason FUTURE_REASON): https://osv.dev/vulnerability/MAL-2026%2Funsafe%20id; +2 more. Verify the advisory details before using this version.",
+    );
+    expect(output).not.toContain("Next:");
+  });
+
+  it("explains every known unknown-evidence classification reason", () => {
+    const reasons = new Map([
+      ["MISSING_DISPLAYED_VERSION", "latest version missing"],
+      ["INVALID_DISPLAYED_VERSION", "latest version invalid"],
+      ["MISSING_AFFECTED_RANGES", "affected ranges missing"],
+      ["EMPTY_AFFECTED_RANGES", "affected ranges empty"],
+      ["INVALID_AFFECTED_RANGE", "affected range invalid"],
+    ]);
+
+    for (const [reason, label] of reasons) {
+      const unknown = candidate({
+        latestVersionMaliciousStatus: "UNKNOWN",
+        latestVersionMaliciousEvidence: {
+          advisories: [
+            {
+              osvId: "MAL-2026-1234",
+              classificationReasons: [reason],
+            },
+          ],
+          totalCount: 1,
+          truncated: false,
+        },
+      });
+      const output = formatResolveTargetTerminal(
+        result({ best: unknown, candidates: [unknown], protectedMatches: [] }),
+        { name: "express", useColors: false },
+      );
+
+      expect(output).toContain(`MAL-2026-1234 (${label})`);
+    }
+  });
+
+  it("restricts ambiguous continuation when any candidate is non-actionable", () => {
+    const clear = candidate();
+    const affected = candidate({
+      canonicalKey: "npm:express-lookalike",
+      latestVersionMaliciousStatus: "AFFECTED",
+    });
+    const output = formatResolveTargetTerminal(
+      result({
+        best: clear,
+        candidates: [clear, affected],
+        protectedMatches: [],
+        ambiguous: true,
+        ambiguousReason: "CLOSE_CANDIDATES",
+      }),
+      { name: "express", useColors: false },
+    );
+
+    expect(output).toContain(
+      "Warning: Some candidates are not actionable. Narrow the result before continuing.",
+    );
+    expect(output).not.toContain("Next after choosing:");
+    expect(output).not.toContain("githits search");
+  });
+
+  it("restricts continuation when a displayed reference has no evidence", () => {
+    const best = candidate({ confidence: "MEDIUM" });
+    const output = formatResolveTargetTerminal(
+      result({
+        best,
+        candidates: [best],
+        protectedMatches: [
+          {
+            kind: "PACKAGE",
+            canonicalKey: "jsr:@express/core",
+            confidence: "EXACT",
+          },
+        ],
+      }),
+      { name: "express", query: "middleware", useColors: false },
+    );
+
+    expect(output).toContain(
+      "Warning: Some candidates are not actionable. Narrow the result before continuing.",
+    );
+    expect(output.match(/Warning:/g)).toHaveLength(1);
+    expect(output).not.toContain("Next:");
+    expect(output).not.toContain("githits search");
   });
 
   it("requires narrowing or an explicit choice for MEDIUM and LOW results", () => {

--- a/packages/mcp/src/shared/resolve-target-response.ts
+++ b/packages/mcp/src/shared/resolve-target-response.ts
@@ -3,7 +3,7 @@ import type {
   ResolveTargetReference,
   ResolveTargetResult,
 } from "@githits/core-internal";
-import { dim, highlight } from "./colors.js";
+import { colorize, dim, highlight } from "./colors.js";
 import { formatCompactNumber } from "./format-number.js";
 import { formatRepositoryTarget } from "./repository-target.js";
 import { shellQuote } from "./shell-quote.js";
@@ -17,6 +17,8 @@ export interface ResolveTargetCandidatePayload {
   registry?: string;
   packageName?: string;
   latestVersion?: string;
+  latestVersionMaliciousStatus?: string;
+  latestVersionMaliciousEvidence?: ResolveTargetMaliciousEvidencePayload;
   repositoryUrl?: string;
   repositoryOwner?: string;
   repositoryName?: string;
@@ -30,6 +32,17 @@ export interface ResolveTargetCandidatePayload {
   matchTier?: number;
   score?: number;
   reason?: string;
+}
+
+export interface ResolveTargetMaliciousAdvisoryPayload {
+  osvId: string;
+  classificationReasons: string[];
+}
+
+export interface ResolveTargetMaliciousEvidencePayload {
+  advisories: ResolveTargetMaliciousAdvisoryPayload[];
+  totalCount: number;
+  truncated: boolean;
 }
 
 export interface ResolveTargetPayload {
@@ -78,6 +91,25 @@ function projectTarget(
   assign(payload, "registry", candidate.registry?.toLowerCase());
   assign(payload, "packageName", candidate.packageName);
   assign(payload, "latestVersion", candidate.latestVersion);
+  assign(
+    payload,
+    "latestVersionMaliciousStatus",
+    candidate.latestVersionMaliciousStatus.toLowerCase(),
+  );
+  if (candidate.latestVersionMaliciousEvidence) {
+    payload.latestVersionMaliciousEvidence = {
+      advisories: candidate.latestVersionMaliciousEvidence.advisories.map(
+        (advisory) => ({
+          osvId: advisory.osvId,
+          classificationReasons: advisory.classificationReasons.map((reason) =>
+            reason.toLowerCase(),
+          ),
+        }),
+      ),
+      totalCount: candidate.latestVersionMaliciousEvidence.totalCount,
+      truncated: candidate.latestVersionMaliciousEvidence.truncated,
+    };
+  }
   assign(payload, "repositoryUrl", candidate.repositoryUrl);
   assign(payload, "repositoryOwner", candidate.repositoryOwner);
   assign(payload, "repositoryName", candidate.repositoryName);
@@ -102,16 +134,17 @@ export interface FormatResolveTargetTerminalOptions {
 
 /**
  * Decide whether consumers may offer the best target as a direct next action.
- * Only canonical uppercase EXACT/HIGH values are actionable; unexpected values
- * fail closed as evidence for an explicit caller choice.
+ * Identity must be non-ambiguous uppercase EXACT/HIGH, and the matching full
+ * candidate must carry CLEAR or NOT_APPLICABLE malicious-content evidence.
  */
 export function isResolveTargetActionable(
-  result: Pick<ResolveTargetResult, "ambiguous" | "best">,
+  result: Pick<ResolveTargetResult, "ambiguous" | "best" | "candidates">,
 ): boolean {
   return (
-    !result.ambiguous &&
-    result.best !== undefined &&
-    (result.best.confidence === "EXACT" || result.best.confidence === "HIGH")
+    isResolveTargetIdentityActionable(result) &&
+    isLatestVersionMaliciousStatusActionable(
+      findResolveTargetBestCandidate(result)?.latestVersionMaliciousStatus,
+    )
   );
 }
 
@@ -125,6 +158,9 @@ export function formatResolveTargetTerminal(
   }
   const useColors = options.useColors ?? false;
   const actionable = isResolveTargetActionable(result);
+  const identityActionable = isResolveTargetIdentityActionable(result);
+  const bestCandidate = findResolveTargetBestCandidate(result);
+  const blockedBest = identityActionable && !actionable;
   const lines: string[] = [];
   if (result.ambiguous) lines.push(ambiguityMessage(result.ambiguousReason));
   const protectedKeys = new Set(
@@ -135,8 +171,15 @@ export function formatResolveTargetTerminal(
     ...result.protectedMatches,
     result.best,
   ]);
+  const hasBlockedReference = candidates.some(
+    (candidate) =>
+      !isCandidate(candidate) ||
+      !isLatestVersionMaliciousStatusActionable(
+        candidate.latestVersionMaliciousStatus,
+      ),
+  );
   lines.push(
-    !result.ambiguous && !actionable
+    !result.ambiguous && !identityActionable
       ? "Unconfirmed ranked candidates:"
       : "Candidates:",
   );
@@ -152,7 +195,25 @@ export function formatResolveTargetTerminal(
   );
 
   const query = sanitizeTerminalText(options.query?.trim() || "<query>");
-  if (result.ambiguous) {
+  if (blockedBest) {
+    if (!bestCandidate) {
+      lines.push(
+        "",
+        formatTerminalWarning(
+          "Malicious-content status is unavailable for the best match. Do not use this target.",
+          useColors,
+        ),
+      );
+    }
+  } else if (result.ambiguous && hasBlockedReference) {
+    lines.push(
+      "",
+      formatTerminalWarning(
+        "Some candidates are not actionable. Narrow the result before continuing.",
+        useColors,
+      ),
+    );
+  } else if (result.ambiguous) {
     lines.push(
       "",
       `Next after choosing: githits search ${shellQuote(query)} --in ${shellQuote("<target>")}`,
@@ -161,6 +222,14 @@ export function formatResolveTargetTerminal(
     lines.push(
       "",
       `Next: githits search ${shellQuote(query)} --in ${shellQuote(sanitizeTerminalText(result.best.canonicalKey))}`,
+    );
+  } else if (hasBlockedReference) {
+    lines.push(
+      "",
+      formatTerminalWarning(
+        "Some candidates are not actionable. Narrow the result before continuing.",
+        useColors,
+      ),
     );
   } else {
     lines.push(
@@ -223,7 +292,121 @@ function formatCandidateLines(
     isCandidate(candidate) ? candidate.description : undefined,
   );
   if (description) lines.push(`     ${dim(description, useColors)}`);
+  const maliciousWarning = isCandidate(candidate)
+    ? formatLatestVersionMaliciousStatus(
+        candidate.latestVersionMaliciousStatus,
+        candidate.latestVersionMaliciousEvidence,
+      )
+    : undefined;
+  if (maliciousWarning) {
+    lines.push(`     ${formatTerminalWarning(maliciousWarning, useColors)}`);
+  }
   return lines;
+}
+
+/** Return concise warning copy only for a non-actionable backend decision. */
+export function formatLatestVersionMaliciousStatus(
+  status: string | undefined,
+  evidence?: ResolveTargetCandidate["latestVersionMaliciousEvidence"],
+): string | undefined {
+  switch (status) {
+    case "AFFECTED":
+      return withMaliciousEvidence(
+        "Malicious content affects the latest version",
+        "Do not use the latest version. Verify another version against the linked evidence.",
+        evidence,
+        false,
+      );
+    case "UNKNOWN":
+      return withMaliciousEvidence(
+        "Malicious-content status is uncertain",
+        "Verify the advisory details before using this version.",
+        evidence,
+        true,
+      );
+    case "CLEAR":
+    case "NOT_APPLICABLE":
+    case undefined:
+      return undefined;
+    default:
+      return `Unrecognized malicious-content status: ${sanitizeTerminalText(status)}. Do not use this target.`;
+  }
+}
+
+function withMaliciousEvidence(
+  message: string,
+  guidance: string,
+  evidence: ResolveTargetCandidate["latestVersionMaliciousEvidence"],
+  includeReasons: boolean,
+): string {
+  if (!evidence || evidence.advisories.length === 0) {
+    return `${message}. ${guidance}`;
+  }
+
+  const details = evidence.advisories.map((advisory) => {
+    const id = sanitizeTerminalText(advisory.osvId);
+    const reasons = includeReasons
+      ? formatMaliciousClassificationReasons(advisory.classificationReasons)
+      : undefined;
+    const label = reasons ? `${id} (${reasons})` : id;
+    return `${label}: https://osv.dev/vulnerability/${encodeURIComponent(advisory.osvId)}`;
+  });
+  const omitted = evidence.totalCount - evidence.advisories.length;
+  if (evidence.truncated && omitted > 0) details.push(`+${omitted} more`);
+  return `${message} — ${details.join("; ")}. ${guidance}`;
+}
+
+const MALICIOUS_CLASSIFICATION_REASON_LABELS: Readonly<Record<string, string>> =
+  {
+    AFFECTED_VERSION_RANGE_MATCH: "affected range matched",
+    MISSING_DISPLAYED_VERSION: "latest version missing",
+    INVALID_DISPLAYED_VERSION: "latest version invalid",
+    MISSING_AFFECTED_RANGES: "affected ranges missing",
+    EMPTY_AFFECTED_RANGES: "affected ranges empty",
+    INVALID_AFFECTED_RANGE: "affected range invalid",
+  };
+
+function formatMaliciousClassificationReasons(
+  reasons: readonly string[],
+): string | undefined {
+  if (reasons.length === 0) return undefined;
+  return reasons
+    .map(
+      (reason) =>
+        MALICIOUS_CLASSIFICATION_REASON_LABELS[reason] ??
+        `unrecognized reason ${sanitizeTerminalText(reason)}`,
+    )
+    .join(", ");
+}
+
+function formatTerminalWarning(message: string, useColors: boolean): string {
+  return colorize(`Warning: ${message}`, "red", useColors);
+}
+
+export function isResolveTargetIdentityActionable(
+  result: Pick<ResolveTargetResult, "ambiguous" | "best">,
+): boolean {
+  return (
+    !result.ambiguous &&
+    result.best !== undefined &&
+    (result.best.confidence === "EXACT" || result.best.confidence === "HIGH")
+  );
+}
+
+export function isLatestVersionMaliciousStatusActionable(
+  status: string | undefined,
+): boolean {
+  return status === "CLEAR" || status === "NOT_APPLICABLE";
+}
+
+export function findResolveTargetBestCandidate(
+  result: Pick<ResolveTargetResult, "best" | "candidates">,
+): ResolveTargetCandidate | undefined {
+  if (!result.best) return undefined;
+  const best = result.best;
+  return result.candidates.find(
+    (candidate) => candidateKey(candidate) === candidateKey(best),
+  );
 }
 
 function compactRepositoryUrl(value: string): string {

--- a/packages/mcp/src/tools/resolve-target.test.ts
+++ b/packages/mcp/src/tools/resolve-target.test.ts
@@ -53,6 +53,7 @@ function result(
         registry: "NPM",
         stars: 66_000,
         downloadsLastMonth: 89_000_000,
+        latestVersionMaliciousStatus: "CLEAR",
         docsAvailable: true,
         codeAvailable: true,
       },
@@ -113,6 +114,8 @@ describe("resolve_target MCP adapter", () => {
       "HIGH",
       "MEDIUM",
       "LOW",
+      "missing statuses",
+      "CLEAR is not a vulnerability-free claim",
       "explicit choice",
     ]) {
       expect(DESCRIPTION).toContain(phrase);
@@ -145,6 +148,8 @@ describe("resolve_target MCP adapter", () => {
     expect(text).toContain("66k");
     expect(text).toContain("89M");
     expect(text).toContain("Fast web framework");
+    expect(text).not.toContain("Warning:");
+    expect(text).not.toContain("malicious");
     expect(text).toContain(
       'Next: pass the canonical target "npm:express" to the next MCP tool.',
     );
@@ -165,8 +170,14 @@ describe("resolve_target MCP adapter", () => {
         canonicalKey: "npm:express",
         confidence,
       };
+      const bestCandidate = {
+        ...best,
+        latestVersionMaliciousStatus: "CLEAR",
+        docsAvailable: false,
+        codeAvailable: false,
+      };
       const text = formatResolveTargetMcpText(
-        result({ best, candidates: [], protectedMatches: [] }),
+        result({ best, candidates: [bestCandidate], protectedMatches: [] }),
         { name: "express" },
       );
 
@@ -177,10 +188,98 @@ describe("resolve_target MCP adapter", () => {
         'Next: pass the canonical target "npm:express" to the next MCP tool.',
       );
       expect(text).not.toContain("Unconfirmed ranked candidates:");
+      expect(text).not.toContain("Warning:");
+      expect(text).not.toContain("malicious");
     }
   });
 
-  it("requires narrowing or an explicit choice for MEDIUM and LOW results", () => {
+  it("fails closed for affected, unknown, and future malicious statuses", () => {
+    const expectedEvidence = new Map([
+      [
+        "AFFECTED",
+        "Malicious content affects the latest version. Do not use the latest version. Verify another version against the linked evidence.",
+      ],
+      [
+        "UNKNOWN",
+        "Malicious-content status is uncertain. Verify the advisory details before using this version.",
+      ],
+      [
+        "REVIEW_REQUIRED",
+        "Unrecognized malicious-content status: REVIEW_REQUIRED. Do not use this target.",
+      ],
+    ]);
+
+    for (const [latestVersionMaliciousStatus, evidence] of expectedEvidence) {
+      const best = {
+        kind: "PACKAGE",
+        canonicalKey: "npm:express",
+        confidence: "EXACT",
+      };
+      const text = formatResolveTargetMcpText(
+        result({
+          best,
+          candidates: [
+            {
+              ...best,
+              latestVersionMaliciousStatus,
+              docsAvailable: false,
+              codeAvailable: false,
+            },
+          ],
+          protectedMatches: [],
+        }),
+        { name: "express" },
+      );
+
+      expect(text).toContain(evidence);
+      expect(text).toContain("Warning:");
+      expect(text).toContain("Candidates:\n  1. npm:express");
+      expect(text).not.toContain("Next:");
+      expect(text).not.toContain("pass the canonical target");
+      expect(text).not.toContain("next MCP tool");
+    }
+  });
+
+  it("renders malicious advisory links and unknown reasons without a handoff", () => {
+    const best = {
+      kind: "PACKAGE",
+      canonicalKey: "npm:lookalike",
+      confidence: "EXACT",
+    };
+    const text = formatResolveTargetMcpText(
+      result({
+        best,
+        candidates: [
+          {
+            ...best,
+            latestVersionMaliciousStatus: "UNKNOWN",
+            latestVersionMaliciousEvidence: {
+              advisories: [
+                {
+                  osvId: "MAL-2026-1234",
+                  classificationReasons: ["MISSING_DISPLAYED_VERSION"],
+                },
+              ],
+              totalCount: 1,
+              truncated: false,
+            },
+            docsAvailable: false,
+            codeAvailable: false,
+          },
+        ],
+        protectedMatches: [],
+      }),
+      { name: "lookalike" },
+    );
+
+    expect(text).toContain(
+      "Warning: Malicious-content status is uncertain — MAL-2026-1234 (latest version missing): https://osv.dev/vulnerability/MAL-2026-1234. Verify the advisory details before using this version.",
+    );
+    expect(text).not.toContain("Next:");
+    expect(text).not.toContain("next MCP tool");
+  });
+
+  it("restricts MEDIUM and LOW continuation when reference evidence is unavailable", () => {
     for (const confidence of ["MEDIUM", "LOW"] as const) {
       const best = {
         kind: "PACKAGE",
@@ -193,6 +292,7 @@ describe("resolve_target MCP adapter", () => {
           candidates: [
             {
               ...best,
+              latestVersionMaliciousStatus: "CLEAR",
               docsAvailable: false,
               codeAvailable: false,
             },
@@ -200,6 +300,7 @@ describe("resolve_target MCP adapter", () => {
               kind: "REPOSITORY",
               canonicalKey: "github:expressjs/express",
               confidence,
+              latestVersionMaliciousStatus: "NOT_APPLICABLE",
               docsAvailable: false,
               codeAvailable: false,
             },
@@ -222,12 +323,47 @@ describe("resolve_target MCP adapter", () => {
         "jsr:@express/core [exact; package] · protected exact-name match",
       );
       expect(text).not.toContain("\nCandidates:\n");
-      expect(text).toContain("narrow the name or filters");
-      expect(text).toContain("explicitly choose a candidate");
-      expect(text).toContain("do not pass the best result automatically");
+      expect(text).toContain(
+        "Warning: Some candidates are not actionable. Narrow the result before continuing.",
+      );
+      expect(text.match(/Warning:/g)).toHaveLength(1);
+      expect(text).not.toContain("Next:");
       expect(text).not.toContain(
         'pass the canonical target "npm:express" to the next MCP tool',
       );
+      expect(text).not.toContain("next MCP tool");
+    }
+  });
+
+  it("requires narrowing or an explicit choice for actionable MEDIUM and LOW candidates", () => {
+    for (const confidence of ["MEDIUM", "LOW"] as const) {
+      const best = {
+        kind: "PACKAGE",
+        canonicalKey: "npm:express",
+        confidence,
+      };
+      const text = formatResolveTargetMcpText(
+        result({
+          best,
+          candidates: [
+            {
+              ...best,
+              latestVersionMaliciousStatus: "CLEAR",
+              docsAvailable: false,
+              codeAvailable: false,
+            },
+          ],
+          protectedMatches: [],
+        }),
+        { name: "express" },
+      );
+
+      expect(text).toContain(
+        `Unconfirmed ranked candidates: the best result is ${confidence.toLowerCase()} confidence.`,
+      );
+      expect(text).toContain("Next: narrow the name or filters");
+      expect(text).toContain("explicitly choose a candidate");
+      expect(text).toContain("do not pass the best result automatically");
     }
   });
 
@@ -247,6 +383,14 @@ describe("resolve_target MCP adapter", () => {
     expect(response.content[0]?.text).toBe(
       JSON.stringify(buildResolveTargetSuccessPayload(result())),
     );
+    expect(JSON.parse(response.content[0]?.text ?? "{}")).toMatchObject({
+      candidates: [
+        {
+          target: "npm:express",
+          latestVersionMaliciousStatus: "clear",
+        },
+      ],
+    });
   });
 
   it("preserves ambiguous resolution guidance without guessing", () => {
@@ -257,6 +401,7 @@ describe("resolve_target MCP adapter", () => {
           kind: "PACKAGE",
           canonicalKey: "npm:express",
           confidence: "HIGH",
+          latestVersionMaliciousStatus: "CLEAR",
           docsAvailable: false,
           codeAvailable: false,
         },
@@ -264,6 +409,7 @@ describe("resolve_target MCP adapter", () => {
           kind: "REPOSITORY",
           canonicalKey: "github:expressjs/express",
           confidence: "HIGH",
+          latestVersionMaliciousStatus: "NOT_APPLICABLE",
           docsAvailable: false,
           codeAvailable: false,
         },
@@ -302,7 +448,11 @@ describe("resolve_target MCP adapter", () => {
       "Ambiguous: low confidence; multiple candidates remain.",
     );
     expect(text).toContain("Candidates:\n  1. npm:express [low; package]");
-    expect(text).toContain("do not auto-select a candidate");
+    expect(text).toContain(
+      "Warning: Some candidates are not actionable. Narrow the result before continuing.",
+    );
+    expect(text.match(/Warning:/g)).toHaveLength(1);
+    expect(text).not.toContain("Next:");
     expect(text).not.toContain("Unconfirmed ranked candidates:");
     expect(text).not.toContain(
       'pass the canonical target "npm:express" to the next MCP tool',
@@ -403,6 +553,7 @@ describe("resolve_target MCP adapter", () => {
         kind: "PACKAGE",
         canonicalKey: `npm:library-${index}`,
         confidence: "HIGH",
+        latestVersionMaliciousStatus: "CLEAR",
         docsAvailable: false,
         codeAvailable: false,
       }),
@@ -439,6 +590,7 @@ describe("resolve_target MCP adapter", () => {
           kind: "PACKAGE",
           canonicalKey: "npm:x\u001b[31m",
           confidence: "EXACT",
+          latestVersionMaliciousStatus: "CLEAR",
           description: `first\n${"x".repeat(300)}\u0007`,
           docsAvailable: true,
           codeAvailable: false,

--- a/packages/mcp/src/tools/resolve-target.ts
+++ b/packages/mcp/src/tools/resolve-target.ts
@@ -11,7 +11,11 @@ import { mapPackageIntelligenceError } from "../shared/package-intelligence-erro
 import { buildResolveTargetParams } from "../shared/resolve-target-request.js";
 import {
   buildResolveTargetSuccessPayload,
+  findResolveTargetBestCandidate,
+  formatLatestVersionMaliciousStatus,
+  isLatestVersionMaliciousStatusActionable,
   isResolveTargetActionable,
+  isResolveTargetIdentityActionable,
   sanitizeTerminalText,
 } from "../shared/resolve-target-response.js";
 import { mcpMappedErrorResult } from "./shared.js";
@@ -75,7 +79,7 @@ const schema: ZodRawShape = {
 };
 
 export const DESCRIPTION =
-  "Experimental tool. Use for fuzzy, ambiguous, misspelled, or human-friendly package and repository names when a canonical target is not known. Do not call for canonical `registry:name` or `github:owner/repo` targets; use those directly with the next MCP tool. The optional `query` and `intent_hints` values leave this machine and must not contain credentials, personal data, private code, or proprietary content. Default `text-v1` (also available as `text`) gives bounded ranked candidates; only a non-ambiguous EXACT or HIGH best result gets a direct MCP follow-up, while MEDIUM or LOW requires narrowing or an explicit choice. Use `json` for the structured result.";
+  "Experimental tool. Use for fuzzy, ambiguous, misspelled, or human-friendly package and repository names when a canonical target is not known. Do not call for canonical `registry:name` or `github:owner/repo` targets; use those directly with the next MCP tool. The optional `query` and `intent_hints` values leave this machine and must not contain credentials, personal data, private code, or proprietary content. Default `text-v1` (also available as `text`) gives bounded ranked candidates. Only a non-ambiguous EXACT or HIGH best result with CLEAR or NOT_APPLICABLE malicious-content status gets a direct follow-up; CLEAR is not a vulnerability-free claim. Other or missing statuses are non-actionable. MEDIUM and LOW require narrowing or an explicit choice. Use `json` for the structured result.";
 
 export function createResolveTargetTool(
   service: ResolveTargetService,
@@ -125,6 +129,9 @@ export function formatResolveTargetMcpText(
   options: FormatResolveTargetMcpTextOptions,
 ): string {
   const actionable = isResolveTargetActionable(result);
+  const identityActionable = isResolveTargetIdentityActionable(result);
+  const bestCandidate = findResolveTargetBestCandidate(result);
+  const blockedBest = identityActionable && !actionable;
   const protectedKeys = new Set(
     result.protectedMatches.map((target) => targetKey(target)),
   );
@@ -133,6 +140,13 @@ export function formatResolveTargetMcpText(
     ...result.protectedMatches,
     ...(result.best ? [result.best] : []),
   ]);
+  const hasBlockedReference = allReferences.some(
+    (target) =>
+      !isCandidate(target) ||
+      !isLatestVersionMaliciousStatusActionable(
+        target.latestVersionMaliciousStatus,
+      ),
+  );
   const references = allReferences.slice(0, 24);
   const omittedReferences = allReferences.slice(references.length);
   const lines: string[] = [];
@@ -143,6 +157,8 @@ export function formatResolveTargetMcpText(
     );
   } else if (actionable && result.best) {
     lines.push(`Best match: ${formatReference(result.best)}.`);
+  } else if (blockedBest && result.best) {
+    lines.push(`Best identity match: ${formatReference(result.best)}.`);
   } else if (result.best) {
     lines.push(
       `Unconfirmed ranked candidates: the best result is ${sanitizeTerminalText(result.best.confidence.toLowerCase())} confidence.`,
@@ -154,7 +170,9 @@ export function formatResolveTargetMcpText(
   }
 
   if (references.length > 0) {
-    if (result.ambiguous || actionable) lines.push("Candidates:");
+    if (result.ambiguous || actionable || blockedBest) {
+      lines.push("Candidates:");
+    }
     references.forEach((target, index) => {
       lines.push(
         `  ${index + 1}. ${formatReference(target)}${
@@ -167,6 +185,15 @@ export function formatResolveTargetMcpText(
         ? compactDescription(target.description)
         : undefined;
       if (description) lines.push(`     ${description}`);
+      const maliciousWarning = isCandidate(target)
+        ? formatLatestVersionMaliciousStatus(
+            target.latestVersionMaliciousStatus,
+            target.latestVersionMaliciousEvidence,
+          )
+        : undefined;
+      if (maliciousWarning) {
+        lines.push(`     Warning: ${maliciousWarning}`);
+      }
     });
   }
 
@@ -182,13 +209,27 @@ export function formatResolveTargetMcpText(
     );
   }
 
-  if (result.ambiguous) {
+  if (blockedBest) {
+    if (!bestCandidate) {
+      lines.push(
+        "Warning: Malicious-content status is unavailable for the best match. Do not use this target.",
+      );
+    }
+  } else if (result.ambiguous && hasBlockedReference) {
+    lines.push(
+      "Warning: Some candidates are not actionable. Narrow the result before continuing.",
+    );
+  } else if (result.ambiguous) {
     lines.push(
       "Next: choose the canonical target that matches the user's intent, then pass that exact target to the next MCP tool; do not auto-select a candidate.",
     );
   } else if (actionable && result.best) {
     lines.push(
       `Next: pass the canonical target "${sanitizeTerminalText(result.best.canonicalKey)}" to the next MCP tool.`,
+    );
+  } else if (result.best && hasBlockedReference) {
+    lines.push(
+      "Warning: Some candidates are not actionable. Narrow the result before continuing.",
     );
   } else if (result.best) {
     lines.push(

--- a/scripts/cli-smoke.ts
+++ b/scripts/cli-smoke.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+import { isResolveDirectTargetUnwarned } from "./resolve-smoke-guidance.ts";
 import {
   createIsolatedSmokeEnvironment,
   createScopedSmokeEnvironment,
@@ -808,6 +809,45 @@ async function assertLiveOrAuthRequired(
   return false;
 }
 
+export function assertExperimentalCliResolveText(resolveText: string): void {
+  assert(
+    (resolveText.includes("Candidates:") ||
+      resolveText.includes("Unconfirmed ranked candidates:")) &&
+      /\n\s+\d+\. (?:npm|github):\S+/.test(resolveText),
+    "experimental resolve text should include ranked canonical candidates",
+  );
+  const directTarget = resolveText.match(
+    /Next: githits search .+ --in '((?:npm|github):[^']+)'/,
+  )?.[1];
+  if (directTarget) {
+    assert(
+      isResolveDirectTargetUnwarned(resolveText, directTarget),
+      "experimental direct resolve action should target a listed candidate without a warning",
+    );
+    return;
+  }
+  if (resolveText.includes("Warning:")) {
+    assert(
+      !resolveText.includes("Next:") &&
+        !resolveText.includes("Next after choosing:"),
+      "experimental malicious-blocked resolve text should omit the normal next action",
+    );
+  } else if (resolveText.includes("Unconfirmed ranked candidates:")) {
+    assert(
+      resolveText.includes("explicitly choose a candidate") &&
+        resolveText.includes("--in '<target>'"),
+      "experimental unconfirmed resolve text should require an explicit choice",
+    );
+  } else if (resolveText.includes("Ambiguous:")) {
+    assert(
+      resolveText.includes("Next after choosing:"),
+      "experimental ambiguous resolve text should require an explicit choice",
+    );
+  } else {
+    assert(false, "experimental resolve text missing continuation guidance");
+  }
+}
+
 async function runExperimentalLiveSmoke(
   env: Record<string, string>,
 ): Promise<void> {
@@ -815,32 +855,7 @@ async function runExperimentalLiveSmoke(
     await runCliWithEnv(["resolve", "express"], env),
     "experimental resolve terminal",
   );
-  assert(
-    (resolveText.includes("Candidates:") ||
-      resolveText.includes("Unconfirmed ranked candidates:")) &&
-      /\n\s+\d+\. (?:npm|github):\S+/.test(resolveText),
-    "experimental resolve text should include ranked canonical candidates",
-  );
-  const hasDirectResolveAction =
-    /Next: githits search .+ --in '(?:npm|github):[^']+'/.test(resolveText);
-  if (resolveText.includes("Unconfirmed ranked candidates:")) {
-    assert(
-      !hasDirectResolveAction &&
-        resolveText.includes("explicitly choose a candidate") &&
-        resolveText.includes("--in '<target>'"),
-      "experimental unconfirmed resolve text should require an explicit choice",
-    );
-  } else if (resolveText.includes("Ambiguous:")) {
-    assert(
-      !hasDirectResolveAction && resolveText.includes("Next after choosing:"),
-      "experimental ambiguous resolve text should require an explicit choice",
-    );
-  } else {
-    assert(
-      hasDirectResolveAction,
-      "experimental actionable resolve text should include a canonical next action",
-    );
-  }
+  assertExperimentalCliResolveText(resolveText);
 
   const resolveJson = assertJsonOutput(
     await runCliWithEnv(
@@ -868,6 +883,13 @@ async function runExperimentalLiveSmoke(
     typeof resolveJson.best === "string" &&
       resolveJson.best === "npm:express" &&
       Array.isArray(resolveJson.candidates) &&
+      resolveJson.candidates.some(
+        (candidate) =>
+          candidate !== null &&
+          typeof candidate === "object" &&
+          candidate.target === "npm:express" &&
+          typeof candidate.latestVersionMaliciousStatus === "string",
+      ) &&
       Array.isArray(resolveJson.protectedMatches),
     "experimental resolve JSON missing structured candidate facts",
   );

--- a/scripts/mcp-smoke.ts
+++ b/scripts/mcp-smoke.ts
@@ -11,6 +11,7 @@ import {
 } from "@githits/mcp/smoke-test";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { isResolveDirectTargetUnwarned } from "./resolve-smoke-guidance.ts";
 import {
   createIsolatedSmokeEnvironment,
   createScopedSmokeEnvironment,
@@ -269,6 +270,45 @@ async function runExperimentalRegistrationSmoke(
   }
 }
 
+export function assertExperimentalMcpResolveText(
+  resolveTextBody: string,
+): void {
+  assert(
+    resolveTextBody.includes("npm:express") &&
+      !resolveTextBody.includes("githits ") &&
+      !resolveTextBody.includes("--"),
+    "experimental resolve text should include MCP-native candidate guidance",
+  );
+  const directTarget = resolveTextBody.match(
+    /Next: pass the canonical target "([^"]+)"/,
+  )?.[1];
+  if (directTarget) {
+    assert(
+      isResolveDirectTargetUnwarned(resolveTextBody, directTarget),
+      "experimental direct resolve action should target a listed candidate without a warning",
+    );
+    return;
+  }
+  if (resolveTextBody.includes("Warning:")) {
+    assert(
+      !resolveTextBody.includes("Next:"),
+      "experimental malicious-blocked resolve text should omit the normal next action",
+    );
+  } else if (resolveTextBody.includes("Unconfirmed ranked candidates:")) {
+    assert(
+      resolveTextBody.includes("do not pass the best result automatically"),
+      "experimental unconfirmed resolve text should require an explicit choice",
+    );
+  } else if (resolveTextBody.includes("Ambiguous:")) {
+    assert(
+      resolveTextBody.includes("do not auto-select a candidate"),
+      "experimental ambiguous resolve text should require an explicit choice",
+    );
+  } else {
+    assert(false, "experimental resolve text missing continuation guidance");
+  }
+}
+
 async function runExperimentalLiveSmoke(
   target: CliLaunchTarget,
 ): Promise<void> {
@@ -313,34 +353,7 @@ async function runExperimentalLiveSmoke(
           resolveText,
           "experimental resolve default text",
         );
-        assert(
-          resolveTextBody.includes("npm:express") &&
-            !resolveTextBody.includes("githits ") &&
-            !resolveTextBody.includes("--"),
-          "experimental resolve text should use MCP-native follow-up guidance",
-        );
-        const hasDirectResolveAction =
-          /Next: pass the canonical target "[^"]+"/.test(resolveTextBody);
-        if (resolveTextBody.includes("Unconfirmed ranked candidates:")) {
-          assert(
-            !hasDirectResolveAction &&
-              resolveTextBody.includes(
-                "do not pass the best result automatically",
-              ),
-            "experimental unconfirmed resolve text should require an explicit choice",
-          );
-        } else if (resolveTextBody.includes("Ambiguous:")) {
-          assert(
-            !hasDirectResolveAction &&
-              resolveTextBody.includes("do not auto-select a candidate"),
-            "experimental ambiguous resolve text should require an explicit choice",
-          );
-        } else {
-          assert(
-            hasDirectResolveAction,
-            "experimental actionable resolve text should include a canonical next action",
-          );
-        }
+        assertExperimentalMcpResolveText(resolveTextBody);
 
         const resolveJson = (await trackSmokeStep(
           "mcp resolve_target JSON experimental live",
@@ -357,6 +370,21 @@ async function runExperimentalLiveSmoke(
         assert(
           resolvePayload !== null && typeof resolvePayload === "object",
           "experimental resolve JSON should be an object",
+        );
+        const resolveRecord = resolvePayload as Record<string, unknown>;
+        const resolveCandidates = resolveRecord.candidates;
+        assert(
+          Array.isArray(resolveCandidates) &&
+            resolveCandidates.some(
+              (candidate: unknown) =>
+                candidate !== null &&
+                typeof candidate === "object" &&
+                "target" in candidate &&
+                candidate.target === "npm:express" &&
+                "latestVersionMaliciousStatus" in candidate &&
+                typeof candidate.latestVersionMaliciousStatus === "string",
+            ),
+          "experimental resolve JSON should preserve malicious-content status for the full npm:express candidate",
         );
 
         const diffText = (await trackSmokeStep(

--- a/scripts/resolve-smoke-guidance.ts
+++ b/scripts/resolve-smoke-guidance.ts
@@ -1,0 +1,20 @@
+/** Verify that a direct resolve handoff names a listed, warning-free candidate. */
+export function isResolveDirectTargetUnwarned(
+  output: string,
+  target: string,
+): boolean {
+  if (/^Warning:/m.test(output)) return false;
+
+  const escapedTarget = target.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const candidatePattern = new RegExp(`^  \\d+\\. ${escapedTarget}(?:\\s|$)`);
+  const lines = output.split("\n");
+  const candidateIndex = lines.findIndex((line) => candidatePattern.test(line));
+  if (candidateIndex < 0) return false;
+
+  for (let index = candidateIndex + 1; index < lines.length; index += 1) {
+    const line = lines[index] ?? "";
+    if (!line.startsWith("     ")) break;
+    if (line.includes("Warning:")) return false;
+  }
+  return true;
+}

--- a/scripts/smoke-scripts.test.ts
+++ b/scripts/smoke-scripts.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { EXPECTED_MCP_TOOLS } from "@githits/mcp/smoke-test";
 import {
+  assertExperimentalCliResolveText,
   assertRootHelpStructure,
   buildMcpParityCommand,
   EXPECTED_EXPERIMENTAL_TOP_LEVEL_COMMANDS,
@@ -15,6 +16,7 @@ import {
 } from "./cli-smoke.ts";
 import { parseMcpCallArgs } from "./mcp-call.ts";
 import {
+  assertExperimentalMcpResolveText,
   EXPECTED_EXPERIMENTAL_MCP_TOOLS,
   parseMcpSmokeArgs,
   STABLE_MCP_SMOKE_CONFIG,
@@ -198,6 +200,76 @@ describe("MCP smoke cohorts", () => {
 
   it("pins every stable cohort to an explicit disabled experimental config", () => {
     expect(STABLE_MCP_SMOKE_CONFIG).toBe("[experimental]\ntools = false\n");
+  });
+});
+
+describe("resolve smoke guidance", () => {
+  const cliMixed = `Candidates:
+  1. npm:express [exact] · package
+  2. npm:express-lookalike [high] · package
+     Warning: Malicious content affects the latest version. Do not use this target.
+
+Next: githits search '<query>' --in 'npm:express'
+`;
+  const mcpMixed = `Best match: npm:express [exact; package].
+Candidates:
+  1. npm:express [exact; package]
+  2. npm:express-lookalike [high; package]
+     Warning: Malicious content affects the latest version. Do not use this target.
+Next: pass the canonical target "npm:express" to the next MCP tool.
+`;
+
+  it("allows a verified best action when only an alternative is warned", () => {
+    expect(() => assertExperimentalCliResolveText(cliMixed)).not.toThrow();
+    expect(() => assertExperimentalMcpResolveText(mcpMixed)).not.toThrow();
+  });
+
+  it("accepts a warning-only blocked result with no normal action", () => {
+    const cliBlocked = cliMixed.replace(/\nNext: githits search[^\n]+\n/, "\n");
+    const mcpBlocked = mcpMixed.replace(
+      /Next: pass the canonical target[^\n]+\n/,
+      "",
+    );
+
+    expect(() => assertExperimentalCliResolveText(cliBlocked)).not.toThrow();
+    expect(() => assertExperimentalMcpResolveText(mcpBlocked)).not.toThrow();
+  });
+
+  it("rejects a direct action for the warned candidate", () => {
+    const cliWarnedBest = cliMixed.replace(
+      "  1. npm:express [exact] · package\n",
+      "  1. npm:express [exact] · package\n     Warning: Malicious content affects the latest version. Do not use this target.\n",
+    );
+    const mcpWarnedBest = mcpMixed.replace(
+      "  1. npm:express [exact; package]\n",
+      "  1. npm:express [exact; package]\n     Warning: Malicious content affects the latest version. Do not use this target.\n",
+    );
+
+    expect(() => assertExperimentalCliResolveText(cliWarnedBest)).toThrow(
+      "without a warning",
+    );
+    expect(() => assertExperimentalMcpResolveText(mcpWarnedBest)).toThrow(
+      "without a warning",
+    );
+  });
+
+  it("rejects aggregate restrictions and ambiguous actions with warnings", () => {
+    const aggregate =
+      "Warning: Some candidates are not actionable. Narrow the result before continuing.\n";
+    expect(() =>
+      assertExperimentalCliResolveText(`${cliMixed}${aggregate}`),
+    ).toThrow("without a warning");
+    expect(() =>
+      assertExperimentalMcpResolveText(`${mcpMixed}${aggregate}`),
+    ).toThrow("without a warning");
+
+    const cliAmbiguous = `${cliMixed.replace(
+      /\nNext: githits search[^\n]+\n/,
+      "\n",
+    )}Next after choosing: githits search '<query>' --in '<target>'\n`;
+    expect(() => assertExperimentalCliResolveText(cliAmbiguous)).toThrow(
+      "omit the normal next action",
+    );
   });
 });
 

--- a/src/commands/resolve.test.ts
+++ b/src/commands/resolve.test.ts
@@ -98,12 +98,29 @@ describe("resolveAction", () => {
     expect(String(writeSpy.mock.calls[0]?.[0])).toContain(
       "Candidates:\n  1. npm:express",
     );
+    expect(String(writeSpy.mock.calls[0]?.[0])).not.toContain("Warning:");
+    expect(String(writeSpy.mock.calls[0]?.[0])).not.toContain("malicious");
   });
 
   it("requests detailed data and prints clean JSON", async () => {
-    const resolveTarget = mock(() =>
-      Promise.resolve(defaultResolveTargetResult),
-    );
+    const affected = structuredClone(defaultResolveTargetResult);
+    const candidate = affected.candidates[0];
+    if (!candidate) throw new Error("fixture missing resolve candidate");
+    affected.candidates[0] = {
+      ...candidate,
+      latestVersionMaliciousStatus: "AFFECTED",
+      latestVersionMaliciousEvidence: {
+        advisories: [
+          {
+            osvId: "MAL-2026-1234",
+            classificationReasons: ["AFFECTED_VERSION_RANGE_MATCH"],
+          },
+        ],
+        totalCount: 1,
+        truncated: false,
+      },
+    };
+    const resolveTarget = mock(() => Promise.resolve(affected));
     const logSpy = spyOn(console, "log").mockImplementation(() => {});
 
     await resolveAction(
@@ -122,6 +139,22 @@ describe("resolveAction", () => {
     expect(JSON.parse(String(logSpy.mock.calls[0]?.[0]))).toMatchObject({
       best: "npm:express",
       ambiguous: false,
+      candidates: [
+        {
+          target: "npm:express",
+          latestVersionMaliciousStatus: "affected",
+          latestVersionMaliciousEvidence: {
+            advisories: [
+              {
+                osvId: "MAL-2026-1234",
+                classificationReasons: ["affected_version_range_match"],
+              },
+            ],
+            totalCount: 1,
+            truncated: false,
+          },
+        },
+      ],
     });
   });
 

--- a/src/services/test-helpers.ts
+++ b/src/services/test-helpers.ts
@@ -1053,6 +1053,7 @@ export const defaultResolveTargetResult: ResolveTargetResult = {
       registry: "NPM",
       stars: 66_000,
       downloadsLastMonth: 89_000_000,
+      latestVersionMaliciousStatus: "CLEAR",
       docsAvailable: true,
       codeAvailable: true,
       confidence: "EXACT",


### PR DESCRIPTION
## Outcome

GitHits now consumes the backend's latest-version malicious-content decision and its bounded OSV evidence throughout `resolve_target`, while keeping ordinary clean output terse and failing closed on malicious or uncertain results.

- selects and validates `latestVersionMaliciousStatus` plus nullable `latestVersionMaliciousEvidence` from schema `sha256:5f58e43a2ddc`
- preserves exact OSV IDs, lowercase classification reasons, advisory counts, and truncation metadata in structured CLI/MCP JSON
- keeps terminal and MCP text silent for `CLEAR` and `NOT_APPLICABLE`; `CLEAR` is not presented as a vulnerability-free claim
- renders red terminal warnings and ANSI-free MCP warnings for `AFFECTED` and `UNKNOWN`, with direct OSV links and concise uncertainty reasons
- percent-encodes advisory IDs as one OSV path segment and reports omitted advisory counts
- treats future malicious-status enum values as non-actionable
- permits ordinary continuation only for the existing non-ambiguous `EXACT`/`HIGH` identity rule with `CLEAR` or `NOT_APPLICABLE`
- removes normal Next/handoff guidance from blocked results and never encourages passing a blocked target to another tool
- leaves backend candidate ranking and filtering unchanged
- adds a `githits` patch release fragment; `@githits/mcp` remains unchanged because the tool is local/internal

Routine output remains compact. For `express`, the development CLI returns the normal candidate list and continuation with no security boilerplate; structured output preserves `clear` / `not_applicable` and omits null evidence.

## Verification

- focused resolve/GraphQL/CLI/MCP/smoke tests — 94 pass, 0 fail, 507 assertions
- copy-specific renderer/MCP/parity/smoke tests — 77 pass, 0 fail, 388 assertions
- `bun run typecheck`, `bun run format:check`, `bun run lint`, and `git diff --check` — pass
- root `githits` and `@githits/mcp` builds — pass
- development CLI smoke — 89 live steps passed
- development MCP smoke — 45 live steps passed, including experimental text and JSON resolve calls
- post-tightening development `resolve express --json` probe — passed with the full evidence selection
- deterministic renderers — affected warnings are red in terminal output; MCP text is ANSI-free; uncertain evidence includes reasons, encoded OSV links, and truncation; blocked results contain no normal handoff
- future status and future reason handling — covered deterministically and fail closed
- retained Claude review loop — clean after one speculative future-cap finding was rejected against the deployed bounded schema contract; the final copy-only delta also reviewed clean

The deployed development stack currently exposes no known public `AFFECTED` / `UNKNOWN` sample suitable for a live probe. Those paths are covered at the GraphQL client, structured payload, terminal, MCP, and actionability layers with deterministic fixtures.

The full repository suite previously completed 3096 tests with one unrelated fixed-five-second agent-eval dry-run timeout: the installed external `opencode --version` command takes about 8.6 seconds. The isolated test passes with a 15-second timeout; this branch does not change that harness.
