### PR TITLE
fix: reject canonical resolve targets before backend calls

### DIFF
--- a/changes/resolve-canonical-input-guidance.fixed.md
+++ b/changes/resolve-canonical-input-guidance.fixed.md
@@ -1,0 +1,6 @@
+---
+"githits": patch
+"@githits/mcp": none
+---
+
+- **Reject canonical resolve inputs locally** - `githits resolve` and local `resolve_target` now direct already-canonical package and GitHub repository targets to the next GitHits tool without calling the resolver backend.

--- a/docs/experimental-tools.md
+++ b/docs/experimental-tools.md
@@ -76,7 +76,9 @@ githits resolve requests --registry pypi --prefer-kind package --json
 ```
 
 Canonical targets such as `npm:express` or `github:expressjs/express` do not
-need resolution.
+need resolution. Passing a package or GitHub repository target already accepted
+by downstream tools is rejected locally with `INVALID_ARGUMENT`; pass that
+target directly to the next GitHits tool instead.
 
 Structured output preserves each candidate's latest-version malicious-content
 decision. Text stays silent for `clear` and `not_applicable`; affected, uncertain,

--- a/docs/implementation/cli-commands.md
+++ b/docs/implementation/cli-commands.md
@@ -315,6 +315,15 @@ stars, the terminal shows its linked repository as compact
 `github:owner/repo` when possible and otherwise preserves the repository URL.
 Missing evidence is omitted rather than shown as zero.
 
+The shared CLI/local-MCP request boundary rejects an already-canonical package
+or GitHub repository target before the resolver service is called. Recognition
+reuses the compact parser used by downstream code-navigation tools, including
+registry-prefixed package targets and supported GitHub shorthand, host, URL,
+and ref forms. The mapped `INVALID_ARGUMENT` guidance tells the caller to pass
+that target directly to the next GitHits tool. Unprefixed human names such as
+`@types/node`, punctuated names, and slash-separated names remain resolver
+input.
+
 Terminal and MCP compact text share one actionability rule. A best result is a
 copyable/direct canonical next action only when it is non-ambiguous and has
 `EXACT` or `HIGH` confidence. Non-ambiguous `MEDIUM` and `LOW` results are
@@ -328,12 +337,14 @@ because the command did not resolve a target. The backend guarantees that
 `best` is absent only when there are no candidates, so the terminal no-result
 message and exit status key off `best`.
 
-`--registry` accepts a comma-separated package-registry list and the command
-help enumerates every accepted value; repository candidates remain eligible.
+`--registry` accepts a comma-separated package-registry list, constrains package
+candidates only, and leaves repository candidates eligible. The command help
+enumerates every accepted value.
 `--prefer-kind package|repository` is a soft preference, not a filter.
 `--intent-hint` is repeatable. `--limit` controls the ranked list from 1-20
 (default 8); protected exact-name matches can be additional. `--query` and
-`--intent-hint` are sent to the service as ranking context and must not contain
+`--intent-hint` are sent to the service as ranking context. They rank retrieved
+candidates and do not expand candidate retrieval, and must not contain
 credentials, personal data, private code, or proprietary content. Terminal
 errors sanitize untrusted service and option text while JSON errors preserve
 the structured value through JSON escaping.

--- a/docs/implementation/mcp-cli-parity.md
+++ b/docs/implementation/mcp-cli-parity.md
@@ -174,6 +174,11 @@ test suite anchors the doc.
   deeply equal. Invalid caller input keeps the stable classification and
   envelope shape; surface-native validation prose is allowed where the CLI
   names a command/flag and MCP names a tool/argument.
+- The shared resolve request boundary recognizes already-canonical package and
+  GitHub repository strings through the same compact parser used by downstream
+  tools. Both surfaces return the same `INVALID_ARGUMENT` guidance without a
+  resolver service call; human-friendly names that the parser does not accept
+  continue through normal resolution.
 - Text rendering, agent-specific descriptions, and the deliberate default
   view divergence are not parity targets. The MCP default is compact
   `text-v1`. Both resolve text renderers nevertheless use the same pure

--- a/packages/mcp/src/shared/resolve-target-request.test.ts
+++ b/packages/mcp/src/shared/resolve-target-request.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { PKGSEER_REGISTRY_ARGS } from "@githits/core-internal";
 import {
   buildResolveTargetParams,
   RESOLVE_TARGET_DEFAULT_LIMIT,
@@ -108,6 +109,38 @@ describe("buildResolveTargetParams", () => {
       registries: ["NPM", "PYPI"],
       preferredKinds: ["REPOSITORY"],
     });
+  });
+
+  it.each([
+    ...PKGSEER_REGISTRY_ARGS.map((registry) => `${registry}:example`),
+    "npm:@types/node",
+    "npm:react@18.2.0",
+    "npm: react state management",
+    "github:facebook/react",
+    "github:facebook/react#main",
+    "github.com/facebook/react",
+    "github.com/facebook/react@main",
+    "https://github.com/facebook/react",
+    "http://github.com/facebook/react#main",
+  ])("rejects already-canonical target %s", (name) => {
+    expect(() =>
+      buildResolveTargetParams({ name, includeDetailedFields: false }),
+    ).toThrow(
+      `Canonical target ${JSON.stringify(name)} does not need resolution. Pass it directly to the next GitHits tool.`,
+    );
+  });
+
+  it.each([
+    "@scope/package",
+    "react-native",
+    "owner/repository",
+    "GitHub Copilot",
+    "npm package react",
+    "acme:widget",
+  ])("preserves nearby human name %s", (name) => {
+    expect(
+      buildResolveTargetParams({ name, includeDetailedFields: false }),
+    ).toMatchObject({ name });
   });
 
   it("rejects invalid MCP registry entries and preserves an empty filter", () => {

--- a/packages/mcp/src/shared/resolve-target-request.ts
+++ b/packages/mcp/src/shared/resolve-target-request.ts
@@ -7,7 +7,11 @@ import {
   type ResolveTargetParams,
   toPkgseerRegistry,
 } from "@githits/core-internal";
-import { InvalidPackageSpecError } from "./package-spec.js";
+import { parseCodeNavigationTargetSpec } from "./code-navigation-target.js";
+import {
+  InvalidArgumentError,
+  InvalidPackageSpecError,
+} from "./package-spec.js";
 
 export const RESOLVE_TARGET_DEFAULT_LIMIT = 8;
 export const RESOLVE_TARGET_MAX_LIMIT = 20;
@@ -28,6 +32,7 @@ export function buildResolveTargetParams(
 ): ResolveTargetParams {
   const name = input.name?.trim() ?? "";
   if (!name) throw new InvalidPackageSpecError("Target name is required.");
+  rejectCanonicalTarget(name);
 
   const limit = input.limit ?? RESOLVE_TARGET_DEFAULT_LIMIT;
   if (
@@ -57,6 +62,19 @@ export function buildResolveTargetParams(
   const intentHints = normaliseStrings(input.intentHints);
   if (intentHints.length > 0) params.intentHints = intentHints;
   return params;
+}
+
+/** Keep fuzzy resolution aligned with the target grammar used downstream. */
+function rejectCanonicalTarget(name: string): void {
+  try {
+    parseCodeNavigationTargetSpec(name);
+  } catch (error) {
+    if (error instanceof InvalidArgumentError) return;
+    throw error;
+  }
+  throw new InvalidArgumentError(
+    `Canonical target ${JSON.stringify(name)} does not need resolution. Pass it directly to the next GitHits tool.`,
+  );
 }
 
 function parseRegistries(

--- a/packages/mcp/src/tools/resolve-target.test.ts
+++ b/packages/mcp/src/tools/resolve-target.test.ts
@@ -96,6 +96,21 @@ describe("resolve_target MCP adapter", () => {
       default: "text-v1",
       enum: ["text-v1", "text", "json"],
     });
+    expect(schema.properties?.query).toMatchObject({
+      description: expect.stringContaining(
+        "rank retrieved candidates and does not expand candidate retrieval",
+      ),
+    });
+    expect(schema.properties?.registries).toMatchObject({
+      description: expect.stringContaining(
+        "constrains package candidates only",
+      ),
+    });
+    expect(schema.properties?.intent_hints).toMatchObject({
+      description: expect.stringContaining(
+        "rank retrieved candidates and do not expand candidate retrieval",
+      ),
+    });
     for (const phrase of [
       "Experimental",
       "fuzzy",

--- a/packages/mcp/src/tools/resolve-target.ts
+++ b/packages/mcp/src/tools/resolve-target.ts
@@ -46,13 +46,13 @@ const schema: ZodRawShape = {
     .string()
     .optional()
     .describe(
-      "Optional task context used for ranking. Do not include credentials, personal data, private code, or proprietary content.",
+      "Optional task context used to rank retrieved candidates and does not expand candidate retrieval. Do not include credentials, personal data, private code, or proprietary content.",
     ),
   registries: z
     .array(z.string())
     .optional()
     .describe(
-      `Optional registry filter. Accepted registries: ${PKGSEER_REGISTRY_LIST}. An empty list deliberately means no filter.`,
+      `Optional registry filter that constrains package candidates only; repository candidates remain eligible. Accepted registries: ${PKGSEER_REGISTRY_LIST}. An empty list deliberately means no filter.`,
     ),
   preferred_kind: z
     .string()
@@ -64,7 +64,7 @@ const schema: ZodRawShape = {
     .array(z.string())
     .optional()
     .describe(
-      "Optional ranking hints. Empty, blank, and duplicate hints are ignored. Do not include credentials, personal data, private code, or proprietary content.",
+      "Optional hints that rank retrieved candidates and do not expand candidate retrieval. Empty, blank, and duplicate hints are ignored. Do not include credentials, personal data, private code, or proprietary content.",
     ),
   limit: z
     .number()

--- a/src/commands/resolve.test.ts
+++ b/src/commands/resolve.test.ts
@@ -439,6 +439,9 @@ describe("registerResolveCommand", () => {
     expect(resolveCommand?.description()).toContain(
       "rank retrieved candidates and do not expand candidate retrieval",
     );
+    expect(resolveCommand?.description()).toContain(
+      "Pass canonical registry:name or github:owner/repo targets directly",
+    );
     for (const registry of PKGSEER_REGISTRY_ARGS) {
       expect(help).toContain(registry);
     }

--- a/src/commands/resolve.test.ts
+++ b/src/commands/resolve.test.ts
@@ -436,13 +436,18 @@ describe("registerResolveCommand", () => {
     expect(resolveCommand?.description()).toContain(
       "include credentials, personal data, private code",
     );
+    expect(resolveCommand?.description()).toContain(
+      "rank retrieved candidates and do not expand candidate retrieval",
+    );
     for (const registry of PKGSEER_REGISTRY_ARGS) {
       expect(help).toContain(registry);
     }
     expect(
       resolveCommand?.options.find((option) => option.long === "--registry")
         ?.description,
-    ).toBe(`Comma-separated package registries: ${PKGSEER_REGISTRY_LIST}`);
+    ).toBe(
+      `Comma-separated filter that constrains package candidates only: ${PKGSEER_REGISTRY_LIST}`,
+    );
   });
 
   it("collects repeated intent hints in command-line order", () => {

--- a/src/commands/resolve.ts
+++ b/src/commands/resolve.ts
@@ -120,6 +120,9 @@ function collectIntentHint(value: string, previous: string[] = []): string[] {
 
 const DESCRIPTION = `Resolve a human-provided name to ranked package or GitHub repository targets.
 
+Pass canonical registry:name or github:owner/repo targets directly to the next
+GitHits command; resolve rejects them locally.
+
 The optional --query and --intent-hint values are sent to the service as ranking
 context. They rank retrieved candidates and do not expand candidate retrieval.
 Do not include credentials, personal data, private code, or proprietary content

--- a/src/commands/resolve.ts
+++ b/src/commands/resolve.ts
@@ -121,8 +121,9 @@ function collectIntentHint(value: string, previous: string[] = []): string[] {
 const DESCRIPTION = `Resolve a human-provided name to ranked package or GitHub repository targets.
 
 The optional --query and --intent-hint values are sent to the service as ranking
-context. Do not include credentials, personal data, private code, or proprietary
-content in either option.`;
+context. They rank retrieved candidates and do not expand candidate retrieval.
+Do not include credentials, personal data, private code, or proprietary content
+in either option.`;
 
 export function registerResolveCommand(program: Command): Command {
   return program
@@ -133,7 +134,7 @@ export function registerResolveCommand(program: Command): Command {
     .option("-q, --query <text>", "Task context used as a soft ranking hint")
     .option(
       "--registry <list>",
-      `Comma-separated package registries: ${PKGSEER_REGISTRY_LIST}`,
+      `Comma-separated filter that constrains package candidates only: ${PKGSEER_REGISTRY_LIST}`,
     )
     .option("--prefer-kind <kind>", "Soft preference: package or repository")
     .option(

--- a/src/tools/resolve-target-parity.test.ts
+++ b/src/tools/resolve-target-parity.test.ts
@@ -214,4 +214,77 @@ describe("resolve_target parity", () => {
       Object.keys(mcp as object).sort(),
     );
   });
+
+  it.each(["npm:react", "github:facebook/react"])(
+    "PARITY-ERROR-ENVELOPE: canonical target %s is rejected before service calls",
+    async (name) => {
+      const cliResolveTarget = mock((_params: ResolveTargetParams) =>
+        Promise.resolve(defaultResolveTargetResult),
+      );
+      const mcpResolveTarget = mock((_params: ResolveTargetParams) =>
+        Promise.resolve(defaultResolveTargetResult),
+      );
+      const cli = await cliJson(
+        name,
+        {},
+        cliDeps({
+          resolveTargetService: createMockResolveTargetService({
+            resolveTarget: cliResolveTarget,
+          }),
+        }),
+      );
+      const tool = createParityExperimentalMcpTool("resolve_target", {
+        resolveTargetService: createMockResolveTargetService({
+          resolveTarget: mcpResolveTarget,
+        }),
+      });
+      const mcpResult = await tool.handler({ name, format: "json" }, {});
+      const mcp = JSON.parse(mcpResult.content[0]?.text ?? "{}");
+
+      expect(cliResolveTarget).not.toHaveBeenCalled();
+      expect(mcpResolveTarget).not.toHaveBeenCalled();
+      expect(mcpResult.isError).toBe(true);
+      expect(cli).toEqual(mcp);
+      expect(cli).toEqual({
+        error: `Canonical target ${JSON.stringify(name)} does not need resolution. Pass it directly to the next GitHits tool.`,
+        code: "INVALID_ARGUMENT",
+        retryable: false,
+      });
+    },
+  );
+
+  it.each(["@scope/package", "react-native", "owner/repository"])(
+    "PARITY-EXPERIMENTAL-LOCAL: human name %s reaches both services",
+    async (name) => {
+      const cliResolveTarget = mock((_params: ResolveTargetParams) =>
+        Promise.resolve(defaultResolveTargetResult),
+      );
+      const mcpResolveTarget = mock((_params: ResolveTargetParams) =>
+        Promise.resolve(defaultResolveTargetResult),
+      );
+
+      await cliJson(
+        name,
+        {},
+        cliDeps({
+          resolveTargetService: createMockResolveTargetService({
+            resolveTarget: cliResolveTarget,
+          }),
+        }),
+      );
+      const tool = createParityExperimentalMcpTool("resolve_target", {
+        resolveTargetService: createMockResolveTargetService({
+          resolveTarget: mcpResolveTarget,
+        }),
+      });
+      await tool.handler({ name, format: "json" }, {});
+
+      expect(cliResolveTarget).toHaveBeenCalledTimes(1);
+      expect(mcpResolveTarget).toHaveBeenCalledTimes(1);
+      expect(cliResolveTarget.mock.calls[0]?.[0]).toEqual(
+        mcpResolveTarget.mock.calls[0]?.[0],
+      );
+      expect(cliResolveTarget.mock.calls[0]?.[0]).toMatchObject({ name });
+    },
+  );
 });


### PR DESCRIPTION
## Outcome

- Reject package and GitHub repository targets already accepted by downstream GitHits tools at the shared resolve request boundary.
- Return identical actionable INVALID_ARGUMENT guidance from githits resolve and local resolve_target without calling the resolver backend.
- Preserve fuzzy and human-friendly inputs, including unprefixed scoped npm names and punctuated or slash-separated names.
- Clarify that registry filters constrain package candidates only, while query and intent hints rank retrieved candidates without expanding retrieval.
- Preserve the malware status, warning, and actionability behavior shipped in PR #304.

## Implementation

Recognition reuses parseCodeNavigationTargetSpec, the existing compact package/repository contract used by downstream CLI and MCP code-navigation tools. The resolver request builder converts parser success into the local direct-use error and treats parser failures as fuzzy input, avoiding a second target grammar.

Release impact is githits patch and @githits/mcp none because resolve_target remains config-gated and local-only.

## Verification

- Focused resolver request, CLI, MCP, and parity suites: 72 tests, 285 assertions.
- Final bun test: 3,192 tests, 9,915 assertions.
- bun run build and commit-hook typecheck/Biome checks passed.
- bun run plugins:generate produced no generated diff; bun run plugins:check validated 10 assets.
- Source MCP smoke passed 45 stable and experimental live steps.
- Source CLI smoke passed 89 stable and experimental live steps.
- Built MCP registration smoke passed 6 steps; final built CLI smoke passed 18 steps.
- Claude and Codex each completed experimental-resolution-follow-up, experimental-code-diff, and express-router against local experimental MCP. All harness workloads succeeded and rated GitHits helpful. Existing lodahs backend ranking/security-message observations reproduced; no canonical-input regression surfaced.

The first concurrent source-smoke attempt hit the backend rate limit; sequential reruns passed both suites.

## Review

- Internal full-delta review: clean.
- Opus round 1: one low CLI-help omission accepted and fixed.
- Internal closure review: clean.
- Opus round 2: clean, no residual risks.