### PR TITLE
feat: add trustworthy local agent eval metrics

### DIFF
--- a/changes/agent-eval-metrics.changed.md
+++ b/changes/agent-eval-metrics.changed.md
@@ -1,0 +1,6 @@
+---
+"githits": none
+"@githits/mcp": none
+---
+
+- **Agent eval metrics** - Maintainer-facing local eval runs now persist normalized usage, cost, tool-surface, and report metrics; public package artifacts are unchanged.

--- a/docs/implementation/agentic-eval-metrics.md
+++ b/docs/implementation/agentic-eval-metrics.md
@@ -60,7 +60,9 @@ status, exit code, timeout, and relative artifact paths.
 failed counts, sorted unique normalized tool names, ordered sequence entries,
 and result bytes when available. Sequence entries retain `mcp` or `cli`
 surface and normalized status (`started`, `completed`, `failed`, or `unknown`).
-The builder preserves duplicate events and order. A persisted call with
+The builder preserves duplicate raw observations and their order; Codex's
+derived sequence applies provider-ID pairing as described below. A persisted
+call with
 `server: "githits-cli"` is `cli`; other persisted GitHits calls are `mcp`.
 
 The run aggregates sum only known record values. Token and cost totals are
@@ -93,12 +95,16 @@ above 272,000, the artifact retains the base estimate and emits
 `long_context_pricing_not_attributable`, because the request that crossed the
 pricing boundary cannot be reconstructed.
 
-The current Codex extraction persists one event per extracted tool event, so
-its logical-call count is provisional: Codex can emit `item.started` and
-`item.completed` for one underlying MCP call. Use `sequence` and the raw
-`tool-calls.json` when exact call pairing matters; a later correction will
-reconcile provider event pairs. Claude and OpenCode currently remain runnable
-but report unknown usage/cost with `adapter_not_implemented`.
+Codex extraction carries the provider's non-sensitive `item.id` on each raw
+tool observation. The metrics builder preserves every observation in
+`rawEventCount`, then pairs only Codex observations with the same surface, ID,
+and normalized tool name. The first observation determines sequence order and
+the latest observation supplies status, so a started-only call counts once and
+separate IDs for the same tool remain separate calls. The derived sequence
+does not persist the provider ID or tool arguments. Observations without an ID
+are not paired heuristically. Claude and OpenCode remain runnable but report
+unknown usage/cost and logical tool count with `adapter_not_implemented` and
+`tool_logical_count_not_implemented`.
 
 ## Report and console fields
 

--- a/docs/implementation/agentic-eval-metrics.md
+++ b/docs/implementation/agentic-eval-metrics.md
@@ -28,6 +28,9 @@ For each run, `scripts/agent-eval.ts`:
 
 The report loader accepts older run directories. It checks that `metrics.json`
 resolves inside the run directory and validates it with the shared Zod schema.
+When `run.json` includes a `runId`, the validated metrics artifact must carry
+the same ID; a mismatch is rejected as unknown rather than attached to the
+run. Legacy run metadata without a `runId` continues to accept valid metrics.
 Missing, malformed, or unsafe metrics make normalized usage, cost, aggregate
 duration, and logical-call values `null`/`unknown`, never fabricated zeroes.
 Duplicate or unmatched records are warned and are not attached to a workload;

--- a/docs/implementation/agentic-eval-metrics.md
+++ b/docs/implementation/agentic-eval-metrics.md
@@ -49,6 +49,10 @@ Skills surface, local or published server, guidance profile, experimental
 tools, published package, target git state, workload timing, process/final
 status, exit code, timeout, and relative artifact paths.
 
+The resolved-model field remains nullable for future provider adapters. The
+current Codex CLI does not expose a provider-resolved model, so Phase 1 writes
+`resolvedModel: null` and the cost adapter uses the requested model.
+
 `usage` contains:
 
 - `providerUsage`, retaining the five validated Codex numeric fields:
@@ -60,8 +64,8 @@ status, exit code, timeout, and relative artifact paths.
   USD, uncertainty, and the embedded Luna rate snapshot.
 
 `tools` contains raw event count, the current logical-call count, completed and
-failed counts, sorted unique normalized tool names, ordered sequence entries,
-and result bytes when available. Sequence entries retain `mcp` or `cli`
+failed counts, sorted unique normalized tool names, and ordered sequence
+entries. Sequence entries retain `mcp` or `cli`
 surface and normalized status (`started`, `completed`, `failed`, or `unknown`).
 The builder preserves duplicate raw observations and their order; Codex's
 derived sequence applies provider-ID pairing as described below. A persisted
@@ -81,6 +85,12 @@ cached and cache-write input:
 ```text
 uncached input = input_tokens - cached_input_tokens - cache_write_input_tokens
 ```
+
+This inclusive-input partition is verified against the upstream Codex parser
+fixture `parses_cache_write_token_usage` (input 100, cached input 40,
+cache-write input 60, total tokens 110). The Luna live canary had zero
+cache-write input, so it did not independently verify a nonzero cache-write
+case.
 
 The Luna base-rate snapshot is effective 2026-08-28 and sourced from the
 [OpenAI gpt-5.6-luna model page](https://developers.openai.com/api/docs/models/gpt-5.6-luna):

--- a/docs/implementation/agentic-eval-metrics.md
+++ b/docs/implementation/agentic-eval-metrics.md
@@ -1,0 +1,158 @@
+# Agentic eval usage metrics
+
+## Purpose
+
+The agentic eval runner preserves raw workload evidence and now derives a
+schema-versioned `metrics.json` artifact for local inspection. `report.json`
+and the console summary are review aids built from that artifact; they do not
+replace the raw terminal output or `tool-calls.json`.
+
+This is local maintainer tooling. It is not a daily pipeline, persistent
+history service, deterministic CI gate, or quality judge. Named suites, daily
+execution, long-term export, and answer-quality scoring remain later phases.
+
+## Run lifecycle
+
+For each run, `scripts/agent-eval.ts`:
+
+1. Creates a run ID and ISO start/end timestamps and records the target git
+   branch, SHA, and dirty state when available.
+2. Runs each workload in its isolated temporary workspace and writes raw
+   workload artifacts first. Live workloads retain redacted stdout/stderr,
+   extracted tool events, discovery events, and the parsed final report when
+   available. Dry runs intentionally have no provider telemetry.
+3. Builds and validates one metrics record per workload, then writes
+   `metrics.json` through the existing secret-redaction boundary.
+4. Derives `report.json` and the console output from the persisted metrics and
+   raw artifacts.
+
+The report loader accepts older run directories. It checks that `metrics.json`
+resolves inside the run directory and validates it with the shared Zod schema.
+Missing, malformed, or unsafe metrics make normalized usage, cost, aggregate
+duration, and logical-call values `null`/`unknown`, never fabricated zeroes.
+Duplicate or unmatched records are warned and are not attached to a workload;
+the validated artifact aggregate remains available for inspection. Legacy
+workload status and duration fields from `run.json` remain readable when
+present.
+
+## Metrics contract
+
+The top-level artifact has `schemaVersion: 1`, `runId`, `startedAt`,
+`completedAt`, `records`, `aggregates`, and de-duplicated `warnings`.
+
+Each record preserves the run/workload identity dimensions: workload ID,
+requested and resolved model, agent and CLI version, reasoning effort, MCP or
+Skills surface, local or published server, guidance profile, experimental
+tools, published package, target git state, workload timing, process/final
+status, exit code, timeout, and relative artifact paths.
+
+`usage` contains:
+
+- `providerUsage`, retaining the five validated Codex numeric fields:
+  inclusive `input_tokens`, `cached_input_tokens`, `cache_write_input_tokens`,
+  `output_tokens`, and `reasoning_output_tokens`;
+- non-overlapping `normalizedTokens`: uncached input, cached input,
+  cache-write input, output, and reasoning output; and
+- `cost`, which is either an explicit unknown or a `base_rate_estimate` with
+  USD, uncertainty, and the embedded Luna rate snapshot.
+
+`tools` contains raw event count, the current logical-call count, completed and
+failed counts, sorted unique normalized tool names, ordered sequence entries,
+and result bytes when available. Sequence entries retain `mcp` or `cli`
+surface and normalized status (`started`, `completed`, `failed`, or `unknown`).
+The builder preserves duplicate events and order. A persisted call with
+`server: "githits-cli"` is `cli`; other persisted GitHits calls are `mcp`.
+
+The run aggregates sum only known record values. Token and cost totals are
+`null` when no contributing value is known. Reasoning output is an output
+detail and is never added to the output total a second time.
+
+## Codex derivation and limitations
+
+The Codex adapter selects the last terminal `turn.completed.usage` object in
+the JSONL stream. Its verified semantics make `input_tokens` inclusive of
+cached and cache-write input:
+
+```text
+uncached input = input_tokens - cached_input_tokens - cache_write_input_tokens
+```
+
+The Luna base-rate snapshot is effective 2026-08-28 and sourced from the
+[OpenAI gpt-5.6-luna model page](https://developers.openai.com/api/docs/models/gpt-5.6-luna):
+
+| Bucket | USD per million tokens |
+|---|---:|
+| Uncached input | 0.20 |
+| Cached input | 0.02 |
+| Cache-write input | 0.25 |
+| Output | 1.20 |
+
+The estimate is not billed, exact, or an upper bound. Codex exposes a
+turn-level aggregate rather than request-level usage. When inclusive input is
+above 272,000, the artifact retains the base estimate and emits
+`long_context_pricing_not_attributable`, because the request that crossed the
+pricing boundary cannot be reconstructed.
+
+The current Codex extraction persists one event per extracted tool event, so
+its logical-call count is provisional: Codex can emit `item.started` and
+`item.completed` for one underlying MCP call. Use `sequence` and the raw
+`tool-calls.json` when exact call pairing matters; a later correction will
+reconcile provider event pairs. Claude and OpenCode currently remain runnable
+but report unknown usage/cost with `adapter_not_implemented`.
+
+## Report and console fields
+
+For a matched metrics record, each `WorkloadReport.metrics` contains normalized
+token buckets, cost kind/USD/uncertainty, logical tool count, MCP and CLI
+sequence counts, and record telemetry warnings. `AgentEvalReport.metrics`
+contains the run aggregates, and `metricsWarnings` contains metrics-load,
+schema, and workload-record warnings. Existing raw tool summaries, artifacts,
+final-report issues, and comparison behavior remain available.
+
+The console prints the same compact per-workload values and one aggregate line.
+Null values print as `unknown`; reasoning is labelled as a detail. MCP CLI
+fallback warnings identify the effective `descriptors` or `full` profile.
+Skills runs use the CLI surface by design and do not receive the MCP fallback
+warning.
+
+## Local Luna-low inspection
+
+Run the smallest one-workload pair when changing MCP descriptions, guidance, or
+the harness:
+
+```bash
+bun run agent:e2e --agent codex --model gpt-5.6-luna --reasoning-effort low --server local --guidance-profile descriptors --workload eval/agentic/workloads/express-router.md
+bun run agent:e2e --agent codex --model gpt-5.6-luna --reasoning-effort low --server local --guidance-profile full --workload eval/agentic/workloads/express-router.md
+```
+
+Use the printed run directory to regenerate the report or inspect its JSON:
+
+```bash
+bun run agent:e2e:report .agent-eval/runs/<run>
+bun run agent:e2e:report --json .agent-eval/runs/<run>
+```
+
+Inspect `metrics.json` for normalized values and warnings, then use
+`tool-calls.json` and redacted `stdout.json` to explain the underlying event
+sequence. Do not interpret a missing metric as zero usage, or a Luna estimate
+as provider billing. Local Codex and Claude profile comparisons also remain
+diagnostic where user-level guidance can leak into the session.
+
+## Security and evidence boundary
+
+Metrics contain validated numeric/provider fields and normalized summaries,
+not stdout, tool arguments, shell commands, or environment values. The runner
+redacts known secret values before writing raw artifacts and metrics. Artifact
+paths are relative and validated; report loading refuses metrics and raw
+artifacts that resolve outside the run directory.
+
+## Key reference files
+
+| File | Responsibility |
+|---|---|
+| `scripts/agent-eval.ts` | Run lifecycle, raw artifacts, redaction, and metrics/report ordering |
+| `scripts/agent-eval-metrics.ts` | Codex adapter, Zod schemas, normalization, and aggregate builder |
+| `scripts/agent-eval-report.ts` | Safe metrics loading, derived report fields, and console formatting |
+| `scripts/agent-eval.test.ts` | Runner, report, fallback, safety, and integration coverage |
+| `scripts/agent-eval-metrics.test.ts` | Adapter and metrics-contract coverage |
+| `eval/agentic/README.md` | User-facing harness usage, workload guidance, and limitations |

--- a/docs/plans/systematic-agent-evals.md
+++ b/docs/plans/systematic-agent-evals.md
@@ -1,0 +1,907 @@
+# Systematic Agent Eval Runs And Metrics
+
+## Status
+
+- Overall: PLANNED
+- Current phase: Phase 1 — trustworthy local metrics (IMPLEMENTATION COMPLETE; pending final validation/live canary)
+- Next phase: Phase 2 — systematic local suites and paired comparison (PLANNED)
+- Owner: repository maintainers
+- Last verified: 2026-08-28
+
+## Problem And Expected Outcome
+
+The repository has a real-agent eval harness and a useful workload corpus. The
+initial implementation was optimized for qualitative, human-driven inspection:
+it did not persist normalized token or cost metrics, its comparison output was
+too narrow for regression analysis, and one verified extraction rule could hide
+GitHits CLI fallback in the minimal MCP profile. Phase 1 now adds local,
+schema-validated metrics and report fields, while comparison breadth, suite
+orchestration, and persistent history remain later work.
+
+When this effort is complete:
+
+- maintainers can run named eval suites locally with Codex Luna-low against both
+  descriptor-only (minimal) and full guidance profiles, with Claude Haiku added
+  only after the Luna pipeline and service integration are stable;
+- every workload/agent execution emits a versioned, vendor-neutral metrics
+  record containing harness identity, tool usage, token usage, duration, cost,
+  status, and links to the raw evidence;
+- a local paired run can compare a candidate checkout with a main baseline while
+  holding agent harness versions and model settings constant;
+- a clean automation runner executes the stable full suite daily from `main`,
+  preserves raw artifacts, and exports the same normalized records to the
+  selected long-term service;
+- daily results are observational and alert on material drift without becoming
+  a flaky merge gate; and
+- result quality can be added later through explicit workload rubrics without
+  changing the execution or metrics contracts.
+
+## Scope
+
+In scope:
+
+- MCP runs against the local checkout using the existing `descriptors` and
+  `full` guidance profiles;
+- initial agent matrix: Codex `gpt-5.6-luna` with `low` reasoning across both
+  guidance profiles;
+- reliable extraction and normalization of tool events, token usage, duration,
+  cost, harness versions, and run identity;
+- named canary, smoke, stable-full, stateful-manual, and experimental suites;
+- local baseline/candidate comparison;
+- scheduled and manually dispatched execution from `main` after runner,
+  authentication, budget, and persistence decisions are made;
+- durable raw-artifact retention plus export to a service selected separately;
+- an advisory drift policy and a later quality-evaluation extension point.
+
+Out of scope for the initial phases:
+
+- replacing the existing agent process runner with a vendor-owned runner;
+- automatically running paid agent evals on every pull request;
+- treating stochastic agent results as deterministic CI gates;
+- OpenCode or the Agent Skills surface in the first scheduled matrix;
+- Claude Haiku metrics, suites, or pipeline execution before the Luna-only
+  pipeline has validated the harness and selected third-party service;
+- the two experimental-tool workloads in the stable daily suite;
+- an LLM judge, golden-answer corpus, or composite quality score before a
+  workload rubric and judge policy are approved;
+- a repository-owned database, queue, cache, lock, or dashboard;
+- selecting the long-term eval service in this plan.
+
+## Verified Current State And Evidence
+
+### Repository behavior
+
+- `scripts/agent-eval.ts` already launches Claude, Codex, or OpenCode in an
+  isolated temporary workspace and persists raw stdout, stderr, tool calls,
+  final JSON, discovery events, effective model settings, agent CLI versions,
+  and git branch/SHA.
+- `scripts/agent-eval-report.ts` derives status, duration, unique tools, raw
+  event count, errors, self-reported issues, and matched normalized metrics.
+  Comparison remains limited to status, tool names/counts, and self-reported
+  issue strings; token/cost deltas remain Phase 2 work.
+- There are 24 non-reporting workloads: 21 automation-safe stable workloads,
+  one stateful onboarding workload, and two explicitly experimental-tool
+  workloads.
+- `.agent-eval/` is gitignored. Each run now writes a normalized `metrics.json`
+  artifact, but no durable history exists.
+- `.github/workflows/main.yml` runs the reusable build/test workflow on pushes
+  to `main`. There is no scheduled live-agent workflow and no agent/provider
+  authentication in CI.
+- The current agentic eval documentation deliberately says the harness is
+  human/agent-driven and not CI. This conflicts with the requested daily run.
+  The resolution is to keep deterministic smoke tests as merge gates and make
+  scheduled live-agent evals observational/advisory until measured evidence
+  supports a different policy.
+- Local Codex and Claude subscription runs cannot prove descriptor/full
+  instruction isolation: Codex can load global `$CODEX_HOME/AGENTS.md`, and
+  Claude bare mode disables subscription authentication. Local comparisons are
+  diagnostic. Acceptance-quality profile comparisons require a clean,
+  authenticated runner whose home and instruction sources are controlled.
+
+### Bounded planning baseline
+
+On 2026-08-28, two workloads were run against all four requested
+agent/profile combinations using the current checkout:
+
+- `package-overview-vulnerabilities` — focused package routing;
+- `express-router` — multi-tool source investigation;
+- Codex `gpt-5.6-luna`, reasoning `low`;
+- Claude `haiku` (resolved by Claude Code to its current Haiku model);
+- local MCP server, `descriptors` and `full` profiles.
+
+The eight executions all completed at the process/harness level. Their total
+sequential agent time was 839.9 seconds. With the four agent/profile shards run
+concurrently, the slowest shard took about 4.5 minutes.
+
+| Agent/profile              | Package duration | Express duration |  Two-workload cost |
+| -------------------------- | ---------------: | ---------------: | -----------------: |
+| Claude Haiku / descriptors |           54.4 s |          124.4 s |  \$0.1636 reported |
+| Claude Haiku / full        |           58.1 s |          211.3 s |  \$0.1676 reported |
+| Luna-low / descriptors     |          123.6 s |           75.1 s | \$0.0205 estimated |
+| Luna-low / full            |           53.9 s |          139.0 s | \$0.0257 estimated |
+| Total                      |                  |                  |       **\$0.3774** |
+
+Claude Code supplied `total_cost_usd`; this is a list-price-equivalent value
+despite the run using subscription authentication. Luna cost was estimated from
+the captured usage and the current official rates of $0.20/M uncached input,
+$0.02/M cached input, and \$1.20/M output. The rate source and effective rate
+snapshot must be stored with future calculated costs:
+<https://developers.openai.com/api/docs/models/gpt-5.6-luna>.
+
+Luna requests over 272K input tokens use higher per-request rates. Codex's
+terminal event exposes only turn-aggregate usage, so it cannot prove which
+individual request crossed that boundary. Luna dollar figures in this plan are
+base-rate estimates and can understate billed cost. Metrics must preserve this
+uncertainty instead of presenting aggregate-derived cost as exact.
+
+The initial rollout is Luna-only. Naively scaling the measured Luna shards gives
+planning numbers, not a budget commitment:
+
+| Suite                                                          | Executions | Approximate wall time at two shards |      Approximate cost |
+| -------------------------------------------------------------- | ---------: | ----------------------------------: | --------------------: |
+| Canary: 2 workloads × 1 agent × 2 profiles                     |          4 |                3.3 minutes measured | \$0.046 base estimate |
+| Smoke: 6 workloads × 1 agent × 2 profiles                      |         12 |                          10 minutes |               \$0.139 |
+| Stable full: 21 workloads × 1 agent × 2 profiles               |         42 |                          35 minutes |               \$0.485 |
+| All current workloads, including stateful/experimental: 24 × 2 |         48 |                          40 minutes |               \$0.554 |
+
+Workload mix and provider behavior can move these figures substantially. Phase
+2 must report actual canary, smoke, and stable-full measurements before Phase 3
+sets a daily budget or timeout.
+
+### Verified instrumentation defect and resolution
+
+The Codex descriptor-only package workload used a GitHits CLI fallback through
+`npx -y githits@latest`, but `tool-calls.json` and the report recorded zero
+calls. `extractToolCalls()` previously included CLI calls only for the Skills
+surface or the full MCP profile. Phase 1 now records the fallback in both MCP
+profiles and reports the effective profile, so a change from MCP use to CLI
+fallback cannot look like no GitHits use at all. Skills runs continue to use the
+CLI surface by design and do not receive the MCP fallback warning.
+
+### Usage-source observations
+
+- Codex emits one `turn.completed.usage` aggregate with input, cached input,
+  cache-write input, output, and reasoning-output fields.
+- Claude emits a terminal `result` record with `modelUsage`, aggregate usage,
+  duration, turns, and provider-reported cost. In the measured full-profile
+  runs, `modelUsage.inputTokens` differed from `usage.input_tokens`; therefore
+  adapters must preserve raw provider fields and explicitly choose/document the
+  normalized source rather than summing repeated assistant-event usage.
+- Reasoning tokens are a detail of output usage, not an extra amount to add to
+  total output, unless a future provider contract explicitly says otherwise.
+
+## Target Architecture
+
+The repository remains the source of truth for workloads and execution. A
+future service stores, visualizes, and optionally judges results; it does not
+need to own the harness.
+
+```text
+suite manifest
+  -> existing agent runner (one agent/profile shard)
+  -> immutable raw workload artifacts
+  -> provider-specific usage/tool adapters
+  -> versioned normalized metrics.json
+  -> local report + compatible baseline comparison
+  -> later: CI artifact retention + selected-service exporter
+```
+
+### Boundaries And Responsibilities
+
+1. **Suite manifest**
+
+   A repository-owned manifest defines stable workload IDs and membership in
+   `canary`, `smoke`, `stable-full`, `stateful-manual`, or `experimental`. It
+   defines execution inputs, not thresholds or vendor configuration. Workload
+   prompts remain guidance-free.
+
+2. **Execution runner**
+
+   `scripts/agent-eval.ts` continues to own isolated workspaces, process
+   invocation, timeouts, redaction, and raw artifacts. A suite command expands
+   the manifest into the existing repeated `--workload` contract. The runner
+   captures the exact agent CLI version, resolved model, reasoning setting,
+   profile, git SHA/dirty state, and timestamps needed to explain drift.
+   Paired execution separates the measurement-harness checkout from the target
+   checkout: the candidate checkout owns suite prompts, reporting/schema,
+   adapters, and comparison for both sides, while an explicit target root owns
+   the local MCP server process and git identity under test.
+
+3. **Provider adapters**
+
+   Small pure adapters parse provider event formats. Phase 1 implements Codex;
+   the same contract accepts a Claude adapter in the later Haiku phase. Adapters
+   preserve the provider payload needed for audit and map it into common
+   non-overlapping fields. Tool extraction records both the logical GitHits
+   operation and its surface (`mcp` or `cli`) in every profile. CLI fallback is
+   visible but never counted as successful MCP use.
+
+4. **Normalized metrics contract**
+
+   One versioned `metrics.json` per run contains a record per
+   workload/agent/profile execution. Each record includes:
+
+   - stable run ID and workload ID;
+   - git SHA/dirty state, suite name, agent CLI/harness version, requested and
+     resolved model, reasoning effort, surface, server, and guidance profile;
+   - start/end/duration, process/final status, timeout, turns when exposed;
+   - raw tool events, logical call count, completed/failed count, unique tools,
+     ordered tool sequence, MCP-versus-CLI surface, and tool-result byte counts
+     when the harness exposes them;
+   - provider-native usage plus normalized uncached input, cache-read input,
+     cache-write input, output, and reasoning-output details;
+   - provider-reported cost when present, otherwise a calculated base-rate
+     estimate plus the recorded rate-card snapshot and pricing uncertainty;
+   - artifact-relative paths and warnings for missing/ambiguous telemetry.
+
+   Missing telemetry is `unknown`, not zero. Raw artifacts remain authoritative.
+
+5. **Comparison**
+
+   Local comparison accepts two run directories and compares only records with
+   compatible workload, agent, model, reasoning, surface, server, profile,
+   experimental-tool setting, and published-package spec when applicable. It
+   shows absolute and percentage token/cost/duration deltas, tool
+   additions/removals, surface changes, ordered tool-use changes, failures, and
+   harness-version changes. Incompatible dimensions are explicit warnings, not
+   silently merged results.
+
+6. **Persistence/export**
+
+   In Phase 3, GitHub artifacts retain immutable raw evidence for replay and the
+   selected service receives normalized records for long-term per-eval/per-agent
+   trends. The exporter is a thin boundary around the service SDK or API. No
+   repository-owned persistence infrastructure is introduced.
+
+7. **Quality evaluation**
+
+   The final JSON and evidence remain available for later scoring. Phase 5 may
+   add deterministic workload rubrics first and an optional judge second. The
+   agent's current self-reported usefulness/confidence is diagnostic metadata,
+   not an authoritative quality score.
+
+## Initial Suite Policy
+
+The manifest starts with:
+
+- **Canary (2):** `package-overview-vulnerabilities`, `express-router`.
+  This is the measured cheap path and covers package routing plus multi-tool
+  code navigation.
+- **Smoke (6):** the canary plus `global-example`,
+  `unified-search-investigation`, `docs-search-followup`, and
+  `package-upgrade-safety`. This spans example discovery, package intelligence,
+  unified search/status, documentation follow-up, and code navigation without
+  duplicating every tool-specific edge case.
+- **Stable full (21):** every current non-reporting workload except
+  `githits-onboarding`, `experimental-resolution-follow-up`, and
+  `experimental-code-diff`.
+- **Stateful manual (1):** `githits-onboarding`. It is never included in a
+  normal local or scheduled suite because the current harness inherits the real
+  home/config roots and the workload can install or modify user-scoped agent/MCP
+  state. Execution requires an explicit stateful acknowledgement and a verified
+  disposable home/config environment.
+- **Experimental (2):** the two experimental-tool workloads, run manually and
+  with their required server flag.
+
+Local policy:
+
+- use canary while changing the harness or metrics adapters;
+- use smoke for broad agent-facing changes and paired baseline/candidate
+  comparison;
+- use targeted workloads from the existing routing table for tool-specific
+  changes;
+- run stable-full locally only when explicitly needed.
+
+Automation policy after Phase 3:
+
+- run stable-full daily from `main` and on manual dispatch;
+- retain the two Luna/profile combinations as separate shards;
+- keep experimental workloads manual;
+- do not run paid evals automatically on every PR initially;
+- keep the scheduled workflow advisory. Deterministic tests remain the merge
+  gate.
+
+The current Phase 3 proposal is to allow daily agent CLI versions to advance so
+harness drift is observable, while recording exact versions. That is not yet an
+approved policy; a pinned control offers stronger attribution at additional
+cost. Local PR comparisons must run baseline and candidate close together with
+the same installed agent versions so repository changes are not confused with
+harness changes.
+
+## Assumptions
+
+- The repository's current workload corpus is the starting definition of
+  supported use cases; suite membership can be revised when execution evidence
+  shows a workload is redundant, unsafe, or consistently non-diagnostic.
+- MCP local mode is the initial scheduled surface because it evaluates the
+  checkout on `main`.
+- Two Luna/profile shards can run concurrently. The bounded local baseline
+  exercised this shape without a verified backend issue; Phase 2 measurements
+  will determine the automation limit.
+- Daily evals are for regression detection and investigation, not deterministic
+  correctness proof.
+- A service-neutral JSON contract lets local work proceed before the team
+  chooses the target service.
+
+## Unknowns And Product Decisions
+
+None block Phase 1 or Phase 2.
+
+The following must be resolved before Phase 3 is detailed or implemented:
+
+- **Long-term service and retention:** which service receives normalized
+  metrics, whether it also stores raw traces, retention duration, dashboard and
+  alert requirements, and available credits.
+- **Automation runner and authentication:** GitHub-hosted clean Linux is the
+  preferred isolation baseline, but Codex CLI installation and API-key
+  authentication must be verified without exposing credentials. If policy or
+  licensing requires a dedicated runner, that is a user-approved infrastructure
+  decision.
+- **Budget and concurrency:** approve a daily dollar/quota ceiling after Phase 2
+  measures the real suites. The current Luna-only planning estimate is about
+  $0.49/day for stable-full, or about $15 per 30-day month, before service
+  charges.
+- **Harness update policy:** confirm whether daily jobs intentionally install
+  latest agent CLIs, use an approved moving version range, or run both floating
+  and pinned controls. Latest-only is the smallest design that detects harness
+  drift but makes upstream changes part of the daily variance.
+
+The following must be resolved before Phase 4:
+
+- when the Luna-only pipeline and service integration are stable enough to add
+  Claude Haiku, and the separate Haiku budget/authentication policy.
+
+The following must be resolved before Phase 5:
+
+- which workloads need objective quality scoring;
+- rubric ownership and acceptable reference-answer maintenance;
+- whether a judge model/service is allowed and its separate cost budget;
+- whether any metric becomes alerting-only, a PR annotation, or a merge gate.
+
+## Cross-Cutting Requirements
+
+### Security And Privacy
+
+- Credentials enter automation only through the chosen runner's secret store
+  and are never written to run metadata, raw artifacts, logs, annotations, or
+  exporter payloads.
+- Extend and fixture-test the existing redaction boundary for every new artifact
+  and exporter field.
+- Store sanitized commands/configuration sufficient to identify the harness;
+  never store token values or credential-bearing environment variables.
+- Keep agent execution in an empty controlled workspace with non-interactive
+  permissions limited to the existing eval workload scope.
+
+### Reliability And Failure Semantics
+
+- Parser/schema failures, missing required telemetry, timeout, invalid final
+  JSON, exporter failure, and agent failure remain distinguishable states.
+- A missing metric is unknown. It must not become zero and distort trends.
+- Raw artifacts are written before derived metrics so normalization can be
+  replayed after parser fixes.
+- Do not add retries or timer-based workarounds for model, backend, or exporter
+  failures. Preserve evidence and fix observed root causes.
+- Service export failure must not destroy the local/GitHub artifact. Phase 3
+  decides whether it fails the advisory workflow or produces a visible partial
+  result based on the selected service contract.
+
+### Compatibility And Migration
+
+- Existing `agent:e2e` commands and raw artifact filenames remain supported.
+- `report.json` can evolve by schema version; old run directories remain
+  readable through tested compatibility fixtures or a clear version error.
+- The new suite command composes the existing runner rather than creating a
+  second execution implementation.
+- Cross-agent metrics are stored together but direct baseline deltas are made
+  only within compatible agent/configuration dimensions.
+
+### Performance And Cost
+
+- Phase 2 establishes release-build-equivalent timing and cost baselines before
+  pipeline concurrency/timeouts are finalized.
+- Reports expose per-workload and aggregate duration/cost so slow or expensive
+  workloads can be identified rather than hidden in one suite total.
+- Mutable package/backend responses are a confounder for token trends. Preserve
+  raw results and result byte counts where exposed so an alert can be
+  investigated; do not claim that a token delta alone proves harness drift.
+- Concurrency is bounded by the explicit two-shard Luna/profile matrix
+  initially. No queue or scheduler is added in the repository.
+
+### Testing
+
+- Use `bun test` with captured, redacted Codex event fixtures in Phase 1; add
+  Claude fixtures with the later Haiku adapter.
+- Test adapters independently from process execution.
+- Cover repeated events, terminal aggregate selection, inclusive cached-token
+  semantics, reasoning-token non-double-counting, absent/partial telemetry,
+  CLI fallback in both profiles, failed calls, and secret redaction.
+- Test suite expansion and compatible/incompatible comparison behavior without
+  invoking paid agents.
+- Run targeted live canary execution only after deterministic tests pass; paid
+  runs are validation evidence, not unit tests.
+
+### Documentation And Release
+
+- Update `eval/agentic/README.md` as commands, artifact contracts, suite policy,
+  and isolation guidance change.
+- Add durable architecture/operations documentation under the distinct name
+  `docs/implementation/agentic-eval-metrics.md` before this plan is removed;
+  `docs/implementation/EVAL_HARNESS.md` already documents a separate prompt
+  injection guardrail harness.
+- Add an independent `changes/<slug>.changed.md` fragment with explicit
+  `githits` and `@githits/mcp` impacts for each implementation increment. The
+  Phase 1 metrics tooling is maintainer/operator-facing, so its fragment uses
+  `none` for both public artifacts.
+- After the complete effort is implemented and documented, delete this plan.
+
+## Phase Map
+
+1. **Phase 1 — trustworthy local metrics (IMPLEMENTATION COMPLETE; pending
+   final validation/live canary):** every existing local run produces auditable
+   per-workload tool/token/cost metrics, including visible CLI fallback and
+   explicit unknown telemetry.
+2. **Phase 2 — systematic local suites and paired comparison (PLANNED):**
+   maintainers can execute canary/smoke/full matrices locally, compare a
+   candidate to a compatible main baseline, and see measured time/cost totals.
+3. **Phase 3 — daily main execution and persistent export (BLOCKED ON PRODUCT
+   DECISIONS):** a clean runner executes the stable full matrix daily from
+   `main`, retains raw evidence, and exports normalized records to the selected
+   service.
+4. **Phase 4 — Claude Haiku expansion (PLANNED):** the proven metrics, suite,
+   comparison, and persistence contracts add Haiku without changing Luna
+   history.
+5. **Phase 5 — trend policy and result quality (PLANNED):** historical variance
+   supports calibrated drift alerts, and approved workload rubrics optionally
+   assess answer quality without changing the execution contract.
+
+## Phase 1 — Trustworthy Local Metrics
+
+### Status
+
+IMPLEMENTATION COMPLETE; pending final validation/live canary
+
+### Expected Outcome
+
+Every Luna-low workload run writes a versioned metrics artifact whose token,
+cost, duration, and GitHits tool-use fields can be traced back to raw Codex
+events. MCP-to-CLI fallback is visible in every guidance profile, and missing
+telemetry cannot silently appear as zero.
+
+### Assumptions
+
+- The captured Codex `turn.completed` record remains the terminal aggregate
+  source for the currently installed CLI version.
+- Provider-specific raw usage remains persisted so an adapter can be corrected
+  without re-running a paid workload.
+- Existing raw artifacts and `report.json` remain supported.
+
+### Unknowns Or Product Decisions
+
+None.
+
+### Dependencies
+
+- Current `scripts/agent-eval.ts`, `scripts/agent-eval-report.ts`, and their Bun
+  tests.
+- The redacted Codex raw fixtures from the bounded baseline, reduced to the
+  smallest representative event records before committing.
+- Official Luna rate snapshot cited above.
+
+### Likely Affected Components
+
+- `scripts/agent-eval.ts`
+- `scripts/agent-eval-report.ts`
+- a small provider-adapter/metrics module under `scripts/` if separation keeps
+  parsing pure and independently testable
+- `scripts/agent-eval.test.ts` and report/adapter tests
+- `eval/agentic/README.md`
+- `changes/`
+
+### Contracts And Failure Behavior
+
+- Introduce a schema-versioned run-level `metrics.json` with one workload
+  record per execution, following the target contract above.
+- Preserve both `providerUsage` and normalized token buckets. Normalization
+  documents whether an input field is inclusive of cached/cache-write tokens.
+- Use the terminal Codex usage aggregate once; derive uncached input only under
+  the verified event semantics, while preserving the raw inclusive input.
+- Record provider-reported cost as `reported`; calculate Luna cost as a
+  `base_rate_estimate` and embed the rate snapshot. When request-level
+  long-context pricing cannot be reconstructed from the turn aggregate, emit a
+  `long_context_pricing_not_attributable` warning. Never present an estimate as
+  a billed value or upper bound.
+- Extract GitHits CLI commands from every agent/profile. Store them with
+  `surface: cli`; MCP calls remain `surface: mcp`.
+- A run with successful process status but missing a required terminal usage
+  aggregate receives a telemetry warning and unknown usage fields. It is not a
+  zero-token run.
+- Until their provider adapters are implemented, Claude and OpenCode runs remain
+  executable and emit unknown normalized usage/cost with an explicit
+  `adapter_not_implemented` warning. This is distinct from a supported Codex
+  run whose expected terminal telemetry is missing.
+- Continue redacting known secrets before any new artifact is written.
+
+### Ordered Implementation Steps
+
+1. **Completed:** Add minimal redacted fixtures for the verified Codex terminal usage, MCP
+   calls, descriptor-profile CLI fallback, failed tool calls, and absent
+   telemetry. Write failing adapter/extraction tests first.
+2. **Completed:** Extract pure provider usage adapters and a common metrics schema. Document
+   field semantics at the interface and validate written artifacts at runtime
+   using the repository's existing Zod convention.
+3. **Completed:** Correct CLI extraction so every GitHits fallback is recorded regardless of
+   guidance profile, and update report warnings to identify the intended MCP
+   surface versus observed CLI surface.
+4. **Completed:** Generate `metrics.json` from completed raw artifacts and enrich the console
+   and JSON report with per-workload and aggregate duration, tokens, tool calls,
+   and cost.
+5. **Completed:** Capture missing run identity needed for interpretation: start/end timestamp,
+   resolved model when exposed, and git dirty state. Propagate the already
+   captured exact agent CLI versions into normalized metrics and reports.
+   Preserve sanitized existing command/config evidence.
+6. **Completed:** Update the agentic eval documentation and add the required change fragment.
+7. **Pending final validation/live canary:** Run deterministic tests, typecheck/format/lint as applicable, then rerun the
+   two-workload canary once for Luna-low across both profiles. Compare emitted
+   metrics manually to the raw terminal records and report actual duration/cost.
+
+### Edge Cases And Boundaries
+
+- Reasoning output is a subset/detail of output unless the provider contract
+  explicitly changes.
+- Tool start/completion events must not inflate logical call count. The current
+  Codex adapter still counts persisted extracted events, so a start/completion
+  pair can overcount one underlying call; logical-call correction remains a
+  final Phase 1 validation item. Preserve raw event count separately.
+- CLI commands with `npx`, the local shim, or `bun run ... githits` normalize to
+  the logical GitHits operation without persisting secret-bearing arguments.
+- Non-GitHits shell commands remain outside GitHits tool metrics.
+- Older run directories without usage events produce a readable report with
+  unknown metrics and a schema warning.
+
+### Verification
+
+- `bun test scripts/agent-eval.test.ts scripts/agent-eval-metrics.test.ts`
+- `bun run typecheck`
+- `bun run format:check`
+- `bun run lint`
+- Targeted two-shard canary: both workloads and both Luna guidance profiles.
+- Inspect each `metrics.json` against its raw terminal aggregate and tool events;
+  specifically verify the descriptor-profile Codex CLI fallback is non-zero and
+  tagged `cli`.
+
+### Deterministic Implementation Evidence
+
+- `bun test scripts/agent-eval.test.ts scripts/agent-eval-metrics.test.ts`:
+  90 tests passed with no failures on 2026-08-28.
+- `bun run typecheck`: passed on 2026-08-28.
+- The implementation increments are committed in repository history; this plan
+  records behavior and verification rather than immutable commit identifiers.
+- The targeted two-workload Luna-low canary and manual raw-artifact comparison
+  remain pending final validation; no paid/live eval was run as part of the
+  deterministic implementation work.
+
+### Acceptance Criteria
+
+- Each of the four canary executions emits one valid metrics record with the
+  complete compatible identity dimensions.
+- Codex token buckets match the terminal aggregate fixtures and reasoning tokens
+  are not double-counted.
+- Provider-reported versus base-rate-estimated cost is explicit, the Luna rate
+  snapshot makes the base calculation reproducible, and request-level
+  long-context uncertainty remains visible.
+- Descriptor-profile CLI fallback is visible and cannot be mistaken for MCP
+  success or zero GitHits use.
+- Missing usage or cost is represented as unknown with a warning.
+- No credential value appears in committed fixtures or generated artifacts.
+- Existing local eval commands and raw artifacts continue to work.
+- Updated documentation accurately states what the metrics do and do not prove.
+
+## Phase 2 — Systematic Local Suites And Paired Comparison
+
+### Status
+
+PLANNED; detailed now, implemented after Phase 1.
+
+### Expected Outcome
+
+Maintainers can invoke a named suite for the requested model/profile matrix and
+can run a compatible main-versus-candidate comparison locally. Output shows
+per-workload and aggregate tool, token, duration, and cost drift, and records
+actual canary/smoke/full sizing evidence for the pipeline decision.
+
+### Assumptions
+
+- Phase 1's metrics schema is stable enough to serve as the suite result
+  contract.
+- Local profile comparisons remain diagnostic because of the documented global
+  instruction isolation limits.
+- Baseline and candidate can use the same installed agent CLI versions during a
+  paired run.
+
+### Unknowns Or Product Decisions
+
+None. The target service and automation budget remain later-phase decisions.
+
+### Dependencies
+
+- Phase 1 accepted and merged.
+- Current workload routing table in `eval/agentic/README.md`.
+- A clean main worktree or equivalent read-only baseline checkout available to
+  the local paired command; the implementation must not mutate or reset user
+  worktrees.
+- Dependencies installed in both target checkouts so the candidate-owned
+  harness can start each checkout's local MCP server.
+
+### Likely Affected Components
+
+- a typed manifest under `eval/agentic/`
+- `scripts/agent-eval.ts` or a thin suite orchestration script that calls its
+  existing execution API
+- `scripts/agent-eval-report.ts` comparison logic
+- deterministic suite/compare tests under `scripts/`
+- `package.json` scripts
+- `eval/agentic/README.md`
+- `changes/`
+
+### Contracts And Failure Behavior
+
+- Named suites expand to explicit workload lists and reject unknown, duplicate,
+  missing, or profile-incompatible entries before invoking an agent.
+- The stateful-manual suite is excluded from all aggregate suites. It refuses a
+  live run without explicit acknowledgement and a verified disposable
+  home/config environment.
+- Matrix defaults are exactly Luna-low across descriptors/full; all dimensions
+  remain overridable for targeted local investigation.
+- A paired comparison records one pair ID and verifies compatible agent/model/
+  effort/surface/server/profile/workload, experimental-tool, and
+  published-package dimensions before calculating deltas.
+- The paired command runs from the candidate checkout. Candidate suite prompts,
+  reporting contract, result schema, usage adapters, and comparison code are
+  used for both sides. Separate explicit target roots select the main-baseline
+  and candidate MCP server checkouts and their git-under-test metadata. This
+  holds the measurement contract constant instead of comparing two different
+  harness implementations.
+- Harness version differences are prominent. A local paired command refuses to
+  label results as a repository-only comparison when versions differ.
+- Partial suite results remain reportable. Failed/missing workloads are listed
+  and excluded from aggregate percentage calculations rather than converted to
+  zero.
+- The command prints total execution count, wall time, cumulative agent time,
+  token buckets, cost, failures, and the paths to raw and normalized artifacts.
+
+### Ordered Implementation Steps
+
+1. Add and validate the initial suite manifest exactly as defined in the suite
+   policy. Keep experimental workload requirements explicit.
+2. Add named-suite execution that reuses the existing runner and produces one
+   parent suite summary over two Luna/profile run directories. Bound concurrency
+   to those two shards; workloads remain sequential within a shard for simple
+   artifact ownership and rate behavior.
+3. Separate measurement-harness root from target-repository root in the runner.
+   Add an explicit target-root option used only for the local MCP launch and
+   git-under-test identity; keep workloads, reporting/schema, normalization, and
+   output ownership in the candidate harness checkout.
+4. Extend comparison to token/cost/duration deltas, logical tool sequence and
+   surface changes, status/failure differences, and harness version changes.
+   Add compatible-dimension and partial-result tests.
+5. Add a local paired workflow that runs a main baseline and candidate with the
+   candidate-owned harness and suite settings. Require explicit target checkout
+   paths or verified worktrees; never reset or clean a user's working tree.
+6. Document canary/smoke/full selection and the difference between a paired
+   repository comparison and a daily harness-drift comparison.
+7. Run canary, smoke, and stable-full once in a controlled local environment.
+   Record actual wall time, per-workload cost, failures, and concurrency behavior
+   in the durable implementation documentation and use it to prepare the Phase
+   3 budget decision. Validate stateful-manual through deterministic guard tests
+   and a dry run; do not execute onboarding against a maintainer's real home.
+
+### Edge Cases And Boundaries
+
+- Candidate and baseline workload/reporting content can differ. Record content
+  hashes and flag the comparison rather than pretending they are identical
+  tests. The default paired workflow avoids this by using the candidate-owned
+  workload/reporting contract for both targets.
+- A dirty checkout is allowed for local exploration but must be labeled; the
+  comparison cannot claim a reproducible git-only baseline.
+- A profile or model missing from one side is a missing matrix cell, not a zero.
+- Experimental suites require the experimental server flag and never merge into
+  stable-full by default.
+- The onboarding workload requires the stateful-manual guard and never merges
+  into stable-full by default.
+- Concurrent shards must use distinct output and temporary workspace paths.
+
+### Verification
+
+- Deterministic tests for manifest validation, expansion, matrix identity,
+  partial failure, compatibility checks, and aggregate math.
+- Existing agent-eval tests plus `bun run typecheck`, `bun run format:check`, and
+  `bun run lint`.
+- Dry-run all named suites and inspect commands/output paths.
+- Live canary, smoke, and stable-full measurements using Luna-low and both
+  profiles.
+- Run a no-change paired comparison; it should show stochastic metric variance
+  but no identity or content mismatch.
+
+### Acceptance Criteria
+
+- One documented command runs each named suite and the default two-cell Luna
+  matrix.
+- Normal local/full execution cannot invoke the onboarding workload, and the
+  stateful-manual command refuses an unisolated live run.
+- One documented local workflow compares a main baseline to a candidate without
+  mutating either checkout.
+- The paired workflow uses one candidate-owned measurement harness for both
+  targets and records measurement-harness identity separately from each target
+  checkout identity.
+- Comparison exposes tool additions/removals and MCP/CLI surface changes, token
+  and cost deltas, duration, failures, content identity, and agent CLI versions.
+- Canary, smoke, and stable-full have measured wall-time and cost summaries;
+  Phase 3 no longer relies on the two-workload linear estimate.
+- Local profile evidence is labeled diagnostic unless the run manifest proves a
+  clean instruction-isolated host.
+- Existing targeted `--workload` usage remains available.
+
+## Phase 3 — Daily Main Execution And Persistent Export
+
+### Status
+
+BLOCKED ON PRODUCT DECISIONS listed above. Detail this phase after Phase 2
+reorientation and service/runner/budget selection.
+
+### Expected Outcome
+
+A clean authenticated runner executes the stable-full two-cell Luna matrix daily
+from `main` and on manual dispatch, retains immutable raw artifacts, publishes a
+human-readable summary, and exports normalized per-workload/profile records to
+the selected long-term service.
+
+### Assumptions
+
+- Phase 2 measurements fit the approved daily budget and provider quotas.
+- The selected service accepts the normalized dimensions or can be integrated
+  through a thin mapping layer.
+- The runner can install or provide the required agent CLIs without leaking
+  credentials.
+
+### Unknowns Or Product Decisions
+
+- Service, retention, runner, authentication, daily budget, concurrency, and
+  harness-version policy must be approved before implementation details are
+  added.
+
+### Dependencies
+
+- Phase 2 accepted and merged.
+- Approved service and runner decisions.
+- Provider and GitHits automation credentials provisioned outside the
+  repository.
+
+### Acceptance Criteria
+
+- A scheduled run checks out the exact `main` SHA and produces all expected
+  stable-full matrix records or explicit partial-failure records.
+- Exact agent CLI versions and resolved models make harness drift identifiable.
+- Raw artifacts and normalized metrics survive the runner lifecycle for the
+  approved retention period.
+- The selected service shows persistent trends by workload, agent, and profile
+  for tool calls/tools used, token buckets, duration, cost, and failures.
+- No credentials appear in artifacts, logs, workflow annotations, or exporter
+  payloads.
+- The workflow is advisory and does not block `main` or PR merges.
+- A manual dispatch can reproduce the same suite/configuration.
+
+## Phase 4 — Claude Haiku Expansion
+
+### Status
+
+PLANNED. Detail only after the Luna-only pipeline and selected service have been
+validated in Phase 3.
+
+### Expected Outcome
+
+Claude Haiku uses the same normalized metrics, suite, comparison, and persistence
+contracts as Luna, adding a second change-sensitive agent without rewriting Luna
+history or coupling service export to one provider.
+
+### Assumptions
+
+- Phase 3 has exposed and resolved the initial harness, runner, authentication,
+  and service-integration bumps.
+- The normalized provider adapter boundary remains sufficient for Claude's
+  terminal `result` and `modelUsage` shapes already observed during planning.
+
+### Unknowns Or Product Decisions
+
+- Haiku automation authentication and budget.
+- Whether Haiku starts with canary/smoke only or joins stable-full immediately.
+
+### Dependencies
+
+- Phase 3 accepted and merged.
+- Approved Haiku rollout and budget decision.
+
+### Acceptance Criteria
+
+- Claude usage, cost, tool, duration, and identity metrics conform to the same
+  versioned contract without changing historical Luna records.
+- Haiku profile isolation is verified on the automation runner before results
+  are treated as causal minimal/full evidence.
+- The selected service can compare Haiku trends within compatible dimensions
+  while keeping cross-agent comparisons explicitly non-equivalent.
+- The approved Haiku suite runs within its measured budget and preserves the
+  same raw-artifact and credential-redaction guarantees.
+
+## Phase 5 — Trend Policy And Result Quality
+
+### Status
+
+PLANNED. Detail after the pipeline has produced enough real history to
+characterize normal variance and after the user approves the quality policy.
+
+### Expected Outcome
+
+Maintainers receive calibrated signals for abnormal harness/tool/token/cost
+changes, and selected workloads can be scored against explicit result-quality
+rubrics with the score and judge provenance stored beside operational metrics.
+
+### Assumptions
+
+- Phase 3 provides queryable Luna history and raw evidence; Phase 4 provides
+  Haiku history if that rollout has been approved.
+- Alerting thresholds are based on observed variance rather than the initial
+  eight-run sample.
+
+### Unknowns Or Product Decisions
+
+- Alert destinations and thresholds.
+- Quality workload subset, rubrics, judge model/service, budget, and whether
+  quality is advisory or gating.
+
+### Dependencies
+
+- Phase 3 accepted and merged; Phase 4 is required only for Haiku-specific trend
+  or quality policy.
+- Approved quality and alerting decisions.
+
+### Acceptance Criteria
+
+- Alerts distinguish harness-version changes, repository changes, and ordinary
+  stochastic variance using recorded dimensions.
+- Thresholds and comparison windows are documented and justified by retained
+  history.
+- Quality-enabled workloads have versioned rubrics and judge provenance; a
+  rubric change starts a new comparable series rather than rewriting history.
+- Operational metrics remain usable without the quality evaluator or selected
+  judge.
+- No merge gate is introduced without a separate explicit user decision and
+  demonstrated false-positive rate.
+
+## Phase-Boundary Reorientation
+
+After each phase merges, run `$next-steps` against current `origin/main` before
+detailing or implementing the next phase. Update this plan with changed
+assumptions, decisions, measured timing/cost evidence, architecture, and scope.
+Do not proceed when `$next-steps` reports `REPLAN` or `PRODUCT INPUT NEEDED`.
+
+At the Phase 2 boundary, explicitly bring the service, runner/authentication,
+budget, concurrency, and harness-update decisions to the user with the measured
+suite evidence. At the Phase 3 boundary, bring the Haiku rollout decision to the
+user with the observed Luna pipeline evidence. Bring the quality/alerting policy
+at the Phase 4 or Phase 5 boundary with observed historical variance.
+
+## Completion And Cleanup
+
+The overall effort is complete when:
+
+- local named suites and paired comparisons are documented and verified;
+- the daily stable-full `main` run persists raw and normalized evidence;
+- the selected service exposes the required per-workload/per-agent trends;
+- the advisory drift policy is documented;
+- any approved quality rubric is implemented or explicitly recorded as out of
+  scope; and
+- durable architecture, schema, operational, cost, isolation, and failure
+  guidance is current under `docs/implementation/` and
+  `eval/agentic/README.md`.
+
+Then delete this temporary plan. Do not leave completed phase instructions as
+permanent project documentation.

--- a/docs/plans/systematic-agent-evals.md
+++ b/docs/plans/systematic-agent-evals.md
@@ -543,15 +543,21 @@ None.
 7. **Pending final validation/live canary:** Run deterministic tests, typecheck/format/lint as applicable, then rerun the
    two-workload canary once for Luna-low across both profiles. Compare emitted
    metrics manually to the raw terminal records and report actual duration/cost.
+   Deterministic coverage now includes provider-ID pairing for Codex MCP and
+   CLI start/completion observations, started-only calls, and repeated calls to
+   one tool under distinct IDs.
 
 ### Edge Cases And Boundaries
 
 - Reasoning output is a subset/detail of output unless the provider contract
   explicitly changes.
-- Tool start/completion events must not inflate logical call count. The current
-  Codex adapter still counts persisted extracted events, so a start/completion
-  pair can overcount one underlying call; logical-call correction remains a
-  final Phase 1 validation item. Preserve raw event count separately.
+- Tool start/completion events must not inflate logical call count. Codex raw
+  observations carry the provider `item.id`; metrics pair only observations
+  with the same surface, ID, and normalized tool, preserve first-call order,
+  and use the latest status. Started-only observations count once, distinct IDs
+  remain distinct calls, and observations without IDs are not paired by
+  heuristics. Preserve raw event count separately. Unsupported agents retain
+  an unknown logical count until their provider semantics are implemented.
 - CLI commands with `npx`, the local shim, or `bun run ... githits` normalize to
   the logical GitHits operation without persisting secret-bearing arguments.
 - Non-GitHits shell commands remain outside GitHits tool metrics.

--- a/docs/plans/systematic-agent-evals.md
+++ b/docs/plans/systematic-agent-evals.md
@@ -162,6 +162,13 @@ CLI surface by design and do not receive the MCP fallback warning.
 
 - Codex emits one `turn.completed.usage` aggregate with input, cached input,
   cache-write input, output, and reasoning-output fields.
+- The inclusive input partition is verified by the upstream Codex parser
+  fixture `parses_cache_write_token_usage` (input 100, cached input 40,
+  cache-write input 60, total tokens 110). The Luna canary had zero cache-write
+  input, so it did not independently verify a nonzero cache-write case.
+- The current Codex CLI does not expose a provider-resolved model. Phase 1
+  writes `resolvedModel: null` and uses the requested model for cost
+  calculation; the nullable field remains for later adapters.
 - Claude emits a terminal `result` record with `modelUsage`, aggregate usage,
   duration, turns, and provider-reported cost. In the measured full-profile
   runs, `modelUsage.inputTokens` differed from `usage.input_tokens`; therefore
@@ -230,8 +237,9 @@ suite manifest
      when the harness exposes them;
    - provider-native usage plus normalized uncached input, cache-read input,
      cache-write input, output, and reasoning-output details;
-   - provider-reported cost when present, otherwise a calculated base-rate
-     estimate plus the recorded rate-card snapshot and pricing uncertainty;
+   - provider-reported cost for a future adapter that exposes it, otherwise a
+     calculated base-rate estimate plus the recorded rate-card snapshot and
+     pricing uncertainty;
    - artifact-relative paths and warnings for missing/ambiguous telemetry.
 
    Missing telemetry is `unknown`, not zero. Raw artifacts remain authoritative.
@@ -504,9 +512,11 @@ None.
   documents whether an input field is inclusive of cached/cache-write tokens.
 - Use the terminal Codex usage aggregate once; derive uncached input only under
   the verified event semantics, while preserving the raw inclusive input.
-- Record provider-reported cost as `reported`; calculate Luna cost as a
-  `base_rate_estimate` and embed the rate snapshot. When request-level
-  long-context pricing cannot be reconstructed from the turn aggregate, emit a
+- Codex exposes no provider-reported cost here, so current cost kinds are
+  `base_rate_estimate` and `unknown`. Calculate Luna cost as a
+  `base_rate_estimate` and embed the rate snapshot. A future provider-reported
+  kind requires a schema revision. When request-level long-context pricing
+  cannot be reconstructed from the turn aggregate, emit a
   `long_context_pricing_not_attributable` warning. Never present an estimate as
   a billed value or upper bound.
 - Extract GitHits CLI commands from every agent/profile. Store them with
@@ -580,7 +590,7 @@ None.
 ### Deterministic Implementation Evidence
 
 - `bun test scripts/agent-eval.test.ts scripts/agent-eval-metrics.test.ts`:
-  92 tests passed with no failures on 2026-08-28.
+  94 tests passed with no failures on 2026-08-28.
 - `bun run typecheck`, `bun run format:check`, `bun run lint`, and
   `bun run build`: passed on 2026-08-28.
 - The full test suite reported 3,335 passing tests and one failure in the
@@ -612,9 +622,10 @@ calls through MCP.
   complete compatible identity dimensions.
 - [x] Codex token buckets match the terminal aggregate fixtures and reasoning tokens
   are not double-counted.
-- [x] Provider-reported versus base-rate-estimated cost is explicit, the Luna rate
-  snapshot makes the base calculation reproducible, and request-level
-  long-context uncertainty remains visible.
+- [x] Current Codex cost is explicit as a base-rate estimate or unknown; the Luna
+  rate snapshot makes the base calculation reproducible, and request-level
+  long-context uncertainty remains visible. A future provider-reported cost
+  kind requires a schema revision.
 - [x] Descriptor-profile CLI fallback is visible and cannot be mistaken for MCP
   success or zero GitHits use.
 - [x] Missing usage or cost is represented as unknown with a warning.

--- a/docs/plans/systematic-agent-evals.md
+++ b/docs/plans/systematic-agent-evals.md
@@ -3,7 +3,7 @@
 ## Status
 
 - Overall: PLANNED
-- Current phase: Phase 1 — trustworthy local metrics (IMPLEMENTATION COMPLETE; pending final validation/live canary)
+- Current phase: Phase 1 — trustworthy local metrics (COMPLETE)
 - Next phase: Phase 2 — systematic local suites and paired comparison (PLANNED)
 - Owner: repository maintainers
 - Last verified: 2026-08-28
@@ -436,10 +436,9 @@ The following must be resolved before Phase 5:
 
 ## Phase Map
 
-1. **Phase 1 — trustworthy local metrics (IMPLEMENTATION COMPLETE; pending
-   final validation/live canary):** every existing local run produces auditable
-   per-workload tool/token/cost metrics, including visible CLI fallback and
-   explicit unknown telemetry.
+1. **Phase 1 — trustworthy local metrics (COMPLETE):** every existing local run
+   produces auditable per-workload tool/token/cost metrics, including visible
+   CLI fallback and explicit unknown telemetry.
 2. **Phase 2 — systematic local suites and paired comparison (PLANNED):**
    maintainers can execute canary/smoke/full matrices locally, compare a
    candidate to a compatible main baseline, and see measured time/cost totals.
@@ -458,7 +457,7 @@ The following must be resolved before Phase 5:
 
 ### Status
 
-IMPLEMENTATION COMPLETE; pending final validation/live canary
+COMPLETE — implementation and validation complete; live canary passed
 
 ### Expected Outcome
 
@@ -540,12 +539,12 @@ None.
    captured exact agent CLI versions into normalized metrics and reports.
    Preserve sanitized existing command/config evidence.
 6. **Completed:** Update the agentic eval documentation and add the required change fragment.
-7. **Pending final validation/live canary:** Run deterministic tests, typecheck/format/lint as applicable, then rerun the
-   two-workload canary once for Luna-low across both profiles. Compare emitted
-   metrics manually to the raw terminal records and report actual duration/cost.
-   Deterministic coverage now includes provider-ID pairing for Codex MCP and
-   CLI start/completion observations, started-only calls, and repeated calls to
-   one tool under distinct IDs.
+7. **Completed:** Run deterministic tests, typecheck/format/lint/build, then
+   rerun the two-workload canary once for Luna-low across both profiles.
+   Compare emitted metrics manually to the raw terminal records and report
+   actual duration/cost. Deterministic coverage includes provider-ID pairing
+   for Codex MCP and CLI start/completion observations, started-only calls, and
+   repeated calls to one tool under distinct IDs.
 
 ### Edge Cases And Boundaries
 
@@ -578,29 +577,47 @@ None.
 ### Deterministic Implementation Evidence
 
 - `bun test scripts/agent-eval.test.ts scripts/agent-eval-metrics.test.ts`:
-  90 tests passed with no failures on 2026-08-28.
-- `bun run typecheck`: passed on 2026-08-28.
+  92 tests passed with no failures on 2026-08-28.
+- `bun run typecheck`, `bun run format:check`, `bun run lint`, and
+  `bun run build`: passed on 2026-08-28.
+- The full test suite reported 3,335 passing tests and one failure in the
+  existing POSIX process-group timing test under full concurrency. The
+  complete `scripts/agent-eval.test.ts` file passed in isolation with 84/84;
+  the full suite is not considered green.
 - The implementation increments are committed in repository history; this plan
   records behavior and verification rather than immutable commit identifiers.
-- The targeted two-workload Luna-low canary and manual raw-artifact comparison
-  remain pending final validation; no paid/live eval was run as part of the
-  deterministic implementation work.
+
+### Luna Validation Canary
+
+The Luna-low two-workload canary completed successfully in all four executions
+(2 workloads × 2 MCP guidance profiles) on 2026-08-28. Metrics aggregates were:
+
+| Guidance profile | Workloads | Summed workload duration | Logical calls | Uncached input | Cached input | Output | Reasoning detail | Base-rate estimate |
+| ---------------- | --------: | -----------------------: | ------------: | -------------: | -----------: | -----: | ---------------: | -----------------: |
+| descriptors       |         2 |                 203.857 s |            14 |         62,329 |      279,296 | 3,063 |             561 |          $0.02172732 |
+| full              |         2 |                 107.390 s |            13 |         66,823 |      278,528 | 2,225 |             452 |          $0.02160516 |
+
+Raw terminal usage matched metrics for all four executions. Raw tool
+observations paired 2:1 by provider ID into logical calls. The descriptors
+express workload used 10 MCP calls and the package workload used 4 CLI calls
+with the expected MCP-to-CLI fallback warning. The full profile used all 13
+calls through MCP.
 
 ### Acceptance Criteria
 
-- Each of the four canary executions emits one valid metrics record with the
+- [x] Each of the four canary executions emits one valid metrics record with the
   complete compatible identity dimensions.
-- Codex token buckets match the terminal aggregate fixtures and reasoning tokens
+- [x] Codex token buckets match the terminal aggregate fixtures and reasoning tokens
   are not double-counted.
-- Provider-reported versus base-rate-estimated cost is explicit, the Luna rate
+- [x] Provider-reported versus base-rate-estimated cost is explicit, the Luna rate
   snapshot makes the base calculation reproducible, and request-level
   long-context uncertainty remains visible.
-- Descriptor-profile CLI fallback is visible and cannot be mistaken for MCP
+- [x] Descriptor-profile CLI fallback is visible and cannot be mistaken for MCP
   success or zero GitHits use.
-- Missing usage or cost is represented as unknown with a warning.
-- No credential value appears in committed fixtures or generated artifacts.
-- Existing local eval commands and raw artifacts continue to work.
-- Updated documentation accurately states what the metrics do and do not prove.
+- [x] Missing usage or cost is represented as unknown with a warning.
+- [x] No credential value appears in committed fixtures or generated artifacts.
+- [x] Existing local eval commands and raw artifacts continue to work.
+- [x] Updated documentation accurately states what the metrics do and do not prove.
 
 ## Phase 2 — Systematic Local Suites And Paired Comparison
 

--- a/docs/plans/systematic-agent-evals.md
+++ b/docs/plans/systematic-agent-evals.md
@@ -562,6 +562,9 @@ None.
 - Non-GitHits shell commands remain outside GitHits tool metrics.
 - Older run directories without usage events produce a readable report with
   unknown metrics and a schema warning.
+- When run metadata includes `runId`, a validated metrics artifact with a
+  different run ID is rejected as unknown; legacy metadata without a run ID
+  remains compatible with valid metrics artifacts.
 
 ### Verification
 

--- a/docs/plans/systematic-agent-evals.md
+++ b/docs/plans/systematic-agent-evals.md
@@ -593,10 +593,8 @@ None.
   94 tests passed with no failures on 2026-08-28.
 - `bun run typecheck`, `bun run format:check`, `bun run lint`, and
   `bun run build`: passed on 2026-08-28.
-- The full test suite reported 3,335 passing tests and one failure in the
-  existing POSIX process-group timing test under full concurrency. The
-  complete `scripts/agent-eval.test.ts` file passed in isolation with 84/84;
-  the full suite is not considered green.
+- `bun test`: 3,338 tests passed with no failures, across 184 files, with
+  10,762 expectations in 59.05 seconds on 2026-08-28.
 - The implementation increments are committed in repository history; this plan
   records behavior and verification rather than immutable commit identifiers.
 

--- a/eval/agentic/README.md
+++ b/eval/agentic/README.md
@@ -369,12 +369,14 @@ Each run writes:
 `metrics.json` is authoritative for normalized usage and cost. For Codex it
 uses the final `turn.completed.usage` aggregate. `input_tokens` is inclusive of
 cached and cache-write input, so uncached input is derived by subtraction;
-reasoning output is an output detail and is not added again. The current
-Codex adapter reports one logical call for each persisted extracted event;
-because Codex can emit both `item.started` and `item.completed` for one MCP
-call, treat logical counts as provisional and inspect the ordered raw sequence
-until that event pairing is reconciled. `server: "githits-cli"` is surfaced as
-`cli`, and other persisted GitHits calls as `mcp`.
+reasoning output is an output detail and is not added again. Raw observations
+retain their provider `item.id` for pairing: Codex logical counts collapse
+observations with the same surface, ID, and normalized tool, keep first-call
+order, and use the latest status. Started-only observations count once and
+separate IDs remain separate calls; observations without IDs are not paired by
+heuristics. The derived metrics sequence does not persist IDs or arguments.
+`server: "githits-cli"` is surfaced as `cli`, and other persisted GitHits calls
+as `mcp`.
 
 Luna cost is a reproducible base-rate estimate using the stored rate snapshot,
 not billed or exact cost. A turn aggregate above 272,000 inclusive input

--- a/eval/agentic/README.md
+++ b/eval/agentic/README.md
@@ -369,6 +369,11 @@ Each run writes:
 `metrics.json` is authoritative for normalized usage and cost. For Codex it
 uses the final `turn.completed.usage` aggregate. `input_tokens` is inclusive of
 cached and cache-write input, so uncached input is derived by subtraction;
+that partition is verified by the upstream Codex parser fixture
+`parses_cache_write_token_usage` (input 100, cached input 40, cache-write input
+60, total tokens 110). The Luna canary had zero cache-write input, so it did
+not independently verify a nonzero cache-write case.
+
 reasoning output is an output detail and is not added again. Raw observations
 retain their provider `item.id` for pairing: Codex logical counts collapse
 observations with the same surface, ID, and normalized tool, keep first-call
@@ -386,6 +391,10 @@ not zero. Claude and OpenCode currently emit unknown usage/cost with
 `adapter_not_implemented`. See
 `docs/implementation/agentic-eval-metrics.md` for the complete derivation and
 limitations.
+
+The current Codex CLI does not expose a provider-resolved model, so Phase 1
+metrics retain `resolvedModel: null` and use the requested model for cost;
+the nullable field supports later provider adapters.
 
 Claude is launched with `--permission-mode bypassPermissions` so non-interactive
 evals can exercise GitHits without a human approval prompt. Non-full MCP runs

--- a/eval/agentic/README.md
+++ b/eval/agentic/README.md
@@ -374,7 +374,7 @@ that partition is verified by the upstream Codex parser fixture
 60, total tokens 110). The Luna canary had zero cache-write input, so it did
 not independently verify a nonzero cache-write case.
 
-reasoning output is an output detail and is not added again. Raw observations
+Reasoning output is an output detail and is not added again. Raw observations
 retain their provider `item.id` for pairing: Codex logical counts collapse
 observations with the same surface, ID, and normalized tool, keep first-call
 order, and use the latest status. Started-only observations count once and

--- a/eval/agentic/README.md
+++ b/eval/agentic/README.md
@@ -11,9 +11,9 @@ This harness is intentionally human/agent-driven, not CI. Use it to understand
 how MCP tool-description, quick-start, or skill changes affect real agent
 behavior. Do not treat a live agent pass/fail result as a deterministic
 regression test: model behavior, backend indexing state, auth state, network
-conditions, and package data can all change. The useful output is the artifact set, especially
-`tool-calls.json`, `final.json`, `toolIssues`, `instructionIssues`, and the
-agent's usefulness assessment.
+conditions, and package data can all change. The useful output is the artifact
+set, especially `tool-calls.json`, `final.json`, `metrics.json`, `report.json`,
+`toolIssues`, `instructionIssues`, and the agent's usefulness assessment.
 
 ## What Is Under Test
 
@@ -71,8 +71,10 @@ and `OPENCODE_DISABLE_CLAUDE_CODE_SKILLS=1` to exclude global and
 Claude-compatible skills. Full MCP runs retain the intended local
 `.opencode/skills` installation. Generated OpenCode config denies task
 delegation (`permission.task: "deny"`) so GitHits calls stay in the observable
-session. Full MCP reports identify any GitHits CLI fallback rather than
-counting it as equivalent MCP usage.
+session. MCP reports identify any GitHits CLI fallback in both the
+`descriptors` and `full` profiles rather than counting it as equivalent MCP
+usage. Skills runs intentionally use the CLI surface and do not receive that
+MCP fallback warning.
 
 GitHits authentication follows normal local behavior. Keychain-backed human
 login should work by default. Automation can use `GITHITS_API_TOKEN`.
@@ -175,11 +177,13 @@ available. The harness stores the effective model and reasoning effort in
 `run.json` and `report.json`, and includes them in the console summary.
 
 After each run, the harness prints a concise summary with the run directory,
-per-workload status, unique GitHits tool count, raw tool event count,
-usefulness/confidence when available, key artifact paths, and reported
-tool/instruction issues. It also prints a `Next:` block with the exact report,
-compare, and raw-call inspection commands an agent should use for follow-up. The
-same summary can be regenerated later from persisted artifacts:
+per-workload status and duration, unique GitHits tool count, raw tool event
+count, normalized token buckets, cost kind/USD/uncertainty, logical call count,
+MCP/CLI call counts, usefulness/confidence when available, key artifact paths,
+and reported tool/instruction issues. Null metrics are printed as `unknown`.
+It also prints a `Next:` block with the exact report, compare, and raw-call
+inspection commands an agent should use for follow-up. The same summary can be
+regenerated later from persisted artifacts:
 
 ```bash
 bun run agent:e2e:report .agent-eval/runs/<run>
@@ -245,6 +249,18 @@ canary in both guidance profiles:
 bun run agent:e2e --agent codex --model gpt-5.6-luna --reasoning-effort low --server local --guidance-profile descriptors --workload eval/agentic/workloads/express-router.md
 bun run agent:e2e --agent codex --model gpt-5.6-luna --reasoning-effort low --server local --guidance-profile full --workload eval/agentic/workloads/express-router.md
 ```
+
+These two commands are the smallest local Luna-low metrics pair. Each run
+writes `metrics.json` and `report.json`; use the printed run directory with:
+
+```bash
+bun run agent:e2e:report --json .agent-eval/runs/<run>
+bun run agent:e2e:report .agent-eval/runs/<run>
+```
+
+Named suites, daily pipeline execution, persistent result history, and quality
+judging are later phases; this implementation runs the existing workload list
+one workload at a time.
 
 For broad skill edits, run at least:
 
@@ -326,8 +342,11 @@ Each run writes:
 
 - `run.json` with command, git, environment, and timing metadata.
 - `summary.json` with backward-compatible execution status metadata.
-- `report.json` with derived review fields, normalized tool summaries, relative
-  artifact paths, and warnings for missing artifacts or self-report drift.
+- `metrics.json` with schema-versioned per-workload and aggregate normalized
+  usage, cost, tool-surface, identity, timing, and warning fields.
+- `report.json` with derived review fields, normalized tool summaries, matched
+  metrics fields, relative artifact paths, and warnings for missing or
+  ambiguous metrics, missing artifacts, CLI fallback, or self-report drift.
 - One workload directory per workload with `prompt.md`, `stdout.json`,
   `stderr.txt`, `tool-calls.json`, and `final.json` when parsing succeeds.
 - Each live or dry-run workload also records `discovery-events.json`. For Claude
@@ -346,6 +365,25 @@ Each run writes:
 - Full MCP runs additionally write `guidance-installation.json` with the
   canonical project instruction paths and copied skill metadata. Paths are
   persisted for inspection; credentials are never persisted.
+
+`metrics.json` is authoritative for normalized usage and cost. For Codex it
+uses the final `turn.completed.usage` aggregate. `input_tokens` is inclusive of
+cached and cache-write input, so uncached input is derived by subtraction;
+reasoning output is an output detail and is not added again. The current
+Codex adapter reports one logical call for each persisted extracted event;
+because Codex can emit both `item.started` and `item.completed` for one MCP
+call, treat logical counts as provisional and inspect the ordered raw sequence
+until that event pairing is reconciled. `server: "githits-cli"` is surfaced as
+`cli`, and other persisted GitHits calls as `mcp`.
+
+Luna cost is a reproducible base-rate estimate using the stored rate snapshot,
+not billed or exact cost. A turn aggregate above 272,000 inclusive input
+tokens retains the estimate and warns that request-level long-context pricing
+cannot be attributed. Missing or invalid Codex terminal telemetry is unknown,
+not zero. Claude and OpenCode currently emit unknown usage/cost with
+`adapter_not_implemented`. See
+`docs/implementation/agentic-eval-metrics.md` for the complete derivation and
+limitations.
 
 Claude is launched with `--permission-mode bypassPermissions` so non-interactive
 evals can exercise GitHits without a human approval prompt. Non-full MCP runs

--- a/scripts/agent-eval-metrics.test.ts
+++ b/scripts/agent-eval-metrics.test.ts
@@ -211,16 +211,19 @@ describe("agent eval usage metrics", () => {
             {
               tool: "mcp__githits__pkg_info",
               server: "githits",
+              providerCallId: "mcp-1",
               status: "in_progress",
             },
             {
               tool: "githits.pkg_info",
               server: "githits",
+              providerCallId: "mcp-1",
               status: "completed",
             },
             {
               tool: "githits.pkg_info",
               server: "githits",
+              providerCallId: "mcp-2",
               status: "completed",
             },
             {
@@ -293,12 +296,11 @@ describe("agent eval usage metrics", () => {
     });
     expect(metrics.records[0]?.tools).toEqual({
       rawEventCount: 5,
-      logicalCallCount: 5,
+      logicalCallCount: 4,
       completedCount: 3,
       failedCount: 1,
       uniqueTools: ["pkg_info", "pkg_vulns", "search"],
       sequence: [
-        { tool: "pkg_info", surface: "mcp", status: "started" },
         { tool: "pkg_info", surface: "mcp", status: "completed" },
         { tool: "pkg_info", surface: "mcp", status: "completed" },
         { tool: "search", surface: "cli", status: "completed" },
@@ -312,7 +314,7 @@ describe("agent eval usage metrics", () => {
       failedCount: 0,
       timedOutCount: 1,
       durationMs: 3000,
-      logicalToolCalls: 6,
+      logicalToolCalls: 5,
       uncachedInputTokens: 120,
       cachedInputTokens: 140,
       cacheWriteInputTokens: 40,
@@ -371,5 +373,102 @@ describe("agent eval usage metrics", () => {
     expect(unknown.aggregates.reasoningOutputTokens).toBeNull();
     expect(unknown.aggregates.baseRateEstimatedCostUsd).toBeNull();
     expect(unknown.aggregates.logicalToolCalls).toBeNull();
+  });
+
+  it("pairs Codex observations by provider ID while preserving raw events", () => {
+    const metrics = buildAgentEvalMetrics({
+      runId: "run-paired-tools",
+      startedAt: "2026-08-28T10:00:00.000Z",
+      completedAt: "2026-08-28T10:00:01.000Z",
+      records: [
+        {
+          workloadId: "paired-tools",
+          requestedModel: LUNA_MODEL,
+          resolvedModel: null,
+          agent: "codex",
+          agentVersion: null,
+          reasoningEffort: "low",
+          surface: "mcp",
+          server: "local",
+          guidanceProfile: "descriptors",
+          experimentalTools: false,
+          publishedPackage: null,
+          targetGit: { branch: null, sha: null, dirty: null },
+          startedAt: null,
+          completedAt: null,
+          durationMs: 1000,
+          processStatus: "success",
+          finalStatus: "success",
+          exitCode: 0,
+          timedOut: false,
+          usage: adaptAgentUsage(
+            codexUsageEvent({
+              input_tokens: 1,
+              cached_input_tokens: 0,
+              cache_write_input_tokens: 0,
+              output_tokens: 1,
+              reasoning_output_tokens: 0,
+            }),
+            "codex",
+            LUNA_MODEL,
+          ),
+          toolCalls: [
+            {
+              tool: "search",
+              server: "githits-cli",
+              providerCallId: "command-1",
+              status: "started",
+            },
+            {
+              tool: "search",
+              server: "githits-cli",
+              providerCallId: "command-1",
+              status: "completed",
+            },
+            {
+              tool: "mcp__githits__search",
+              server: "githits",
+              providerCallId: "mcp-1",
+              status: "in_progress",
+            },
+            {
+              tool: "mcp__githits__search",
+              server: "githits",
+              providerCallId: "mcp-1",
+              status: "completed",
+            },
+            {
+              tool: "mcp__githits__search",
+              server: "githits",
+              providerCallId: "mcp-2",
+              status: "completed",
+            },
+            {
+              tool: "mcp__githits__search",
+              server: "githits",
+              providerCallId: "mcp-3",
+              status: "in_progress",
+            },
+          ],
+          artifacts: {},
+        },
+      ],
+    });
+
+    expect(metrics.records[0]?.tools).toEqual({
+      rawEventCount: 6,
+      logicalCallCount: 4,
+      completedCount: 3,
+      failedCount: 0,
+      uniqueTools: ["search"],
+      sequence: [
+        { tool: "search", surface: "cli", status: "completed" },
+        { tool: "search", surface: "mcp", status: "completed" },
+        { tool: "search", surface: "mcp", status: "completed" },
+        { tool: "search", surface: "mcp", status: "started" },
+      ],
+      resultBytes: null,
+    });
+    expect(JSON.stringify(metrics)).not.toContain("providerCallId");
   });
 });

--- a/scripts/agent-eval-metrics.test.ts
+++ b/scripts/agent-eval-metrics.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "bun:test";
+import {
+  adaptAgentUsage,
+  agentUsageMetricsSchema,
+  LUNA_MODEL,
+  LUNA_RATE_EFFECTIVE_DATE,
+  LUNA_RATE_SOURCE,
+} from "./agent-eval-metrics.ts";
+
+function codexUsageEvent(usage: Record<string, number>): string {
+  return JSON.stringify({ type: "turn.completed", usage });
+}
+
+describe("agent eval usage metrics", () => {
+  it("normalizes inclusive Luna usage and does not double-count reasoning", () => {
+    const metrics = adaptAgentUsage(
+      codexUsageEvent({
+        input_tokens: 100,
+        cached_input_tokens: 40,
+        cache_write_input_tokens: 20,
+        output_tokens: 10,
+        reasoning_output_tokens: 4,
+      }),
+      "codex",
+      LUNA_MODEL,
+    );
+
+    expect(metrics.normalizedTokens).toEqual({
+      uncachedInputTokens: 40,
+      cachedInputTokens: 40,
+      cacheWriteInputTokens: 20,
+      outputTokens: 10,
+      reasoningOutputTokens: 4,
+    });
+    expect(metrics.cost.kind).toBe("base_rate_estimate");
+    if (metrics.cost.kind !== "base_rate_estimate") return;
+    expect(metrics.cost.usd).toBeCloseTo(0.0000258, 12);
+    expect(metrics.cost.usd).not.toBeCloseTo(0.0000306, 12);
+    expect(metrics.cost.rateSnapshot).toMatchObject({
+      model: LUNA_MODEL,
+      effectiveDate: LUNA_RATE_EFFECTIVE_DATE,
+      source: LUNA_RATE_SOURCE,
+    });
+    expect(metrics.warnings).toEqual([]);
+    expect(agentUsageMetricsSchema.parse(metrics)).toEqual(metrics);
+  });
+
+  it("uses the last terminal Codex aggregate", () => {
+    const metrics = adaptAgentUsage(
+      [
+        codexUsageEvent({
+          input_tokens: 100,
+          cached_input_tokens: 0,
+          cache_write_input_tokens: 0,
+          output_tokens: 10,
+          reasoning_output_tokens: 2,
+        }),
+        codexUsageEvent({
+          input_tokens: 200,
+          cached_input_tokens: 100,
+          cache_write_input_tokens: 20,
+          output_tokens: 30,
+          reasoning_output_tokens: 5,
+        }),
+      ].join("\n"),
+      "codex",
+      LUNA_MODEL,
+    );
+
+    expect(metrics.providerUsage?.input_tokens).toBe(200);
+    expect(metrics.normalizedTokens.uncachedInputTokens).toBe(80);
+  });
+
+  it("marks input above the long-context boundary as unattributable", () => {
+    const metrics = adaptAgentUsage(
+      codexUsageEvent({
+        input_tokens: 272_001,
+        cached_input_tokens: 0,
+        cache_write_input_tokens: 0,
+        output_tokens: 1,
+        reasoning_output_tokens: 0,
+      }),
+      "codex",
+      LUNA_MODEL,
+    );
+
+    expect(metrics.cost.kind).toBe("base_rate_estimate");
+    expect(metrics.cost.uncertainty).toBe(
+      "long_context_pricing_not_attributable",
+    );
+    expect(metrics.warnings).toContain("long_context_pricing_not_attributable");
+
+    const atBoundary = adaptAgentUsage(
+      codexUsageEvent({
+        input_tokens: 272_000,
+        cached_input_tokens: 0,
+        cache_write_input_tokens: 0,
+        output_tokens: 1,
+        reasoning_output_tokens: 0,
+      }),
+      "codex",
+      LUNA_MODEL,
+    );
+    expect(atBoundary.warnings).not.toContain(
+      "long_context_pricing_not_attributable",
+    );
+  });
+
+  it("returns unknown usage for missing and invalid Codex telemetry", () => {
+    const missing = adaptAgentUsage(
+      '{"type":"turn.started"}',
+      "codex",
+      LUNA_MODEL,
+    );
+    expect(missing.normalizedTokens.uncachedInputTokens).toBeNull();
+    expect(missing.cost.usd).toBeNull();
+    expect(missing.warnings).toContain("codex_terminal_usage_missing");
+
+    const invalid = adaptAgentUsage(
+      codexUsageEvent({
+        input_tokens: -1,
+        cached_input_tokens: 0,
+        cache_write_input_tokens: 0,
+        output_tokens: 1,
+        reasoning_output_tokens: 0,
+      }),
+      "codex",
+      LUNA_MODEL,
+    );
+    expect(invalid.normalizedTokens.outputTokens).toBeNull();
+    expect(invalid.warnings).toContain("codex_terminal_usage_invalid");
+  });
+
+  it("keeps unsupported agents and unconfigured Codex models explicitly unknown", () => {
+    const claude = adaptAgentUsage("", "claude", "haiku");
+    expect(claude.normalizedTokens.outputTokens).toBeNull();
+    expect(claude.cost.kind).toBe("unknown");
+    expect(claude.warnings).toEqual(["adapter_not_implemented"]);
+
+    const opencode = adaptAgentUsage("", "opencode", "some-model");
+    expect(opencode.warnings).toEqual(["adapter_not_implemented"]);
+
+    const otherModel = adaptAgentUsage(
+      codexUsageEvent({
+        input_tokens: 10,
+        cached_input_tokens: 5,
+        cache_write_input_tokens: 0,
+        output_tokens: 2,
+        reasoning_output_tokens: 1,
+      }),
+      "codex",
+      "gpt-5.4-mini",
+    );
+    expect(otherModel.normalizedTokens.uncachedInputTokens).toBe(5);
+    expect(otherModel.cost.kind).toBe("unknown");
+    expect(otherModel.warnings).toContain("rate_card_not_configured");
+  });
+});

--- a/scripts/agent-eval-metrics.test.ts
+++ b/scripts/agent-eval-metrics.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import {
+  type AgentEvalRecordInput,
   adaptAgentUsage,
   agentEvalMetricsSchema,
   agentUsageMetricsSchema,
@@ -158,6 +159,85 @@ describe("agent eval usage metrics", () => {
     expect(otherModel.warnings).toContain("rate_card_not_configured");
   });
 
+  it("keeps known aggregate values when another record is unknown", () => {
+    const known: AgentEvalRecordInput = {
+      workloadId: "known",
+      requestedModel: LUNA_MODEL,
+      resolvedModel: null,
+      agent: "codex",
+      agentVersion: null,
+      reasoningEffort: "low",
+      surface: "mcp",
+      server: "local",
+      guidanceProfile: "descriptors",
+      experimentalTools: false,
+      publishedPackage: null,
+      targetGit: { branch: "main", sha: "abc123", dirty: false },
+      startedAt: "2026-08-28T10:00:00.000Z",
+      completedAt: "2026-08-28T10:00:01.000Z",
+      durationMs: 1000,
+      processStatus: "success",
+      finalStatus: "success",
+      exitCode: 0,
+      timedOut: false,
+      usage: adaptAgentUsage(
+        codexUsageEvent({
+          input_tokens: 100,
+          cached_input_tokens: 40,
+          cache_write_input_tokens: 20,
+          output_tokens: 10,
+          reasoning_output_tokens: 4,
+        }),
+        "codex",
+        LUNA_MODEL,
+      ),
+      toolCalls: [{ tool: "search", server: "githits", status: "completed" }],
+      artifacts: {},
+    };
+    const unknown: AgentEvalRecordInput = {
+      ...known,
+      workloadId: "unknown",
+      requestedModel: LUNA_MODEL,
+      agent: "codex",
+      agentVersion: null,
+      reasoningEffort: null,
+      durationMs: null,
+      processStatus: "failed",
+      finalStatus: "failure",
+      exitCode: 1,
+      usage: adaptAgentUsage("", "codex", LUNA_MODEL),
+      toolCalls: [],
+    };
+
+    const metrics = buildAgentEvalMetrics({
+      runId: "run-mixed",
+      startedAt: "2026-08-28T10:00:00.000Z",
+      completedAt: "2026-08-28T10:00:01.000Z",
+      records: [known, unknown],
+    });
+
+    expect(metrics.records[1]?.warnings).toEqual([
+      "codex_terminal_usage_missing",
+    ]);
+    expect(metrics.aggregates).toMatchObject({
+      workloadCount: 2,
+      durationMs: 1000,
+      logicalToolCalls: 1,
+      uncachedInputTokens: 40,
+      cachedInputTokens: 40,
+      cacheWriteInputTokens: 20,
+      outputTokens: 10,
+      reasoningOutputTokens: 4,
+      baseRateEstimatedCostUsd: 0.0000258,
+    });
+    expect(metrics.aggregates).not.toMatchObject({
+      durationMs: 0,
+      uncachedInputTokens: 0,
+      baseRateEstimatedCostUsd: 0,
+    });
+    expect(metrics.warnings).toEqual(["codex_terminal_usage_missing"]);
+  });
+
   it("builds a schema-valid run with identity, tool, and aggregate metrics", () => {
     const firstUsage = adaptAgentUsage(
       codexUsageEvent({
@@ -230,7 +310,6 @@ describe("agent eval usage metrics", () => {
               tool: "search",
               server: "githits-cli",
               status: "completed",
-              resultBytes: 12,
             },
             {
               tool: "pkg_vulns",
@@ -306,7 +385,6 @@ describe("agent eval usage metrics", () => {
         { tool: "search", surface: "cli", status: "completed" },
         { tool: "pkg_vulns", surface: "mcp", status: "failed" },
       ],
-      resultBytes: 12,
     });
     expect(metrics.aggregates).toMatchObject({
       workloadCount: 2,
@@ -467,7 +545,6 @@ describe("agent eval usage metrics", () => {
         { tool: "search", surface: "mcp", status: "completed" },
         { tool: "search", surface: "mcp", status: "started" },
       ],
-      resultBytes: null,
     });
     expect(JSON.stringify(metrics)).not.toContain("providerCallId");
   });

--- a/scripts/agent-eval-metrics.test.ts
+++ b/scripts/agent-eval-metrics.test.ts
@@ -322,7 +322,7 @@ describe("agent eval usage metrics", () => {
     });
   });
 
-  it("excludes unknown usage, cost, and duration from aggregate totals", () => {
+  it("builds unsupported-agent records without a requested model", () => {
     const unknown = buildAgentEvalMetrics({
       runId: "run-unknown",
       startedAt: "2026-08-28T10:00:00.000Z",
@@ -330,7 +330,6 @@ describe("agent eval usage metrics", () => {
       records: [
         {
           workloadId: "unknown",
-          requestedModel: "haiku",
           resolvedModel: null,
           agent: "claude",
           agentVersion: null,
@@ -355,6 +354,15 @@ describe("agent eval usage metrics", () => {
       ],
     });
 
+    expect(agentEvalMetricsSchema.parse(unknown)).toEqual(unknown);
+    expect(unknown.records[0]).toMatchObject({
+      agent: "claude",
+      requestedModel: null,
+      warnings: [
+        "adapter_not_implemented",
+        "tool_logical_count_not_implemented",
+      ],
+    });
     expect(unknown.aggregates.durationMs).toBeNull();
     expect(unknown.aggregates.uncachedInputTokens).toBeNull();
     expect(unknown.aggregates.cachedInputTokens).toBeNull();

--- a/scripts/agent-eval-metrics.test.ts
+++ b/scripts/agent-eval-metrics.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "bun:test";
 import {
   adaptAgentUsage,
+  agentEvalMetricsSchema,
   agentUsageMetricsSchema,
+  buildAgentEvalMetrics,
   LUNA_MODEL,
   LUNA_RATE_EFFECTIVE_DATE,
   LUNA_RATE_SOURCE,
@@ -154,5 +156,212 @@ describe("agent eval usage metrics", () => {
     expect(otherModel.normalizedTokens.uncachedInputTokens).toBe(5);
     expect(otherModel.cost.kind).toBe("unknown");
     expect(otherModel.warnings).toContain("rate_card_not_configured");
+  });
+
+  it("builds a schema-valid run with identity, tool, and aggregate metrics", () => {
+    const firstUsage = adaptAgentUsage(
+      codexUsageEvent({
+        input_tokens: 100,
+        cached_input_tokens: 40,
+        cache_write_input_tokens: 20,
+        output_tokens: 10,
+        reasoning_output_tokens: 4,
+      }),
+      "codex",
+      LUNA_MODEL,
+    );
+    const secondUsage = adaptAgentUsage(
+      codexUsageEvent({
+        input_tokens: 200,
+        cached_input_tokens: 100,
+        cache_write_input_tokens: 20,
+        output_tokens: 30,
+        reasoning_output_tokens: 5,
+      }),
+      "codex",
+      LUNA_MODEL,
+    );
+    const metrics = buildAgentEvalMetrics({
+      runId: "run-1",
+      startedAt: "2026-08-28T10:00:00.000Z",
+      completedAt: "2026-08-28T10:00:03.000Z",
+      records: [
+        {
+          workloadId: "pkg-info",
+          requestedModel: LUNA_MODEL,
+          resolvedModel: LUNA_MODEL,
+          agent: "codex",
+          agentVersion: "0.150.1",
+          reasoningEffort: "low",
+          surface: "mcp",
+          server: "local",
+          guidanceProfile: "descriptors",
+          experimentalTools: false,
+          publishedPackage: null,
+          targetGit: { branch: "main", sha: "abc123", dirty: false },
+          startedAt: "2026-08-28T10:00:00.000Z",
+          completedAt: "2026-08-28T10:00:01.000Z",
+          durationMs: 1000,
+          processStatus: "success",
+          finalStatus: "success",
+          exitCode: 0,
+          timedOut: false,
+          usage: firstUsage,
+          toolCalls: [
+            {
+              tool: "mcp__githits__pkg_info",
+              server: "githits",
+              status: "in_progress",
+            },
+            {
+              tool: "githits.pkg_info",
+              server: "githits",
+              status: "completed",
+            },
+            {
+              tool: "githits.pkg_info",
+              server: "githits",
+              status: "completed",
+            },
+            {
+              tool: "search",
+              server: "githits-cli",
+              status: "completed",
+              resultBytes: 12,
+            },
+            {
+              tool: "pkg_vulns",
+              server: "githits",
+              status: "error",
+              error: "backend unavailable",
+            },
+          ],
+          artifacts: {
+            toolCalls: "workloads/pkg-info/tool-calls.json",
+            final: "workloads/pkg-info/final.json",
+          },
+        },
+        {
+          workloadId: "docs-search",
+          requestedModel: LUNA_MODEL,
+          resolvedModel: null,
+          agent: "codex",
+          agentVersion: null,
+          reasoningEffort: "low",
+          surface: "mcp",
+          server: "local",
+          guidanceProfile: "full",
+          experimentalTools: false,
+          publishedPackage: null,
+          targetGit: { branch: null, sha: null, dirty: null },
+          startedAt: null,
+          completedAt: null,
+          durationMs: 2000,
+          processStatus: "timeout",
+          finalStatus: null,
+          exitCode: null,
+          timedOut: true,
+          usage: secondUsage,
+          toolCalls: [
+            {
+              tool: "docs_search",
+              server: "githits",
+              status: "completed",
+            },
+          ],
+          artifacts: {},
+        },
+      ],
+    });
+
+    expect(agentEvalMetricsSchema.parse(metrics)).toEqual(metrics);
+    expect(metrics.runId).toBe("run-1");
+    expect(metrics.records[0]).toMatchObject({
+      workloadId: "pkg-info",
+      requestedModel: LUNA_MODEL,
+      resolvedModel: LUNA_MODEL,
+      agentVersion: "0.150.1",
+      targetGit: { branch: "main", sha: "abc123", dirty: false },
+      processStatus: "success",
+      finalStatus: "success",
+      durationMs: 1000,
+      exitCode: 0,
+      timedOut: false,
+      artifacts: {
+        toolCalls: "workloads/pkg-info/tool-calls.json",
+      },
+    });
+    expect(metrics.records[0]?.tools).toEqual({
+      rawEventCount: 5,
+      logicalCallCount: 5,
+      completedCount: 3,
+      failedCount: 1,
+      uniqueTools: ["pkg_info", "pkg_vulns", "search"],
+      sequence: [
+        { tool: "pkg_info", surface: "mcp", status: "started" },
+        { tool: "pkg_info", surface: "mcp", status: "completed" },
+        { tool: "pkg_info", surface: "mcp", status: "completed" },
+        { tool: "search", surface: "cli", status: "completed" },
+        { tool: "pkg_vulns", surface: "mcp", status: "failed" },
+      ],
+      resultBytes: 12,
+    });
+    expect(metrics.aggregates).toMatchObject({
+      workloadCount: 2,
+      succeededCount: 1,
+      failedCount: 0,
+      timedOutCount: 1,
+      durationMs: 3000,
+      logicalToolCalls: 6,
+      uncachedInputTokens: 120,
+      cachedInputTokens: 140,
+      cacheWriteInputTokens: 40,
+      outputTokens: 40,
+      reasoningOutputTokens: 9,
+      baseRateEstimatedCostUsd: 0.0000848,
+    });
+  });
+
+  it("excludes unknown usage, cost, and duration from aggregate totals", () => {
+    const unknown = buildAgentEvalMetrics({
+      runId: "run-unknown",
+      startedAt: "2026-08-28T10:00:00.000Z",
+      completedAt: "2026-08-28T10:00:01.000Z",
+      records: [
+        {
+          workloadId: "unknown",
+          requestedModel: "haiku",
+          resolvedModel: null,
+          agent: "claude",
+          agentVersion: null,
+          reasoningEffort: null,
+          surface: "mcp",
+          server: "local",
+          guidanceProfile: "descriptors",
+          experimentalTools: false,
+          publishedPackage: null,
+          targetGit: { branch: null, sha: null, dirty: null },
+          startedAt: null,
+          completedAt: null,
+          durationMs: null,
+          processStatus: "failed",
+          finalStatus: "failure",
+          exitCode: 1,
+          timedOut: false,
+          usage: adaptAgentUsage("", "claude", "haiku"),
+          toolCalls: [],
+          artifacts: {},
+        },
+      ],
+    });
+
+    expect(unknown.aggregates.durationMs).toBeNull();
+    expect(unknown.aggregates.uncachedInputTokens).toBeNull();
+    expect(unknown.aggregates.cachedInputTokens).toBeNull();
+    expect(unknown.aggregates.cacheWriteInputTokens).toBeNull();
+    expect(unknown.aggregates.outputTokens).toBeNull();
+    expect(unknown.aggregates.reasoningOutputTokens).toBeNull();
+    expect(unknown.aggregates.baseRateEstimatedCostUsd).toBeNull();
+    expect(unknown.aggregates.logicalToolCalls).toBeNull();
   });
 });

--- a/scripts/agent-eval-metrics.test.ts
+++ b/scripts/agent-eval-metrics.test.ts
@@ -230,11 +230,6 @@ describe("agent eval usage metrics", () => {
       reasoningOutputTokens: 4,
       baseRateEstimatedCostUsd: 0.0000258,
     });
-    expect(metrics.aggregates).not.toMatchObject({
-      durationMs: 0,
-      uncachedInputTokens: 0,
-      baseRateEstimatedCostUsd: 0,
-    });
     expect(metrics.warnings).toEqual(["codex_terminal_usage_missing"]);
   });
 

--- a/scripts/agent-eval-metrics.ts
+++ b/scripts/agent-eval-metrics.ts
@@ -1,0 +1,265 @@
+import { z } from "zod";
+
+export type EvalAgent = "claude" | "codex" | "opencode";
+
+export const LUNA_MODEL = "gpt-5.6-luna" as const;
+export const LUNA_RATE_SOURCE =
+  "https://developers.openai.com/api/docs/models/gpt-5.6-luna" as const;
+export const LUNA_RATE_EFFECTIVE_DATE = "2026-08-28" as const;
+
+const LUNA_RATES = {
+  uncachedInputUsdPerMillion: 0.2,
+  cachedInputUsdPerMillion: 0.02,
+  cacheWriteInputUsdPerMillion: 0.25,
+  outputUsdPerMillion: 1.2,
+} as const;
+
+const nonNegativeInteger = z.number().int().nonnegative();
+
+export const codexProviderUsageSchema = z
+  .object({
+    input_tokens: nonNegativeInteger,
+    cached_input_tokens: nonNegativeInteger,
+    cache_write_input_tokens: nonNegativeInteger,
+    output_tokens: nonNegativeInteger,
+    reasoning_output_tokens: nonNegativeInteger,
+  })
+  .passthrough();
+
+export type CodexProviderUsage = z.infer<typeof codexProviderUsageSchema>;
+
+export const lunaRateSnapshotSchema = z.object({
+  model: z.literal(LUNA_MODEL),
+  currency: z.literal("USD"),
+  unit: z.literal("per_million_tokens"),
+  effectiveDate: z.literal(LUNA_RATE_EFFECTIVE_DATE),
+  source: z.literal(LUNA_RATE_SOURCE),
+  rates: z.object({
+    uncachedInputUsdPerMillion: z.literal(
+      LUNA_RATES.uncachedInputUsdPerMillion,
+    ),
+    cachedInputUsdPerMillion: z.literal(LUNA_RATES.cachedInputUsdPerMillion),
+    cacheWriteInputUsdPerMillion: z.literal(
+      LUNA_RATES.cacheWriteInputUsdPerMillion,
+    ),
+    outputUsdPerMillion: z.literal(LUNA_RATES.outputUsdPerMillion),
+  }),
+});
+
+export type LunaRateSnapshot = z.infer<typeof lunaRateSnapshotSchema>;
+
+const normalizedTokensSchema = z.object({
+  uncachedInputTokens: nonNegativeInteger.nullable(),
+  cachedInputTokens: nonNegativeInteger.nullable(),
+  cacheWriteInputTokens: nonNegativeInteger.nullable(),
+  outputTokens: nonNegativeInteger.nullable(),
+  reasoningOutputTokens: nonNegativeInteger.nullable(),
+});
+
+const costSchema = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.literal("base_rate_estimate"),
+    usd: z.number().nonnegative(),
+    uncertainty: z.enum([
+      "rate_based_estimate",
+      "long_context_pricing_not_attributable",
+    ]),
+    rateSnapshot: lunaRateSnapshotSchema,
+  }),
+  z.object({
+    kind: z.literal("unknown"),
+    usd: z.null(),
+    uncertainty: z.literal("unknown"),
+    rateSnapshot: z.null(),
+  }),
+]);
+
+export const agentUsageMetricsSchema = z.object({
+  schemaVersion: z.literal(1),
+  agent: z.enum(["claude", "codex", "opencode"]),
+  model: z.string().nullable(),
+  providerUsage: codexProviderUsageSchema.nullable(),
+  normalizedTokens: normalizedTokensSchema,
+  cost: costSchema,
+  warnings: z.array(z.string()),
+});
+
+export type AgentUsageMetrics = z.infer<typeof agentUsageMetricsSchema>;
+
+const LONG_CONTEXT_INPUT_LIMIT = 272_000;
+
+const UNKNOWN_TOKENS = {
+  uncachedInputTokens: null,
+  cachedInputTokens: null,
+  cacheWriteInputTokens: null,
+  outputTokens: null,
+  reasoningOutputTokens: null,
+} as const;
+
+function unknownCost(): AgentUsageMetrics["cost"] {
+  return {
+    kind: "unknown",
+    usd: null,
+    uncertainty: "unknown",
+    rateSnapshot: null,
+  };
+}
+
+function unknownMetrics(
+  agent: EvalAgent,
+  model: string | undefined,
+  warnings: string[],
+): AgentUsageMetrics {
+  return agentUsageMetricsSchema.parse({
+    schemaVersion: 1,
+    agent,
+    model: model ?? null,
+    providerUsage: null,
+    normalizedTokens: UNKNOWN_TOKENS,
+    cost: unknownCost(),
+    warnings,
+  });
+}
+
+function lastCodexTerminalUsage(stdout: string): {
+  found: boolean;
+  value: unknown;
+} {
+  let found = false;
+  let value: unknown;
+  for (const line of stdout.split("\n")) {
+    if (line.trim().length === 0) continue;
+    try {
+      const event = JSON.parse(line) as Record<string, unknown>;
+      if (event.type !== "turn.completed") continue;
+      found = true;
+      value = event.usage;
+    } catch {
+      // Ignore non-JSON lines emitted by the CLI.
+    }
+  }
+  return { found, value };
+}
+
+function lunaCost(
+  tokens: AgentUsageMetrics["normalizedTokens"],
+  longContext: boolean,
+): AgentUsageMetrics["cost"] {
+  const uncachedInputTokens = tokens.uncachedInputTokens;
+  const cachedInputTokens = tokens.cachedInputTokens;
+  const cacheWriteInputTokens = tokens.cacheWriteInputTokens;
+  const outputTokens = tokens.outputTokens;
+  if (
+    uncachedInputTokens === null ||
+    cachedInputTokens === null ||
+    cacheWriteInputTokens === null ||
+    outputTokens === null
+  ) {
+    return unknownCost();
+  }
+  const usd =
+    (uncachedInputTokens * LUNA_RATES.uncachedInputUsdPerMillion +
+      cachedInputTokens * LUNA_RATES.cachedInputUsdPerMillion +
+      cacheWriteInputTokens * LUNA_RATES.cacheWriteInputUsdPerMillion +
+      outputTokens * LUNA_RATES.outputUsdPerMillion) /
+    1_000_000;
+  return {
+    kind: "base_rate_estimate",
+    usd,
+    uncertainty: longContext
+      ? "long_context_pricing_not_attributable"
+      : "rate_based_estimate",
+    rateSnapshot: {
+      model: LUNA_MODEL,
+      currency: "USD",
+      unit: "per_million_tokens",
+      effectiveDate: LUNA_RATE_EFFECTIVE_DATE,
+      source: LUNA_RATE_SOURCE,
+      rates: LUNA_RATES,
+    },
+  };
+}
+
+function unavailableCodexWarnings(
+  model: string | undefined,
+  warning: string,
+): string[] {
+  const warnings = [warning];
+  if (model !== LUNA_MODEL) warnings.push("rate_card_not_configured");
+  return warnings;
+}
+
+/**
+ * Adapts one agent JSONL stream into a validated, provider-neutral usage
+ * record. Codex usage is sourced from its final turn.completed aggregate.
+ */
+export function adaptAgentUsage(
+  stdout: string,
+  agent: EvalAgent,
+  model?: string,
+): AgentUsageMetrics {
+  if (agent !== "codex") {
+    return unknownMetrics(agent, model, ["adapter_not_implemented"]);
+  }
+
+  const terminal = lastCodexTerminalUsage(stdout);
+  if (!terminal.found) {
+    return unknownMetrics(
+      agent,
+      model,
+      unavailableCodexWarnings(model, "codex_terminal_usage_missing"),
+    );
+  }
+
+  const parsed = codexProviderUsageSchema.safeParse(terminal.value);
+  if (!parsed.success) {
+    return unknownMetrics(
+      agent,
+      model,
+      unavailableCodexWarnings(model, "codex_terminal_usage_invalid"),
+    );
+  }
+
+  const providerUsage = parsed.data;
+  const uncachedInputTokens =
+    providerUsage.input_tokens -
+    providerUsage.cached_input_tokens -
+    providerUsage.cache_write_input_tokens;
+  if (
+    uncachedInputTokens < 0 ||
+    providerUsage.reasoning_output_tokens > providerUsage.output_tokens
+  ) {
+    return unknownMetrics(
+      agent,
+      model,
+      unavailableCodexWarnings(model, "codex_terminal_usage_invalid"),
+    );
+  }
+
+  const normalizedTokens = {
+    uncachedInputTokens,
+    cachedInputTokens: providerUsage.cached_input_tokens,
+    cacheWriteInputTokens: providerUsage.cache_write_input_tokens,
+    outputTokens: providerUsage.output_tokens,
+    reasoningOutputTokens: providerUsage.reasoning_output_tokens,
+  };
+  const longContext = providerUsage.input_tokens > LONG_CONTEXT_INPUT_LIMIT;
+  const warnings: string[] = [];
+  let cost = unknownCost();
+  if (model === LUNA_MODEL) {
+    cost = lunaCost(normalizedTokens, longContext);
+    if (longContext) warnings.push("long_context_pricing_not_attributable");
+  } else {
+    warnings.push("rate_card_not_configured");
+  }
+
+  return agentUsageMetricsSchema.parse({
+    schemaVersion: 1,
+    agent,
+    model: model ?? null,
+    providerUsage,
+    normalizedTokens,
+    cost,
+    warnings,
+  });
+}

--- a/scripts/agent-eval-metrics.ts
+++ b/scripts/agent-eval-metrics.ts
@@ -101,6 +101,7 @@ export type NormalizedToolStatus =
 export interface PersistedToolCall {
   tool: string;
   server?: string;
+  providerCallId?: string;
   status?: string;
   error?: unknown;
   resultBytes?: number | null;
@@ -457,22 +458,70 @@ function sumKnown(values: Array<number | null>): number | null {
     : known.reduce((sum, value) => sum + value, 0);
 }
 
+interface NormalizedToolObservation {
+  tool: string;
+  surface: "mcp" | "cli";
+  status: NormalizedToolStatus;
+  resultBytes: number | null;
+}
+
+function normalizeToolObservation(
+  call: PersistedToolCall,
+): NormalizedToolObservation {
+  return {
+    tool: normalizeToolName(call.tool),
+    surface: call.server === "githits-cli" ? "cli" : "mcp",
+    status: normalizeToolStatus(call.status, call.error),
+    resultBytes: call.resultBytes ?? null,
+  };
+}
+
+function normalizeLogicalToolObservations(
+  agent: EvalAgent,
+  calls: PersistedToolCall[],
+): NormalizedToolObservation[] {
+  const observations: NormalizedToolObservation[] = [];
+  if (agent !== "codex") {
+    return calls.map(normalizeToolObservation);
+  }
+
+  const indexesByIdentity: Map<string, number> = new Map();
+  for (const call of calls) {
+    const observation: NormalizedToolObservation =
+      normalizeToolObservation(call);
+    const providerCallId: string | undefined = call.providerCallId;
+    if (providerCallId === undefined || providerCallId.length === 0) {
+      observations.push(observation);
+      continue;
+    }
+
+    const identity: string = `${observation.surface}\0${providerCallId}\0${observation.tool}`;
+    const previousIndex: number | undefined = indexesByIdentity.get(identity);
+    if (previousIndex === undefined) {
+      indexesByIdentity.set(identity, observations.length);
+      observations.push(observation);
+    } else {
+      observations[previousIndex] = observation;
+    }
+  }
+  return observations;
+}
+
 function buildAgentEvalRecord(input: AgentEvalRecordInput): AgentEvalRecord {
   const usage = agentUsageMetricsSchema.parse(input.usage);
-  const sequence = input.toolCalls.map((call) => ({
-    tool: normalizeToolName(call.tool),
-    surface:
-      call.server === "githits-cli" ? ("cli" as const) : ("mcp" as const),
-    status: normalizeToolStatus(call.status, call.error),
+  const observations: NormalizedToolObservation[] =
+    normalizeLogicalToolObservations(input.agent, input.toolCalls);
+  const sequence = observations.map(({ tool, surface, status }) => ({
+    tool,
+    surface,
+    status,
   }));
   const warnings = [...usage.warnings];
   if (input.agent !== "codex") {
     warnings.push("tool_logical_count_not_implemented");
   }
 
-  const resultBytes = sumKnown(
-    input.toolCalls.map((call) => call.resultBytes ?? null),
-  );
+  const resultBytes = sumKnown(observations.map((call) => call.resultBytes));
   const record = {
     workloadId: input.workloadId,
     requestedModel: input.requestedModel ?? null,
@@ -500,7 +549,7 @@ function buildAgentEvalRecord(input: AgentEvalRecordInput): AgentEvalRecord {
     usage,
     tools: {
       rawEventCount: input.toolCalls.length,
-      logicalCallCount: input.agent === "codex" ? input.toolCalls.length : null,
+      logicalCallCount: input.agent === "codex" ? observations.length : null,
       completedCount: sequence.filter((call) => call.status === "completed")
         .length,
       failedCount: sequence.filter((call) => call.status === "failed").length,

--- a/scripts/agent-eval-metrics.ts
+++ b/scripts/agent-eval-metrics.ts
@@ -16,15 +16,13 @@ const LUNA_RATES = {
 
 const nonNegativeInteger = z.number().int().nonnegative();
 
-export const codexProviderUsageSchema = z
-  .object({
-    input_tokens: nonNegativeInteger,
-    cached_input_tokens: nonNegativeInteger,
-    cache_write_input_tokens: nonNegativeInteger,
-    output_tokens: nonNegativeInteger,
-    reasoning_output_tokens: nonNegativeInteger,
-  })
-  .passthrough();
+export const codexProviderUsageSchema = z.object({
+  input_tokens: nonNegativeInteger,
+  cached_input_tokens: nonNegativeInteger,
+  cache_write_input_tokens: nonNegativeInteger,
+  output_tokens: nonNegativeInteger,
+  reasoning_output_tokens: nonNegativeInteger,
+});
 
 export type CodexProviderUsage = z.infer<typeof codexProviderUsageSchema>;
 

--- a/scripts/agent-eval-metrics.ts
+++ b/scripts/agent-eval-metrics.ts
@@ -104,7 +104,6 @@ export interface PersistedToolCall {
   providerCallId?: string;
   status?: string;
   error?: unknown;
-  resultBytes?: number | null;
 }
 
 export interface AgentEvalRecordInput {
@@ -173,7 +172,6 @@ const toolsMetricsSchema = z.object({
   failedCount: nonNegativeInteger,
   uniqueTools: z.array(z.string()),
   sequence: z.array(toolSequenceEntrySchema),
-  resultBytes: nonNegativeInteger.nullable(),
 });
 
 export const agentEvalRecordSchema = z.object({
@@ -462,7 +460,6 @@ interface NormalizedToolObservation {
   tool: string;
   surface: "mcp" | "cli";
   status: NormalizedToolStatus;
-  resultBytes: number | null;
 }
 
 function normalizeToolObservation(
@@ -472,7 +469,6 @@ function normalizeToolObservation(
     tool: normalizeToolName(call.tool),
     surface: call.server === "githits-cli" ? "cli" : "mcp",
     status: normalizeToolStatus(call.status, call.error),
-    resultBytes: call.resultBytes ?? null,
   };
 }
 
@@ -521,7 +517,6 @@ function buildAgentEvalRecord(input: AgentEvalRecordInput): AgentEvalRecord {
     warnings.push("tool_logical_count_not_implemented");
   }
 
-  const resultBytes = sumKnown(observations.map((call) => call.resultBytes));
   const record = {
     workloadId: input.workloadId,
     requestedModel: input.requestedModel ?? null,
@@ -555,7 +550,6 @@ function buildAgentEvalRecord(input: AgentEvalRecordInput): AgentEvalRecord {
       failedCount: sequence.filter((call) => call.status === "failed").length,
       uniqueTools: [...new Set(sequence.map((call) => call.tool))].sort(),
       sequence,
-      resultBytes,
     },
     artifacts: input.artifacts,
     warnings: uniqueStrings(warnings),

--- a/scripts/agent-eval-metrics.ts
+++ b/scripts/agent-eval-metrics.ts
@@ -269,6 +269,14 @@ function unknownMetrics(
   });
 }
 
+export function unknownAgentUsage(
+  agent: EvalAgent,
+  model?: string | null,
+  warning = "adapter_not_implemented",
+): AgentUsageMetrics {
+  return unknownMetrics(agent, model ?? undefined, [warning]);
+}
+
 function lastCodexTerminalUsage(stdout: string): {
   found: boolean;
   value: unknown;

--- a/scripts/agent-eval-metrics.ts
+++ b/scripts/agent-eval-metrics.ts
@@ -110,7 +110,7 @@ export interface PersistedToolCall {
 
 export interface AgentEvalRecordInput {
   workloadId: string;
-  requestedModel: string;
+  requestedModel?: string | null;
   resolvedModel?: string | null;
   agent: EvalAgent;
   agentVersion?: string | null;
@@ -179,7 +179,7 @@ const toolsMetricsSchema = z.object({
 
 export const agentEvalRecordSchema = z.object({
   workloadId: z.string().min(1),
-  requestedModel: z.string().min(1),
+  requestedModel: z.string().nullable(),
   resolvedModel: z.string().nullable(),
   agent: z.enum(["claude", "codex", "opencode"]),
   agentVersion: z.string().nullable(),
@@ -469,7 +469,7 @@ function buildAgentEvalRecord(input: AgentEvalRecordInput): AgentEvalRecord {
   );
   const record = {
     workloadId: input.workloadId,
-    requestedModel: input.requestedModel,
+    requestedModel: input.requestedModel ?? null,
     resolvedModel: input.resolvedModel ?? null,
     agent: input.agent,
     agentVersion: input.agentVersion ?? null,

--- a/scripts/agent-eval-metrics.ts
+++ b/scripts/agent-eval-metrics.ts
@@ -86,6 +86,154 @@ export const agentUsageMetricsSchema = z.object({
 
 export type AgentUsageMetrics = z.infer<typeof agentUsageMetricsSchema>;
 
+export type AgentEvalProcessStatus =
+  | "dry-run"
+  | "success"
+  | "failed"
+  | "timeout";
+export type AgentEvalFinalStatus = "success" | "failure" | "inconclusive";
+export type EvalSurface = "mcp" | "skills";
+export type EvalServer = "local" | "published";
+export type NormalizedToolStatus =
+  | "started"
+  | "completed"
+  | "failed"
+  | "unknown";
+
+export interface PersistedToolCall {
+  tool: string;
+  server?: string;
+  status?: string;
+  error?: unknown;
+  resultBytes?: number | null;
+}
+
+export interface AgentEvalRecordInput {
+  workloadId: string;
+  requestedModel: string;
+  resolvedModel?: string | null;
+  agent: EvalAgent;
+  agentVersion?: string | null;
+  reasoningEffort?: string | null;
+  surface: EvalSurface;
+  server: EvalServer;
+  guidanceProfile?: "descriptors" | "full" | null;
+  experimentalTools: boolean;
+  publishedPackage?: string | null;
+  targetGit: {
+    branch?: string | null;
+    sha?: string | null;
+    dirty?: boolean | null;
+  };
+  startedAt?: string | null;
+  completedAt?: string | null;
+  durationMs?: number | null;
+  processStatus: AgentEvalProcessStatus;
+  finalStatus?: AgentEvalFinalStatus | null;
+  exitCode?: number | null;
+  timedOut?: boolean | null;
+  usage: AgentUsageMetrics;
+  toolCalls: PersistedToolCall[];
+  artifacts: Record<string, string>;
+}
+
+export interface AgentEvalMetricsInput {
+  runId: string;
+  startedAt: string;
+  completedAt: string;
+  records: AgentEvalRecordInput[];
+}
+
+const relativeArtifactPathSchema = z
+  .string()
+  .min(1)
+  .refine((value) => {
+    if (value.startsWith("/") || /^[A-Za-z]:[\\/]/.test(value)) return false;
+    const segments = value.split(/[\\/]/);
+    return segments.every(
+      (segment) => segment.length > 0 && segment !== "." && segment !== "..",
+    );
+  }, "artifact paths must be sanitized relative paths");
+
+const targetGitSchema = z.object({
+  branch: z.string().nullable(),
+  sha: z.string().nullable(),
+  dirty: z.boolean().nullable(),
+});
+
+const toolSequenceEntrySchema = z.object({
+  tool: z.string(),
+  surface: z.enum(["mcp", "cli"]),
+  status: z.enum(["started", "completed", "failed", "unknown"]),
+});
+
+const toolsMetricsSchema = z.object({
+  rawEventCount: nonNegativeInteger,
+  logicalCallCount: nonNegativeInteger.nullable(),
+  completedCount: nonNegativeInteger,
+  failedCount: nonNegativeInteger,
+  uniqueTools: z.array(z.string()),
+  sequence: z.array(toolSequenceEntrySchema),
+  resultBytes: nonNegativeInteger.nullable(),
+});
+
+export const agentEvalRecordSchema = z.object({
+  workloadId: z.string().min(1),
+  requestedModel: z.string().min(1),
+  resolvedModel: z.string().nullable(),
+  agent: z.enum(["claude", "codex", "opencode"]),
+  agentVersion: z.string().nullable(),
+  reasoningEffort: z.string().nullable(),
+  surface: z.enum(["mcp", "skills"]),
+  server: z.enum(["local", "published"]),
+  guidanceProfile: z.enum(["descriptors", "full"]).nullable(),
+  experimentalTools: z.boolean(),
+  publishedPackage: z.string().nullable(),
+  targetGit: targetGitSchema,
+  startedAt: z.string().nullable(),
+  completedAt: z.string().nullable(),
+  durationMs: nonNegativeInteger.nullable(),
+  processStatus: z.enum(["dry-run", "success", "failed", "timeout"]),
+  finalStatus: z.enum(["success", "failure", "inconclusive"]).nullable(),
+  exitCode: z.number().int().nullable(),
+  timedOut: z.boolean().nullable(),
+  usage: agentUsageMetricsSchema,
+  tools: toolsMetricsSchema,
+  artifacts: z.record(z.string(), relativeArtifactPathSchema),
+  warnings: z.array(z.string()),
+});
+
+const aggregateMetricSchema = z.number().nonnegative().nullable();
+const aggregateIntegerMetricSchema = nonNegativeInteger.nullable();
+
+const aggregateMetricsSchema = z.object({
+  workloadCount: nonNegativeInteger,
+  succeededCount: nonNegativeInteger,
+  failedCount: nonNegativeInteger,
+  timedOutCount: nonNegativeInteger,
+  durationMs: aggregateIntegerMetricSchema,
+  logicalToolCalls: aggregateIntegerMetricSchema,
+  uncachedInputTokens: aggregateIntegerMetricSchema,
+  cachedInputTokens: aggregateIntegerMetricSchema,
+  cacheWriteInputTokens: aggregateIntegerMetricSchema,
+  outputTokens: aggregateIntegerMetricSchema,
+  reasoningOutputTokens: aggregateIntegerMetricSchema,
+  baseRateEstimatedCostUsd: aggregateMetricSchema,
+});
+
+export const agentEvalMetricsSchema = z.object({
+  schemaVersion: z.literal(1),
+  runId: z.string().min(1),
+  startedAt: z.string().min(1),
+  completedAt: z.string().min(1),
+  records: z.array(agentEvalRecordSchema),
+  aggregates: aggregateMetricsSchema,
+  warnings: z.array(z.string()),
+});
+
+export type AgentEvalRecord = z.infer<typeof agentEvalRecordSchema>;
+export type AgentEvalMetrics = z.infer<typeof agentEvalMetricsSchema>;
+
 const LONG_CONTEXT_INPUT_LIMIT = 272_000;
 
 const UNKNOWN_TOKENS = {
@@ -261,5 +409,163 @@ export function adaptAgentUsage(
     normalizedTokens,
     cost,
     warnings,
+  });
+}
+
+export function normalizeToolName(name: string): string {
+  const trimmed = name.trim();
+  const claude = trimmed.match(/^mcp__.+__\.?(.+)$/);
+  if (claude?.[1]) return claude[1].replace(/^\./, "");
+  const dotted = trimmed.match(/^mcp__[^.]+\.([^\s]+)$/);
+  if (dotted?.[1]) return dotted[1];
+  return trimmed.replace(/^githits[_.-]/, "");
+}
+
+export function normalizeToolStatus(
+  status: string | undefined,
+  error?: unknown,
+): NormalizedToolStatus {
+  if (error !== undefined && error !== null) return "failed";
+  if (!status) return "unknown";
+  const normalized = status.toLowerCase().replace(/[\s-]/g, "_");
+  if (["completed", "success", "succeeded", "done"].includes(normalized)) {
+    return "completed";
+  }
+  if (["failed", "failure", "error", "errored"].includes(normalized)) {
+    return "failed";
+  }
+  if (["started", "in_progress", "running", "pending"].includes(normalized)) {
+    return "started";
+  }
+  return "unknown";
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
+function sumKnown(values: Array<number | null>): number | null {
+  const known = values.filter((value): value is number => value !== null);
+  return known.length === 0
+    ? null
+    : known.reduce((sum, value) => sum + value, 0);
+}
+
+function buildAgentEvalRecord(input: AgentEvalRecordInput): AgentEvalRecord {
+  const usage = agentUsageMetricsSchema.parse(input.usage);
+  const sequence = input.toolCalls.map((call) => ({
+    tool: normalizeToolName(call.tool),
+    surface:
+      call.server === "githits-cli" ? ("cli" as const) : ("mcp" as const),
+    status: normalizeToolStatus(call.status, call.error),
+  }));
+  const warnings = [...usage.warnings];
+  if (input.agent !== "codex") {
+    warnings.push("tool_logical_count_not_implemented");
+  }
+
+  const resultBytes = sumKnown(
+    input.toolCalls.map((call) => call.resultBytes ?? null),
+  );
+  const record = {
+    workloadId: input.workloadId,
+    requestedModel: input.requestedModel,
+    resolvedModel: input.resolvedModel ?? null,
+    agent: input.agent,
+    agentVersion: input.agentVersion ?? null,
+    reasoningEffort: input.reasoningEffort ?? null,
+    surface: input.surface,
+    server: input.server,
+    guidanceProfile: input.guidanceProfile ?? null,
+    experimentalTools: input.experimentalTools,
+    publishedPackage: input.publishedPackage ?? null,
+    targetGit: {
+      branch: input.targetGit.branch ?? null,
+      sha: input.targetGit.sha ?? null,
+      dirty: input.targetGit.dirty ?? null,
+    },
+    startedAt: input.startedAt ?? null,
+    completedAt: input.completedAt ?? null,
+    durationMs: input.durationMs ?? null,
+    processStatus: input.processStatus,
+    finalStatus: input.finalStatus ?? null,
+    exitCode: input.exitCode ?? null,
+    timedOut: input.timedOut ?? null,
+    usage,
+    tools: {
+      rawEventCount: input.toolCalls.length,
+      logicalCallCount: input.agent === "codex" ? input.toolCalls.length : null,
+      completedCount: sequence.filter((call) => call.status === "completed")
+        .length,
+      failedCount: sequence.filter((call) => call.status === "failed").length,
+      uniqueTools: [...new Set(sequence.map((call) => call.tool))].sort(),
+      sequence,
+      resultBytes,
+    },
+    artifacts: input.artifacts,
+    warnings: uniqueStrings(warnings),
+  };
+  return agentEvalRecordSchema.parse(record);
+}
+
+/**
+ * Builds a validated run-level metrics artifact from already-sanitized data.
+ * This function intentionally performs no filesystem, process, or git access.
+ */
+export function buildAgentEvalMetrics(
+  input: AgentEvalMetricsInput,
+): AgentEvalMetrics {
+  const records = input.records.map(buildAgentEvalRecord);
+  const aggregates = {
+    workloadCount: records.length,
+    succeededCount: records.filter(
+      (record) => record.processStatus === "success",
+    ).length,
+    failedCount: records.filter((record) => record.processStatus === "failed")
+      .length,
+    timedOutCount: records.filter(
+      (record) => record.processStatus === "timeout",
+    ).length,
+    durationMs: sumKnown(records.map((record) => record.durationMs)),
+    logicalToolCalls: sumKnown(
+      records.map((record) => record.tools.logicalCallCount),
+    ),
+    uncachedInputTokens: sumKnown(
+      records.map(
+        (record) => record.usage.normalizedTokens.uncachedInputTokens,
+      ),
+    ),
+    cachedInputTokens: sumKnown(
+      records.map((record) => record.usage.normalizedTokens.cachedInputTokens),
+    ),
+    cacheWriteInputTokens: sumKnown(
+      records.map(
+        (record) => record.usage.normalizedTokens.cacheWriteInputTokens,
+      ),
+    ),
+    outputTokens: sumKnown(
+      records.map((record) => record.usage.normalizedTokens.outputTokens),
+    ),
+    reasoningOutputTokens: sumKnown(
+      records.map(
+        (record) => record.usage.normalizedTokens.reasoningOutputTokens,
+      ),
+    ),
+    baseRateEstimatedCostUsd: sumKnown(
+      records.map((record) =>
+        record.usage.cost.kind === "base_rate_estimate"
+          ? record.usage.cost.usd
+          : null,
+      ),
+    ),
+  };
+  return agentEvalMetricsSchema.parse({
+    schemaVersion: 1,
+    runId: input.runId,
+    startedAt: input.startedAt,
+    completedAt: input.completedAt,
+    records,
+    aggregates,
+    warnings: uniqueStrings(records.flatMap((record) => record.warnings)),
   });
 }

--- a/scripts/agent-eval-report.ts
+++ b/scripts/agent-eval-report.ts
@@ -1,5 +1,11 @@
 import { existsSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
 import { basename, isAbsolute, join, relative, resolve } from "node:path";
+import {
+  type AgentEvalMetrics,
+  type AgentEvalRecord,
+  type AgentUsageMetrics,
+  agentEvalMetricsSchema,
+} from "./agent-eval-metrics.ts";
 
 export type AgentEvalReportMode = "report" | "json" | "compare";
 
@@ -64,6 +70,30 @@ export interface ToolCallSummary {
   errors: string[];
 }
 
+export interface WorkloadMetricsReport {
+  normalizedTokens: AgentUsageMetrics["normalizedTokens"];
+  cost: Pick<AgentUsageMetrics["cost"], "kind" | "usd" | "uncertainty">;
+  logicalToolCount: number | null;
+  mcpCallCount: number | null;
+  cliCallCount: number | null;
+  telemetryWarnings: string[];
+}
+
+export interface AgentEvalAggregateMetricsReport {
+  workloadCount: number;
+  succeededCount: number;
+  failedCount: number;
+  timedOutCount: number;
+  durationMs: number | null;
+  logicalToolCalls: number | null;
+  uncachedInputTokens: number | null;
+  cachedInputTokens: number | null;
+  cacheWriteInputTokens: number | null;
+  outputTokens: number | null;
+  reasoningOutputTokens: number | null;
+  baseRateEstimatedCostUsd: number | null;
+}
+
 export interface DiscoverySummary {
   status: DiscoveryObservation;
   eventCount: number;
@@ -89,6 +119,7 @@ export interface WorkloadReport {
   artifacts: Record<string, string>;
   missingArtifacts: string[];
   toolCalls: ToolCallSummary;
+  metrics: WorkloadMetricsReport;
   discovery?: DiscoverySummary;
   finalReport?: FinalReportSummary;
   warnings: string[];
@@ -107,6 +138,8 @@ export interface AgentEvalReport {
   git?: Record<string, string | undefined>;
   runDir: string;
   workloads: WorkloadReport[];
+  metrics: AgentEvalAggregateMetricsReport;
+  metricsWarnings: string[];
   warnings: string[];
 }
 
@@ -190,6 +223,115 @@ function realPathInsideRun(runDir: string, path: string): string | undefined {
   const relativePath = relative(realRunDir, realPath);
   if (!isContainedRelativePath(relativePath)) return undefined;
   return realPath;
+}
+
+interface LoadedMetrics {
+  value?: AgentEvalMetrics;
+  warnings: string[];
+}
+
+function unknownWorkloadMetrics(warning: string): WorkloadMetricsReport {
+  return {
+    normalizedTokens: {
+      uncachedInputTokens: null,
+      cachedInputTokens: null,
+      cacheWriteInputTokens: null,
+      outputTokens: null,
+      reasoningOutputTokens: null,
+    },
+    cost: { kind: "unknown", usd: null, uncertainty: "unknown" },
+    logicalToolCount: null,
+    mcpCallCount: null,
+    cliCallCount: null,
+    telemetryWarnings: [warning],
+  };
+}
+
+function workloadMetricsFromRecord(
+  record: AgentEvalRecord,
+): WorkloadMetricsReport {
+  return {
+    normalizedTokens: record.usage.normalizedTokens,
+    cost: {
+      kind: record.usage.cost.kind,
+      usd: record.usage.cost.usd,
+      uncertainty: record.usage.cost.uncertainty,
+    },
+    logicalToolCount: record.tools.logicalCallCount,
+    mcpCallCount: record.tools.sequence.filter((call) => call.surface === "mcp")
+      .length,
+    cliCallCount: record.tools.sequence.filter((call) => call.surface === "cli")
+      .length,
+    telemetryWarnings: record.warnings,
+  };
+}
+
+function unknownAggregateMetrics(
+  workloads: WorkloadRunMetadata[],
+): AgentEvalAggregateMetricsReport {
+  return {
+    workloadCount: workloads.length,
+    succeededCount: workloads.filter(
+      (workload) => workload.status === "success",
+    ).length,
+    failedCount: workloads.filter((workload) => workload.status === "failed")
+      .length,
+    timedOutCount: workloads.filter((workload) => workload.status === "timeout")
+      .length,
+    durationMs: null,
+    logicalToolCalls: null,
+    uncachedInputTokens: null,
+    cachedInputTokens: null,
+    cacheWriteInputTokens: null,
+    outputTokens: null,
+    reasoningOutputTokens: null,
+    baseRateEstimatedCostUsd: null,
+  };
+}
+
+function loadRunMetrics(runDir: string): LoadedMetrics {
+  const metricsPath = join(runDir, "metrics.json");
+  if (!existsSync(metricsPath)) {
+    return {
+      warnings: [
+        "metrics.json missing; normalized usage, cost, and logical tool metrics are unknown",
+      ],
+    };
+  }
+
+  let safePath: string | undefined;
+  try {
+    safePath = realPathInsideRun(runDir, metricsPath);
+  } catch {
+    safePath = undefined;
+  }
+  if (!safePath) {
+    return {
+      warnings: [
+        "metrics.json path outside run directory ignored; normalized usage, cost, and logical tool metrics are unknown",
+      ],
+    };
+  }
+
+  let value: unknown;
+  try {
+    value = readJson(safePath);
+  } catch {
+    return {
+      warnings: [
+        "metrics.json invalid; normalized usage, cost, and logical tool metrics are unknown",
+      ],
+    };
+  }
+  const parsed = agentEvalMetricsSchema.safeParse(value);
+  if (!parsed.success) {
+    return {
+      warnings: [
+        "metrics.json invalid; normalized usage, cost, and logical tool metrics are unknown",
+      ],
+    };
+  }
+  return { value: parsed.data, warnings: [] };
 }
 
 export function parseReportArgs(argv: string[]): AgentEvalReportOptions {
@@ -365,7 +507,9 @@ function readDiscovery(path: string): DiscoverySummary | undefined {
 function buildWorkloadReport(
   runDir: string,
   workload: WorkloadRunMetadata,
-  warnOnCliFallback: boolean,
+  fallbackGuidanceProfile: string | undefined,
+  metricsRecord: AgentEvalRecord | undefined,
+  metricsWarning: string | undefined,
 ): WorkloadReport {
   const workloadDir = workloadDirFor(runDir, workload);
   const paths = {
@@ -419,7 +563,7 @@ function buildWorkloadReport(
       `success workload is missing artifacts: ${missingArtifacts.join(", ")}`,
     );
   }
-  if (warnOnCliFallback) {
+  if (fallbackGuidanceProfile) {
     const cliFallbackTools = [
       ...new Set(
         persistedToolCalls
@@ -429,10 +573,16 @@ function buildWorkloadReport(
     ].sort();
     if (cliFallbackTools.length > 0) {
       warnings.push(
-        `MCP full guidance run used GitHits CLI fallback: ${cliFallbackTools.join(", ")}`,
+        `MCP ${fallbackGuidanceProfile} guidance run used GitHits CLI fallback: ${cliFallbackTools.join(", ")}`,
       );
     }
   }
+  const metrics = metricsRecord
+    ? workloadMetricsFromRecord(metricsRecord)
+    : unknownWorkloadMetrics(
+        metricsWarning ??
+          "metrics record missing; normalized usage, cost, and logical tool metrics are unknown",
+      );
   if (finalReport) {
     const rawTools = new Set(toolCalls.uniqueTools);
     const drift = finalReport.unexpectedToolUse.filter(
@@ -454,6 +604,7 @@ function buildWorkloadReport(
     artifacts,
     missingArtifacts,
     toolCalls,
+    metrics,
     discovery,
     finalReport,
     warnings,
@@ -465,13 +616,56 @@ export function buildRunReportFromMetadata(
   metadata: AgentEvalRunMetadata,
 ): AgentEvalReport {
   const workloads = metadata.workloads ?? [];
-  const ids = new Set<string>();
+  const workloadIds = new Set<string>();
+  const duplicateWorkloadIds = new Set<string>();
   const warnings: string[] = [];
   for (const workload of workloads) {
-    if (ids.has(workload.id))
+    if (workloadIds.has(workload.id)) {
+      duplicateWorkloadIds.add(workload.id);
       warnings.push(`duplicate workload id in run metadata: ${workload.id}`);
-    ids.add(workload.id);
+    }
+    workloadIds.add(workload.id);
   }
+  const loadedMetrics = loadRunMetrics(runDir);
+  const metrics = loadedMetrics.value;
+  const metricsByWorkloadId = new Map<string, AgentEvalRecord>();
+  const duplicateMetricIds = new Set<string>();
+  const metricsMatchingWarnings: string[] = [];
+  if (metrics) {
+    for (const record of metrics.records) {
+      if (duplicateMetricIds.has(record.workloadId)) continue;
+      if (metricsByWorkloadId.has(record.workloadId)) {
+        duplicateMetricIds.add(record.workloadId);
+        metricsByWorkloadId.delete(record.workloadId);
+        metricsMatchingWarnings.push(
+          `duplicate metrics record for workload: ${record.workloadId}`,
+        );
+        continue;
+      }
+      metricsByWorkloadId.set(record.workloadId, record);
+    }
+    for (const workloadId of metricsByWorkloadId.keys()) {
+      if (!workloadIds.has(workloadId)) {
+        metricsMatchingWarnings.push(
+          `metrics record has no matching workload: ${workloadId}`,
+        );
+      }
+    }
+    for (const workload of workloads) {
+      if (duplicateMetricIds.has(workload.id)) continue;
+      if (!metricsByWorkloadId.has(workload.id)) {
+        metricsMatchingWarnings.push(
+          `metrics record missing for workload: ${workload.id}`,
+        );
+      }
+    }
+  }
+  const metricWarnings = [
+    ...loadedMetrics.warnings,
+    ...(metrics?.warnings ?? []),
+    ...metricsMatchingWarnings,
+  ];
+  warnings.push(...metricWarnings);
   const isolationWarning = profileIsolationWarning(metadata.agent);
   if (
     isolationWarning &&
@@ -484,7 +678,19 @@ export function buildRunReportFromMetadata(
     buildWorkloadReport(
       runDir,
       workload,
-      metadata.surface === "mcp" && metadata.guidanceProfile === "full",
+      metadata.surface === "mcp"
+        ? (metadata.guidanceProfile ?? "descriptors")
+        : undefined,
+      duplicateWorkloadIds.has(workload.id)
+        ? undefined
+        : metricsByWorkloadId.get(workload.id),
+      metrics
+        ? duplicateMetricIds.has(workload.id)
+          ? `duplicate metrics records; metrics for ${workload.id} are unknown`
+          : metricsByWorkloadId.has(workload.id)
+            ? undefined
+            : `metrics record missing for workload: ${workload.id}`
+        : loadedMetrics.warnings[0],
     ),
   );
   const status = reports.some((workload) =>
@@ -507,6 +713,8 @@ export function buildRunReportFromMetadata(
     git: metadata.git,
     runDir,
     workloads: reports,
+    metrics: metrics?.aggregates ?? unknownAggregateMetrics(workloads),
+    metricsWarnings: metricWarnings,
     warnings,
   };
 }
@@ -518,9 +726,50 @@ export function loadRunReport(runDir: string): AgentEvalReport {
   return buildRunReportFromMetadata(runDir, metadata as AgentEvalRunMetadata);
 }
 
-function formatDuration(ms: number | undefined): string {
+function formatDuration(ms: number | null | undefined): string {
   if (ms === undefined) return "n/a";
+  if (ms === null) return "unknown";
   return `${(ms / 1000).toFixed(1)}s`;
+}
+
+function formatMetricValue(value: number | null): string {
+  return value === null ? "unknown" : String(value);
+}
+
+function formatWorkloadMetrics(metrics: WorkloadMetricsReport): string {
+  const tokens = metrics.normalizedTokens;
+  return [
+    `tokens=uncachedInput=${formatMetricValue(tokens.uncachedInputTokens)}`,
+    `cachedInput=${formatMetricValue(tokens.cachedInputTokens)}`,
+    `cacheWriteInput=${formatMetricValue(tokens.cacheWriteInputTokens)}`,
+    `output=${formatMetricValue(tokens.outputTokens)}`,
+    `reasoning(detail)=${formatMetricValue(tokens.reasoningOutputTokens)}`,
+    `cost=${metrics.cost.kind}`,
+    `costUsd=${formatMetricValue(metrics.cost.usd)}`,
+    `costUncertainty=${metrics.cost.uncertainty}`,
+    `logicalCalls=${formatMetricValue(metrics.logicalToolCount)}`,
+    `mcpCalls=${formatMetricValue(metrics.mcpCallCount)}`,
+    `cliCalls=${formatMetricValue(metrics.cliCallCount)}`,
+  ].join(" ");
+}
+
+function formatAggregateMetrics(
+  metrics: AgentEvalAggregateMetricsReport,
+): string {
+  return [
+    `aggregate workloads=${metrics.workloadCount}`,
+    `succeeded=${metrics.succeededCount}`,
+    `failed=${metrics.failedCount}`,
+    `timedOut=${metrics.timedOutCount}`,
+    `duration=${formatDuration(metrics.durationMs)}`,
+    `logicalCalls=${formatMetricValue(metrics.logicalToolCalls)}`,
+    `tokens=uncachedInput=${formatMetricValue(metrics.uncachedInputTokens)}`,
+    `cachedInput=${formatMetricValue(metrics.cachedInputTokens)}`,
+    `cacheWriteInput=${formatMetricValue(metrics.cacheWriteInputTokens)}`,
+    `output=${formatMetricValue(metrics.outputTokens)}`,
+    `reasoning(detail)=${formatMetricValue(metrics.reasoningOutputTokens)}`,
+    `baseRateCostUsd=${formatMetricValue(metrics.baseRateEstimatedCostUsd)}`,
+  ].join(" ");
 }
 
 export function formatRunReport(report: AgentEvalReport): string {
@@ -537,7 +786,7 @@ export function formatRunReport(report: AgentEvalReport): string {
       ? ` usefulness=${final.usefulness} confidence=${final.confidence}`
       : "";
     lines.push(
-      `${workload.id} ${workload.status} ${formatDuration(workload.durationMs)} uniqueTools=${workload.toolCalls.uniqueTools.length} rawEvents=${workload.toolCalls.rawCount}${workload.discovery ? ` discovery=${workload.discovery.status}` : ""}${details}`,
+      `${workload.id} ${workload.status} ${formatDuration(workload.durationMs)} uniqueTools=${workload.toolCalls.uniqueTools.length} rawEvents=${workload.toolCalls.rawCount} ${formatWorkloadMetrics(workload.metrics)}${workload.discovery ? ` discovery=${workload.discovery.status}` : ""}${details}`,
     );
     const artifacts = [
       workload.artifacts.toolCalls,
@@ -549,9 +798,14 @@ export function formatRunReport(report: AgentEvalReport): string {
     ].filter(Boolean);
     if (artifacts.length > 0)
       lines.push(`  artifacts: ${artifacts.join(", ")}`);
+    for (const warning of workload.metrics.telemetryWarnings)
+      lines.push(`  metrics warning: ${warning}`);
     for (const warning of workload.warnings)
       lines.push(`  warning: ${warning}`);
   }
+  lines.push(formatAggregateMetrics(report.metrics));
+  for (const warning of report.metricsWarnings)
+    if (!report.warnings.includes(warning)) lines.push(`Warning: ${warning}`);
   for (const warning of report.warnings) lines.push(`Warning: ${warning}`);
   const issues = report.workloads.flatMap((workload) => {
     const final = workload.finalReport;

--- a/scripts/agent-eval-report.ts
+++ b/scripts/agent-eval-report.ts
@@ -35,6 +35,12 @@ export interface AgentEvalReportOptions {
   afterRunDir?: string;
 }
 
+export interface AgentEvalGitMetadata {
+  branch?: string | null;
+  sha?: string | null;
+  dirty?: boolean | null;
+}
+
 export interface AgentEvalRunMetadata {
   runId?: string;
   agent?: string;
@@ -44,7 +50,7 @@ export interface AgentEvalRunMetadata {
   server?: string;
   guidanceProfile?: string;
   dryRun?: boolean;
-  git?: Record<string, string | undefined>;
+  git?: AgentEvalGitMetadata;
   workloads?: WorkloadRunMetadata[];
 }
 
@@ -136,7 +142,7 @@ export interface AgentEvalReport {
   server?: string;
   guidanceProfile?: string;
   dryRun?: boolean;
-  git?: Record<string, string | undefined>;
+  git?: AgentEvalGitMetadata;
   runDir: string;
   workloads: WorkloadReport[];
   metrics: AgentEvalAggregateMetricsReport;
@@ -812,8 +818,6 @@ export function formatRunReport(report: AgentEvalReport): string {
       lines.push(`  warning: ${warning}`);
   }
   lines.push(formatAggregateMetrics(report.metrics));
-  for (const warning of report.metricsWarnings)
-    if (!report.warnings.includes(warning)) lines.push(`Warning: ${warning}`);
   for (const warning of report.warnings) lines.push(`Warning: ${warning}`);
   const issues = report.workloads.flatMap((workload) => {
     const final = workload.finalReport;

--- a/scripts/agent-eval-report.ts
+++ b/scripts/agent-eval-report.ts
@@ -36,6 +36,7 @@ export interface AgentEvalReportOptions {
 }
 
 export interface AgentEvalRunMetadata {
+  runId?: string;
   agent?: string;
   model?: string;
   reasoningEffort?: string;
@@ -289,7 +290,7 @@ function unknownAggregateMetrics(
   };
 }
 
-function loadRunMetrics(runDir: string): LoadedMetrics {
+function loadRunMetrics(runDir: string, expectedRunId?: string): LoadedMetrics {
   const metricsPath = join(runDir, "metrics.json");
   if (!existsSync(metricsPath)) {
     return {
@@ -328,6 +329,13 @@ function loadRunMetrics(runDir: string): LoadedMetrics {
     return {
       warnings: [
         "metrics.json invalid; normalized usage, cost, and logical tool metrics are unknown",
+      ],
+    };
+  }
+  if (expectedRunId !== undefined && parsed.data.runId !== expectedRunId) {
+    return {
+      warnings: [
+        "metrics.json runId mismatch; normalized usage, cost, and logical tool metrics are unknown",
       ],
     };
   }
@@ -626,7 +634,7 @@ export function buildRunReportFromMetadata(
     }
     workloadIds.add(workload.id);
   }
-  const loadedMetrics = loadRunMetrics(runDir);
+  const loadedMetrics = loadRunMetrics(runDir, metadata.runId);
   const metrics = loadedMetrics.value;
   const metricsByWorkloadId = new Map<string, AgentEvalRecord>();
   const duplicateMetricIds = new Set<string>();

--- a/scripts/agent-eval.test.ts
+++ b/scripts/agent-eval.test.ts
@@ -1313,6 +1313,8 @@ describe("agent eval harness", () => {
       expect(run.runId).toEqual(metrics.runId);
       expect(run.startedAt).toEqual(metrics.startedAt);
       expect(run.completedAt).toEqual(metrics.completedAt);
+      expect(report.git).toEqual(run.git);
+      expect(report.git).toHaveProperty("dirty");
       expect(metrics.records).toHaveLength(1);
       expect(metrics.records[0]).toMatchObject({
         agent: "codex",
@@ -1340,6 +1342,9 @@ describe("agent eval harness", () => {
         usd: null,
         uncertainty: "unknown",
       });
+      expect(
+        formatRunReport(report).match(/Warning: dry_run_no_telemetry/g),
+      ).toHaveLength(1);
     } finally {
       rmSync(outDir, { recursive: true, force: true });
     }
@@ -1886,7 +1891,6 @@ describe("agent eval harness", () => {
         },
       })}\n`,
       "claude",
-      "skills",
     );
 
     expect(calls.map((call) => call.tool)).toEqual([
@@ -1937,12 +1941,7 @@ describe("agent eval harness", () => {
         arguments: { path: "packages/opencode/src/session/compaction.ts" },
       },
     ];
-    expect(extractToolCalls(stdout, "codex", "mcp", "full")).toEqual(
-      expectedCalls,
-    );
-    expect(extractToolCalls(stdout, "codex", "mcp", "descriptors")).toEqual(
-      expectedCalls,
-    );
+    expect(extractToolCalls(stdout, "codex")).toEqual(expectedCalls);
   });
 
   it("ignores non-MCP Claude tool calls", () => {

--- a/scripts/agent-eval.test.ts
+++ b/scripts/agent-eval.test.ts
@@ -57,6 +57,7 @@ import {
   formatCompareReport,
   formatRunReport,
   isContainedRelativePath,
+  loadRunReport,
   normalizeToolName,
   normalizeToolStatus,
   parseReportArgs,
@@ -2177,6 +2178,39 @@ describe("agent eval harness", () => {
     expect(formatRunReport(longContextReport)).toContain(
       "costUncertainty=long_context_pricing_not_attributable",
     );
+  });
+
+  it("binds metrics to run identity while accepting legacy run metadata", () => {
+    const runDir = createRunFixture();
+    writeMetricsFixture(runDir, [createMetricsRecord("pkg-vulns")]);
+    const workloads = [
+      {
+        id: "pkg-vulns",
+        status: "success",
+      },
+    ];
+
+    writeJson(join(runDir, "run.json"), {
+      runId: "run-other",
+      workloads,
+    });
+    const mismatch = loadRunReport(runDir);
+    expect(mismatch.metrics.baseRateEstimatedCostUsd).toBeNull();
+    expect(mismatch.workloads[0]?.metrics.logicalToolCount).toBeNull();
+    expect(mismatch.metricsWarnings).toContain(
+      "metrics.json runId mismatch; normalized usage, cost, and logical tool metrics are unknown",
+    );
+
+    const matching = buildRunReportFromMetadata(runDir, {
+      runId: "run-metrics",
+      workloads,
+    });
+    expect(matching.workloads[0]?.metrics.logicalToolCount).toBe(2);
+    expect(matching.metrics.baseRateEstimatedCostUsd).not.toBeNull();
+
+    const legacy = buildRunReportFromMetadata(runDir, { workloads });
+    expect(legacy.workloads[0]?.metrics.logicalToolCount).toBe(2);
+    expect(legacy.metrics.baseRateEstimatedCostUsd).not.toBeNull();
   });
 
   it("keeps old and unsafe metrics runs reportable with unknown values", () => {

--- a/scripts/agent-eval.test.ts
+++ b/scripts/agent-eval.test.ts
@@ -1486,12 +1486,18 @@ describe("agent eval harness", () => {
     expect(calls[0]?.server).toBe("githits-cli");
   });
 
-  it("extracts CLI fallback from full MCP Codex runs only", () => {
+  it("extracts CLI fallback from MCP profiles and ignores unrelated shell commands", () => {
     const stdout = [
       JSON.stringify({
         item: {
           type: "command_execution",
           command: "githits search opencode",
+        },
+      }),
+      JSON.stringify({
+        item: {
+          type: "command_execution",
+          command: "git status --short",
         },
       }),
       JSON.stringify({
@@ -1504,31 +1510,28 @@ describe("agent eval harness", () => {
         },
       }),
     ].join("\n");
-    expect(extractToolCalls(stdout, "codex", "mcp", "full")).toEqual([
+    const expectedCalls = [
       {
-        agent: "codex",
+        agent: "codex" as const,
         server: "githits-cli",
         tool: "search",
         status: "started",
         arguments: { command: "githits search opencode" },
       },
       {
-        agent: "codex",
+        agent: "codex" as const,
         server: "githits",
         tool: "code_read",
         status: "completed",
         arguments: { path: "packages/opencode/src/session/compaction.ts" },
       },
-    ]);
-    expect(extractToolCalls(stdout, "codex", "mcp", "descriptors")).toEqual([
-      {
-        agent: "codex",
-        server: "githits",
-        tool: "code_read",
-        status: "completed",
-        arguments: { path: "packages/opencode/src/session/compaction.ts" },
-      },
-    ]);
+    ];
+    expect(extractToolCalls(stdout, "codex", "mcp", "full")).toEqual(
+      expectedCalls,
+    );
+    expect(extractToolCalls(stdout, "codex", "mcp", "descriptors")).toEqual(
+      expectedCalls,
+    );
   });
 
   it("ignores non-MCP Claude tool calls", () => {

--- a/scripts/agent-eval.test.ts
+++ b/scripts/agent-eval.test.ts
@@ -1585,6 +1585,124 @@ describe("agent eval harness", () => {
     ]);
   });
 
+  it("preserves Codex provider IDs and statuses for paired MCP and CLI events", () => {
+    const events = [
+      {
+        type: "item.started",
+        item: {
+          type: "command_execution",
+          id: "command-1",
+          command: "githits search express",
+          status: "in_progress",
+        },
+      },
+      {
+        type: "item.completed",
+        item: {
+          type: "command_execution",
+          id: "command-1",
+          command: "githits search express",
+          status: "completed",
+        },
+      },
+      {
+        type: "item.started",
+        item: {
+          type: "mcp_tool_call",
+          id: "mcp-1",
+          server: "githits",
+          tool: "search",
+          status: "in_progress",
+        },
+      },
+      {
+        type: "item.completed",
+        item: {
+          type: "mcp_tool_call",
+          id: "mcp-1",
+          server: "githits",
+          tool: "search",
+          status: "completed",
+        },
+      },
+      {
+        type: "item.completed",
+        item: {
+          type: "mcp_tool_call",
+          id: "mcp-2",
+          server: "githits",
+          tool: "search",
+          status: "completed",
+        },
+      },
+      {
+        type: "item.started",
+        item: {
+          type: "mcp_tool_call",
+          id: "mcp-3",
+          server: "githits",
+          tool: "search",
+          status: "in_progress",
+        },
+      },
+    ].map((event) => JSON.stringify(event));
+
+    expect(extractToolCalls(events.join("\n"), "codex")).toEqual([
+      {
+        agent: "codex",
+        server: "githits-cli",
+        tool: "search",
+        providerCallId: "command-1",
+        status: "in_progress",
+        arguments: { command: "githits search express" },
+      },
+      {
+        agent: "codex",
+        server: "githits-cli",
+        tool: "search",
+        providerCallId: "command-1",
+        status: "completed",
+        arguments: { command: "githits search express" },
+      },
+      {
+        agent: "codex",
+        server: "githits",
+        tool: "search",
+        providerCallId: "mcp-1",
+        status: "in_progress",
+        arguments: undefined,
+        error: undefined,
+      },
+      {
+        agent: "codex",
+        server: "githits",
+        tool: "search",
+        providerCallId: "mcp-1",
+        status: "completed",
+        arguments: undefined,
+        error: undefined,
+      },
+      {
+        agent: "codex",
+        server: "githits",
+        tool: "search",
+        providerCallId: "mcp-2",
+        status: "completed",
+        arguments: undefined,
+        error: undefined,
+      },
+      {
+        agent: "codex",
+        server: "githits",
+        tool: "search",
+        providerCallId: "mcp-3",
+        status: "in_progress",
+        arguments: undefined,
+        error: undefined,
+      },
+    ]);
+  });
+
   it("extracts Claude MCP tool calls from verbose stream events", () => {
     const calls = extractToolCalls(
       `${JSON.stringify({

--- a/scripts/agent-eval.test.ts
+++ b/scripts/agent-eval.test.ts
@@ -16,6 +16,7 @@ import {
   GITHITS_GUIDANCE_MARKER,
 } from "../src/commands/init/guidance-assets.ts";
 import {
+  buildAgentEvalMetricsArtifact,
   buildClaudeCommand,
   buildCodexCommand,
   buildCodexConfig,
@@ -25,6 +26,9 @@ import {
   buildOpenCodeCommand,
   buildOpenCodeConfig,
   buildOpenCodeSkillsConfig,
+  type CommandProbe,
+  type CommandProbeResult,
+  collectGitMetadata,
   collectSecretValues,
   DEFAULT_CODEX_MODEL,
   DEFAULT_CODEX_REASONING_EFFORT,
@@ -40,6 +44,7 @@ import {
   runWithTimeout,
   sanitizedEnvSummary,
 } from "./agent-eval.ts";
+import { agentEvalMetricsSchema } from "./agent-eval-metrics.ts";
 import {
   assertUniqueWorkloadIds,
   buildRunReportFromMetadata,
@@ -1078,6 +1083,211 @@ describe("agent eval harness", () => {
     expect(() =>
       parseArgs(["--experimental-tools", "--surface", "skills"], repoRoot),
     ).toThrow("--experimental-tools requires --surface mcp --server local");
+  });
+
+  it("builds metrics through the runner seam without persisting tool arguments", () => {
+    const metrics = buildAgentEvalMetricsArtifact({
+      runId: "run-synthetic",
+      startedAt: "2026-08-28T10:00:00.000Z",
+      completedAt: "2026-08-28T10:00:03.000Z",
+      records: [
+        {
+          workloadId: "pkg-info",
+          requestedModel: DEFAULT_CODEX_MODEL,
+          resolvedModel: null,
+          agent: "codex",
+          agentVersion: "codex 0.150.1",
+          reasoningEffort: "low",
+          surface: "mcp",
+          server: "local",
+          guidanceProfile: "descriptors",
+          experimentalTools: false,
+          publishedPackage: null,
+          targetGit: { branch: "main", sha: "abc123", dirty: true },
+          startedAt: "2026-08-28T10:00:00.000Z",
+          completedAt: "2026-08-28T10:00:03.000Z",
+          durationMs: 3000,
+          processStatus: "success",
+          finalStatus: "success",
+          exitCode: 0,
+          timedOut: false,
+          toolCalls: [
+            { tool: "search", server: "githits-cli", status: "started" },
+            {
+              tool: "mcp__githits__pkg_info",
+              server: "githits",
+              status: "completed",
+            },
+          ],
+          artifacts: {
+            toolCalls: "workloads/pkg-info/tool-calls.json",
+            final: "workloads/pkg-info/final.json",
+          },
+          stdout: [
+            JSON.stringify({
+              type: "command_execution",
+              command: "githits search express --json --token secret-value",
+            }),
+            JSON.stringify({
+              type: "item.completed",
+              item: {
+                type: "mcp_tool_call",
+                server: "githits",
+                tool: "pkg_info",
+                status: "completed",
+              },
+            }),
+            JSON.stringify({
+              type: "turn.completed",
+              usage: {
+                input_tokens: 100,
+                cached_input_tokens: 40,
+                cache_write_input_tokens: 20,
+                output_tokens: 10,
+                reasoning_output_tokens: 4,
+              },
+            }),
+          ].join("\n"),
+          dryRun: false,
+        },
+      ],
+    });
+
+    expect(agentEvalMetricsSchema.parse(metrics)).toEqual(metrics);
+    expect(metrics.runId).toBe("run-synthetic");
+    expect(metrics.records[0]).toMatchObject({
+      agentVersion: "codex 0.150.1",
+      requestedModel: DEFAULT_CODEX_MODEL,
+      resolvedModel: null,
+      targetGit: { branch: "main", sha: "abc123", dirty: true },
+      processStatus: "success",
+      durationMs: 3000,
+      artifacts: {
+        toolCalls: "workloads/pkg-info/tool-calls.json",
+        final: "workloads/pkg-info/final.json",
+      },
+      usage: {
+        normalizedTokens: {
+          uncachedInputTokens: 40,
+          cachedInputTokens: 40,
+          cacheWriteInputTokens: 20,
+          outputTokens: 10,
+          reasoningOutputTokens: 4,
+        },
+      },
+    });
+    expect(metrics.records[0]?.tools.sequence).toEqual([
+      { tool: "search", surface: "cli", status: "started" },
+      { tool: "pkg_info", surface: "mcp", status: "completed" },
+    ]);
+    expect(metrics.aggregates).toMatchObject({
+      durationMs: 3000,
+      logicalToolCalls: 2,
+      uncachedInputTokens: 40,
+      cachedInputTokens: 40,
+      cacheWriteInputTokens: 20,
+      outputTokens: 10,
+      reasoningOutputTokens: 4,
+      baseRateEstimatedCostUsd: 0.0000258,
+    });
+    const serialized = JSON.stringify(metrics);
+    expect(serialized).not.toContain("githits search express");
+    expect(serialized).not.toContain("secret-value");
+  });
+
+  it("writes unknown Codex dry-run metrics without probing availability or versions", async () => {
+    const outDir = mkdtempSync(join(tmpdir(), "agent-eval-codex-dry-run-"));
+    let availabilityProbeCalls = 0;
+    let versionProbeCalls = 0;
+    try {
+      const options = parseArgs(
+        [
+          "--agent",
+          "codex",
+          "--dry-run",
+          "--out",
+          outDir,
+          "--workload",
+          "eval/agentic/workloads/express-router.md",
+        ],
+        process.cwd(),
+      );
+      await runAgentEval(options, {
+        assertAgentAvailable: () => {
+          availabilityProbeCalls += 1;
+          return Promise.resolve();
+        },
+        collectAgentVersions: () => {
+          versionProbeCalls += 1;
+          return Promise.resolve([
+            "stub-claude-version",
+            "stub-codex-version",
+            "stub-opencode-version",
+          ]);
+        },
+      });
+
+      const run = JSON.parse(readFileSync(join(outDir, "run.json"), "utf8"));
+      const metrics = JSON.parse(
+        readFileSync(join(outDir, "metrics.json"), "utf8"),
+      );
+      expect(availabilityProbeCalls).toBe(0);
+      expect(versionProbeCalls).toBe(0);
+      expect(run.runId).toEqual(metrics.runId);
+      expect(run.startedAt).toEqual(metrics.startedAt);
+      expect(run.completedAt).toEqual(metrics.completedAt);
+      expect(metrics.records).toHaveLength(1);
+      expect(metrics.records[0]).toMatchObject({
+        agent: "codex",
+        requestedModel: DEFAULT_CODEX_MODEL,
+        resolvedModel: null,
+        agentVersion: null,
+        processStatus: "dry-run",
+        usage: {
+          normalizedTokens: {
+            uncachedInputTokens: null,
+            outputTokens: null,
+          },
+          cost: { kind: "unknown", usd: null },
+          warnings: ["dry_run_no_telemetry"],
+        },
+      });
+      expect(metrics.records[0]?.artifacts).toMatchObject({
+        dryRun: "workloads/express-router/dry-run.json",
+        discoveryEvents: "workloads/express-router/discovery-events.json",
+      });
+      expect(agentEvalMetricsSchema.parse(metrics)).toEqual(metrics);
+    } finally {
+      rmSync(outDir, { recursive: true, force: true });
+    }
+  });
+
+  it("distinguishes clean, dirty, and failed Git metadata probes", async () => {
+    const probe =
+      (status: CommandProbeResult): CommandProbe =>
+      async (_command, args) => {
+        if (args[0] === "status") return status;
+        return {
+          stdout: args[0] === "branch" ? "main\n" : "abc123\n",
+          exitCode: 0,
+        };
+      };
+
+    await expect(
+      collectGitMetadata("/repo", probe({ stdout: "", exitCode: 0 })),
+    ).resolves.toEqual({ branch: "main", sha: "abc123", dirty: false });
+    await expect(
+      collectGitMetadata(
+        "/repo",
+        probe({ stdout: "?? untracked.txt\n", exitCode: 0 }),
+      ),
+    ).resolves.toEqual({ branch: "main", sha: "abc123", dirty: true });
+    await expect(
+      collectGitMetadata(
+        "/repo",
+        probe({ stdout: "status details", exitCode: 1 }),
+      ),
+    ).resolves.toEqual({ branch: "main", sha: "abc123", dirty: null });
   });
 
   it("persists the enabled flag without probing agent versions during dry runs", async () => {

--- a/scripts/agent-eval.test.ts
+++ b/scripts/agent-eval.test.ts
@@ -44,7 +44,12 @@ import {
   runWithTimeout,
   sanitizedEnvSummary,
 } from "./agent-eval.ts";
-import { agentEvalMetricsSchema } from "./agent-eval-metrics.ts";
+import {
+  type AgentEvalRecordInput,
+  adaptAgentUsage,
+  agentEvalMetricsSchema,
+  buildAgentEvalMetrics,
+} from "./agent-eval-metrics.ts";
 import {
   assertUniqueWorkloadIds,
   buildRunReportFromMetadata,
@@ -104,6 +109,72 @@ function createRunFixture(status = "success"): string {
     ],
   });
   return runDir;
+}
+
+function createMetricsRecord(
+  workloadId: string,
+  overrides: Partial<AgentEvalRecordInput> = {},
+): AgentEvalRecordInput {
+  return {
+    workloadId,
+    requestedModel: DEFAULT_CODEX_MODEL,
+    resolvedModel: null,
+    agent: "codex",
+    agentVersion: "codex 0.150.1",
+    reasoningEffort: "high",
+    surface: "mcp",
+    server: "local",
+    guidanceProfile: "descriptors",
+    experimentalTools: false,
+    publishedPackage: null,
+    targetGit: { branch: "main", sha: "abc123", dirty: false },
+    startedAt: "2026-08-28T10:00:00.000Z",
+    completedAt: "2026-08-28T10:00:01.000Z",
+    durationMs: 1000,
+    processStatus: "success",
+    finalStatus: "success",
+    exitCode: 0,
+    timedOut: false,
+    usage: adaptAgentUsage(
+      JSON.stringify({
+        type: "turn.completed",
+        usage: {
+          input_tokens: 100,
+          cached_input_tokens: 40,
+          cache_write_input_tokens: 20,
+          output_tokens: 10,
+          reasoning_output_tokens: 4,
+        },
+      }),
+      "codex",
+      DEFAULT_CODEX_MODEL,
+    ),
+    toolCalls: [
+      {
+        tool: "mcp__githits__pkg_info",
+        server: "githits",
+        status: "completed",
+      },
+      { tool: "search", server: "githits-cli", status: "completed" },
+    ],
+    artifacts: {},
+    ...overrides,
+  };
+}
+
+function writeMetricsFixture(
+  runDir: string,
+  records: AgentEvalRecordInput[],
+): void {
+  writeJson(
+    join(runDir, "metrics.json"),
+    buildAgentEvalMetrics({
+      runId: "run-metrics",
+      startedAt: "2026-08-28T10:00:00.000Z",
+      completedAt: "2026-08-28T10:00:03.000Z",
+      records,
+    }),
+  );
 }
 
 describe("agent eval harness", () => {
@@ -1233,6 +1304,9 @@ describe("agent eval harness", () => {
       const metrics = JSON.parse(
         readFileSync(join(outDir, "metrics.json"), "utf8"),
       );
+      const report = JSON.parse(
+        readFileSync(join(outDir, "report.json"), "utf8"),
+      );
       expect(availabilityProbeCalls).toBe(0);
       expect(versionProbeCalls).toBe(0);
       expect(run.runId).toEqual(metrics.runId);
@@ -1259,6 +1333,12 @@ describe("agent eval harness", () => {
         discoveryEvents: "workloads/express-router/discovery-events.json",
       });
       expect(agentEvalMetricsSchema.parse(metrics)).toEqual(metrics);
+      expect(report.metricsWarnings).toContain("dry_run_no_telemetry");
+      expect(report.workloads[0].metrics.cost).toEqual({
+        kind: "unknown",
+        usd: null,
+        uncertainty: "unknown",
+      });
     } finally {
       rmSync(outDir, { recursive: true, force: true });
     }
@@ -1844,11 +1924,242 @@ describe("agent eval harness", () => {
     );
   });
 
-  it("warns when a full MCP run uses CLI fallback", () => {
-    const runDir = mkdtempSync(join(tmpdir(), "agent-eval-cli-fallback-"));
-    const workloadDir = join(runDir, "workloads", "fallback");
-    mkdirSync(workloadDir, { recursive: true });
-    writeJson(join(workloadDir, "tool-calls.json"), [
+  it("attaches per-workload and aggregate usage metrics to the report", () => {
+    const runDir = mkdtempSync(join(tmpdir(), "agent-eval-metrics-report-"));
+    const firstWorkloadDir = join(runDir, "workloads", "pkg-info");
+    const secondWorkloadDir = join(runDir, "workloads", "docs-search");
+    mkdirSync(firstWorkloadDir, { recursive: true });
+    mkdirSync(secondWorkloadDir, { recursive: true });
+    writeJson(join(firstWorkloadDir, "tool-calls.json"), []);
+    writeJson(join(secondWorkloadDir, "tool-calls.json"), []);
+
+    const first = createMetricsRecord("pkg-info");
+    const second = createMetricsRecord("docs-search", {
+      durationMs: 2000,
+      processStatus: "timeout",
+      timedOut: true,
+      toolCalls: [
+        {
+          tool: "mcp__githits__docs_search",
+          server: "githits",
+          status: "completed",
+        },
+      ],
+      usage: adaptAgentUsage(
+        JSON.stringify({
+          type: "turn.completed",
+          usage: {
+            input_tokens: 200,
+            cached_input_tokens: 100,
+            cache_write_input_tokens: 20,
+            output_tokens: 30,
+            reasoning_output_tokens: 5,
+          },
+        }),
+        "codex",
+        DEFAULT_CODEX_MODEL,
+      ),
+    });
+    writeMetricsFixture(runDir, [first, second]);
+    const report = buildRunReportFromMetadata(runDir, {
+      agent: "codex",
+      model: DEFAULT_CODEX_MODEL,
+      surface: "mcp",
+      server: "local",
+      workloads: [
+        {
+          id: "pkg-info",
+          status: "success",
+          durationMs: 1000,
+          workloadDir: firstWorkloadDir,
+        },
+        {
+          id: "docs-search",
+          status: "timeout",
+          durationMs: 2000,
+          workloadDir: secondWorkloadDir,
+        },
+      ],
+    });
+
+    expect(report.workloads[0]?.metrics).toMatchObject({
+      normalizedTokens: {
+        uncachedInputTokens: 40,
+        cachedInputTokens: 40,
+        cacheWriteInputTokens: 20,
+        outputTokens: 10,
+        reasoningOutputTokens: 4,
+      },
+      cost: {
+        kind: "base_rate_estimate",
+        usd: 0.0000258,
+        uncertainty: "rate_based_estimate",
+      },
+      logicalToolCount: 2,
+      mcpCallCount: 1,
+      cliCallCount: 1,
+    });
+    expect(report.workloads[1]?.metrics).toMatchObject({
+      logicalToolCount: 1,
+      mcpCallCount: 1,
+      cliCallCount: 0,
+    });
+    expect(report.metrics).toMatchObject({
+      workloadCount: 2,
+      succeededCount: 1,
+      failedCount: 0,
+      timedOutCount: 1,
+      durationMs: 3000,
+      logicalToolCalls: 3,
+      uncachedInputTokens: 120,
+      cachedInputTokens: 140,
+      cacheWriteInputTokens: 40,
+      outputTokens: 40,
+      reasoningOutputTokens: 9,
+      baseRateEstimatedCostUsd: 0.0000848,
+    });
+    const formatted = formatRunReport(report);
+    expect(formatted).toContain("tokens=uncachedInput=40");
+    expect(formatted).toContain("output=10 reasoning(detail)=4");
+    expect(formatted).toContain("cost=base_rate_estimate costUsd=0.0000258");
+    expect(formatted).toContain("aggregate workloads=2");
+    expect(formatted).toContain("baseRateCostUsd=0.0000848");
+    expect(formatted).not.toContain("output=14");
+
+    const longContextRunDir = mkdtempSync(
+      join(tmpdir(), "agent-eval-long-context-report-"),
+    );
+    writeMetricsFixture(longContextRunDir, [
+      createMetricsRecord("long-context", {
+        usage: adaptAgentUsage(
+          JSON.stringify({
+            type: "turn.completed",
+            usage: {
+              input_tokens: 272_001,
+              cached_input_tokens: 0,
+              cache_write_input_tokens: 0,
+              output_tokens: 1,
+              reasoning_output_tokens: 0,
+            },
+          }),
+          "codex",
+          DEFAULT_CODEX_MODEL,
+        ),
+      }),
+    ]);
+    const longContextReport = buildRunReportFromMetadata(longContextRunDir, {
+      agent: "codex",
+      model: DEFAULT_CODEX_MODEL,
+      surface: "mcp",
+      workloads: [{ id: "long-context", status: "success" }],
+    });
+    expect(longContextReport.workloads[0]?.metrics.cost.uncertainty).toBe(
+      "long_context_pricing_not_attributable",
+    );
+    expect(formatRunReport(longContextReport)).toContain(
+      "costUncertainty=long_context_pricing_not_attributable",
+    );
+  });
+
+  it("keeps old and unsafe metrics runs reportable with unknown values", () => {
+    const missingRunDir = createRunFixture();
+    const missing = buildRunReportFromMetadata(
+      missingRunDir,
+      JSON.parse(readFileSync(join(missingRunDir, "run.json"), "utf8")),
+    );
+    expect(missing.metrics.durationMs).toBeNull();
+    expect(missing.metrics.baseRateEstimatedCostUsd).toBeNull();
+    expect(missing.workloads[0]?.metrics.logicalToolCount).toBeNull();
+    expect(missing.metricsWarnings[0]).toContain("metrics.json missing");
+    expect(formatRunReport(missing)).toContain("costUsd=unknown");
+
+    const invalidRunDir = createRunFixture();
+    writeFileSync(join(invalidRunDir, "metrics.json"), "not json");
+    const invalid = buildRunReportFromMetadata(
+      invalidRunDir,
+      JSON.parse(readFileSync(join(invalidRunDir, "run.json"), "utf8")),
+    );
+    expect(invalid.metricsWarnings[0]).toContain("metrics.json invalid");
+    expect(invalid.workloads[0]?.metrics.cliCallCount).toBeNull();
+
+    const unsafeRunDir = createRunFixture();
+    const outsideDir = mkdtempSync(
+      join(tmpdir(), "agent-eval-unsafe-metrics-"),
+    );
+    writeJson(join(outsideDir, "metrics.json"), {});
+    symlinkSync(
+      join(outsideDir, "metrics.json"),
+      join(unsafeRunDir, "metrics.json"),
+    );
+    const unsafe = buildRunReportFromMetadata(
+      unsafeRunDir,
+      JSON.parse(readFileSync(join(unsafeRunDir, "run.json"), "utf8")),
+    );
+    expect(unsafe.metricsWarnings[0]).toContain(
+      "metrics.json path outside run directory ignored",
+    );
+    expect(unsafe.workloads[0]?.metrics.normalizedTokens.outputTokens).toBe(
+      null,
+    );
+  });
+
+  it("does not attach duplicate or missing metrics records by accident", () => {
+    const runDir = mkdtempSync(join(tmpdir(), "agent-eval-metric-ids-"));
+    writeMetricsFixture(runDir, [
+      createMetricsRecord("pkg-vulns"),
+      createMetricsRecord("pkg-vulns", { durationMs: 2000 }),
+      createMetricsRecord("extra"),
+    ]);
+    const report = buildRunReportFromMetadata(runDir, {
+      workloads: [
+        { id: "pkg-vulns", status: "success" },
+        { id: "missing", status: "success" },
+      ],
+    });
+
+    expect(report.warnings).toContain(
+      "duplicate metrics record for workload: pkg-vulns",
+    );
+    expect(report.warnings).toContain(
+      "metrics record has no matching workload: extra",
+    );
+    expect(report.warnings).toContain(
+      "metrics record missing for workload: missing",
+    );
+    expect(report.workloads[0]?.metrics.logicalToolCount).toBeNull();
+    expect(report.workloads[1]?.metrics.logicalToolCount).toBeNull();
+  });
+
+  it("warns when any MCP profile uses CLI fallback", () => {
+    for (const guidanceProfile of ["descriptors", "full"] as const) {
+      const runDir = mkdtempSync(join(tmpdir(), "agent-eval-cli-fallback-"));
+      const workloadDir = join(runDir, "workloads", "fallback");
+      mkdirSync(workloadDir, { recursive: true });
+      writeJson(join(workloadDir, "tool-calls.json"), [
+        {
+          agent: "codex",
+          server: "githits-cli",
+          tool: "search",
+          status: "started",
+        },
+      ]);
+      writeFileSync(join(workloadDir, "stderr.txt"), "");
+      const report = buildRunReportFromMetadata(runDir, {
+        agent: "codex",
+        surface: "mcp",
+        guidanceProfile,
+        workloads: [{ id: "fallback", status: "failed", workloadDir }],
+      });
+      expect(report.workloads[0]?.warnings).toContain(
+        `MCP ${guidanceProfile} guidance run used GitHits CLI fallback: search`,
+      );
+      expect(formatRunReport(report)).toContain("CLI fallback");
+    }
+
+    const skillsRunDir = mkdtempSync(join(tmpdir(), "agent-eval-cli-skills-"));
+    const skillsWorkloadDir = join(skillsRunDir, "workloads", "fallback");
+    mkdirSync(skillsWorkloadDir, { recursive: true });
+    writeJson(join(skillsWorkloadDir, "tool-calls.json"), [
       {
         agent: "codex",
         server: "githits-cli",
@@ -1856,17 +2167,14 @@ describe("agent eval harness", () => {
         status: "started",
       },
     ]);
-    writeFileSync(join(workloadDir, "stderr.txt"), "");
-    const report = buildRunReportFromMetadata(runDir, {
+    const skillsReport = buildRunReportFromMetadata(skillsRunDir, {
       agent: "codex",
-      surface: "mcp",
-      guidanceProfile: "full",
-      workloads: [{ id: "fallback", status: "failed", workloadDir }],
+      surface: "skills",
+      workloads: [
+        { id: "fallback", status: "success", workloadDir: skillsWorkloadDir },
+      ],
     });
-    expect(report.workloads[0]?.warnings).toContain(
-      "MCP full guidance run used GitHits CLI fallback: search",
-    );
-    expect(formatRunReport(report)).toContain("CLI fallback");
+    expect(skillsReport.workloads[0]?.warnings).not.toContain("CLI fallback");
   });
 
   it("reports discovery status and artifact path", () => {

--- a/scripts/agent-eval.test.ts
+++ b/scripts/agent-eval.test.ts
@@ -1145,6 +1145,7 @@ describe("agent eval harness", () => {
                 cache_write_input_tokens: 20,
                 output_tokens: 10,
                 reasoning_output_tokens: 4,
+                diagnostic: "secret-value",
               },
             }),
           ].join("\n"),
@@ -1192,6 +1193,7 @@ describe("agent eval harness", () => {
     });
     const serialized = JSON.stringify(metrics);
     expect(serialized).not.toContain("githits search express");
+    expect(serialized).not.toContain("diagnostic");
     expect(serialized).not.toContain("secret-value");
   });
 

--- a/scripts/agent-eval.ts
+++ b/scripts/agent-eval.ts
@@ -1290,8 +1290,8 @@ function extractCliToolCalls(
 export function extractToolCalls(
   stdout: string,
   agent: AgentName,
-  surface: EvalSurface = "mcp",
-  guidanceProfile?: GuidanceProfile,
+  _surface: EvalSurface = "mcp",
+  _guidanceProfile?: GuidanceProfile,
 ): ExtractedToolCall[] {
   const calls: ExtractedToolCall[] = [];
   for (const line of stdout.split("\n")) {

--- a/scripts/agent-eval.ts
+++ b/scripts/agent-eval.ts
@@ -1198,27 +1198,19 @@ export function extractToolCalls(
   guidanceProfile?: GuidanceProfile,
 ): ExtractedToolCall[] {
   const calls: ExtractedToolCall[] = [];
-  const includeCliCalls =
-    surface === "skills" || (surface === "mcp" && guidanceProfile === "full");
   for (const line of stdout.split("\n")) {
     if (line.trim().length === 0) continue;
     try {
       const event = JSON.parse(line) as Record<string, unknown>;
       if (agent === "claude") {
-        if (includeCliCalls) {
-          calls.push(...extractCliToolCalls(event, agent));
-        }
+        calls.push(...extractCliToolCalls(event, agent));
         calls.push(...extractClaudeToolCalls(event));
       } else if (agent === "codex") {
-        if (includeCliCalls) {
-          calls.push(...extractCliToolCalls(event, agent));
-        }
+        calls.push(...extractCliToolCalls(event, agent));
         const call = extractCodexToolCall(event);
         if (call) calls.push(call);
       } else {
-        if (includeCliCalls) {
-          calls.push(...extractCliToolCalls(event, agent));
-        }
+        calls.push(...extractCliToolCalls(event, agent));
         const call = extractOpenCodeToolCall(event);
         if (call) calls.push(call);
       }

--- a/scripts/agent-eval.ts
+++ b/scripts/agent-eval.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import {
   chmodSync,
   cpSync,
@@ -11,12 +12,28 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { delimiter, dirname, isAbsolute, join, resolve } from "node:path";
+import {
+  delimiter,
+  dirname,
+  isAbsolute,
+  join,
+  relative,
+  resolve,
+} from "node:path";
 import {
   GITHITS_GUIDANCE_BLOCK,
   GITHITS_GUIDANCE_MARKER,
 } from "../src/commands/init/guidance-assets.ts";
 import { mergeManagedBlock } from "../src/commands/init/setup-handlers.ts";
+import {
+  type AgentEvalFinalStatus,
+  type AgentEvalMetrics,
+  type AgentEvalRecordInput,
+  adaptAgentUsage,
+  buildAgentEvalMetrics,
+  type PersistedToolCall,
+  unknownAgentUsage,
+} from "./agent-eval-metrics.ts";
 import {
   assertUniqueWorkloadIds,
   buildRunReportFromMetadata,
@@ -98,6 +115,9 @@ interface WorkloadRunMetadata {
   exitCode?: number;
   durationMs?: number;
   timedOut?: boolean;
+  startedAt?: string;
+  completedAt?: string;
+  finalStatus?: AgentEvalFinalStatus;
   command: string[];
   workspaceDir: string;
   workloadDir: string;
@@ -105,6 +125,43 @@ interface WorkloadRunMetadata {
   experimentalTools: boolean;
   skillInstallation?: SkillInstallationMetadata;
   guidanceInstallation?: GuidanceInstallationMetadata;
+}
+
+export interface GitMetadata {
+  branch: string | null;
+  sha: string | null;
+  dirty: boolean | null;
+}
+
+export interface CommandProbeResult {
+  stdout: string;
+  exitCode: number;
+}
+
+export type CommandProbe = (
+  command: string,
+  args: string[],
+  cwd: string,
+) => Promise<CommandProbeResult | undefined>;
+
+interface WorkloadRunExecution {
+  metadata: WorkloadRunMetadata;
+  stdout?: string;
+  toolCalls: PersistedToolCall[];
+  artifacts: Record<string, string>;
+}
+
+export interface AgentEvalMetricsExecutionInput
+  extends Omit<AgentEvalRecordInput, "usage"> {
+  stdout?: string;
+  dryRun: boolean;
+}
+
+export interface AgentEvalMetricsRunInput {
+  runId: string;
+  startedAt: string;
+  completedAt: string;
+  records: AgentEvalMetricsExecutionInput[];
 }
 
 const MCP_CONFIG_ENV_KEYS = [
@@ -862,11 +919,11 @@ function redactValue(value: unknown, secretValues: string[]): unknown {
   return value;
 }
 
-async function commandOutput(
+async function commandProbe(
   command: string,
   args: string[],
   cwd: string,
-): Promise<string | undefined> {
+): Promise<CommandProbeResult | undefined> {
   try {
     const proc = Bun.spawn([command, ...args], {
       cwd,
@@ -877,23 +934,39 @@ async function commandOutput(
       new Response(proc.stdout).text(),
       proc.exited,
     ]);
-    if (exitCode !== 0) {
-      return undefined;
-    }
-    return stdout.trim() || undefined;
+    return { stdout, exitCode };
   } catch {
     return undefined;
   }
 }
 
-async function collectGitMetadata(
+async function commandOutput(
+  command: string,
+  args: string[],
+  cwd: string,
+): Promise<string | undefined> {
+  const result = await commandProbe(command, args, cwd);
+  if (result === undefined || result.exitCode !== 0) return undefined;
+  return result.stdout.trim() || undefined;
+}
+
+export async function collectGitMetadata(
   repoRoot: string,
-): Promise<Record<string, string | undefined>> {
-  const [branch, sha] = await Promise.all([
-    commandOutput("git", ["branch", "--show-current"], repoRoot),
-    commandOutput("git", ["rev-parse", "HEAD"], repoRoot),
+  probe: CommandProbe = commandProbe,
+): Promise<GitMetadata> {
+  const [branch, sha, status] = await Promise.all([
+    probe("git", ["branch", "--show-current"], repoRoot),
+    probe("git", ["rev-parse", "HEAD"], repoRoot),
+    probe("git", ["status", "--porcelain", "--untracked-files=all"], repoRoot),
   ]);
-  return { branch, sha };
+  return {
+    branch: branch?.exitCode === 0 ? branch.stdout.trim() || null : null,
+    sha: sha?.exitCode === 0 ? sha.stdout.trim() || null : null,
+    dirty:
+      status === undefined || status.exitCode !== 0
+        ? null
+        : status.stdout.trim().length > 0,
+  };
 }
 
 async function claudeVersion(): Promise<string | undefined> {
@@ -1592,6 +1665,59 @@ function buildAgentCommand(
   return buildOpenCodeCommand(prompt, workspaceDir, options);
 }
 
+export function buildAgentEvalMetricsArtifact(
+  input: AgentEvalMetricsRunInput,
+): AgentEvalMetrics {
+  const records: AgentEvalRecordInput[] = input.records.map(
+    ({ stdout, dryRun, ...record }) => {
+      const model = record.resolvedModel ?? record.requestedModel ?? undefined;
+      return {
+        ...record,
+        usage: dryRun
+          ? unknownAgentUsage(record.agent, model, "dry_run_no_telemetry")
+          : adaptAgentUsage(stdout ?? "", record.agent, model),
+      };
+    },
+  );
+  return buildAgentEvalMetrics({
+    runId: input.runId,
+    startedAt: input.startedAt,
+    completedAt: input.completedAt,
+    records,
+  });
+}
+
+const WORKLOAD_ARTIFACTS = [
+  ["prompt", "prompt.md"],
+  ["mcpConfig", "mcp.json"],
+  ["codexConfig", "codex-config.toml"],
+  ["codexFinal", "codex-final.txt"],
+  ["openCodeConfig", "opencode.json"],
+  ["stdout", "stdout.json"],
+  ["stderr", "stderr.txt"],
+  ["toolCalls", "tool-calls.json"],
+  ["discoveryEvents", "discovery-events.json"],
+  ["final", "final.json"],
+  ["invalidFinal", "invalid-final.json"],
+  ["dryRun", "dry-run.json"],
+  ["skillInstallation", "skill-installation.json"],
+  ["guidanceInstallation", "guidance-installation.json"],
+] as const;
+
+function existingWorkloadArtifacts(
+  runDir: string,
+  workloadDir: string,
+): Record<string, string> {
+  const artifacts: Record<string, string> = {};
+  for (const [key, name] of WORKLOAD_ARTIFACTS) {
+    const path = join(workloadDir, name);
+    if (existsSync(path) && lstatSync(path).isFile()) {
+      artifacts[key] = relative(runDir, path);
+    }
+  }
+  return artifacts;
+}
+
 async function runWorkload(
   options: AgentEvalOptions,
   workloadPath: string,
@@ -1599,7 +1725,7 @@ async function runWorkload(
   env: Record<string, string>,
   mcpConfig: McpServerConfig,
   secretValues: string[],
-): Promise<WorkloadRunMetadata> {
+): Promise<WorkloadRunExecution> {
   assert(existsSync(workloadPath), `Workload not found: ${workloadPath}`);
   assert(
     existsSync(options.reportingPath),
@@ -1686,9 +1812,14 @@ async function runWorkload(
         status: options.agent === "claude" ? "not_observed" : "not_exposed",
         events: [],
       });
-      return { ...metadataBase, status: "dry-run" };
+      return {
+        metadata: { ...metadataBase, status: "dry-run" },
+        toolCalls: [],
+        artifacts: existingWorkloadArtifacts(runDir, workloadDir),
+      };
     }
 
+    const startedAt = new Date().toISOString();
     const started = Date.now();
     const result = await runWithTimeout(
       command,
@@ -1697,6 +1828,7 @@ async function runWorkload(
       options.timeoutSeconds,
     );
     const durationMs = Date.now() - started;
+    const completedAt = new Date().toISOString();
 
     writeFileSync(
       join(workloadDir, "stdout.json"),
@@ -1758,13 +1890,36 @@ async function runWorkload(
         ? "success"
         : "failed";
 
+    const finalStatus =
+      validFinalJson &&
+      reportJson !== null &&
+      typeof reportJson === "object" &&
+      !Array.isArray(reportJson) &&
+      typeof (reportJson as Record<string, unknown>).status === "string"
+        ? ((reportJson as Record<string, unknown>)
+            .status as AgentEvalFinalStatus)
+        : undefined;
+
     return {
-      ...metadataBase,
-      status,
-      exitCode: result.exitCode,
-      durationMs,
-      timedOut: result.timedOut,
-      toolCallCount: toolCalls.length,
+      metadata: {
+        ...metadataBase,
+        status,
+        exitCode: result.exitCode,
+        durationMs,
+        timedOut: result.timedOut,
+        startedAt,
+        completedAt,
+        ...(finalStatus ? { finalStatus } : {}),
+        toolCallCount: toolCalls.length,
+      },
+      stdout: result.stdout,
+      toolCalls: toolCalls.map(({ tool, server, status, error }) => ({
+        tool,
+        server,
+        status,
+        error,
+      })),
+      artifacts: existingWorkloadArtifacts(runDir, workloadDir),
     };
   } finally {
     rmSync(workspaceDir, { recursive: true, force: true });
@@ -1780,6 +1935,8 @@ export async function runAgentEval(
     `Schema not found: ${options.schemaPath}`,
   );
   mkdirSync(options.outDir, { recursive: true });
+  const runId = randomUUID();
+  const startedAt = new Date().toISOString();
   assertUniqueWorkloadIds(options.workloads);
   if (options.surface === "mcp" && options.guidanceProfile === undefined) {
     options.guidanceProfile = "descriptors";
@@ -1809,9 +1966,9 @@ export async function runAgentEval(
     versionsPromise,
   ]);
 
-  const workloadResults: WorkloadRunMetadata[] = [];
+  const workloadExecutions: WorkloadRunExecution[] = [];
   for (const workload of options.workloads) {
-    workloadResults.push(
+    workloadExecutions.push(
       await runWorkload(
         options,
         workload,
@@ -1822,8 +1979,15 @@ export async function runAgentEval(
       ),
     );
   }
+  const completedAt = new Date().toISOString();
+  const workloadResults = workloadExecutions.map(
+    (execution) => execution.metadata,
+  );
 
   const runMetadata = {
+    runId,
+    startedAt,
+    completedAt,
     agent: options.agent,
     model: options.model,
     surface: options.surface,
@@ -1866,8 +2030,54 @@ export async function runAgentEval(
     ),
   });
 
-  const report = buildRunReportFromMetadata(options.outDir, runMetadata);
+  const report = buildRunReportFromMetadata(options.outDir, {
+    ...runMetadata,
+    git: {
+      branch: git.branch ?? undefined,
+      sha: git.sha ?? undefined,
+    },
+  });
   writeReportJson(options.outDir, report);
+  const agentVersion =
+    options.agent === "claude"
+      ? claude
+      : options.agent === "codex"
+        ? codex
+        : opencode;
+  const metrics = buildAgentEvalMetricsArtifact({
+    runId,
+    startedAt,
+    completedAt,
+    records: workloadExecutions.map(
+      ({ metadata, stdout, toolCalls, artifacts }) => ({
+        workloadId: metadata.id,
+        requestedModel: options.model ?? null,
+        resolvedModel: null,
+        agent: options.agent,
+        agentVersion: agentVersion ?? null,
+        reasoningEffort: options.reasoningEffort ?? null,
+        surface: options.surface,
+        server: options.server,
+        guidanceProfile: options.guidanceProfile ?? null,
+        experimentalTools: options.experimentalTools,
+        publishedPackage:
+          options.server === "local" ? null : options.publishedPackage,
+        targetGit: git,
+        startedAt: metadata.startedAt ?? null,
+        completedAt: metadata.completedAt ?? null,
+        durationMs: metadata.durationMs ?? null,
+        processStatus: metadata.status,
+        finalStatus: metadata.finalStatus ?? null,
+        exitCode: metadata.exitCode ?? null,
+        timedOut: metadata.timedOut ?? null,
+        toolCalls,
+        artifacts,
+        stdout,
+        dryRun: options.dryRun,
+      }),
+    ),
+  });
+  writeJson(join(options.outDir, "metrics.json"), metrics);
   console.log(formatRunReport(report).trimEnd());
 }
 

--- a/scripts/agent-eval.ts
+++ b/scripts/agent-eval.ts
@@ -176,6 +176,7 @@ interface ExtractedToolCall {
   agent: AgentName;
   server?: string;
   tool: string;
+  providerCallId?: string;
   status?: string;
   arguments?: unknown;
   error?: unknown;
@@ -1128,10 +1129,15 @@ function extractCodexToolCall(
   if (record.type !== "mcp_tool_call" || typeof record.tool !== "string") {
     return undefined;
   }
+  const providerCallId =
+    typeof record.id === "string" && record.id.length > 0
+      ? record.id
+      : undefined;
   return {
     agent: "codex",
     server: typeof record.server === "string" ? record.server : undefined,
     tool: record.tool,
+    ...(providerCallId ? { providerCallId } : {}),
     status: typeof record.status === "string" ? record.status : undefined,
     arguments: record.arguments,
     error: record.error,
@@ -1245,6 +1251,22 @@ function extractCliToolCalls(
   agent: AgentName,
 ): ExtractedToolCall[] {
   const commands = collectCommandStrings(event);
+  const item = event.item;
+  const providerCallId =
+    agent === "codex" &&
+    item !== null &&
+    typeof item === "object" &&
+    typeof (item as Record<string, unknown>).id === "string" &&
+    ((item as Record<string, unknown>).id as string).length > 0
+      ? ((item as Record<string, unknown>).id as string)
+      : undefined;
+  const itemStatus =
+    agent === "codex" &&
+    item !== null &&
+    typeof item === "object" &&
+    typeof (item as Record<string, unknown>).status === "string"
+      ? ((item as Record<string, unknown>).status as string)
+      : undefined;
   const seen = new Set<string>();
   return commands.flatMap((command): ExtractedToolCall[] => {
     const tool = cliToolNameFromCommand(command);
@@ -1257,7 +1279,8 @@ function extractCliToolCalls(
         agent,
         server: "githits-cli",
         tool,
-        status: "started",
+        ...(providerCallId ? { providerCallId } : {}),
+        status: itemStatus ?? "started",
         arguments: { command },
       },
     ];
@@ -1913,12 +1936,15 @@ async function runWorkload(
         toolCallCount: toolCalls.length,
       },
       stdout: result.stdout,
-      toolCalls: toolCalls.map(({ tool, server, status, error }) => ({
-        tool,
-        server,
-        status,
-        error,
-      })),
+      toolCalls: toolCalls.map(
+        ({ tool, server, providerCallId, status, error }) => ({
+          tool,
+          server,
+          ...(providerCallId ? { providerCallId } : {}),
+          status,
+          error,
+        }),
+      ),
       artifacts: existingWorkloadArtifacts(runDir, workloadDir),
     };
   } finally {

--- a/scripts/agent-eval.ts
+++ b/scripts/agent-eval.ts
@@ -1290,8 +1290,6 @@ function extractCliToolCalls(
 export function extractToolCalls(
   stdout: string,
   agent: AgentName,
-  _surface: EvalSurface = "mcp",
-  _guidanceProfile?: GuidanceProfile,
 ): ExtractedToolCall[] {
   const calls: ExtractedToolCall[] = [];
   for (const line of stdout.split("\n")) {
@@ -1862,12 +1860,7 @@ async function runWorkload(
       redactText(result.stderr, secretValues),
     );
 
-    const toolCalls = extractToolCalls(
-      result.stdout,
-      options.agent,
-      options.surface,
-      options.guidanceProfile,
-    );
+    const toolCalls = extractToolCalls(result.stdout, options.agent);
     writeJson(
       join(workloadDir, "tool-calls.json"),
       redactValue(toolCalls, secretValues),
@@ -2101,10 +2094,7 @@ export async function runAgentEval(
   );
   const report = buildRunReportFromMetadata(options.outDir, {
     ...runMetadata,
-    git: {
-      branch: git.branch ?? undefined,
-      sha: git.sha ?? undefined,
-    },
+    git,
   });
   writeReportJson(options.outDir, report);
   console.log(formatRunReport(report).trimEnd());

--- a/scripts/agent-eval.ts
+++ b/scripts/agent-eval.ts
@@ -2077,7 +2077,10 @@ export async function runAgentEval(
       }),
     ),
   });
-  writeJson(join(options.outDir, "metrics.json"), metrics);
+  writeJson(
+    join(options.outDir, "metrics.json"),
+    redactValue(metrics, secretValues),
+  );
   console.log(formatRunReport(report).trimEnd());
 }
 

--- a/scripts/agent-eval.ts
+++ b/scripts/agent-eval.ts
@@ -2030,14 +2030,6 @@ export async function runAgentEval(
     ),
   });
 
-  const report = buildRunReportFromMetadata(options.outDir, {
-    ...runMetadata,
-    git: {
-      branch: git.branch ?? undefined,
-      sha: git.sha ?? undefined,
-    },
-  });
-  writeReportJson(options.outDir, report);
   const agentVersion =
     options.agent === "claude"
       ? claude
@@ -2081,6 +2073,14 @@ export async function runAgentEval(
     join(options.outDir, "metrics.json"),
     redactValue(metrics, secretValues),
   );
+  const report = buildRunReportFromMetadata(options.outDir, {
+    ...runMetadata,
+    git: {
+      branch: git.branch ?? undefined,
+      sha: git.sha ?? undefined,
+    },
+  });
+  writeReportJson(options.outDir, report);
   console.log(formatRunReport(report).trimEnd());
 }
 

--- a/scripts/agent-eval.ts
+++ b/scripts/agent-eval.ts
@@ -1733,7 +1733,7 @@ function existingWorkloadArtifacts(
   for (const [key, name] of WORKLOAD_ARTIFACTS) {
     const path = join(workloadDir, name);
     if (existsSync(path) && lstatSync(path).isFile()) {
-      artifacts[key] = relative(runDir, path);
+      artifacts[key] = relative(runDir, path).replaceAll("\\", "/");
     }
   }
   return artifacts;


### PR DESCRIPTION
## Summary

- persist schema-versioned `metrics.json` for every local agent-eval run
- normalize Codex/Luna token usage, base-rate cost estimates, timing, identity, and logical MCP/CLI tool calls
- expose descriptor/full CLI fallback, unknown telemetry, stale artifact identity, and compatibility warnings in reports
- document the local Luna workflow and the later suite, pipeline, persistence-service, Haiku, and quality phases

## Validation

- `bun test`: 3,338 pass, 0 fail across 184 files
- `bun run typecheck`
- `bun run format:check`
- `bun run lint`
- `bun run build`
- Luna-low canary: 4/4 workload executions succeeded across descriptor/full profiles
- canary base-rate estimate: $0.04333248 total
- raw terminal token aggregates matched all four metrics records; started/completed tool observations paired 2:1 by provider item ID
- final internal review and three-round Claude Opus loop completed clean

## Scope

This PR completes Phase 1 only. Named suites, paired local comparison, daily CI execution, persistent third-party export, Haiku, and quality scoring remain documented later phases.