### PR TITLE
chore: prepare githits 0.11.0 release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,12 +6,12 @@
   },
   "metadata": {
     "description": "The code context layer for AI coding agents",
-    "version": "0.10.2"
+    "version": "0.11.0"
   },
   "plugins": [
     {
       "name": "githits",
-      "version": "0.10.2",
+      "version": "0.11.0",
       "description": "The code context layer for AI coding agents",
       "author": {
         "name": "GitHits"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@ range semantics.
 - **Improve remote MCP tool routing** - Make tool catalogs benefit-first with
   explicit workflow handoffs, replace inconsistently surfaced server
   instructions with a one-call `quick_start` guide, and compact the packaged
-  Agent Skill to point at that guide.
+  Agent Skill to point at that guide. Deploy the hosted endpoint with
+  `@githits/mcp` 0.11.0 before relying on `quick_start` from remote plugins and
+  extensions.
 
 ### Fixed
 
@@ -26,10 +28,12 @@ range semantics.
   setup while retaining the nested compatibility alias.
 - **Correct changelog range semantics** - Document and expose `from` as an
   exclusive lower bound, so exact-release and range requests use the backend
-  contract consistently.
-- **Reject canonical resolve inputs locally** - `githits resolve` and local
-  `resolve_target` now direct already-canonical package and GitHub repository
-  targets to the next GitHits tool without calling the resolver backend.
+  contract consistently. Returned entries preserve backend/source order;
+  consumers must not assume newest-first ordering.
+- **Reject canonical resolve inputs locally** - The opt-in experimental
+  `githits resolve` command and local `resolve_target` tool now direct
+  already-canonical package and GitHub repository targets to the next GitHits
+  tool without calling the resolver backend.
 
 ## [@githits/mcp 0.11.0] - 2026-08-26
 
@@ -43,12 +47,16 @@ routing, and aligns changelog range semantics with the backend contract.
   server instructions with a one-call `quick_start` guide. `createMcpServer()`
   now leaves initialize instructions caller-owned; use `quickStartOptions`
   instead of the deprecated `instructionOptions` to configure the guide.
+  `buildMcpInstructions()` remains a deprecated alias for
+  `buildMcpQuickStart()`, and the public smoke helper now requires and checks
+  `quick_start` in the stable tool inventory.
 
 ### Fixed
 
 - **Correct changelog range semantics** - Document and expose `from` as an
   exclusive lower bound, so exact-release and range requests use the backend
-  contract consistently.
+  contract consistently. Returned entries preserve backend/source order;
+  consumers must not assume newest-first ordering.
 
 ## [githits 0.10.2] - 2026-08-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,52 @@ changes use independent files under [`changes/`](changes/README.md) and are
 consolidated here only during release preparation. Dated, versioned sections
 are historical records and change only to correct blatant factual errors.
 
+## [githits 0.11.0] - 2026-08-26
+
+Minor release: adds portable MCP quick-start guidance, makes onboarding setup
+and removal predictable, and tightens local request validation and changelog
+range semantics.
+
+### Changed
+
+- **Improve remote MCP tool routing** - Make tool catalogs benefit-first with
+  explicit workflow handoffs, replace inconsistently handled server
+  instructions with a one-call `quick_start` guide, compact the Agent Skill to
+  point at that guide, and add MCP-only versus fully guided eval coverage with
+  Luna/high Codex defaults.
+
+### Fixed
+
+- **Make onboarding setup and removal predictable** - `init` now targets
+  selected agents and repairs all packaged guidance with transport-aware
+  readiness output; the canonical `githits uninstall` command removes GitHits
+  setup while retaining the nested compatibility alias.
+- **Correct changelog range semantics** - Document and expose `from` as an
+  exclusive lower bound, so exact-release and range requests use the backend
+  contract consistently.
+- **Reject canonical resolve inputs locally** - `githits resolve` and local
+  `resolve_target` now direct already-canonical package and GitHub repository
+  targets to the next GitHits tool without calling the resolver backend.
+
+## [@githits/mcp 0.11.0] - 2026-08-26
+
+Coordinated minor release: adds portable one-call MCP guidance, improves tool
+routing, and aligns changelog range semantics with the backend contract.
+
+### Changed
+
+- **Improve remote MCP tool routing** - Make tool catalogs benefit-first with
+  explicit workflow handoffs, replace inconsistently handled server
+  instructions with a one-call `quick_start` guide, compact the Agent Skill to
+  point at that guide, and add MCP-only versus fully guided eval coverage with
+  Luna/high Codex defaults.
+
+### Fixed
+
+- **Correct changelog range semantics** - Document and expose `from` as an
+  exclusive lower bound, so exact-release and range requests use the backend
+  contract consistently.
+
 ## [githits 0.10.2] - 2026-08-25
 
 Patch release: fine-tunes opt-in experimental target resolution for safer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,9 @@ range semantics.
 ### Changed
 
 - **Improve remote MCP tool routing** - Make tool catalogs benefit-first with
-  explicit workflow handoffs, replace inconsistently handled server
-  instructions with a one-call `quick_start` guide, compact the Agent Skill to
-  point at that guide, and add MCP-only versus fully guided eval coverage with
-  Luna/high Codex defaults.
+  explicit workflow handoffs, replace inconsistently surfaced server
+  instructions with a one-call `quick_start` guide, and compact the packaged
+  Agent Skill to point at that guide.
 
 ### Fixed
 
@@ -40,10 +39,10 @@ routing, and aligns changelog range semantics with the backend contract.
 ### Changed
 
 - **Improve remote MCP tool routing** - Make tool catalogs benefit-first with
-  explicit workflow handoffs, replace inconsistently handled server
-  instructions with a one-call `quick_start` guide, compact the Agent Skill to
-  point at that guide, and add MCP-only versus fully guided eval coverage with
-  Luna/high Codex defaults.
+  explicit workflow handoffs and replace inconsistently surfaced default
+  server instructions with a one-call `quick_start` guide. `createMcpServer()`
+  now leaves initialize instructions caller-owned; use `quickStartOptions`
+  instead of the deprecated `instructionOptions` to configure the guide.
 
 ### Fixed
 

--- a/bun.lock
+++ b/bun.lock
@@ -44,7 +44,7 @@
     },
     "packages/mcp": {
       "name": "@githits/mcp",
-      "version": "0.10.1",
+      "version": "0.11.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "^4.4.3",

--- a/changes/onboarding-audit.fixed.md
+++ b/changes/onboarding-audit.fixed.md
@@ -1,6 +1,0 @@
----
-"githits": patch
-"@githits/mcp": none
----
-
-- **Make onboarding setup and removal predictable** - `init` now targets selected agents and repairs all packaged guidance with transport-aware readiness output; the canonical `githits uninstall` command removes GitHits setup while retaining the nested compatibility alias.

--- a/changes/pkg-changelog-exclusive-range.fixed.md
+++ b/changes/pkg-changelog-exclusive-range.fixed.md
@@ -1,6 +1,0 @@
----
-"githits": patch
-"@githits/mcp": patch
----
-
-- **Correct changelog range semantics** - Document and expose `from` as an exclusive lower bound, so exact-release and range requests use the backend contract consistently.

--- a/changes/remote-mcp-tool-routing.changed.md
+++ b/changes/remote-mcp-tool-routing.changed.md
@@ -1,6 +1,0 @@
----
-"githits": minor
-"@githits/mcp": minor
----
-
-- **Improve remote MCP tool routing** - Make tool catalogs benefit-first with explicit workflow handoffs, replace inconsistently handled server instructions with a one-call `quick_start` guide, compact the Agent Skill to point at that guide, and add MCP-only versus fully guided eval coverage with Luna/high Codex defaults.

--- a/changes/resolve-canonical-input-guidance.fixed.md
+++ b/changes/resolve-canonical-input-guidance.fixed.md
@@ -1,6 +1,0 @@
----
-"githits": patch
-"@githits/mcp": none
----
-
-- **Reject canonical resolve inputs locally** - `githits resolve` and local `resolve_target` now direct already-canonical package and GitHub repository targets to the next GitHits tool without calling the resolver backend.

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "description": "The code context layer for AI coding agents",
   "mcpServers": {
     "githits": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "githits",
   "description": "The code context layer for AI coding agents",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "mcpName": "com.githits/githits",
   "type": "module",
   "workspaces": [

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@githits/mcp",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "Reusable MCP server APIs and tools for GitHits",
   "type": "module",
   "files": [

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "githits",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/server.json
+++ b/server.json
@@ -16,7 +16,7 @@
     "source": "github",
     "id": "1165453165"
   },
-  "version": "0.10.2",
+  "version": "0.11.0",
   "remotes": [
     {
       "type": "streamable-http",
@@ -28,7 +28,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "githits",
-      "version": "0.10.2",
+      "version": "0.11.0",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Summary

- bump githits and @githits/mcp to the coordinated minor version 0.11.0
- consolidate all four pending fragments into separate dated changelog sections and remove the consumed files
- align server.json, bun.lock, and every generated version-bearing plugin, marketplace, and extension manifest
- document the hosted MCP rollout dependency and public MCP compatibility changes found during release review

## Release scope

This minor release adds the portable quick_start MCP guidance flow, improves tool routing, makes onboarding setup/removal predictable, corrects changelog range and ordering contracts, and rejects canonical experimental resolve inputs locally.

The hosted endpoint must deploy @githits/mcp 0.11.0 before remote plugins and extensions rely on quick_start.

## Validation

- bun run plugins:generate — generated 10 assets
- bun run plugins:check — validated 10 assets
- bun test — passed
- bun run typecheck — passed
- bun run lint — passed
- bun run format:check — 422 files checked, no fixes
- bun run build — passed
- bun run --cwd packages/mcp build — passed
- bun run validate:packages — passed
- bun run validate:packages:mcp-publish — passed
- bun run smoke:cli — authenticated stable and experimental cohorts passed, 89 steps
- bun run smoke:mcp — authenticated stable and experimental cohorts passed, 46 steps
- bun run smoke:cli:built — Node-built stable and experimental unauthenticated suite passed, 18 steps
- bun run smoke:mcp:built — Node-built stable and experimental registration suite passed, 7 steps
- bun test src/package-release-boundaries.test.ts after review changes — 7 passed, 0 failed, 41 assertions
- git diff --check — passed
- direct mcp-publisher validate server.json was not run because the pinned binary is unavailable locally; server.json changes only the two aligned SemVer strings on the previously accepted shape

## Review

Claude Opus review loop completed in three rounds:

- round 1 found two valid artifact-accuracy gaps, both fixed; one category suggestion was rejected because categories derive from fragment suffixes
- round 2 verified those closures and found four minor compatibility/rollout note gaps through its one permitted fresh-context check; all were verified and fixed
- round 3 verified every closure and reported no findings
- internal Codex review was clean before every external round

The Claude reviewer remains retained for pre-merge follow-up.

## Publishing behavior

Do not merge without separate explicit approval for this PR. After an approved merge, a successful Main workflow will trigger both release workflows: publish githits@0.11.0 and @githits/mcp@0.11.0, create their tags/releases, and publish com.githits/githits@0.11.0 to the MCP registry. Hosted MCP deployment remains a separate operator action.