### PR TITLE
fix: improve vulnerability tool selection

### DIFF
--- a/changes/package-vulnerability-question-routing.changed.md
+++ b/changes/package-vulnerability-question-routing.changed.md
@@ -1,0 +1,8 @@
+---
+"githits": patch
+"@githits/mcp": patch
+---
+
+- **Route broad vulnerability questions to current evidence** - `pkg_vulns`
+  now explicitly covers qualitative package security questions and directs
+  agents away from potentially outdated training data.

--- a/docs/implementation/tools.md
+++ b/docs/implementation/tools.md
@@ -41,6 +41,12 @@ Write the prefix as the answer to “why would an agent choose this tool now?”
 - Match natural questions such as “is this version vulnerable?” or “what does
   this package depend on?”, rather than catalog taxonomy or implementation
   mechanics.
+- For mutable facts, cover broad qualitative questions as well as exact
+  lookups, and explain why current evidence outranks model memory. Describe the
+  stable mechanism without asserting an unverified update cadence or a
+  model-specific amount of staleness. The complete `pkg_vulns` description, for
+  example, must cover both “is this version vulnerable?” and “does this package
+  have a lot of vulnerabilities?”.
 - Distinguish sibling tools before adding shared corpus terms. For example,
   package health, advisory detail, dependency graphs, changelog history, and
   upgrade review need visibly different openings.
@@ -109,7 +115,7 @@ Use the tools in these roles:
 | `docs_list` | `registry`, `package_name`, `version?`, `limit?`, `after?`, `format?` | List package documentation pages and hand off to `docs_read`; use `search` for topic discovery. Repo-backed entries include exact source metadata for `code_read` when available. |
 | `docs_read` | `page_id`, `start_line?`, `end_line?`, `format?` | Read a package documentation page by ID; use `docs_list` to browse and `search` to find topics. Text output returns 150 lines by default or up to 300 with an explicit range; repo-backed pages include exact `code_read` metadata. |
 | `pkg_info` | `registry`, `package_name`, `verbose?`, `format?` | Assess latest package health and adoption through license, downloads, and activity. Use `pkg_vulns` for advisory detail, `pkg_deps` for dependency graphs, `pkg_changelog` for release evidence, or `pkg_upgrade_review` for current-vs-target comparison. |
-| `pkg_vulns` | `registry`, `package_name`, `version?`, `min_severity?`, `advisory_scope?`, `include_withdrawn?`, `verbose?`, `format?` | Check whether a package version is vulnerable and find affected and fixed versions. Use `pkg_info` for a latest health overview or `pkg_upgrade_review` for current-vs-target evidence. |
+| `pkg_vulns` | `registry`, `package_name`, `version?`, `min_severity?`, `advisory_scope?`, `include_withdrawn?`, `verbose?`, `format?` | Check current package advisories instead of trusting memory for vulnerabilities. Advisories can be published or revised after training, so a cutoff disclaimer is not current evidence. Covers pinned releases, latest-version risk, and vague questions about vulnerability volume or a package's security track record. Use `pkg_info` for a latest health overview or `pkg_upgrade_review` for current-vs-target evidence. |
 | `pkg_deps` | `registry`, `package_name`, `version?`, `lifecycle?`, `include_importers?`, `max_depth?`, `format?` | Inspect what a package depends on, directly or transitively. Use `pkg_info` for health, `pkg_vulns` for advisories, or `pkg_upgrade_review` for current-vs-target evidence. |
 | `pkg_changelog` | `registry?`, `package_name?`, `repo_url?`, `from_version?`, `to_version?`, `limit?`, `git_ref?`, `omit_bodies?`, `verbose?`, `body_lines?`, `format?` | Find release notes and changelog history for a package or public GitHub repository. Latest mode returns recent entries without promising date order; range mode covers `(from_version, to_version]`. Use latest mode with `to_version` and `limit: 1` for one exact release. Use `pkg_info` for a quick health view or `pkg_upgrade_review` for upgrade evidence. |
 | `pkg_upgrade_review` | `registry?`, `package_name?`, `current_version?`, `target_version?`, `packages?`, `skip_transitive_security?`, `include_dependency_issues?`, `min_severity?`, `verbose?`, `format?` | Review a package upgrade using vulnerability, release, peer, and dependency-change evidence. Use `pkg_info` for health, `pkg_changelog` for release notes, `pkg_vulns` for advisory detail, or `pkg_deps` for dependency graphs. |

--- a/eval/agentic/README.md
+++ b/eval/agentic/README.md
@@ -565,6 +565,18 @@ Notable findings to keep in mind when evaluating future changes:
   ToolSearch for all four, then incorrectly treated the discovered deferred
   tools as uncallable in two runs; keep discovery selection separate from
   post-selection invocation failures.
+- The 2026-08-31 `pkg_vulns` description comparison ran the overview, pinned
+  severity, qualitative history, and RubyGems workloads against clean
+  `origin/main` and the candidate with Luna-low descriptor-only intent. All
+  candidate calls completed successfully with no CLI fallback. Overview and
+  pinned-filter tool counts were unchanged; history kept three calls while
+  replacing `pkg_info` with a second `pkg_vulns` scope; RubyGems improved from
+  seven unrelated `search` / `search_status` / `code_grep` calls to direct
+  `quick_start` + `pkg_vulns`. The matching neutral discovery cells exposed no
+  tools and made zero calls, so they are host-discovery evidence rather than
+  descriptor-selection evidence. This single Luna-low sample found no harmful
+  routing regression; it is not a deterministic quality guarantee or a
+  claude.ai reproduction.
 - `package-vulnerability-rubygems.md` guards non-npm routing without naming
   RubyGems in the `pkg_vulns` prefix. Haiku called the intended package tools;
   Luna-low browsed instead on one run but called `pkg_vulns` and

--- a/eval/agentic/workloads/package-vulnerability-history.md
+++ b/eval/agentic/workloads/package-vulnerability-history.md
@@ -1,7 +1,6 @@
-# Workload: Package Vulnerability History Check
+# Workload: Next.js Vulnerability History Check
 
-You are evaluating whether the latest `npm:express` release is safe from known
-active vulnerabilities, and whether there are older historical advisories for
-the package that do not affect the latest version. Summarize both the current
-risk and the historical advisory evidence. Be explicit about whether any listed
-advisory affects the inspected latest version.
+Does Next.js have a lot of vulnerabilities? Use current evidence to assess both
+the latest release's active risk and the package's overall advisory history. Be
+explicit about whether historical advisories affect the inspected latest
+version.

--- a/packages/mcp/src/mcp/server.test.ts
+++ b/packages/mcp/src/mcp/server.test.ts
@@ -171,10 +171,14 @@ const DESCRIPTION_ROUTING: Record<
     ],
   },
   pkg_vulns: {
-    prefix: /^Check whether a package version is vulnerable/,
+    prefix: /^Check current package advisories\. Do not trust your memory/,
     exactPrefix:
-      "Check whether a package version is vulnerable; find affected and fixed versions.",
+      "Check current package advisories. Do not trust your memory for vulnerabilities. ",
     body: [
+      "a cutoff disclaimer is not current evidence",
+      '`advisory_scope:"all"`',
+      '`{"registry":"npm","package_name":"next","advisory_scope":"all"}`',
+      "Pinned lookup",
       "identifiers and aliases, including CVEs when available",
       "identifier aliases (including CVEs)",
       "`pkg_info`",

--- a/packages/mcp/src/tools/package-vulnerabilities.test.ts
+++ b/packages/mcp/src/tools/package-vulnerabilities.test.ts
@@ -20,7 +20,13 @@ describe("createPackageVulnerabilitiesTool — metadata", () => {
     expect(tool.description).toContain("Swift");
     expect(tool.description).toContain("vcpkg and Zig");
     expect(tool.description).toContain(
-      "Check whether a package version is vulnerable",
+      "Check current package advisories. Do not trust your memory for vulnerabilities.",
+    );
+    expect(tool.description).toContain(
+      "Advisories can be published or revised after training; a cutoff disclaimer is not current evidence.",
+    );
+    expect(tool.description).toContain(
+      '`{"registry":"npm","package_name":"next","advisory_scope":"all"}`',
     );
     expect(tool.description).toContain(
       "identifiers and aliases, including CVEs when available",

--- a/packages/mcp/src/tools/package-vulnerabilities.ts
+++ b/packages/mcp/src/tools/package-vulnerabilities.ts
@@ -78,21 +78,24 @@ const schema: ZodRawShape = {
 };
 
 export const DESCRIPTION_BASE: string =
-  "Check whether a package version is vulnerable; find affected and fixed versions. Supports npm, PyPI, Hex, " +
+  "Check current package advisories. Do not trust your memory for vulnerabilities. " +
+  "Advisories can be published or revised after training; a cutoff disclaimer is not current evidence. " +
+  "Covers pinned releases, latest-version risk, and vague questions about vulnerability volume or a package's security track record. " +
+  'For package-wide questions, omit `version` and pass `advisory_scope:"all"`: `{"registry":"npm","package_name":"next","advisory_scope":"all"}`. ' +
+  "Supports npm, PyPI, Hex, " +
   "Crates, NuGet, Maven, Packagist, RubyGems, Go, and Swift (vcpkg and Zig " +
   "are not supported for vulnerability data). Returns a count summary and advisory details: identifiers and aliases, including CVEs when available, " +
   "severity, affected ranges, and fix versions. Malicious-package " +
-  "advisories surface in a separate bucket. Example: " +
+  "advisories surface in a separate bucket. Pinned lookup: " +
   '`{"registry":"npm","package_name":"lodash","version":"4.17.20","min_severity":"high"}`. ' +
-  "Pass `version` to inspect " +
-  "a pinned release; omit it for latest. Default text is capped for " +
+  "Pass `version` to inspect a pinned release; omit it for latest. Default text is capped for " +
   "readability; use `verbose:true` for all selected advisory rows and identifier aliases (including CVEs), or " +
   '`format:"json"` for the complete envelope. Use ' +
   "`min_severity` to filter to a threshold (`low`, `medium`, `high`, " +
   "`critical`) and `include_withdrawn` to also see retracted " +
   'advisories. Use `advisory_scope:"non_affecting"` to list ' +
-  "historical advisories that do not affect the inspected version, or " +
-  '`advisory_scope:"all"` to list affected and historical advisories together. Use `pkg_info` for a latest-version health overview or `pkg_upgrade_review` for current-vs-target upgrade evidence.';
+  "historical advisories that do not affect the inspected version. " +
+  "Use `pkg_info` for a latest-version health overview or `pkg_upgrade_review` for current-vs-target upgrade evidence.";
 
 export const DESCRIPTION: string = `${DESCRIPTION_BASE}\n\n${PKG_VULNS_GUARDRAIL}`;
 

--- a/src/commands/mcp-instructions.test.ts
+++ b/src/commands/mcp-instructions.test.ts
@@ -192,7 +192,7 @@ describe("buildMcpQuickStart", () => {
       "Enumerate text, regex, or identifier matches in any public GitHub repo/package",
     );
     expect(descriptions.get("pkg_vulns")).toStartWith(
-      "Check whether a package version is vulnerable",
+      "Check current package advisories. Do not trust your memory for vulnerabilities.",
     );
   });
 


### PR DESCRIPTION
## Summary

- lead `pkg_vulns` with a 79-character current-advisory routing rule
- cover vague package security questions and provide aggregate and pinned examples in the loaded description
- add first-80 contract coverage, implementation guidance, a targeted agent workload, eval evidence, and release metadata

## Validation

- `bun test` — 3,619 pass, 0 fail
- targeted descriptor tests — 34 pass, 0 fail
- `bun run build`
- `bun run lint`
- `bun run typecheck`
- `bun run format:check`
- `bun run plugins:generate`
- `bun run plugins:check`
- `bun run smoke:cli`
- `bun run smoke:mcp` — standalone rerun passed all 47 steps
- descriptor-only Luna-low candidate/control workloads: overview and filtering were unchanged; history routed more directly; the RubyGems qualitative question changed from seven unrelated search calls to `quick_start` plus `pkg_vulns`

## Review

Claude Opus review round 1 found two low-severity issues: 12 characters of total descriptor-budget headroom and ambiguous implementation-doc wording. Both are fixed. Internal re-review and Opus round 2 were clean.

## Notes

The agent eval is one Luna-low sample, not a deterministic result or a claude.ai reproduction. Claude CLI was unauthenticated, so a live Claude run was not available.

The hosted backend descriptor must mirror and deploy this description before hosted connector sessions receive the change.