### PR TITLE
chore: prepare 0.11.1 patch releases

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,12 +6,12 @@
   },
   "metadata": {
     "description": "The code context layer for AI coding agents",
-    "version": "0.11.0"
+    "version": "0.11.1"
   },
   "plugins": [
     {
       "name": "githits",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "description": "The code context layer for AI coding agents",
       "author": {
         "name": "GitHits"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,68 @@ changes use independent files under [`changes/`](changes/README.md) and are
 consolidated here only during release preparation. Dated, versioned sections
 are historical records and change only to correct blatant factual errors.
 
+## [githits 0.11.1] - 2026-08-27
+
+Patch release: reduces agent context round trips, improves package-tool
+selection, and makes selected uninstall cleanup and diagnostics ownership more
+predictable.
+
+### Changed
+
+- **Reduce agent context round trips** - Allow deliberate 300-line source and
+  documentation reads while keeping 150-line defaults, align grep per-file
+  limits with requested totals, clarify served indexing snapshots, and improve
+  public-repository discovery and source safety guidance.
+- **Clarify packaged ownership guidance** - Agent guidance now assigns
+  diagnostics lifecycle and output destinations to the CLI host while core and
+  MCP remain host-neutral; MCP error classifiers no longer emit CLI debug
+  lines, while core service diagnostics can still emit when the CLI container
+  injects them.
+- **Improve package-tool selection** - Package MCP descriptions now lead with
+  compact user-intent phrases so truncated tool catalogs distinguish health,
+  vulnerability, dependency, changelog, and upgrade questions.
+
+### Fixed
+
+- **Respect uninstall selection for guidance** - Interactive user uninstall
+  now removes guidance only for selected tools whose MCP is absent after
+  cleanup and preserves shared guidance usable by any detected tool that was
+  kept.
+
+## [@githits/mcp 0.11.1] - 2026-08-27
+
+Coordinated patch release: adds the browser-callable tool entry, propagates
+host execution context, reduces agent context round trips, and tightens the
+public client boundary.
+
+### Added
+
+- **Add browser-callable tools entry** - `@githits/mcp/tools` exposes the
+  validated `get_example` callable surface for frontend WebMCP integration;
+  only this selected runtime graph is browser-safe, while the installed package
+  and other entries remain Node-oriented.
+
+### Changed
+
+- **Reduce agent context round trips** - Allow deliberate 300-line source and
+  documentation reads while keeping 150-line defaults, align grep per-file
+  limits with requested totals, clarify served indexing snapshots, and improve
+  public-repository discovery and source safety guidance.
+- **Add host-aware terms remediation and cancellation** - Hosted and
+  browser-callable defaults now use canonical acceptance-URL guidance, while
+  local CLI and stdio hosts preserve the CLI command override; explicit caller
+  cancellation propagates through execution context so trace hooks observe
+  rejection and cancelled work cannot refresh or retry.
+- **Improve package-tool selection** - Package MCP descriptions now lead with
+  compact user-intent phrases so truncated tool catalogs distinguish health,
+  vulnerability, dependency, changelog, and upgrade questions.
+
+### Removed
+
+- **Remove client telemetry lifecycle globals** - The pre-1.0
+  `@githits/mcp/client` telemetry lifecycle exports are removed; remote hosts
+  inject `ServiceDiagnostics` when they need operation or debug diagnostics.
+
 ## [githits 0.11.0] - 2026-08-26
 
 Minor release: adds portable MCP quick-start guidance, makes onboarding setup

--- a/bun.lock
+++ b/bun.lock
@@ -44,7 +44,7 @@
     },
     "packages/mcp": {
       "name": "@githits/mcp",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "^4.4.3",

--- a/changes/agent-context-caps.changed.md
+++ b/changes/agent-context-caps.changed.md
@@ -1,9 +1,0 @@
----
-"githits": patch
-"@githits/mcp": patch
----
-
-- **Reduce agent context round trips** - Allow deliberate 300-line source and
-  documentation reads while keeping 150-line defaults, align grep per-file
-  limits with requested totals, clarify served indexing snapshots, and improve
-  public-repository discovery and source safety guidance.

--- a/changes/core-mcp-host-boundary-browser-tools.added.md
+++ b/changes/core-mcp-host-boundary-browser-tools.added.md
@@ -1,6 +1,0 @@
----
-"githits": none
-"@githits/mcp": minor
----
-
-- **Add browser-callable tools entry** - `@githits/mcp/tools` exposes the validated `get_example` callable surface for frontend WebMCP integration; only this selected runtime graph is browser-safe, while the installed package and other entries remain Node-oriented.

--- a/changes/core-mcp-host-boundary-execution-context.changed.md
+++ b/changes/core-mcp-host-boundary-execution-context.changed.md
@@ -1,6 +1,0 @@
----
-"githits": none
-"@githits/mcp": minor
----
-
-- **Add host-aware terms remediation and cancellation** - Hosted and browser-callable defaults now use canonical acceptance-URL guidance, while local CLI and stdio hosts preserve the CLI command override; explicit caller cancellation propagates through execution context so trace hooks observe rejection and cancelled work cannot refresh or retry.

--- a/changes/core-mcp-host-boundary-mcp-telemetry-exports.removed.md
+++ b/changes/core-mcp-host-boundary-mcp-telemetry-exports.removed.md
@@ -1,6 +1,0 @@
----
-"githits": none
-"@githits/mcp": patch
----
-
-- **Remove client telemetry lifecycle globals** - The pre-1.0 `@githits/mcp/client` telemetry lifecycle exports are removed; remote hosts inject `ServiceDiagnostics` when they need operation or debug diagnostics.

--- a/changes/core-mcp-host-boundary-packaged-agent-guidance.changed.md
+++ b/changes/core-mcp-host-boundary-packaged-agent-guidance.changed.md
@@ -1,6 +1,0 @@
----
-"githits": patch
-"@githits/mcp": none
----
-
-- **Clarify packaged ownership guidance** - Agent guidance now assigns diagnostics lifecycle and output destinations to the CLI host while core and MCP remain host-neutral; MCP error classifiers no longer emit CLI debug lines, while core service diagnostics can still emit when the CLI container injects them.

--- a/changes/package-tool-trigger-descriptions.changed.md
+++ b/changes/package-tool-trigger-descriptions.changed.md
@@ -1,8 +1,0 @@
----
-"githits": patch
-"@githits/mcp": patch
----
-
-- **Improve package-tool selection** - Package MCP descriptions now lead with
-  compact user-intent phrases so truncated tool catalogs distinguish health,
-  vulnerability, dependency, changelog, and upgrade questions.

--- a/changes/scope-interactive-uninstall-guidance.fixed.md
+++ b/changes/scope-interactive-uninstall-guidance.fixed.md
@@ -1,6 +1,0 @@
----
-"githits": patch
-"@githits/mcp": none
----
-
-- **Respect uninstall selection for guidance** - Interactive user uninstall now removes guidance only for selected tools whose MCP is absent after cleanup and preserves shared guidance usable by any detected tool that was kept.

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "The code context layer for AI coding agents",
   "mcpServers": {
     "githits": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "githits",
   "description": "The code context layer for AI coding agents",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "mcpName": "com.githits/githits",
   "type": "module",
   "workspaces": [

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@githits/mcp",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Reusable MCP server APIs and tools for GitHits",
   "type": "module",
   "files": [

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "githits",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/server.json
+++ b/server.json
@@ -16,7 +16,7 @@
     "source": "github",
     "id": "1165453165"
   },
-  "version": "0.11.0",
+  "version": "0.11.1",
   "remotes": [
     {
       "type": "streamable-http",
@@ -28,7 +28,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "githits",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Summary

- prepare coordinated patch releases for githits 0.11.1 and @githits/mcp 0.11.1
- consolidate all seven pending fragments into separate dated artifact sections and remove the consumed files
- align package, MCP registry, lockfile, and generated plugin/extension versions

## SemVer decision

Two consumed @githits/mcp fragments were marked minor. Per explicit maintainer direction, this release applies a patch bump instead: GitHits is currently the only MCP package consumer, and both public artifacts remain aligned on the 0.11 minor line.

## Validation

- bun run plugins:check
- git diff --check
- bun test — 3321 passed, 0 failed
- bun run build
- bun run validate:packages
- bun run validate:packages:mcp-publish
- source and built unauthenticated CLI/MCP smoke suites
- bun run smoke:cli — 89 live steps passed
- bun run smoke:mcp — 46 live steps passed
- mcp-publisher v1.7.9 checksum verification and server.json validation
- targeted Codex and Claude package-tool routing evals, including a clean identical Codex rerun for one model-variance miss
- internal Codex review and Claude Opus review — clean

## Release gate

Opening this PR completes release preparation. Do not merge or enable auto-merge until a maintainer gives separate explicit approval for this PR.