### PR TITLE
chore: prepare githits 0.10.2 release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,12 +6,12 @@
   },
   "metadata": {
     "description": "The code context layer for AI coding agents",
-    "version": "0.10.1"
+    "version": "0.10.2"
   },
   "plugins": [
     {
       "name": "githits",
-      "version": "0.10.1",
+      "version": "0.10.2",
       "description": "The code context layer for AI coding agents",
       "author": {
         "name": "GitHits"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ changes use independent files under [`changes/`](changes/README.md) and are
 consolidated here only during release preparation. Dated, versioned sections
 are historical records and change only to correct blatant factual errors.
 
+## [githits 0.10.2] - 2026-08-25
+
+Patch release: fine-tunes opt-in experimental target resolution for safer
+partial-readiness handling and makes targeted init reliability improvements.
+
+### Fixed
+
+- **Reliable init install and uninstall** - Use structured Claude user MCP
+  inspection and best-effort guidance cleanup so absent state is safe, failures
+  remain visible, and guidance reporting stays separate from agent counts.
+
+### Security
+
+- **Fail closed on malicious package candidates** - The opt-in experimental
+  resolver now preserves latest-version malicious-content decisions and bounded
+  OSV evidence, links affected or uncertain advisories in warnings, and
+  withholds normal CLI/MCP continuation for affected, unknown, or unrecognized
+  states.
+
 ## [githits 0.10.1] - 2026-08-24
 
 Patch release: hardens concurrent CLI authentication and preserves queryable

--- a/changes/init-uninstall-reliability.fixed.md
+++ b/changes/init-uninstall-reliability.fixed.md
@@ -1,6 +1,0 @@
----
-"githits": patch
-"@githits/mcp": none
----
-
-- **Reliable init install and uninstall** - Use structured Claude user MCP inspection and best-effort guidance cleanup so absent state is safe, failures remain visible, and guidance reporting stays separate from agent counts.

--- a/changes/resolve-target-malicious-status.security.md
+++ b/changes/resolve-target-malicious-status.security.md
@@ -1,6 +1,0 @@
----
-"githits": patch
-"@githits/mcp": none
----
-
-- **Fail closed on malicious package candidates** - Resolve output now preserves latest-version malicious-content decisions and bounded OSV evidence, links affected or uncertain advisories in warnings, and withholds normal CLI/MCP continuation for affected, unknown, or unrecognized states.

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "The code context layer for AI coding agents",
   "mcpServers": {
     "githits": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "githits",
   "description": "The code context layer for AI coding agents",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "mcpName": "com.githits/githits",
   "type": "module",
   "workspaces": [

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "githits",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/server.json
+++ b/server.json
@@ -16,7 +16,7 @@
     "source": "github",
     "id": "1165453165"
   },
-  "version": "0.10.1",
+  "version": "0.10.2",
   "remotes": [
     {
       "type": "streamable-http",
@@ -28,7 +28,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "githits",
-      "version": "0.10.1",
+      "version": "0.10.2",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Summary

- bump the root `githits` package and MCP registry manifest from `0.10.1` to `0.10.2`
- consolidate the two pending root fragments into the dated `githits 0.10.2` changelog section
- regenerate and align every versioned plugin, marketplace, and extension manifest
- keep `@githits/mcp` at `0.10.1` because the resolver behavior is reachable only through the workspace-only internal entrypoint; no public MCP export or declaration changed, and the MCP package is not republished

## Release scope

This is a narrow patch release. It fine-tunes the opt-in experimental target resolver for malicious-content and partial-readiness handling, and adds targeted reliability fixes for init install/uninstall state. No major GA surface changed.

## Validation

- `bun run plugins:generate`
- `bun run plugins:check`
- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `bun test` — 3,160 passed
- `bun run build`
- `bun run validate:packages`
- source CLI unauthenticated smoke passed
- source MCP stable + experimental registration smoke passed
- built Node CLI unauthenticated smoke passed
- built Node MCP stable + experimental registration smoke passed
- authenticated live CLI and MCP smoke reached the backend; each later `get_example` JSON call was rejected with HTTP 429 `RATE_LIMITED`, unrelated to this delta
- Claude and Codex experimental resolver evals both found GitHits helpful and preserved medium-confidence candidates as non-actionable; Claude also observed an unrelated backend error for the literal typo and Codex observed one normal indexing continuation
- Claude and Codex experimental code-diff evals succeeded with high confidence and no tool or instruction issues
- Claude and Codex `express-router` regression evals succeeded with high confidence and no tool or instruction issues
- checksum-verified `mcp-publisher` v1.7.9 validated `server.json`
- `githits@0.10.2` is not currently published; `@githits/mcp@0.10.1` remains published and unchanged
- `git diff --check`

## Publishing behavior

After merge, a successful `Main` workflow will publish `githits@0.10.2`, tag `v0.10.2`, create the GitHub release, and publish `com.githits/githits@0.10.2` to the MCP registry. No `@githits/mcp` release is expected.