### PR TITLE
ci: run daily Luna agent evals

### DIFF
--- a/.github/workflows/agent-evals.yml
+++ b/.github/workflows/agent-evals.yml
@@ -22,7 +22,7 @@ jobs:
       (github.event.label.name == 'agent-eval' &&
       github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 40
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/agent-evals.yml
+++ b/.github/workflows/agent-evals.yml
@@ -39,7 +39,11 @@ jobs:
             workload-concurrency: 4
     steps:
       - name: Prepare scenario output
-        run: mkdir -p "$RUNNER_TEMP/agent-eval-${{ matrix.id }}"
+        run: |
+          set -euo pipefail
+          scenario_out="$RUNNER_TEMP/agent-eval-${{ matrix.id }}"
+          mkdir -p "$scenario_out"
+          printf 'scenario=%s\n' '${{ matrix.id }}' > "$scenario_out/execution-started.txt"
 
       - name: Checkout evaluated SHA
         uses: actions/checkout@v7

--- a/.github/workflows/agent-evals.yml
+++ b/.github/workflows/agent-evals.yml
@@ -1,0 +1,173 @@
+name: Agent Evals
+
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+    types: [labeled]
+
+permissions:
+  contents: read
+
+env:
+  CHECKOUT_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+
+jobs:
+  scenario:
+    name: ${{ matrix.label }} agent eval
+    if: >-
+      github.event_name != 'pull_request' ||
+      (github.event.label.name == 'agent-eval' &&
+      github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - id: discovery
+            label: Discovery
+            suite: canary
+            scenario: discovery
+            workload-concurrency: 2
+          - id: intent
+            label: Intent
+            suite: stable-full
+            scenario: intent
+            workload-concurrency: 4
+    steps:
+      - name: Prepare scenario output
+        run: mkdir -p "$RUNNER_TEMP/agent-eval-${{ matrix.id }}"
+
+      - name: Checkout evaluated SHA
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ env.CHECKOUT_SHA }}
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version-file: ".node-version"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Install current Codex CLI
+        run: npm install --global @openai/codex@latest
+
+      - name: Record Codex CLI version
+        run: codex --version
+
+      - name: Initialize empty Codex home
+        env:
+          CODEX_HOME: ${{ runner.temp }}/agent-eval-codex-home-${{ matrix.id }}
+        run: mkdir -p "$CODEX_HOME"
+
+      - name: Authenticate Codex with API key
+        env:
+          CODEX_HOME: ${{ runner.temp }}/agent-eval-codex-home-${{ matrix.id }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          set -euo pipefail
+          printf '%s' "$OPENAI_API_KEY" | codex login --with-api-key
+
+      - name: Run ${{ matrix.label }} suite
+        env:
+          CODEX_HOME: ${{ runner.temp }}/agent-eval-codex-home-${{ matrix.id }}
+          SCENARIO_OUT: ${{ runner.temp }}/agent-eval-${{ matrix.id }}
+          GITHITS_API_TOKEN: ${{ secrets.GITHITS_API_TOKEN }}
+        run: |
+          set -euo pipefail
+          bun run agent:e2e:suite run \
+            --suite "${{ matrix.suite }}" \
+            --scenario "${{ matrix.scenario }}" \
+            --concurrency "${{ matrix.workload-concurrency }}" \
+            --out "$SCENARIO_OUT"
+
+      - name: Upload ${{ matrix.label }} artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: agent-eval-${{ matrix.id }}
+          path: ${{ runner.temp }}/agent-eval-${{ matrix.id }}
+          if-no-files-found: warn
+          retention-days: 14
+
+  summary:
+    name: Agent eval summary
+    if: >-
+      always() &&
+      (github.event_name != 'pull_request' ||
+      (github.event.label.name == 'agent-eval' &&
+      github.event.pull_request.head.repo.full_name == github.repository))
+    needs: scenario
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prepare artifact directories
+        run: mkdir -p "$RUNNER_TEMP/agent-eval-artifacts/discovery" "$RUNNER_TEMP/agent-eval-artifacts/intent"
+
+      - name: Download discovery artifacts
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: agent-eval-discovery
+          path: ${{ runner.temp }}/agent-eval-artifacts/discovery
+
+      - name: Download intent artifacts
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: agent-eval-intent
+          path: ${{ runner.temp }}/agent-eval-artifacts/intent
+
+      - name: Checkout evaluated SHA
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ env.CHECKOUT_SHA }}
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version-file: ".node-version"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Render agent eval summary
+        id: report
+        env:
+          REPORT_OUT: ${{ runner.temp }}/agent-eval-summary.md
+        run: |
+          set +e
+          bun run agent:e2e:ci-report \
+            --suite discovery="$RUNNER_TEMP/agent-eval-artifacts/discovery/suite.json" \
+            --suite intent="$RUNNER_TEMP/agent-eval-artifacts/intent/suite.json" \
+            --run-url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --out "$REPORT_OUT"
+          report_status=$?
+          set -e
+          if [ "${{ needs.scenario.result }}" != "success" ]; then
+            report_status=1
+          fi
+          if [ -f "$REPORT_OUT" ]; then
+            cat "$REPORT_OUT" >> "$GITHUB_STEP_SUMMARY"
+          else
+            {
+              echo "# Agent eval CI report"
+              echo ""
+              echo "Reporter did not produce a summary artifact."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+          exit "$report_status"

--- a/changes/agent-eval-ci.changed.md
+++ b/changes/agent-eval-ci.changed.md
@@ -1,0 +1,6 @@
+---
+"githits": none
+"@githits/mcp": none
+---
+
+- **Daily Luna agent eval workflow** - Add maintainer-authorized daily, manual, and same-repository labeled-pull-request execution for the Luna discovery and intent suites, bounded concurrency, 14-day raw artifact retention, and concise absolute summaries. Public package behavior is unchanged.

--- a/docs/implementation/agentic-eval-metrics.md
+++ b/docs/implementation/agentic-eval-metrics.md
@@ -60,8 +60,10 @@ CODEX_HOME="$HOME/.codex-eval" bun run agent:e2e --agent codex --surface skills 
 ```
 
 The CI workflow provides a clean `CODEX_HOME` with `OPENAI_API_KEY`
-authentication. The harness does not read auth material and never copies it
-into artifacts. Every
+authentication. It forwards `GITHITS_API_TOKEN` to Codex by variable name
+through the MCP server's `env_vars`; the token value is never written to
+`codex-config.toml` or an artifact. The harness does not read auth material and
+never copies it into artifacts. Every
 Codex run with a supplied `CODEX_HOME`—including live runs and dry runs with an
 explicit or ambient value—preflights root-level `AGENTS.override.md` and
 `AGENTS.md`, plus every direct `$CODEX_HOME/skills` entry except `.system`.

--- a/docs/implementation/agentic-eval-metrics.md
+++ b/docs/implementation/agentic-eval-metrics.md
@@ -235,8 +235,9 @@ present.
 
 The suite layer emits schema-v3 `suite.json` around child run artifacts.
 The fixed execution matrix is Codex `gpt-5.6-luna`, reasoning `low`, local MCP;
-its scenario-keyed shards may run concurrently while workloads remain
-sequential within each shard. The closed scenarios are `discovery`
+its scenario-keyed shards may run concurrently, and each shard runs workloads
+through a bounded pool selected by `workloadConcurrency` (default `1`). Results
+remain in manifest order. The closed scenarios are `discovery`
 (`descriptors` + `neutral`), `intent` (`descriptors` + `githits`), and `full`
 (`full` + `neutral`). Canary defaults to `discovery` plus `intent`; smoke,
 stable-full, stateful-manual, and experimental default to `intent` only. The

--- a/docs/implementation/agentic-eval-metrics.md
+++ b/docs/implementation/agentic-eval-metrics.md
@@ -7,10 +7,11 @@ schema-versioned `metrics.json` artifact for local inspection. `report.json`
 and the console summary are review aids built from that artifact; they do not
 replace the raw terminal output or `tool-calls.json`.
 
-This is local maintainer tooling. It is not a daily pipeline, persistent
-history service, deterministic CI gate, or quality judge. Named Luna suites and
-local paired/offline comparisons are implemented here; daily execution,
-long-term export, and answer-quality scoring remain later phases.
+This is local maintainer tooling plus the repository's dedicated Luna CI
+workflow. It is not a persistent history service, deterministic CI gate, or
+quality judge. Named Luna suites, local paired/offline comparisons, and daily
+or explicitly authorized pull-request execution are implemented here;
+long-term export and answer-quality scoring remain later phases.
 
 ## Scenario and intent identity
 
@@ -58,8 +59,9 @@ CODEX_HOME="$HOME/.codex-eval" bun run agent:e2e --agent codex --surface mcp --s
 CODEX_HOME="$HOME/.codex-eval" bun run agent:e2e --agent codex --surface skills --server local --workload eval/agentic/workloads/package-overview-vulnerabilities.md
 ```
 
-CI should provide a clean `CODEX_HOME` with `OPENAI_API_KEY` authentication. The
-harness does not read auth material and never copies it into artifacts. Every
+The CI workflow provides a clean `CODEX_HOME` with `OPENAI_API_KEY`
+authentication. The harness does not read auth material and never copies it
+into artifacts. Every
 Codex run with a supplied `CODEX_HOME`—including live runs and dry runs with an
 explicit or ambient value—preflights root-level `AGENTS.override.md` and
 `AGENTS.md`, plus every direct `$CODEX_HOME/skills` entry except `.system`.
@@ -204,7 +206,7 @@ access was needed for this diagnostic; the normal temporary-workspace trust
 prompt required human approval. Two earlier stable intent attempts that waited
 at an unattended macOS Keychain approval prompt are invalid/excluded evidence,
 not a harness timeout defect. Local subscription/keychain-backed runs can
-require operator presence; future daily CI must use separately provisioned
+require operator presence. The daily CI workflow uses separately provisioned
 non-interactive API credentials without copying or reading credentials into
 artifacts.
 
@@ -231,7 +233,7 @@ present.
 
 ## Named suite and comparison artifacts
 
-The Phase 2 suite layer emits schema-v2 `suite.json` around child run artifacts.
+The suite layer emits schema-v3 `suite.json` around child run artifacts.
 The fixed execution matrix is Codex `gpt-5.6-luna`, reasoning `low`, local MCP;
 its scenario-keyed shards may run concurrently while workloads remain
 sequential within each shard. The closed scenarios are `discovery`
@@ -247,7 +249,7 @@ suite, which enables the experimental-tools option.
 Use the local entrypoint as follows:
 
 ```bash
-bun run agent:e2e:suite run --suite canary [--dry-run] [--out <dir>]
+bun run agent:e2e:suite run --suite canary [--concurrency <positive integer>] [--dry-run] [--out <dir>]
 bun run agent:e2e:suite pair --suite canary --baseline-root ../githits-main [--dry-run] [--out <dir>]
 bun run agent:e2e:suite compare --baseline-suite <path> --candidate-suite <path> [--out <dir>]
 ```
@@ -268,7 +270,13 @@ target Git identity, and full-profile `skills/githits-mcp` plus
 `GITHITS_GUIDANCE_BLOCK`; a single-target run can select a target with
 `--target-root`.
 
-`suite.json` is schema version 2 and records the suite execution ID, matrix,
+One-off and suite workload concurrency defaults to `1`. The runner uses an
+in-process bounded pool and keeps results in input/manifest order while
+continuing ordinary workload failures; unexpected executor exceptions still
+reject the run. CI selects `2` for discovery and `4` for intent. The selected
+value is recorded in one-off `run.json` and suite `suite.json` metadata.
+
+`suite.json` is schema version 3 and records the suite execution ID, matrix,
 selected scenarios/workloads, measurement-harness and target Git identities,
 wall and cumulative agent time, scenario shard status/errors, scenario/workload
 cell status, normalized tokens, cost, duration, aggregate logical calls by
@@ -313,9 +321,10 @@ telemetry remain in the full status matrix but are excluded from the affected
 cohort. A suite aggregate `callsByTool` is null when any selected cell lacks
 consistent logical telemetry, with those cell IDs listed; a mismatch between
 `logicalCallCount` and sequence length is treated as inconsistent telemetry.
-The suite loader deterministically normalizes valid schema-v1 artifacts at the
-boundary: historical descriptor shards/cells become `discovery`, and full
-becomes `full`. The historical v1 contract requires one of those exact
+The suite loader deterministically normalizes valid schema-v1 and schema-v2
+artifacts at the boundary. Missing `workloadConcurrency` becomes `1`;
+historical descriptor shards/cells become `discovery`, and full becomes `full`.
+The historical v1 contract requires one of those exact
 profiles; missing, null, or other profiles are rejected rather than mapped to
 `intent`. Their child `metrics.json` files are loaded through
 `parseAgentEvalMetrics`, which normalizes metrics v1 without inventing intent
@@ -323,8 +332,61 @@ evidence. Cell IDs are rewritten to
 `<scenario>/<workload>` during normalization; contamination and isolation
 warnings and contained child references are preserved.
 Raw child artifacts remain authoritative and partial shards preserve successful
-siblings. These commands perform no retries, service export, persistence,
-scheduled CI execution, Haiku runs, or quality judging.
+siblings. Workload concurrency is execution metadata, not a comparison
+dimension; valid metric deltas remain visible when it differs. These commands
+perform no retries, service export, persistence, Haiku runs, or quality judging.
+
+## Phase 3 CI workflow
+
+`.github/workflows/agent-evals.yml` composes the validated local runner and CI
+reporter into two independent matrix entries on GitHub-hosted Ubuntu:
+
+| Entry     | Suite        | Scenario    | Workload concurrency | Timeout |
+| --------- | ------------ | ----------- | -------------------: | -------: |
+| discovery | `canary`      | `discovery` |                    2 | 30 min  |
+| intent    | `stable-full` | `intent`    |                    4 | 30 min  |
+
+It triggers at `03:00` UTC from the default branch, on `workflow_dispatch`, and
+on `pull_request` events of type `labeled` targeting `main`. The paid jobs run
+for a pull request only when the event label is exactly `agent-eval` and the
+head repository is the current repository. They check out the immutable
+labeled head SHA; scheduled and manual runs use `github.sha`. A later
+`synchronize` event does not rerun while the label remains. Removing and
+re-adding the label authorizes a newer SHA. Applying the label is an explicit
+maintainer review of the workflow and all code at that SHA, including any
+workflow changes that SHA contains.
+
+Each paid job creates its output directory before checkout, installs Bun,
+Node, frozen dependencies, and the current `@openai/codex` CLI, and records
+`codex --version`. It creates an empty per-scenario `CODEX_HOME` below
+`runner.temp` and authenticates with the official stdin API-key flow.
+`OPENAI_API_KEY` is scoped only to authentication; `GITHITS_API_TOKEN` is
+scoped only to paid suite execution. No local subscription state, Keychain
+data, user config, or personal skills are copied into the runner. Scenario
+outputs are uploaded as `agent-eval-discovery` and `agent-eval-intent` with
+14-day retention, including partial setup/execution evidence.
+
+The unconditional summary job downloads those artifacts into separate,
+non-flattened directories, checks out the same SHA, installs dependencies with
+no secrets, and runs `agent:e2e:ci-report`. It appends the generated Markdown
+to `GITHUB_STEP_SUMMARY` before returning a failure for malformed or missing
+suite evidence. The report is absolute and links to the workflow run; it shows
+schema/harness and Codex identity, status, cells, timing, logical MCP/CLI
+calls, deterministic per-tool counts, tokens, cost uncertainty, concurrency,
+and warnings. It never reads a baseline, calculates deltas, writes PR comments,
+or judges answer quality. Partial/failed/timeout execution, unknown or missing
+cells, CLI fallback, isolation violations, and missing evidence fail after the
+summary is rendered. Zero-call discovery and ordinary telemetry warnings stay
+advisory. The measured healthy path is expected to take 5–6 minutes and cost
+about $0.23 as a base-rate estimate, not a billing guarantee. No cross-run
+concurrency group is configured, so independent schedule, dispatch, and label
+runs may overlap.
+
+The local implementation and deterministic validation are complete. A live
+scheduled/manual/label-authorized workflow run remains pending; the repository
+administrator-verified secret names are `OPENAI_API_KEY` and
+`GITHITS_API_TOKEN` (verified 2026-08-31 without reading their values). No live
+duration, quota, or hosted-run evidence is claimed here yet.
 
 ## Previous paid comparison: contaminated; capacity evidence only
 
@@ -590,7 +652,9 @@ artifacts that resolve outside the run directory.
 | `scripts/agent-eval-metrics.ts`      | Codex adapter, Zod schemas, normalization, and aggregate builder                                 |
 | `scripts/agent-eval-report.ts`       | Safe metrics loading, derived report fields, and console formatting                              |
 | `scripts/agent-eval-suite.ts`        | Named-suite manifest validation, Luna orchestration, paired comparison, and artifact containment |
+| `scripts/agent-eval-ci-report.ts`    | Schema-validated absolute CI Markdown report and failure classification                        |
 | `scripts/agent-eval-suite.test.ts`   | Suite, comparison, CLI, failure, and containment coverage                                        |
 | `scripts/agent-eval.test.ts`         | Runner, report, fallback, safety, and integration coverage                                       |
 | `scripts/agent-eval-metrics.test.ts` | Adapter and metrics-contract coverage                                                            |
+| `.github/workflows/agent-evals.yml`  | Daily, labeled-PR, and manual Luna execution plus unconditional summary                         |
 | `eval/agentic/README.md`             | User-facing harness usage, workload guidance, and limitations                                    |

--- a/docs/implementation/agentic-eval-metrics.md
+++ b/docs/implementation/agentic-eval-metrics.md
@@ -381,17 +381,37 @@ and warnings. It never reads a baseline, calculates deltas, writes PR comments,
 or judges answer quality. Partial/failed/timeout execution, unknown or missing
 cells, zero selected workloads or zero expected executions, CLI fallback,
 isolation violations, and missing evidence fail after the summary is rendered.
-Zero-call discovery and ordinary telemetry warnings stay advisory. The measured
-healthy path is expected to take 5–6 minutes and cost
-about $0.23 as a base-rate estimate, not a billing guarantee. No cross-run
+Zero-call discovery and ordinary telemetry warnings stay advisory. No cross-run
 concurrency group is configured, so independent schedule, dispatch, and label
 runs may overlap.
 
-The local implementation and deterministic validation are complete. A live
-scheduled/manual/label-authorized workflow run remains pending; the repository
-administrator-verified secret names are `OPENAI_API_KEY` and
-`GITHITS_API_TOKEN` (verified 2026-08-31 without reading their values). No live
-duration, quota, or hosted-run evidence is claimed here yet.
+### Live CI validation evidence
+
+The first same-repository label run, `33379420414` at SHA `6f26242`, rendered
+its summary but failed execution validation: discovery was 2/2, intent was
+20/21, authenticated MCP data calls returned `AUTH_REQUIRED`, and
+`docs-discovery` used the GitHits CLI fallback. The root cause was missing
+Codex stdio `env_vars` forwarding. This confirms failure detection and is not
+model-quality evidence.
+
+The corrected same-repository label run
+([workflow run 33380560726](https://github.com/githits-com/githits-cli/actions/runs/33380560726))
+at exact SHA `16fd964` succeeded. The discovery job took 44 seconds, intent
+took 2 minutes 24 seconds, and summary rendering took 13 seconds. The workflow
+ran from 10:02:30Z to 10:05:12Z (about 2 minutes 42 seconds end to end).
+Discovery suite wall/cumulative time was 24.804/44.386 seconds; intent was
+124.898/454.773 seconds. The cells were 2/2 and 21/21 at workload concurrency
+2/4, using Codex CLI 0.151.0. Logical calls were 10 + 115 = 125, all MCP;
+there were no isolation-violation files, CLI calls/fallbacks, `AUTH_REQUIRED`
+responses, or warnings. Reporter cost estimates were $0.0265 + $0.2249,
+about $0.2514 total. Token totals were 417 uncached input, 2,474,289 cached
+input, 701,553 cache-write input, 22,048 output, and 4,739 reasoning tokens.
+
+All 23 Codex configs contained only the name-only `GITHITS_API_TOKEN`
+`env_vars` entry and no literal token assignment; secret values were not read
+during inspection. The same-repository label path is live-validated. Default
+branch scheduled/manual execution remains pending merge, so this does not yet
+establish scheduled/manual behavior or complete all deployment acceptance.
 
 ## Previous paid comparison: contaminated; capacity evidence only
 

--- a/docs/implementation/agentic-eval-metrics.md
+++ b/docs/implementation/agentic-eval-metrics.md
@@ -344,8 +344,8 @@ reporter into two independent matrix entries on GitHub-hosted Ubuntu:
 
 | Entry     | Suite        | Scenario    | Workload concurrency | Timeout |
 | --------- | ------------ | ----------- | -------------------: | -------: |
-| discovery | `canary`      | `discovery` |                    2 | 30 min  |
-| intent    | `stable-full` | `intent`    |                    4 | 30 min  |
+| discovery | `canary`      | `discovery` |                    2 | 40 min  |
+| intent    | `stable-full` | `intent`    |                    4 | 40 min  |
 
 It triggers at `03:00` UTC from the default branch, on `workflow_dispatch`, and
 on `pull_request` events of type `labeled` targeting `main`. The paid jobs run

--- a/docs/implementation/agentic-eval-metrics.md
+++ b/docs/implementation/agentic-eval-metrics.md
@@ -274,8 +274,9 @@ target Git identity, and full-profile `skills/githits-mcp` plus
 One-off and suite workload concurrency defaults to `1`. The runner uses an
 in-process bounded pool and keeps results in input/manifest order while
 continuing ordinary workload failures; unexpected executor exceptions still
-reject the run. CI selects `2` for discovery and `4` for intent. The selected
-value is recorded in one-off `run.json` and suite `suite.json` metadata.
+reject the run. An empty suite selection fails during preflight before child
+execution. CI selects `2` for discovery and `4` for intent. The selected value
+is recorded in one-off `run.json` and suite `suite.json` metadata.
 
 `suite.json` is schema version 3 and records the suite execution ID, matrix,
 selected scenarios/workloads, measurement-harness and target Git identities,
@@ -370,15 +371,16 @@ outputs are uploaded as `agent-eval-discovery` and `agent-eval-intent` with
 The unconditional summary job downloads those artifacts into separate,
 non-flattened directories, checks out the same SHA, installs dependencies with
 no secrets, and runs `agent:e2e:ci-report`. It appends the generated Markdown
-to `GITHUB_STEP_SUMMARY` before returning a failure for malformed or missing
-suite evidence. The report is absolute and links to the workflow run; it shows
-schema/harness and Codex identity, status, cells, timing, logical MCP/CLI
+to `GITHUB_STEP_SUMMARY` before returning a failure for malformed, empty, or
+missing suite evidence. The report is absolute and links to the workflow run;
+it shows schema/harness and Codex identity, status, cells, timing, logical MCP/CLI
 calls, deterministic per-tool counts, tokens, cost uncertainty, concurrency,
 and warnings. It never reads a baseline, calculates deltas, writes PR comments,
 or judges answer quality. Partial/failed/timeout execution, unknown or missing
-cells, CLI fallback, isolation violations, and missing evidence fail after the
-summary is rendered. Zero-call discovery and ordinary telemetry warnings stay
-advisory. The measured healthy path is expected to take 5–6 minutes and cost
+cells, zero selected workloads or zero expected executions, CLI fallback,
+isolation violations, and missing evidence fail after the summary is rendered.
+Zero-call discovery and ordinary telemetry warnings stay advisory. The measured
+healthy path is expected to take 5–6 minutes and cost
 about $0.23 as a base-rate estimate, not a billing guarantee. No cross-run
 concurrency group is configured, so independent schedule, dispatch, and label
 runs may overlap.

--- a/docs/plans/systematic-agent-evals.md
+++ b/docs/plans/systematic-agent-evals.md
@@ -1623,7 +1623,8 @@ None.
    status classification, including zero-call discovery, per-tool frequencies,
    unknown telemetry, partial/missing suites, CLI fallback, and isolation
    violations. Implement the pure formatter and thin CLI entrypoint.
-3. **Implemented locally; same-repository label path live-validated:** Add the dedicated workflow with the three triggers, an explicit
+3. **Implemented locally; same-repository label path
+   live-validated:** Add the dedicated workflow with the three triggers, an explicit
    `github.event.label.name == 'agent-eval'` job gate, same-repository label/SHA
    authorization, clean Codex home and API-key setup, the two scenario jobs,
    unconditional artifact upload/reporting, 14-day retention, and minimal
@@ -1634,7 +1635,8 @@ None.
    contract, and the required no-public-impact change fragment. Document label
    authorization, re-label behavior, exact suites/concurrency, expected
    duration/cost, secret names, and artifact/report locations.
-5. **Local and label evidence complete; scheduled/manual evidence pending merge:** Run focused tests, all suite dry-runs at concurrency 1 and the CI-selected
+5. **Local and label evidence complete; scheduled/manual evidence pending
+   merge:** Run focused tests, all suite dry-runs at concurrency 1 and the CI-selected
    values, `bun test`, typecheck, format, lint, build, and workflow syntax/action
    validation. The same-repository label path is live-validated with no global
    skill/guidance reads or CLI fallbacks. After the change is merged, manually
@@ -1645,14 +1647,17 @@ None.
 
 - Default local execution remains sequential; explicit concurrency never
   exceeds the requested in-flight workload count and preserves manifest order.
-- A same-repository label run checks out the exact labeled head SHA and
+- MET: A same-repository label run checks out the exact labeled head SHA and
   produces 2/2 discovery plus 21/21 intent records with concurrency 2/4
-  captured in artifacts; scheduled/default-branch manual execution remains
-  pending merge.
+  captured in artifacts.
+- PENDING AFTER MERGE: A trusted manual run and a scheduled default-branch run
+  check out the exact intended SHA and produce 2/2 discovery plus 21/21 intent
+  records, or explicit failed/missing records, with concurrency 2/4 captured in
+  artifacts.
 - A same-repository PR runs only after the exact `agent-eval` label event at the
   labeled head SHA; forks and later unlabeled SHAs cannot consume secrets.
 - The corrected same-repository label workflow completed in about 2 minutes 42
-  seconds at an estimated $0.2514 base cost; actual wall time, cost, and any
+  seconds at a $0.2514 rate-based estimate; actual wall time, cost, and any
   provider-quota behavior are recorded rather than hidden by retries.
 - The GitHub summary concisely shows status, exact Codex CLI/model identity,
   tool calls/tools used, tokens, duration, cost uncertainty, and evidence links

--- a/docs/plans/systematic-agent-evals.md
+++ b/docs/plans/systematic-agent-evals.md
@@ -909,9 +909,9 @@ model matrix for Phase 5.
    initial paid behavior cell is Codex `gpt-5.6-luna`, reasoning `low`, local
    MCP. Scenario cells are explicit records rather than an unconditional
    guidance-profile Cartesian product, so the canary can later include approved
-   agent/model cells without applying them to all 21 workloads. Workloads remain
-   sequential inside each cell; configured cells may run concurrently within
-   the approved bound.
+   agent/model cells without applying them to all 21 workloads. Configured
+   scenario shards may run concurrently; each shard uses the explicit bounded
+   `workloadConcurrency` pool (default `1`) and preserves manifest order.
 
    The one-off runner accepts the same intent profile so targeted and suite
    evidence have identical prompt construction. It appends the exact harness-
@@ -1083,9 +1083,10 @@ model matrix for Phase 5.
    semantics and a guidance-only difference between two target fixtures.
    Preserve current one-off defaults and artifact compatibility.
 4. Add single-target suite orchestration with an injected shard executor for
-   deterministic tests. Execute the two profile shards concurrently, preserve
-   sequential workloads inside each runner, and write a validated partial or
-   complete `suite.json` after both shards settle.
+   deterministic tests. Execute the two profile shards concurrently, run each
+   shard's workloads through its explicit bounded pool while preserving
+   manifest order, and write a validated partial or complete `suite.json` after
+   both shards settle.
 5. Add live pair mode from the current candidate checkout with one explicit
    baseline root, plus offline compare mode over two existing `suite.json`
    artifacts. Route both through the same pure comparison, validate compatible
@@ -1569,8 +1570,9 @@ None.
    reports suite status, successful/expected cells, wall and cumulative agent
    time, logical MCP/CLI calls, token buckets, estimated cost/uncertainty,
    Codex CLI version, isolation/telemetry warnings, and deterministic per-tool
-   logical call counts. It links to the workflow artifacts but does not load a
-   baseline, calculate deltas, or write PR comments.
+   logical call counts. The workflow supplies a run URL, which the reporter
+   renders as the evidence link to the workflow run containing the artifacts;
+   it does not load a baseline, calculate deltas, or write PR comments.
 
    The summary job runs with `if: always()` so missing and failed scenario jobs
    remain visible. Missing/unparseable suite evidence, isolation violations,

--- a/docs/plans/systematic-agent-evals.md
+++ b/docs/plans/systematic-agent-evals.md
@@ -4,7 +4,8 @@
 
 - Overall: IN PROGRESS
 - Current phase: Phase 3 — Parallel CI Execution And Concise Reporting
-  (IMPLEMENTED LOCALLY; LIVE VALIDATION PENDING)
+  (IMPLEMENTED LOCALLY; SAME-REPOSITORY LABEL PATH LIVE-VALIDATED; SCHEDULED/MANUAL
+  PATH PENDING MERGE)
 - Previous work: Phase 2 correction is COMPLETE. Its discovery, intent, full,
   scenario-aware comparison, metrics-compatibility, and Codex interactive
   isolation contracts are locally validated; CI execution is Phase 3 and
@@ -12,9 +13,9 @@
 - Owner: repository maintainers
 - Last verified: 2026-08-31
 - Deployment: Phases 1 and 2 merged to `main`; local maintainer tooling and the
-  Phase 3 workflow/report are implemented. Live scheduled and label-authorized
-  validation is pending. Braintrust persistence is a separate Phase 4
-  increment.
+  Phase 3 workflow/report are implemented. Same-repository label-authorized
+  validation is live; scheduled/manual default-branch validation remains
+  pending merge. Braintrust persistence is a separate Phase 4 increment.
 
 ## Problem And Expected Outcome
 
@@ -114,8 +115,9 @@ Out of scope for the initial phases:
   to `main`, and `.github/workflows/agent-evals.yml` now defines the scheduled,
   manual, and same-repository label-authorized Luna workflow. Repository
   administrators verified the required secret names `OPENAI_API_KEY` and
-  `GITHITS_API_TOKEN` on 2026-08-31 without reading their values. A live
-  workflow run is still required before Phase 3 can be accepted as fully
+  `GITHITS_API_TOKEN` on 2026-08-31 without reading their values. The
+  same-repository label path is live-validated; default-branch scheduled/manual
+  execution remains pending merge before Phase 3 can be accepted as fully
   complete.
 - The agentic eval documentation now distinguishes local human/agent-driven
   inspection from the dedicated CI workflow. Deterministic smoke tests remain
@@ -156,10 +158,11 @@ deterministic input-order pool gives 411,742 ms at concurrency 2, 280,622 ms at
 sequentially; its two workloads project to 234,795 ms when run together because
 the slower workload dominates. Running discovery and intent as two concurrent
 CI jobs, with workload concurrency 2 and 4 respectively, therefore projects the
-paid-agent critical path at about 3.9 minutes. Setup and reporting should keep a
-healthy workflow near 5–6 minutes. Intent concurrency above 4 would not shorten
-the current critical path, so it would add provider load without useful runtime
-improvement.
+paid-agent critical path at about 3.9 minutes. The corrected same-repository
+label run later measured about 2 minutes 42 seconds end to end, superseding the
+provisional 5–6 minute target for the validated path. Intent concurrency above
+4 would not shorten the current critical path, so it would add provider load
+without useful runtime improvement.
 
 The two scheduled suites used an estimated \$0.2297134 in the accepted local
 evidence (\$0.0266578 discovery plus \$0.2030556 intent). This is a base-rate
@@ -474,9 +477,10 @@ changes are not confused with harness changes.
 
 ## Unknowns And Product Decisions
 
-None block Phase 3 implementation. Live activation and acceptance remain
-pending external workflow execution using the verified `OPENAI_API_KEY` and
-`GITHITS_API_TOKEN` secret names; this is an operational validation dependency,
+None block Phase 3 implementation. The same-repository label path is
+live-validated; scheduled/manual activation and final acceptance remain pending
+external workflow execution after merge using the verified `OPENAI_API_KEY` and
+`GITHITS_API_TOKEN` secret names. This is an operational validation dependency,
 not a product decision.
 
 The following must be resolved before Phase 4 is detailed:
@@ -605,10 +609,11 @@ The following must be resolved before Phase 6:
    validated; corrected discovery/intent evidence supersedes the two-profile
    behavior policy.
 3. **Phase 3 — parallel CI execution and concise reporting (IMPLEMENTED
-   LOCALLY; LIVE VALIDATION PENDING):** clean GitHub-hosted jobs run the Luna
-   discovery and intent suites daily or after an authorized PR label, retain
-   raw evidence, and render a concise no-baseline summary. Do not mark this
-   phase complete until a live workflow passes.
+   LOCALLY; SAME-REPOSITORY LABEL PATH LIVE-VALIDATED; SCHEDULED/MANUAL PATH
+   PENDING MERGE):** clean GitHub-hosted jobs run the Luna discovery and intent
+   suites daily or after an authorized PR label, retain raw evidence, and
+   render a concise no-baseline summary. Do not mark this phase complete until
+   the scheduled/manual default-branch path is validated after merge.
 4. **Phase 4 — Braintrust persistence proof of concept (PLANNED):** normalized
    Phase 3 records become durable per-workload/per-agent history without making
    the runner dependent on Braintrust.
@@ -1445,11 +1450,35 @@ captured below; Braintrust persistence is intentionally a later phase.
 
 ### Status
 
-IMPLEMENTED LOCALLY. The runner, schema-v3 suite artifacts, CI reporter,
-workflow, and operational documentation are complete and locally validated.
-Live scheduled/manual/label-authorized execution and paid acceptance remain
-pending; do not mark Phase 3 complete until a live workflow passes its clean
-runner and summary checks.
+IMPLEMENTED LOCALLY; SAME-REPOSITORY LABEL PATH LIVE-VALIDATED. The runner,
+schema-v3 suite artifacts, CI reporter, workflow, and operational documentation
+are complete and locally validated. The corrected label run passed its clean
+runner and summary checks; default-branch scheduled/manual execution remains
+pending merge, so Phase 3 deployment acceptance is not complete.
+
+### Live label-run evidence
+
+The first same-repository label run, `33379420414` at SHA `6f26242`, rendered
+its summary but failed execution validation: discovery was 2/2, intent was
+20/21, authenticated MCP data calls returned `AUTH_REQUIRED`, and
+`docs-discovery` used the GitHits CLI fallback. The root cause was missing
+Codex stdio `env_vars` forwarding. This demonstrates failure detection, not
+model quality.
+
+The corrected same-repository label run
+([workflow run 33380560726](https://github.com/githits-com/githits-cli/actions/runs/33380560726))
+at exact SHA `16fd964` succeeded: discovery took 44 seconds and intent 2
+minutes 24 seconds, with 13 seconds for summary rendering; end to end it ran
+from 10:02:30Z to 10:05:12Z (about 2 minutes 42 seconds). Suite
+wall/cumulative seconds were 24.804/44.386 for discovery and 124.898/454.773
+for intent. The cells were 2/2 and 21/21 at workload concurrency 2/4, using
+Codex CLI 0.151.0. All 125 logical calls (10 + 115) were MCP; there were no
+isolation-violation files, CLI calls/fallbacks, `AUTH_REQUIRED` responses, or
+warnings. Reporter estimates were $0.0265 + $0.2249 (about $0.2514 total),
+with 417 uncached input, 2,474,289 cached input, 701,553 cache-write input,
+22,048 output, and 4,739 reasoning tokens. All 23 Codex configs used only the
+name-only `GITHITS_API_TOKEN` `env_vars` entry and no literal token assignment;
+secret values were not read during inspection.
 
 ### Expected Outcome
 
@@ -1594,35 +1623,37 @@ None.
    status classification, including zero-call discovery, per-tool frequencies,
    unknown telemetry, partial/missing suites, CLI fallback, and isolation
    violations. Implement the pure formatter and thin CLI entrypoint.
-3. **Implemented locally; live validation pending:** Add the dedicated workflow with the three triggers, an explicit
+3. **Implemented locally; same-repository label path live-validated:** Add the dedicated workflow with the three triggers, an explicit
    `github.event.label.name == 'agent-eval'` job gate, same-repository label/SHA
    authorization, clean Codex home and API-key setup, the two scenario jobs,
    unconditional artifact upload/reporting, 14-day retention, and minimal
-   permissions. Keep secret scope to the paid execution steps.
+   permissions. Keep secret scope to the paid execution steps. The corrected
+   label run passed; default-branch scheduled/manual execution remains pending
+   merge.
 4. **Completed locally:** Update local/CI operational documentation, the durable implementation
    contract, and the required no-public-impact change fragment. Document label
    authorization, re-label behavior, exact suites/concurrency, expected
    duration/cost, secret names, and artifact/report locations.
-5. **Local evidence complete; live evidence pending:** Run focused tests, all suite dry-runs at concurrency 1 and the CI-selected
+5. **Local and label evidence complete; scheduled/manual evidence pending merge:** Run focused tests, all suite dry-runs at concurrency 1 and the CI-selected
    values, `bun test`, typecheck, format, lint, build, and workflow syntax/action
-   validation. After secrets are provisioned, manually dispatch the workflow,
-   verify no global skill/guidance reads or CLI fallbacks, compare observed wall
-   time/cost with the baseline, and inspect the rendered summary and downloaded
-   artifacts before enabling the schedule/label operationally.
+   validation. The same-repository label path is live-validated with no global
+   skill/guidance reads or CLI fallbacks. After the change is merged, manually
+   dispatch the workflow and verify the scheduled/default-branch path before
+   treating Phase 3 deployment acceptance as complete.
 
 ### Acceptance Criteria
 
 - Default local execution remains sequential; explicit concurrency never
   exceeds the requested in-flight workload count and preserves manifest order.
-- A trusted manual run and a scheduled default-branch run check out the exact
-  intended SHA and produce 2/2 discovery plus 21/21 intent records, or explicit
-  failed/missing records, with concurrency 2/4 captured in artifacts.
+- A same-repository label run checks out the exact labeled head SHA and
+  produces 2/2 discovery plus 21/21 intent records with concurrency 2/4
+  captured in artifacts; scheduled/default-branch manual execution remains
+  pending merge.
 - A same-repository PR runs only after the exact `agent-eval` label event at the
   labeled head SHA; forks and later unlabeled SHAs cannot consume secrets.
-- A healthy live workflow completes near the evidence-backed 5–6 minute target;
-  actual wall time, cost, and any provider-quota behavior are recorded rather
-  than hidden by retries. Material deviation is investigated before changing
-  concurrency.
+- The corrected same-repository label workflow completed in about 2 minutes 42
+  seconds at an estimated $0.2514 base cost; actual wall time, cost, and any
+  provider-quota behavior are recorded rather than hidden by retries.
 - The GitHub summary concisely shows status, exact Codex CLI/model identity,
   tool calls/tools used, tokens, duration, cost uncertainty, and evidence links
   for both scenarios, with no baseline or `main` comparison.

--- a/docs/plans/systematic-agent-evals.md
+++ b/docs/plans/systematic-agent-evals.md
@@ -1521,7 +1521,8 @@ None.
 
    Ordinary workload failures already return persisted failure evidence; they
    do not prevent unscheduled siblings from running. An unexpected executor
-   exception rejects the run as today. Do not add retries, provider backoff,
+   exception rejects the run as today. An empty suite selection fails during
+   preflight before child execution. Do not add retries, provider backoff,
    locks, a queue, or a scheduler. Concurrent workloads continue to receive
    separate disposable acting-agent homes/workspaces and share only the
    caller-supplied clean `CODEX_HOME`, as current concurrent scenario shards do.
@@ -1576,9 +1577,10 @@ None.
 
    The summary job runs with `if: always()` so missing and failed scenario jobs
    remain visible. Missing/unparseable suite evidence, isolation violations,
-   CLI fallback in an MCP run, timeouts, and failed/missing workload cells make
-   the workflow fail after the summary is written. A successful discovery cell
-   with zero GitHits calls remains a valid observed result. Metric movement
+   CLI fallback in an MCP run, timeouts, zero selected workloads or zero
+   expected executions, and failed/missing workload cells make the workflow
+   fail after the summary is written. A successful discovery cell with zero
+   GitHits calls remains a valid observed result. Metric movement
    alone cannot fail because this phase performs no comparison or thresholding.
 
 ### Ordered Implementation Steps

--- a/docs/plans/systematic-agent-evals.md
+++ b/docs/plans/systematic-agent-evals.md
@@ -3,16 +3,18 @@
 ## Status
 
 - Overall: IN PROGRESS
-- Current phase: Phase 3 — Daily Main Execution And Persistent Export (BLOCKED ON
-  PRODUCT DECISIONS)
+- Current phase: Phase 3 — Parallel CI Execution And Concise Reporting
+  (IMPLEMENTED LOCALLY; LIVE VALIDATION PENDING)
 - Previous work: Phase 2 correction is COMPLETE. Its discovery, intent, full,
   scenario-aware comparison, metrics-compatibility, and Codex interactive
-  isolation contracts are locally validated; daily execution and persistence
-  remain Phase 3 work.
+  isolation contracts are locally validated; CI execution is Phase 3 and
+  Braintrust persistence is Phase 4.
 - Owner: repository maintainers
 - Last verified: 2026-08-31
-- Deployment: Phase 1 merged to `main`; local maintainer tooling is available.
-  Scheduled execution and external persistence remain Phase 3 work.
+- Deployment: Phases 1 and 2 merged to `main`; local maintainer tooling and the
+  Phase 3 workflow/report are implemented. Live scheduled and label-authorized
+  validation is pending. Braintrust persistence is a separate Phase 4
+  increment.
 
 ## Problem And Expected Outcome
 
@@ -40,10 +42,12 @@ When this effort is complete:
   status, and links to the raw evidence;
 - a local paired run can compare a candidate checkout with a main baseline while
   holding agent harness versions and model settings constant;
-- a clean automation runner executes the approved neutral discovery canary
-  across the approved agent/model matrix and the normal Luna intent suite
-  daily from `main`, preserves raw artifacts, and exports the same normalized
-  records to the selected long-term service;
+- a clean automation runner executes the two-workload neutral discovery canary
+  and normal Luna intent suite daily from `main`, or on an explicitly
+  maintainer-authorized pull request, preserves raw artifacts, and renders a
+  concise report without manufacturing a baseline comparison;
+- a later Braintrust integration persists the same normalized records for
+  per-workload/per-agent history without changing the runner contract;
 - daily results are observational and alert on material drift without becoming
   a flaky merge gate; and
 - result quality can be added later through explicit workload rubrics without
@@ -66,15 +70,17 @@ In scope:
   cost, harness versions, and run identity;
 - named canary, smoke, stable-full, stateful-manual, and experimental suites;
 - local baseline/candidate comparison;
-- scheduled and manually dispatched execution from `main` after runner,
-  authentication, budget, and persistence decisions are made;
-- durable raw-artifact retention plus export to a service selected separately;
+- scheduled and manually dispatched execution from `main`, plus a
+  maintainer-label-triggered same-repository pull-request path;
+- short-lived CI raw-artifact retention for diagnosis, followed by a separate
+  Braintrust proof of concept for durable normalized history;
 - an advisory drift policy and a later quality-evaluation extension point.
 
 Out of scope for the initial phases:
 
 - replacing the existing agent process runner with a vendor-owned runner;
-- automatically running paid agent evals on every pull request;
+- automatically running paid agent evals on every pull request or on fork pull
+  requests;
 - treating stochastic agent results as deterministic CI gates;
 - OpenCode or the Agent Skills surface in the first scheduled matrix;
 - automated expansion to Claude or additional Codex models before their exact
@@ -83,7 +89,8 @@ Out of scope for the initial phases:
 - an LLM judge, golden-answer corpus, or composite quality score before a
   workload rubric and judge policy are approved;
 - a repository-owned database, queue, cache, lock, or dashboard;
-- selecting the long-term eval service in this plan.
+- baseline or `main` comparison inside the CI workflow;
+- Braintrust integration in the pipeline increment itself.
 
 ## Verified Current State And Evidence
 
@@ -104,13 +111,16 @@ Out of scope for the initial phases:
 - `.agent-eval/` is gitignored. Each run now writes a normalized `metrics.json`
   artifact, but no durable history exists.
 - `.github/workflows/main.yml` runs the reusable build/test workflow on pushes
-  to `main`. There is no scheduled live-agent workflow and no agent/provider
-  authentication in CI.
-- The current agentic eval documentation deliberately says the harness is
-  human/agent-driven and not CI. This conflicts with the requested daily run.
-  The resolution is to keep deterministic smoke tests as merge gates and make
-  scheduled live-agent evals observational/advisory until measured evidence
-  supports a different policy.
+  to `main`, and `.github/workflows/agent-evals.yml` now defines the scheduled,
+  manual, and same-repository label-authorized Luna workflow. Repository
+  administrators verified the required secret names `OPENAI_API_KEY` and
+  `GITHITS_API_TOKEN` on 2026-08-31 without reading their values. A live
+  workflow run is still required before Phase 3 can be accepted as fully
+  complete.
+- The agentic eval documentation now distinguishes local human/agent-driven
+  inspection from the dedicated CI workflow. Deterministic smoke tests remain
+  merge gates, while scheduled live-agent evals are observational/advisory
+  until measured evidence supports a different policy.
 - The corrected Codex workload and interactive paths require a caller-supplied
   dedicated eval home containing authentication and Codex-managed runtime
   state, keep fresh per-workload OS homes, and reject root-level global
@@ -118,8 +128,7 @@ Out of scope for the initial phases:
   `--ignore-user-config`; interactive `agent:session` omits that exec-only flag,
   strictly validates direct skills/config inputs, and disables the external
   app/plugin surfaces. The clean scenario evidence and the 2026-08-31 manual
-  Luna session now establish the local isolation contract; Phase 3 remains
-  blocked on the service, runner, and budget decisions below.
+  Luna session now establish the local isolation contract.
 - The accepted v4 Luna-low descriptor cell was clean but made zero GitHits calls;
   its paired full-guidance cell made three successful MCP calls. A separate
   clean Luna-high descriptor run on 2026-08-29 also made zero GitHits or CLI
@@ -137,6 +146,25 @@ Out of scope for the initial phases:
   ambient MCP servers, and keeps only the intended local GitHits MCP target.
   Manual Luna validation confirms that caller-global skills do not appear;
   Claude and OpenCode remain non-causal for instruction-isolation evidence.
+
+### Phase 3 concurrency baseline
+
+The corrected Luna-low intent suite took 798,452 ms wall time with workloads
+executed sequentially. Replaying its recorded per-workload durations through a
+deterministic input-order pool gives 411,742 ms at concurrency 2, 280,622 ms at
+3, and 213,885 ms at 4. The corrected discovery canary took 267,221 ms
+sequentially; its two workloads project to 234,795 ms when run together because
+the slower workload dominates. Running discovery and intent as two concurrent
+CI jobs, with workload concurrency 2 and 4 respectively, therefore projects the
+paid-agent critical path at about 3.9 minutes. Setup and reporting should keep a
+healthy workflow near 5–6 minutes. Intent concurrency above 4 would not shorten
+the current critical path, so it would add provider load without useful runtime
+improvement.
+
+The two scheduled suites used an estimated \$0.2297134 in the accepted local
+evidence (\$0.0266578 discovery plus \$0.2030556 intent). This is a base-rate
+estimate with recorded long-context uncertainty, not a billing guarantee.
+Concurrency changes wall time, not the workload count or expected model cost.
 
 ### Bounded planning baseline
 
@@ -187,8 +215,8 @@ historical capacity numbers, not the cost of the revised scenario policy:
 
 Workload mix, the one-line intent prompt, and provider behavior can move these
 figures substantially. The corrected neutral canary and Luna intent suite
-measurements below provide evidence for Phase 3's later budget and timeout
-decisions. The
+measurements below are the evidence used for Phase 3's concurrency, budget, and
+timeout decisions. The
 contaminated two-profile stable-full total cannot be divided in half and called
 a verified intent-suite estimate.
 
@@ -350,16 +378,26 @@ suite manifest
    changes, failures, and harness-version changes. Incompatible dimensions are
    explicit warnings, not silently merged results.
 
-7. **Persistence/export**
+7. **Automation and reporting**
 
-   In Phase 3, GitHub artifacts retain immutable raw evidence for replay and the
-   selected service receives normalized records for long-term per-eval/per-agent
-   trends. The exporter is a thin boundary around the service SDK or API. No
-   repository-owned persistence infrastructure is introduced.
+   Phase 3 composes the existing suite runner in one dedicated GitHub Actions
+   workflow. Discovery and intent are separate jobs, each using a bounded
+   workload pool; a final job reads their validated `suite.json` artifacts and
+   renders one concise GitHub step summary. The workflow never reads a baseline
+   or calculates deltas. Short-lived GitHub artifacts preserve raw evidence for
+   diagnosis, and exact checkout and Codex CLI versions identify the run.
 
-8. **Quality evaluation**
+8. **Persistence/export**
 
-   The final JSON and evidence remain available for later scoring. Phase 5 may
+   Phase 4 maps the same normalized suite records into Braintrust for long-term
+   per-eval/per-agent trends. The exporter remains a thin boundary around the
+   verified Braintrust SDK or API contract. No repository-owned persistence
+   infrastructure is introduced, and the runner does not depend on Braintrust
+   to produce valid local or GitHub artifacts.
+
+9. **Quality evaluation**
+
+   The final JSON and evidence remain available for later scoring. Phase 6 may
    add deterministic workload rubrics first and an optional judge second. The
    agent's current self-reported usefulness/confidence is diagnostic metadata,
    not an authoritative quality score.
@@ -402,23 +440,23 @@ Local policy:
 
 Automation policy after Phase 3:
 
-- run the two-workload neutral descriptor canary from `main` across the approved
-  agent/model cells to detect autonomous-discovery drift;
-- run the normal Luna-low workload set with the one-line intent nudge, with the
-  final daily suite size chosen from corrected timing and cost measurements;
+- run the two-workload neutral descriptor canary with Luna-low to detect
+  autonomous-discovery drift;
+- run the 21-workload Luna-low stable-full suite with the one-line intent nudge;
 - do not run neutral descriptors across the remaining stable workloads and do
   not schedule full guidance by default;
 - keep experimental workloads manual;
-- do not run paid evals automatically on every PR initially;
+- run daily from the default branch and when a maintainer adds the exact
+  `agent-eval` label to a same-repository pull request; later commits require
+  removing and re-adding the label rather than silently reusing authorization;
 - keep the scheduled workflow advisory. Deterministic tests remain the merge
   gate.
 
-The current Phase 3 proposal is to allow daily agent CLI versions to advance so
-harness drift is observable, while recording exact versions. That is not yet an
-approved policy; a pinned control offers stronger attribution at additional
-cost. Local PR comparisons must run baseline and candidate close together with
-the same installed agent versions so repository changes are not confused with
-harness changes.
+Phase 3 intentionally installs the current Codex CLI on each clean runner so
+harness drift is observable, records the exact installed version, and does not
+add a pinned control. Local paired comparisons continue to run baseline and
+candidate close together with the same installed agent version so repository
+changes are not confused with harness changes.
 
 ## Assumptions
 
@@ -427,9 +465,8 @@ harness changes.
   shows a workload is redundant, unsafe, or consistently non-diagnostic.
 - MCP local mode is the initial scheduled surface because it evaluates the
   checkout on `main`.
-- The existing two-shard Luna validation is useful capacity evidence but does
-  not define the corrected scenario matrix. Concurrency and cost must be
-  remeasured for the neutral-canary plus intent-suite shape.
+- The accepted corrected discovery and intent artifacts are the capacity and
+  cost baseline for the first workflow.
 - Daily evals are for regression detection and investigation, not deterministic
   correctness proof.
 - A service-neutral JSON contract lets local work proceed before the team
@@ -437,38 +474,26 @@ harness changes.
 
 ## Unknowns And Product Decisions
 
-None block Phase 1 or Phase 2.
+None block Phase 3 implementation. Live activation and acceptance remain
+pending external workflow execution using the verified `OPENAI_API_KEY` and
+`GITHITS_API_TOKEN` secret names; this is an operational validation dependency,
+not a product decision.
 
-The following must be resolved before Phase 3 is detailed or implemented:
+The following must be resolved before Phase 4 is detailed:
 
-- **Long-term service and retention:** which service receives normalized
-  metrics, whether it also stores raw traces, retention duration, dashboard and
-  alert requirements, and available credits.
-- **Automation runner and authentication:** GitHub-hosted clean Linux is the
-  preferred isolation baseline, but Codex CLI installation and API-key
-  authentication must be verified without exposing credentials. If policy or
-  licensing requires a dedicated runner, that is a user-approved infrastructure
-  decision.
-- **Budget and concurrency:** approve a daily dollar/quota ceiling before Phase
-  3. The measured Luna-only stable-full run cost an estimated \$0.48549548 for
-     both historical profiles, before service charges; it is contaminated capacity
-     evidence, not the revised intent-suite budget.
-- **Harness update policy:** confirm whether daily jobs intentionally install
-  latest agent CLIs, use an approved moving version range, or run both floating
-  and pinned controls. Latest-only is the smallest design that detects harness
-  drift but makes upstream changes part of the daily variance.
-- **Discovery matrix:** approve the exact agent CLI/model/reasoning cells and cadence
-  for the neutral two-workload canary. The manual `claude.ai` observation does
-  not authorize or configure Claude Code automation, and marketed model names
-  alone are insufficient identity.
+- Braintrust project/account ownership, available credits, retention, and the
+  accepted SDK/API ingestion path;
+- whether Braintrust should store raw traces or only normalized records and
+  GitHub artifact links;
+- required dashboard grouping and any Phase 4 notification destination.
 
-The following must be resolved before Phase 4:
+The following must be resolved before Phase 5:
 
 - which additional Codex and Claude agent/model cells are worth retaining in the
   discovery canary after the Luna-only pipeline and service integration are
   stable, including their adapter, authentication, cadence, and budget policy.
 
-The following must be resolved before Phase 5:
+The following must be resolved before Phase 6:
 
 - which workloads need objective quality scoring;
 - rubric ownership and acceptable reference-answer maintenance;
@@ -501,9 +526,8 @@ The following must be resolved before Phase 5:
   replayed after parser fixes.
 - Do not add retries or timer-based workarounds for model, backend, or exporter
   failures. Preserve evidence and fix observed root causes.
-- Service export failure must not destroy the local/GitHub artifact. Phase 3
-  decides whether it fails the advisory workflow or produces a visible partial
-  result based on the selected service contract.
+- A Phase 4 Braintrust export failure must not destroy the local/GitHub artifact.
+  Its workflow status policy will be decided from the verified service contract.
 
 ### Compatibility And Migration
 
@@ -531,8 +555,11 @@ The following must be resolved before Phase 5:
 - Mutable package/backend responses are a confounder for token trends. Preserve
   raw results and result byte counts where exposed so an alert can be
   investigated; do not claim that a token delta alone proves harness drift.
-- Concurrency is bounded by the explicit configured scenario cells. No queue or
-  scheduler is added in the repository.
+- Workload concurrency is an explicit positive integer execution input, defaults
+  to 1 locally, and is recorded in suite identity. The implementation is a small
+  in-process promise pool with deterministic result order, not a queue, scheduler,
+  lock, retry, or persistent coordination layer. CI uses 2 for discovery and 4
+  for intent based on the measured baseline above.
 
 ### Testing
 
@@ -577,14 +604,18 @@ The following must be resolved before Phase 5:
    isolation, and Codex interactive isolation parity are implemented and
    validated; corrected discovery/intent evidence supersedes the two-profile
    behavior policy.
-3. **Phase 3 — daily main execution and persistent export (BLOCKED ON PRODUCT
-   DECISIONS):** a clean runner executes the approved neutral discovery canary
-   and Luna intent suite daily from `main`, retains raw evidence, and exports
-   normalized records to the selected service.
-4. **Phase 4 — broader discovery matrix (PLANNED):** the proven metrics, suite,
-   comparison, and persistence contracts add approved Codex/Claude agent-model
-   cells to the neutral canary without changing Luna history.
-5. **Phase 5 — trend policy and result quality (PLANNED):** historical variance
+3. **Phase 3 — parallel CI execution and concise reporting (IMPLEMENTED
+   LOCALLY; LIVE VALIDATION PENDING):** clean GitHub-hosted jobs run the Luna
+   discovery and intent suites daily or after an authorized PR label, retain
+   raw evidence, and render a concise no-baseline summary. Do not mark this
+   phase complete until a live workflow passes.
+4. **Phase 4 — Braintrust persistence proof of concept (PLANNED):** normalized
+   Phase 3 records become durable per-workload/per-agent history without making
+   the runner dependent on Braintrust.
+5. **Phase 5 — broader discovery matrix (PLANNED):** the proven metrics, suite,
+   CI, and persistence contracts add approved Codex/Claude agent-model cells to
+   the neutral canary without changing Luna history.
+6. **Phase 6 — trend policy and result quality (PLANNED):** historical variance
    supports calibrated drift alerts, and approved workload rubrics optionally
    assess answer quality without changing the execution contract.
 
@@ -820,10 +851,10 @@ automation is designed.
 
 ### Unknowns Or Product Decisions
 
-The exact scheduled discovery model matrix remains a Phase 3 product decision.
-Phase 2 supports explicit scenario/model identity and validates Luna locally;
-it does not spend across an unapproved broad model matrix. The target service
-and automation budget also remain later-phase decisions.
+At Phase 2 completion the scheduled discovery model matrix, target service, and
+automation budget were unresolved. Subsequent user decisions selected Luna-low
+only for Phase 3, separated Braintrust into Phase 4, and retained any broader
+model matrix for Phase 5.
 
 ### Dependencies
 
@@ -969,9 +1000,9 @@ and automation budget also remain later-phase decisions.
    `callsByTool`, and warnings. Raw workload artifacts and child `metrics.json`
    files remain authoritative. Introduce a scenario-aware suite schema version;
    preserve schema-version-1 reading through the deterministic historical
-      descriptor-to-discovery and full-to-full mapping above. Only the exact
-      historical `descriptors` and `full` profiles are valid; missing, null, or
-      other profiles are rejected rather than inferred as `intent`.
+   descriptor-to-discovery and full-to-full mapping above. Only the exact
+   historical `descriptors` and `full` profiles are valid; missing, null, or
+   other profiles are rejected rather than inferred as `intent`.
 
    Live paired mode and offline compare mode call the same pure comparison and
    write a schema-validated `comparison.json` with one pair ID and references to
@@ -1125,7 +1156,7 @@ choice, not a causal requirement of the suite schema.
    actual time/cost; the smoke cohort is measured as the named subset of that
    stable run rather than rerun. This deliberately repeats only the bounded
    package cells after the safety check. Do not spend on a broader model matrix
-   until Phase 3 approves it.
+   without the later explicit rollout decision; Phase 3 now remains Luna-only.
 
 ### Edge Cases And Boundaries
 
@@ -1263,7 +1294,7 @@ choice, not a causal requirement of the suite schema.
       canary wall/cumulative time is 267,221/266,375 ms; stable wall/cumulative
       time is 798,452/796,139 ms. Stable totals are 115 MCP calls, zero CLI
       calls, zero isolation violations, 655,840 uncached and 2,389,760 cached
-      tokens, and an estimated $0.2030556. The named six-workload smoke subset
+      tokens, and an estimated \$0.2030556. The named six-workload smoke subset
       is derived from those same stable metrics and is documented below.
 - [x] Focused tests (178 pass, 1,004 expectations), full tests (3,605 pass,
       12,040 expectations), typecheck, format (442 files), lint (442 files),
@@ -1280,7 +1311,8 @@ choice, not a causal requirement of the suite schema.
 
 COMPLETE — the corrected workload and interactive Codex paths validate the
 disposable acting-agent boundary, trusted MCP authentication, scenario identity,
-and intended tool surface. Phase 3 remains blocked on product decisions.
+and intended tool surface. Subsequent user decisions and measured concurrency
+evidence make Phase 3 ready, subject to CI secret provisioning.
 
 ### Canary evidence and correction history
 
@@ -1342,7 +1374,7 @@ The discovery canary artifact recorded 2/2 process and final successes, 267,221
 ms wall time, 266,375 ms cumulative agent time, two logical MCP `code_files`
 calls (started), zero CLI calls, zero isolation violations, 77,831 uncached
 input, 376,320 cached input, 2,971 output, 591 reasoning-detail tokens, and an
-estimated $0.0266578 with `long_context_pricing_not_attributable` uncertainty.
+estimated \$0.0266578 with `long_context_pricing_not_attributable` uncertainty.
 
 The stable-full intent artifact recorded 21/21 process and final successes with
 no failures, timeouts, or missing cells: 798,452 ms wall time, 796,139 ms
@@ -1373,7 +1405,7 @@ access was needed for this diagnostic; the normal temporary-workspace trust
 prompt required human approval. Two earlier stable intent attempts that waited
 at an unattended macOS Keychain approval prompt are invalid/excluded evidence,
 not a harness timeout defect. Local subscription/keychain-backed runs can
-require operator presence; future daily CI must use separately provisioned
+require operator presence. The daily CI workflow uses separately provisioned
 non-interactive API credentials without copying or reading credentials into
 artifacts.
 
@@ -1405,86 +1437,268 @@ redacted in persisted artifacts.
 Phase 2 correction is complete. The prior 42-cell behavior comparison remains
 contaminated and must not be reinterpreted; v4 remains historical
 discovery/full evidence, while the current scenario artifacts above establish
-the corrected discovery canary and intent suite. Phase 3 remains blocked on the
-existing service, runner, discovery-matrix, authentication, budget, concurrency,
-and retention product decisions.
+the corrected discovery canary and intent suite. The pipeline decisions are
+captured below; Braintrust persistence is intentionally a later phase.
 
-## Phase 3 — Daily Main Execution And Persistent Export
+## Phase 3 — Parallel CI Execution And Concise Reporting
 
 ### Status
 
-BLOCKED ON PRODUCT DECISIONS listed above. Detail this phase after the Phase 2
-scenario/isolation correction and service/runner/budget/discovery-matrix
-selection.
+IMPLEMENTED LOCALLY. The runner, schema-v3 suite artifacts, CI reporter,
+workflow, and operational documentation are complete and locally validated.
+Live scheduled/manual/label-authorized execution and paid acceptance remain
+pending; do not mark Phase 3 complete until a live workflow passes its clean
+runner and summary checks.
 
 ### Expected Outcome
 
-A clean authenticated runner executes the two-workload neutral discovery canary
-for each approved agent/model cell plus the approved Luna-low intent suite daily
-from `main` and on manual dispatch. It retains immutable raw artifacts,
-publishes a human-readable summary, and exports normalized per-workload/scenario
-records to the selected long-term service. Full guidance remains local/manual.
+A clean GitHub-hosted runner executes Luna-low discovery and intent suites in
+parallel each day from the default branch, on trusted manual dispatch, or once
+when a maintainer adds `agent-eval` to a same-repository pull request. A final
+job renders one concise report containing execution status, exact harness
+identity, durations, token buckets, estimated cost, logical call totals, and
+per-tool call counts. It performs no baseline or `main` comparison. Full
+guidance remains local/manual.
 
 ### Assumptions
 
-- Corrected Phase 2 discovery and intent measurements fit the approved daily
-  budget and provider quotas.
-- The selected service accepts the normalized dimensions or can be integrated
-  through a thin mapping layer.
-- The runner can install or provide the required agent CLIs without leaking
-  credentials.
+- The first scheduled shape is the two-workload discovery canary plus the
+  21-workload stable-full intent suite, both Codex `gpt-5.6-luna` at low
+  reasoning.
+- GitHub-hosted Ubuntu is the clean execution boundary. The current Codex CLI is
+  deliberately installed on every run so version drift is measured, and its
+  exact version is captured in existing artifacts and the concise report.
+- A provisional daily schedule of 03:00 UTC is acceptable; changing the cron
+  later does not alter the execution or metrics contract.
+- GitHub artifacts are diagnostic rather than long-term persistence. Retain
+  them for 14 days until Phase 4 establishes the Braintrust retention policy.
+- The accepted \$0.2297134 local estimate is sufficient cost evidence for the
+  first Luna-only daily shape; no hard cost gate is introduced.
 
 ### Unknowns Or Product Decisions
 
-- Service, retention, runner, authentication, daily intent-suite size, discovery
-  agent/model cells and cadence, budget, concurrency, and harness-version policy
-  must be approved before implementation details are added.
+None.
 
 ### Dependencies
 
-- Phase 2 accepted and merged.
-- Approved service and runner decisions.
-- Provider and GitHits automation credentials provisioned outside the
-  repository.
+- Phase 2 accepted and merged at `origin/main` commit `68f4b96`.
+- Repository administrators verified the required secret names
+  `OPENAI_API_KEY` and `GITHITS_API_TOKEN` on 2026-08-31 without reading their
+  values. Secret values are never read into a developer or review session.
+- Existing GitHub-hosted runner access and provider quotas support two
+  discovery calls plus four concurrent intent calls per workflow. Independent
+  schedule, dispatch, and label-triggered workflows may overlap and multiply
+  that load; Phase 3 deliberately adds no cross-run lock or queue, so any
+  resulting provider failure remains visible evidence.
+
+### Affected Components
+
+- `scripts/agent-eval.ts` and focused tests for bounded workload execution;
+- `scripts/agent-eval-suite.ts` and focused tests for CLI propagation,
+  execution identity, and suite validation;
+- a small CI-summary script and its tests, plus a package-script entrypoint;
+- `.github/workflows/agent-evals.yml` as a dedicated paid workflow, leaving the
+  deterministic `main.yml`, `pr.yml`, and reusable `ci.yml` paths unchanged;
+- `eval/agentic/README.md`,
+  `docs/implementation/agentic-eval-metrics.md`, and one maintainer-facing
+  change fragment with `none` impact for both public packages.
+
+### Contracts And Failure Behavior
+
+1. **Bounded workload execution**
+
+   Add an explicit positive-integer `--concurrency` input to the one-off and
+   suite run commands. It defaults to 1, preserving current local behavior.
+   The runner uses a small in-process promise pool, starts at most the requested
+   number of workloads, and stores results in manifest order regardless of
+   completion order. The selected concurrency is recorded in `run.json` and
+   `suite.json` execution metadata so duration evidence remains attributable.
+   The suite writer advances to schema version 3; version 1 and 2 readers
+   normalize absent workload concurrency to 1. It is execution configuration,
+   not a prompt/content compatibility dimension, so it is reported but does not
+   suppress otherwise valid tool/token comparisons.
+
+   Ordinary workload failures already return persisted failure evidence; they
+   do not prevent unscheduled siblings from running. An unexpected executor
+   exception rejects the run as today. Do not add retries, provider backoff,
+   locks, a queue, or a scheduler. Concurrent workloads continue to receive
+   separate disposable acting-agent homes/workspaces and share only the
+   caller-supplied clean `CODEX_HOME`, as current concurrent scenario shards do.
+
+2. **Workflow triggers and authorization**
+
+   Add one workflow with `schedule`, `workflow_dispatch`, and
+   `pull_request: {types: [labeled]}` triggers. Scheduled runs use the workflow
+   from the default branch and check out that exact SHA. PR execution requires
+   both the exact `agent-eval` label event and
+   `head.repo.full_name == github.repository`; it checks out the immutable
+   `github.event.pull_request.head.sha` from that label event. A later
+   `synchronize` event does not rerun while the label remains. Maintainers must
+   remove/re-add the label to authorize a newer SHA.
+
+   Do not use `pull_request_target`, do not accept fork PRs, and set workflow
+   permissions to `contents: read`. Applying the label is authorization to run
+   that reviewed same-repository SHA with provider secrets, including any
+   changes it makes to `.github/workflows/agent-evals.yml`; this operational rule
+   is documented beside the workflow.
+
+3. **Clean Codex and credential boundary**
+
+   Install the current Codex CLI using the official supported installer, then
+   record `codex --version`. Create an empty absolute `CODEX_HOME` under
+   `runner.temp` so the existing validator proves no global `AGENTS.md` or
+   non-system skills are present. Authenticate non-interactively through the
+   official API-key flow and expose provider/GitHits secrets only to the
+   execution steps. The existing environment allowlist passes
+   `OPENAI_API_KEY` and `GITHITS_API_TOKEN`; artifact redaction remains the
+   enforcement boundary. Do not copy local subscription state, Keychain data,
+   user config, skills, or auth files into CI.
+
+4. **Two scenario jobs**
+
+   Run discovery as `canary --scenario discovery --concurrency 2` and intent as
+   `stable-full --scenario intent --concurrency 4` in two matrix entries/jobs.
+   Each job has a 30-minute timeout, uploads its complete suite directory even
+   after a recorded failure, and retains it for 14 days. Full, experimental,
+   stateful, neutral non-canary, Claude, and baseline/candidate cells are absent.
+
+5. **Concise report and workflow status**
+
+   A pure formatter reads one or more schema-validated suite artifacts and
+   emits a compact Markdown table for `$GITHUB_STEP_SUMMARY`. Per scenario it
+   reports suite status, successful/expected cells, wall and cumulative agent
+   time, logical MCP/CLI calls, token buckets, estimated cost/uncertainty,
+   Codex CLI version, isolation/telemetry warnings, and deterministic per-tool
+   logical call counts. It links to the workflow artifacts but does not load a
+   baseline, calculate deltas, or write PR comments.
+
+   The summary job runs with `if: always()` so missing and failed scenario jobs
+   remain visible. Missing/unparseable suite evidence, isolation violations,
+   CLI fallback in an MCP run, timeouts, and failed/missing workload cells make
+   the workflow fail after the summary is written. A successful discovery cell
+   with zero GitHits calls remains a valid observed result. Metric movement
+   alone cannot fail because this phase performs no comparison or thresholding.
+
+### Ordered Implementation Steps
+
+1. **Completed:** Add focused failing tests for concurrency parsing, a maximum-in-flight
+   invariant, continued execution after ordinary workload failure, unexpected
+   executor rejection, and manifest-order output. Implement the minimal pool and
+   record/propagate the selected value through run and suite artifacts while
+   keeping default concurrency 1.
+2. **Completed:** Add focused failing tests for compact multi-suite Markdown output and its
+   status classification, including zero-call discovery, per-tool frequencies,
+   unknown telemetry, partial/missing suites, CLI fallback, and isolation
+   violations. Implement the pure formatter and thin CLI entrypoint.
+3. **Implemented locally; live validation pending:** Add the dedicated workflow with the three triggers, an explicit
+   `github.event.label.name == 'agent-eval'` job gate, same-repository label/SHA
+   authorization, clean Codex home and API-key setup, the two scenario jobs,
+   unconditional artifact upload/reporting, 14-day retention, and minimal
+   permissions. Keep secret scope to the paid execution steps.
+4. **Completed locally:** Update local/CI operational documentation, the durable implementation
+   contract, and the required no-public-impact change fragment. Document label
+   authorization, re-label behavior, exact suites/concurrency, expected
+   duration/cost, secret names, and artifact/report locations.
+5. **Local evidence complete; live evidence pending:** Run focused tests, all suite dry-runs at concurrency 1 and the CI-selected
+   values, `bun test`, typecheck, format, lint, build, and workflow syntax/action
+   validation. After secrets are provisioned, manually dispatch the workflow,
+   verify no global skill/guidance reads or CLI fallbacks, compare observed wall
+   time/cost with the baseline, and inspect the rendered summary and downloaded
+   artifacts before enabling the schedule/label operationally.
 
 ### Acceptance Criteria
 
-- A scheduled run checks out the exact `main` SHA and produces all expected
-  neutral-canary and intent-suite records or explicit partial-failure records.
-- Exact agent CLI versions and resolved models make harness drift identifiable.
-- Raw artifacts and normalized metrics survive the runner lifecycle for the
-  approved retention period.
-- The selected service shows persistent trends by workload, agent, exact agent
-  CLI version, guidance, and intent for tool calls/tools used, token buckets, duration, cost,
-  and failures.
-- No credentials appear in artifacts, logs, workflow annotations, or exporter
-  payloads.
-- The workflow is advisory and does not block `main` or PR merges.
-- A manual dispatch can reproduce the same suite/configuration.
-- No scheduled full-guidance cells or neutral descriptor runs outside canary are
-  present unless a later explicit policy change approves them.
+- Default local execution remains sequential; explicit concurrency never
+  exceeds the requested in-flight workload count and preserves manifest order.
+- A trusted manual run and a scheduled default-branch run check out the exact
+  intended SHA and produce 2/2 discovery plus 21/21 intent records, or explicit
+  failed/missing records, with concurrency 2/4 captured in artifacts.
+- A same-repository PR runs only after the exact `agent-eval` label event at the
+  labeled head SHA; forks and later unlabeled SHAs cannot consume secrets.
+- A healthy live workflow completes near the evidence-backed 5–6 minute target;
+  actual wall time, cost, and any provider-quota behavior are recorded rather
+  than hidden by retries. Material deviation is investigated before changing
+  concurrency.
+- The GitHub summary concisely shows status, exact Codex CLI/model identity,
+  tool calls/tools used, tokens, duration, cost uncertainty, and evidence links
+  for both scenarios, with no baseline or `main` comparison.
+- Execution-invalid evidence makes the workflow red only after the summary is
+  rendered; zero-call discovery and ordinary metric values remain advisory.
+- No secret value, local auth state, global guidance, or personal skill appears
+  in logs, artifacts, summaries, or acting-agent context.
+- Raw/normalized artifacts remain downloadable for 14 days; no Braintrust SDK,
+  exporter, repository persistence, queue, retry, lock, or quality judge is
+  introduced.
 
-## Phase 4 — Broader Discovery Matrix
+## Phase 4 — Braintrust Persistence Proof Of Concept
 
 ### Status
 
-PLANNED. Detail only after the Luna-only pipeline and selected service have been
-validated in Phase 3 and the user approves specific additional cells.
+PLANNED. Reorient and detail after Phase 3 is merged and its first clean runner
+evidence is available.
+
+### Expected Outcome
+
+Braintrust persistently exposes each Luna workload/scenario execution and its
+tool-call frequencies, tools used, token buckets, duration, estimated cost,
+status, repository SHA, exact Codex CLI/model identity, and links to raw CI
+evidence. Local and GitHub suite generation remain fully functional when
+Braintrust is unavailable.
+
+### Assumptions
+
+- Phase 3's normalized records are sufficient input; Braintrust does not become
+  the source of truth for raw provider evidence.
+- The service can accept the existing versioned dimensions through a thin
+  mapping rather than forcing runner-specific instrumentation.
+
+### Unknowns Or Product Decisions
+
+- Braintrust account/project ownership, available credits, authentication,
+  retention, and ingestion API/SDK.
+- Whether raw traces are uploaded or retained only in GitHub with durable links.
+- Dashboard grouping and whether exporter failure makes the advisory workflow
+  partial or failed.
+
+### Dependencies
+
+- Phase 3 accepted and merged.
+- Approved Braintrust proof-of-concept contract and credentials.
+
+### Acceptance Criteria
+
+- Braintrust shows durable records grouped by workload, agent, exact CLI/model,
+  reasoning, guidance, and intent, including per-tool call counts, token
+  buckets, duration, estimated cost/uncertainty, and failures.
+- Exported values reconcile to the source `suite.json`/`metrics.json` artifacts,
+  and missing telemetry remains unknown rather than zero.
+- Export failure never destroys raw GitHub evidence and cannot prevent local
+  suite/report generation.
+- No Braintrust credential appears in logs, artifacts, summaries, or records.
+- The proof of concept adds no repository database, queue, retry layer, or
+  runner replacement.
+
+## Phase 5 — Broader Discovery Matrix
+
+### Status
+
+PLANNED. Detail only after the Luna-only pipeline and Braintrust proof of
+concept have been validated and the user approves specific additional cells.
 
 ### Expected Outcome
 
 Approved additional Codex and Claude agent/model cells use the same neutral
-two-workload discovery canary, normalized metrics, comparison, and persistence
+two-workload discovery canary, normalized metrics, CI report, and persistence
 contracts as Luna. This tracks which agents autonomously select registered
-GitHits tools without rewriting Luna history or coupling service export to one
+GitHits tools without rewriting Luna history or coupling persistence to one
 provider.
 
 ### Assumptions
 
-- Phase 3 has exposed and resolved the initial harness, runner, authentication,
-  and service-integration bumps.
-- Each added agent CLI has a provider adapter sufficient for tool, token, duration,
-  cost, and identity telemetry before it enters the scheduled matrix.
+- Phases 3 and 4 have exposed and resolved the initial harness, runner,
+  authentication, and service-integration bumps.
+- Each added agent CLI has a provider adapter sufficient for tool, token,
+  duration, cost, and identity telemetry before entering the scheduled matrix.
 
 ### Unknowns Or Product Decisions
 
@@ -1497,22 +1711,21 @@ provider.
 
 ### Dependencies
 
-- Phase 3 accepted and merged.
+- Phases 3 and 4 accepted and merged.
 - Approved broader-matrix rollout and budget decision.
 
 ### Acceptance Criteria
 
-- Usage, cost, tool, duration, agent CLI, and identity metrics conform to the same
-  versioned contract without changing historical Luna records.
-- Every new agent CLI's neutral prompt and isolation are verified on the automation
-  runner before results are treated as causal discovery evidence.
-- The selected service compares trends only within compatible agent/model/
-  reasoning/scenario dimensions; cross-agent values remain explicitly
-  non-equivalent.
+- Usage, cost, tool, duration, agent CLI, and identity metrics conform to the
+  same versioned contract without changing historical Luna records.
+- Every new agent CLI's neutral prompt and isolation are verified on the clean
+  automation runner before results are treated as causal discovery evidence.
+- Braintrust compares trends only within compatible agent/model/reasoning/
+  scenario dimensions; cross-agent values remain explicitly non-equivalent.
 - The approved canary matrix runs within its measured budget and preserves the
   same raw-artifact and credential-redaction guarantees.
 
-## Phase 5 — Trend Policy And Result Quality
+## Phase 6 — Trend Policy And Result Quality
 
 ### Status
 
@@ -1527,7 +1740,7 @@ rubrics with the score and judge provenance stored beside operational metrics.
 
 ### Assumptions
 
-- Phase 3 provides queryable Luna history and raw evidence; Phase 4 provides
+- Phase 4 provides queryable Luna history and raw evidence; Phase 5 provides
   broader discovery history if that rollout has been approved.
 - Alerting thresholds are based on observed variance rather than the initial
   eight-run sample.
@@ -1540,7 +1753,7 @@ rubrics with the score and judge provenance stored beside operational metrics.
 
 ### Dependencies
 
-- Phase 3 accepted and merged; Phase 4 is required only for additional-model
+- Phase 4 accepted and merged; Phase 5 is required only for additional-model
   trend or quality policy.
 - Approved quality and alerting decisions.
 
@@ -1564,21 +1777,21 @@ detailing or implementing the next phase. Update this plan with changed
 assumptions, decisions, measured timing/cost evidence, architecture, and scope.
 Do not proceed when `$next-steps` reports `REPLAN` or `PRODUCT INPUT NEEDED`.
 
-At the Phase 2 boundary, explicitly bring the service, runner/authentication,
-budget, concurrency, discovery agent/model cells, intent-suite size, and harness-
-update decisions to the user with the corrected measurements. At the Phase 3
-boundary, bring the broader discovery-matrix decision to the user with the
-observed Luna pipeline evidence. Bring the quality/alerting policy at the Phase
-4 or Phase 5 boundary with observed historical variance.
+At the Phase 3 boundary, record actual CI duration, cost, concurrency behavior,
+Codex version, quota failures, summary usefulness, and any isolation or fallback
+evidence, then resolve the Braintrust contract before detailing Phase 4. At the
+Phase 4 boundary, bring the broader discovery-matrix decision to the user with
+the observed Luna pipeline and persistence evidence. Bring the quality/alerting
+policy at the Phase 5 or Phase 6 boundary with observed historical variance.
 
 ## Completion And Cleanup
 
 The overall effort is complete when:
 
 - local named suites and paired comparisons are documented and verified;
-- the daily neutral discovery canary and approved Luna intent suite persist raw
-  and normalized evidence;
-- the selected service exposes the required per-workload/per-agent trends;
+- the daily and label-authorized neutral discovery canary and Luna intent suite
+  preserve raw and normalized evidence and render concise CI reports;
+- Braintrust exposes the required per-workload/per-agent trends;
 - the advisory drift policy is documented;
 - any approved quality rubric is implemented or explicitly recorded as out of
   scope; and

--- a/docs/plans/systematic-agent-evals.md
+++ b/docs/plans/systematic-agent-evals.md
@@ -1559,7 +1559,7 @@ None.
 
    Run discovery as `canary --scenario discovery --concurrency 2` and intent as
    `stable-full --scenario intent --concurrency 4` in two matrix entries/jobs.
-   Each job has a 30-minute timeout, uploads its complete suite directory even
+   Each job has a 40-minute timeout, uploads its complete suite directory even
    after a recorded failure, and retains it for 14 days. Full, experimental,
    stateful, neutral non-canary, Claude, and baseline/candidate cells are absent.
 

--- a/eval/agentic/README.md
+++ b/eval/agentic/README.md
@@ -110,7 +110,9 @@ Windows.
 
 The CI workflow creates a clean `CODEX_HOME` and authenticates Codex with
 `OPENAI_API_KEY`. It sets `GITHITS_API_TOKEN` for deterministic GitHits
-authentication. Never copy a personal auth file into a run directory.
+authentication. Codex receives that token only by variable name through the MCP
+server's `env_vars`; the value is never written to `codex-config.toml` or an
+eval artifact. Never copy a personal auth file into a run directory.
 Non-interactive eval commands retain the supported `--ignore-user-config` and
 explicitly disable Codex's `apps`, `plugins`, and `remote_plugin` features. The
 flag suppresses Codex `config.toml`/user configuration only; explicit preflight

--- a/eval/agentic/README.md
+++ b/eval/agentic/README.md
@@ -7,18 +7,20 @@ effectively from the exposed guidance.
 It is not a smoke test. Smoke tests exercise CLI and MCP contracts directly.
 Agentic evals exercise agent behavior end-to-end.
 
-This harness is intentionally human/agent-driven, not CI. Use it to understand
-how MCP tool-description, quick-start, or skill changes affect real agent
-behavior. Do not treat a live agent pass/fail result as a deterministic
+Use this harness locally to understand how MCP tool-description, quick-start,
+or skill changes affect real agent behavior. The dedicated CI workflow runs a
+small Luna matrix daily and on explicitly authorized same-repository pull
+requests. Do not treat a live agent pass/fail result as a deterministic
 regression test: model behavior, backend indexing state, auth state, network
 conditions, and package data can all change. The useful output is the artifact
 set, especially `tool-calls.json`, `final.json`, `metrics.json`, `report.json`,
 and `isolation-violations.json`.
 
-The repository-local named-suite commands below are the Phase 2 measurement
+The repository-local named-suite commands below are the local measurement
 workflow. They run the fixed Luna matrix and produce validated suite and
-comparison artifacts, but they do not yet schedule paid runs, retain history in
-a service, or judge answer quality.
+comparison artifacts. The CI workflow composes the same commands for daily and
+explicitly authorized pull-request runs; it retains raw artifacts for diagnosis
+but does not provide long-term service history or judge answer quality.
 
 ## What Is Under Test
 
@@ -106,8 +108,8 @@ environment. When an optional config root is unset, the harness uses the
 platform default: `HOME/.config` on POSIX or `USERPROFILE/AppData/Roaming` on
 Windows.
 
-CI should create a clean `CODEX_HOME` and authenticate Codex with
-`OPENAI_API_KEY`. Set `GITHITS_API_TOKEN` for deterministic GitHits
+The CI workflow creates a clean `CODEX_HOME` and authenticates Codex with
+`OPENAI_API_KEY`. It sets `GITHITS_API_TOKEN` for deterministic GitHits
 authentication. Never copy a personal auth file into a run directory.
 Non-interactive eval commands retain the supported `--ignore-user-config` and
 explicitly disable Codex's `apps`, `plugins`, and `remote_plugin` features. The
@@ -185,9 +187,9 @@ access was needed for this diagnostic; the normal temporary-workspace trust
 prompt required human approval. Two earlier stable intent attempts that waited
 at an unattended macOS Keychain approval prompt are invalid/excluded evidence,
 not a harness timeout defect. Local subscription/keychain-backed runs can
-require operator presence; daily CI remains a future decision and must use
-separately provisioned non-interactive API credentials without copying or
-reading credentials into artifacts.
+require operator presence. The daily CI workflow uses separately provisioned
+non-interactive API credentials without copying or reading credentials into
+artifacts.
 
 Trace validation fails an MCP workload if it observes an external
 `AGENTS.md`/`SKILL.md` read, a guidance read in the descriptor profile, or any
@@ -235,8 +237,8 @@ curated workload policy rather than one manually selected workload:
 
 ```bash
 # One target checkout; default output is .agent-eval/suites/<timestamp>
-bun run agent:e2e:suite run --suite canary --dry-run
-bun run agent:e2e:suite run --suite smoke --out .agent-eval/suites/smoke-local
+bun run agent:e2e:suite run --suite canary --concurrency 2 --dry-run
+bun run agent:e2e:suite run --suite smoke --concurrency 4 --out .agent-eval/suites/smoke-local
 
 # Compare the current checkout with an explicit baseline target checkout
 bun run agent:e2e:suite pair --suite canary --baseline-root ../githits-main --dry-run
@@ -262,7 +264,10 @@ workloads never enter those stable suites.
 
 Every named suite uses exactly Codex `gpt-5.6-luna`, reasoning `low`, local MCP,
 and scenario-keyed shards. Shards may run concurrently; workloads remain
-sequential within each shard. By default, `canary` runs `discovery` and
+sequential within each shard. Workload concurrency defaults to `1` locally and
+is recorded in `run.json` and schema-v3 `suite.json`; set it explicitly when
+you want a bounded local pool. CI runs `discovery` with concurrency `2` and
+`intent` with concurrency `4`. By default, `canary` runs `discovery` and
 `intent`; `smoke`, `stable-full`, `stateful-manual`, and `experimental` run
 `intent` only. Repeatable `--scenario discovery|intent|full` explicitly selects
 the scenario cells and replaces the default selection, so `full` is a local or
@@ -305,7 +310,11 @@ MCP and CLI rows. Raw provider event counts remain separate audit evidence.
 `callsByTool: null`, unknown token/cost/duration values, and missing cell IDs
 mean telemetry was not available or was inconsistent; they are never silently
 converted to zero. Partial shards preserve their successful sibling and the
-full status matrix. Suite and comparison artifacts are schema version 2.
+full status matrix. Suite artifacts are schema version 3 and record
+`workloadConcurrency` as execution metadata. Version-1 and version-2 suite
+artifacts remain readable and normalize a missing concurrency value to `1`.
+Comparison output does not treat concurrency as a content dimension, so valid
+metric deltas remain visible.
 
 Pair/offline comparison matches cells by scenario and workload. Agent, model,
 reasoning, guidance profile, intent profile, and intent-fragment hash must also
@@ -322,9 +331,64 @@ descriptor shards/cells to `discovery` and full to `full`; missing, null, or
 other profiles are rejected rather than mapped to `intent`. Legacy child
 `metrics.json` files use the one-off v1 metrics normalizer.
 
-These local commands are diagnostic measurement tools. Paid CI scheduling,
-persistent result history, service export, Haiku coverage, and quality judging
-remain later phases.
+These local commands are diagnostic measurement tools. CI scheduling is
+implemented by `.github/workflows/agent-evals.yml`; persistent result history,
+service export, Haiku coverage, and quality judging remain later phases.
+
+## Daily CI workflow
+
+`.github/workflows/agent-evals.yml` runs the two initial Luna-low cells in
+parallel on GitHub-hosted Ubuntu:
+
+| Job       | Suite                  | Scenario    | Workload concurrency |
+| --------- | ---------------------- | ----------- | -------------------: |
+| discovery | `canary`                | `discovery` |                    2 |
+| intent    | `stable-full`           | `intent`    |                    4 |
+
+The workflow runs at 03:00 UTC from the default branch, on manual
+`workflow_dispatch`, and for a `pull_request` `labeled` event targeting
+`main`. A pull request run is authorized only when the event label is exactly
+`agent-eval` and `github.event.pull_request.head.repo.full_name` equals the
+repository; forks cannot consume the provider secrets. The workflow checks out
+the immutable labeled head SHA for that event and `github.sha` for scheduled or
+manual runs. Later commits on a still-labeled pull request do not rerun the
+workflow; remove and re-add the label to authorize the newer SHA. Applying the
+label is an explicit maintainer review of the code and any changes to
+`.github/workflows/agent-evals.yml` before granting that SHA access to paid
+credentials.
+
+Each scenario job has a 30-minute timeout and creates its output directory
+under `runner.temp` before checkout or setup. It installs the current Codex CLI
+and records `codex --version`, creates an empty per-scenario `CODEX_HOME`, and
+authenticates through Codex's stdin API-key flow. `OPENAI_API_KEY` is scoped to
+that authentication step; `GITHITS_API_TOKEN` is scoped only to the paid suite
+execution. Local subscription state, Keychain data, personal skills, and user
+configuration are never copied into CI. The scenario directories are uploaded
+as `agent-eval-discovery` and `agent-eval-intent` artifacts for 14 days.
+
+The final summary job always runs for an authorized workflow, downloads both
+scenario artifacts without flattening them, and appends the concise report to
+`GITHUB_STEP_SUMMARY`. The local equivalent is:
+
+```bash
+bun run agent:e2e:ci-report \
+  --suite discovery=.agent-eval/ci-validation/discovery/suite.json \
+  --suite intent=.agent-eval/ci-validation/intent/suite.json \
+  --out .agent-eval/ci-validation/summary.md
+```
+
+The report is absolute: it links to the workflow run, shows schema/harness and
+Codex identity, successful/expected cells, wall and cumulative time, logical
+MCP/CLI calls, deterministic per-tool counts, token buckets, cost uncertainty,
+concurrency, and warnings. It never loads a baseline or calculates deltas.
+Missing or malformed suite evidence, partial/failed/timeout execution, unknown
+or missing workload cells, CLI fallback, and isolation violations make the
+workflow fail only after the report is rendered. A successful discovery run
+with zero GitHits calls and ordinary telemetry warnings remain advisory. The
+initial healthy two-job path is expected to take about 5–6 minutes and costs
+about $0.23 as a base-rate estimate, not a billing guarantee. The workflow
+does not judge answer quality or provide persistent history; those are later
+service work.
 
 For ad hoc interactive testing with the same MCP/skills setup logic:
 
@@ -378,6 +442,7 @@ Useful options:
                                 One-off prompt intent; defaults to `neutral`
 --reasoning-effort <minimal|low|medium|high|xhigh|max|ultra>
                                 Codex reasoning effort; automated Codex defaults to `high`
+--concurrency <positive integer> Maximum workloads in flight; defaults to `1`
 --dry-run                       Generate artifacts without invoking the agent
 --out <dir>                     Output directory, default `.agent-eval/runs/<timestamp>`
 --timeout <seconds>             Per-workload timeout, default 300
@@ -505,9 +570,9 @@ bun run agent:e2e:report .agent-eval/runs/<run>
 ```
 
 Named suites are available through `agent:e2e:suite`. Use
-`--scenario full` for a local/manual full-guidance run; daily pipeline
-execution, persistent result history, service export, and quality judging
-remain later phases.
+`--scenario full` for a local/manual full-guidance run. Daily pipeline
+execution is provided by `.github/workflows/agent-evals.yml`; persistent result
+history, service export, and quality judging remain later phases.
 
 For broad skill edits, run at least:
 

--- a/eval/agentic/README.md
+++ b/eval/agentic/README.md
@@ -270,7 +270,8 @@ recorded in `run.json` and schema-v3 `suite.json`. CI runs `discovery` with
 concurrency `2` and `intent` with concurrency `4`. By default, `canary` runs
 `discovery` and `intent`; `smoke`, `stable-full`, `stateful-manual`, and
 `experimental` run
-`intent` only. Repeatable `--scenario discovery|intent|full` explicitly selects
+`intent` only. An empty suite selection fails during preflight before child
+execution. Repeatable `--scenario discovery|intent|full` explicitly selects
 the scenario cells and replaces the default selection, so `full` is a local or
 manual opt-in. The experimental suite passes the explicit experimental-tools
 option. The pair command runs the baseline target fully before the current
@@ -382,11 +383,12 @@ The report is absolute: it links to the workflow run, shows schema/harness and
 Codex identity, successful/expected cells, wall and cumulative time, logical
 MCP/CLI calls, deterministic per-tool counts, token buckets, cost uncertainty,
 concurrency, and warnings. It never loads a baseline or calculates deltas.
-Missing or malformed suite evidence, partial/failed/timeout execution, unknown
-or missing workload cells, CLI fallback, and isolation violations make the
-workflow fail only after the report is rendered. A successful discovery run
-with zero GitHits calls and ordinary telemetry warnings remain advisory. The
-initial healthy two-job path is expected to take about 5–6 minutes and costs
+Missing or malformed suite evidence, zero selected workloads or zero expected
+executions, partial/failed/timeout execution, unknown or missing workload cells,
+CLI fallback, and isolation violations make the workflow fail only after the
+report is rendered. A successful discovery run with zero GitHits calls and
+ordinary telemetry warnings remain advisory. The initial healthy two-job path
+is expected to take about 5–6 minutes and costs
 about $0.23 as a base-rate estimate, not a billing guarantee. The workflow
 does not judge answer quality or provide persistent history; those are later
 service work.

--- a/eval/agentic/README.md
+++ b/eval/agentic/README.md
@@ -263,12 +263,13 @@ subset of smoke, smoke is a subset of stable-full, and stateful or experimental
 workloads never enter those stable suites.
 
 Every named suite uses exactly Codex `gpt-5.6-luna`, reasoning `low`, local MCP,
-and scenario-keyed shards. Shards may run concurrently; workloads remain
-sequential within each shard. Workload concurrency defaults to `1` locally and
-is recorded in `run.json` and schema-v3 `suite.json`; set it explicitly when
-you want a bounded local pool. CI runs `discovery` with concurrency `2` and
-`intent` with concurrency `4`. By default, `canary` runs `discovery` and
-`intent`; `smoke`, `stable-full`, `stateful-manual`, and `experimental` run
+and scenario-keyed shards. Shards may run concurrently; each shard runs its
+workloads through a bounded pool selected by `workloadConcurrency`, which
+defaults to `1` locally. Results remain in manifest order and the value is
+recorded in `run.json` and schema-v3 `suite.json`. CI runs `discovery` with
+concurrency `2` and `intent` with concurrency `4`. By default, `canary` runs
+`discovery` and `intent`; `smoke`, `stable-full`, `stateful-manual`, and
+`experimental` run
 `intent` only. Repeatable `--scenario discovery|intent|full` explicitly selects
 the scenario cells and replaces the default selection, so `full` is a local or
 manual opt-in. The experimental suite passes the explicit experimental-tools

--- a/eval/agentic/README.md
+++ b/eval/agentic/README.md
@@ -358,7 +358,7 @@ label is an explicit maintainer review of the code and any changes to
 `.github/workflows/agent-evals.yml` before granting that SHA access to paid
 credentials.
 
-Each scenario job has a 30-minute timeout and creates its output directory
+Each scenario job has a 40-minute timeout and creates its output directory
 under `runner.temp` before checkout or setup. It installs the current Codex CLI
 and records `codex --version`, creates an empty per-scenario `CODEX_HOME`, and
 authenticates through Codex's stdin API-key flow. `OPENAI_API_KEY` is scoped to

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "agent:e2e": "bun run scripts/agent-eval.ts",
     "agent:e2e:suite": "bun run scripts/agent-eval-suite.ts",
     "agent:e2e:report": "bun run scripts/agent-eval-report.ts",
+    "agent:e2e:ci-report": "bun run scripts/agent-eval-ci-report.ts",
     "agent:session": "bun run scripts/agent-session.ts",
     "eval": "bun run eval/run.ts",
     "test": "bun test",

--- a/scripts/agent-eval-ci-report.test.ts
+++ b/scripts/agent-eval-ci-report.test.ts
@@ -222,6 +222,28 @@ describe("agent eval CI report", () => {
     expect(result.markdown).toContain("dry_run_no_telemetry");
   });
 
+  it("fails suite evidence with no expected executions", () => {
+    const base = suiteArtifact();
+    const artifact = suiteArtifact({
+      selectedWorkloads: [],
+      contentIdentity: { ...base.contentIdentity, workloads: [] },
+      cells: [],
+      totals: {
+        ...base.totals,
+        expectedExecutions: 0,
+        observedExecutions: 0,
+        successfulExecutions: 0,
+        workloadCount: 0,
+      },
+    });
+    const result = formatAgentEvalCiReport({
+      suites: [{ label: "empty", artifact }],
+    });
+    expect(result.failed).toBe(true);
+    expect(result.markdown).toContain("| empty | FAIL | 0/0 |");
+    expect(result.markdown).toContain("suite has no expected executions");
+  });
+
   it("renders unknown tool and token telemetry without failing", () => {
     const result = formatAgentEvalCiReport({
       suites: [

--- a/scripts/agent-eval-ci-report.test.ts
+++ b/scripts/agent-eval-ci-report.test.ts
@@ -1,0 +1,497 @@
+import { describe, expect, it } from "bun:test";
+import { randomUUID } from "node:crypto";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  formatAgentEvalCiReport,
+  parseAgentEvalCiReportArgs,
+  runAgentEvalCiReportCli,
+} from "./agent-eval-ci-report.ts";
+import { LUNA_MODEL } from "./agent-eval-metrics.ts";
+import {
+  type AgentEvalSuiteArtifact,
+  parseSuiteArtifact,
+} from "./agent-eval-suite.ts";
+
+const HASH = "a".repeat(64);
+
+function suiteArtifact(
+  overrides: Partial<AgentEvalSuiteArtifact> = {},
+): AgentEvalSuiteArtifact {
+  return parseSuiteArtifact({
+    schemaVersion: 3,
+    suiteId: randomUUID(),
+    suiteName: "canary",
+    status: "success",
+    dryRun: false,
+    startedAt: "2026-08-31T00:00:00.000Z",
+    completedAt: "2026-08-31T00:00:01.250Z",
+    measurementRoot: "/repo",
+    measurementGit: { branch: "main", sha: "harness-sha", dirty: false },
+    targetRoot: "/repo",
+    targetGit: { branch: "main", sha: "target-sha", dirty: false },
+    matrix: {
+      agent: "codex",
+      model: LUNA_MODEL,
+      reasoningEffort: "low",
+      surface: "mcp",
+      server: "local",
+      scenarios: ["discovery"],
+    },
+    selectedWorkloads: [
+      {
+        id: "stable-a",
+        path: "eval/agentic/workloads/stable-a.md",
+        safety: "stable",
+      },
+    ],
+    contentIdentity: {
+      workloads: [
+        {
+          path: "eval/agentic/workloads/stable-a.md",
+          sha256: HASH,
+          bytes: 10,
+        },
+      ],
+      reportingContract: {
+        path: "eval/agentic/workloads/REPORTING.md",
+        sha256: HASH,
+        bytes: 10,
+      },
+      resultSchema: {
+        path: "eval/agentic/schema.json",
+        sha256: HASH,
+        bytes: 10,
+      },
+    },
+    targetGuidanceIdentity: {
+      skillFiles: [],
+      guidanceBlock: { sha256: HASH, bytes: 10 },
+    },
+    shards: [
+      {
+        scenario: "discovery",
+        profile: "descriptors",
+        guidanceProfile: "descriptors",
+        intentProfile: "neutral",
+        intentFragmentHash: null,
+        agent: "codex",
+        model: LUNA_MODEL,
+        reasoningEffort: "low",
+        status: "success",
+        error: null,
+        runPath: "shards/discovery/run.json",
+        metricsPath: "shards/discovery/metrics.json",
+        reportPath: "shards/discovery/report.json",
+      },
+    ],
+    cells: [
+      {
+        id: "discovery/stable-a",
+        scenario: "discovery",
+        profile: "descriptors",
+        guidanceProfile: "descriptors",
+        intentProfile: "neutral",
+        intentFragmentHash: null,
+        agent: "codex",
+        model: LUNA_MODEL,
+        reasoningEffort: "low",
+        workloadId: "stable-a",
+        workloadPath: "eval/agentic/workloads/stable-a.md",
+        status: "success",
+        durationMs: 1_250,
+      },
+    ],
+    wallTimeMs: 1_250,
+    cumulativeAgentTimeMs: 1_250,
+    workloadConcurrency: 2,
+    totals: {
+      expectedExecutions: 1,
+      observedExecutions: 1,
+      successfulExecutions: 1,
+      failedExecutions: 0,
+      unknownExecutions: 0,
+      missingExecutions: 0,
+      workloadCount: 1,
+      failedWorkloadCount: 0,
+      missingWorkloadCount: 0,
+    },
+    logicalToolCalls: 3,
+    tokens: {
+      uncachedInputTokens: 100,
+      cachedInputTokens: 20,
+      cacheWriteInputTokens: 5,
+      outputTokens: 30,
+      reasoningOutputTokens: 10,
+    },
+    cost: {
+      kind: "base_rate_estimate",
+      usd: 0.01234,
+      uncertainty: "rate_based_estimate",
+    },
+    callsByTool: [
+      {
+        surface: "mcp",
+        tool: "z_tool",
+        total: 1,
+        started: 1,
+        completed: 1,
+        failed: 0,
+        unknown: 0,
+      },
+      {
+        surface: "mcp",
+        tool: "a_tool",
+        total: 2,
+        started: 2,
+        completed: 1,
+        failed: 1,
+        unknown: 0,
+      },
+    ],
+    missingToolTelemetryCellIds: [],
+    codexVersions: ["codex 1.2.3"],
+    warnings: [],
+    ...overrides,
+  });
+}
+
+function writeJson(path: string, value: unknown): void {
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+describe("agent eval CI report", () => {
+  it("formats valid success with identity, metrics, concurrency, and tool counts", () => {
+    const result = formatAgentEvalCiReport({
+      suites: [{ label: "discovery", artifact: suiteArtifact() }],
+    });
+    expect(result.failed).toBe(false);
+    expect(result.markdown).toContain("| discovery | PASS | 1/1 |");
+    expect(result.markdown).toContain("schema v3; harness harness-sha");
+    expect(result.markdown).toContain("Concurrency");
+    expect(result.markdown).toContain("| 2 |");
+    expect(result.markdown).toContain("codex 1.2.3");
+    expect(result.markdown).toContain(
+      "in=100 cached=20 write=5 out=30 reasoning=10",
+    );
+    expect(result.markdown).toContain("$0.0123 (rate_based_estimate)");
+    expect(result.markdown).toContain("mcp/a_tool");
+    expect(result.markdown).toContain(
+      "total 2 (started 2, completed 1, failed 1, unknown 0)",
+    );
+    expect(result.markdown.indexOf("mcp/a_tool")).toBeLessThan(
+      result.markdown.indexOf("mcp/z_tool"),
+    );
+  });
+
+  it("accepts a dry-run with zero discovery calls", () => {
+    const result = formatAgentEvalCiReport({
+      suites: [
+        {
+          label: "discovery",
+          artifact: suiteArtifact({
+            status: "dry-run",
+            dryRun: true,
+            logicalToolCalls: 0,
+            callsByTool: [],
+            cumulativeAgentTimeMs: null,
+            tokens: {
+              uncachedInputTokens: null,
+              cachedInputTokens: null,
+              cacheWriteInputTokens: null,
+              outputTokens: null,
+              reasoningOutputTokens: null,
+            },
+            cost: { kind: "unknown", usd: null, uncertainty: "unknown" },
+            codexVersions: [],
+            warnings: ["discovery metrics warning: dry_run_no_telemetry"],
+          }),
+        },
+      ],
+    });
+    expect(result.failed).toBe(false);
+    expect(result.markdown).toContain("| discovery | DRY-RUN | 1/1 |");
+    expect(result.markdown).toContain("Tool calls: none");
+    expect(result.markdown).toContain("dry_run_no_telemetry");
+  });
+
+  it("renders unknown tool and token telemetry without failing", () => {
+    const result = formatAgentEvalCiReport({
+      suites: [
+        {
+          label: "unknown",
+          artifact: suiteArtifact({
+            callsByTool: null,
+            missingToolTelemetryCellIds: ["discovery/stable-a"],
+            logicalToolCalls: null,
+            tokens: {
+              uncachedInputTokens: null,
+              cachedInputTokens: null,
+              cacheWriteInputTokens: null,
+              outputTokens: null,
+              reasoningOutputTokens: null,
+            },
+            cost: { kind: "unknown", usd: null, uncertainty: "unknown" },
+          }),
+        },
+      ],
+    });
+    expect(result.failed).toBe(false);
+    expect(result.markdown).toContain("Tool calls: unknown");
+    expect(result.markdown).toContain("missing telemetry for 1 cell");
+    expect(result.markdown).toContain("Logical calls");
+  });
+
+  it("shows ordinary warnings but classifies invalid execution warnings as failures", () => {
+    const ordinary = formatAgentEvalCiReport({
+      suites: [
+        {
+          label: "ordinary",
+          artifact: suiteArtifact({
+            warnings: ["long_context_pricing_not_attributable"],
+          }),
+        },
+      ],
+    });
+    expect(ordinary.failed).toBe(false);
+    expect(ordinary.markdown).toContain(
+      "long_context_pricing_not_attributable",
+    );
+
+    const invalid = formatAgentEvalCiReport({
+      suites: [
+        {
+          label: "invalid",
+          artifact: suiteArtifact({
+            warnings: [
+              "MCP descriptors guidance run used GitHits CLI fallback: search",
+              "external guidance read outside isolated workspace: /tmp/host",
+            ],
+          }),
+        },
+      ],
+    });
+    expect(invalid.failed).toBe(true);
+    expect(invalid.markdown).toContain("| invalid | FAIL |");
+    expect(invalid.markdown).toContain("CLI fallback");
+    expect(invalid.markdown).toContain("isolated workspace");
+  });
+
+  it("fails partial and failed suites and all non-success workload cells", () => {
+    for (const status of ["partial", "failed"] as const) {
+      const result = formatAgentEvalCiReport({
+        suites: [{ label: status, artifact: suiteArtifact({ status }) }],
+      });
+      expect(result.failed).toBe(true);
+      expect(result.markdown).toContain(`| ${status} | FAIL |`);
+    }
+    for (const cellStatus of ["failed", "missing", "unknown"] as const) {
+      const result = formatAgentEvalCiReport({
+        suites: [
+          {
+            label: cellStatus,
+            artifact: suiteArtifact({
+              cells: [
+                {
+                  ...suiteArtifact().cells[0]!,
+                  status: cellStatus,
+                },
+              ],
+              totals: {
+                ...suiteArtifact().totals,
+                successfulExecutions: 0,
+                failedExecutions: cellStatus === "failed" ? 1 : 0,
+                missingExecutions: cellStatus === "missing" ? 1 : 0,
+                unknownExecutions: cellStatus === "unknown" ? 1 : 0,
+              },
+            }),
+          },
+        ],
+      });
+      expect(result.failed).toBe(true);
+      expect(result.markdown).toContain(`| ${cellStatus} | FAIL |`);
+    }
+  });
+
+  it("renders ordered labeled scenarios and an optional run URL without comparison language", () => {
+    const result = formatAgentEvalCiReport({
+      suites: [
+        { label: "discovery", artifact: suiteArtifact() },
+        {
+          label: "intent",
+          artifact: suiteArtifact({ workloadConcurrency: 4 }),
+        },
+      ],
+      runUrl: "https://github.example/runs/1",
+    });
+    expect(result.markdown.indexOf("| discovery | PASS |")).toBeLessThan(
+      result.markdown.indexOf("| intent | PASS |"),
+    );
+    expect(result.markdown).toContain(
+      "[workflow run](<https://github.example/runs/1>)",
+    );
+    expect(result.markdown).not.toMatch(/baseline|delta/i);
+  });
+
+  it("renders a failed diagnostic row for missing or unparseable artifacts", () => {
+    const result = formatAgentEvalCiReport({
+      suites: [
+        {
+          label: "missing",
+          artifact: null,
+          error: "Suite artifact is not valid JSON: unexpected end of input",
+        },
+      ],
+    });
+    expect(result.failed).toBe(true);
+    expect(result.markdown).toContain("| missing | FAIL | unknown |");
+    expect(result.markdown).toContain("unexpected end of input");
+
+    const root = mkdtempSync(join(tmpdir(), "agent-eval-ci-report-invalid-"));
+    const artifactPath = join(root, "invalid.json");
+    const out = join(root, "summary.md");
+    try {
+      writeFileSync(artifactPath, "not json\n");
+      const cliResult = runAgentEvalCiReportCli([
+        "--suite",
+        `invalid=${artifactPath}`,
+        "--out",
+        out,
+      ]);
+      expect(cliResult.failed).toBe(true);
+      expect(readFileSync(out, "utf8")).toContain("not valid JSON");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("classifies explicit missing-required-evidence diagnostics as failures", () => {
+    const result = formatAgentEvalCiReport({
+      suites: [
+        {
+          label: "evidence",
+          artifact: suiteArtifact({
+            warnings: ["missing required evidence: report.json"],
+          }),
+        },
+      ],
+    });
+    expect(result.failed).toBe(true);
+    expect(result.markdown).toContain("| evidence | FAIL |");
+  });
+
+  it("validates CLI arguments before reading files", () => {
+    expect(() => parseAgentEvalCiReportArgs([])).toThrow(
+      "at least one --suite",
+    );
+    expect(() => parseAgentEvalCiReportArgs(["--out", "summary.md"])).toThrow(
+      "at least one --suite",
+    );
+    expect(() =>
+      parseAgentEvalCiReportArgs([
+        "--suite",
+        "malformed",
+        "--out",
+        "summary.md",
+      ]),
+    ).toThrow("<label>=<path>");
+    expect(() =>
+      parseAgentEvalCiReportArgs([
+        "--suite",
+        "one=missing.json",
+        "--suite",
+        "one=other.json",
+        "--out",
+        "summary.md",
+      ]),
+    ).toThrow("duplicate suite label");
+    expect(() =>
+      parseAgentEvalCiReportArgs([
+        "--suite",
+        "one=missing.json",
+        "--unknown",
+        "x",
+        "--out",
+        "summary.md",
+      ]),
+    ).toThrow("unknown flag");
+    expect(() =>
+      parseAgentEvalCiReportArgs(["--suite", "one=missing.json", "--out"]),
+    ).toThrow("--out requires a value");
+  });
+
+  it("writes the report before returning failed for missing suite evidence", () => {
+    const root = mkdtempSync(join(tmpdir(), "agent-eval-ci-report-test-"));
+    const out = join(root, "nested", "summary.md");
+    try {
+      const result = runAgentEvalCiReportCli([
+        "--suite",
+        "missing=missing.json",
+        "--out",
+        out,
+      ]);
+      expect(result.failed).toBe(true);
+      expect(existsSync(out)).toBe(true);
+      expect(readFileSync(out, "utf8")).toContain("| missing | FAIL |");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("loads ordered suite files and reports a successful dry-run", () => {
+    const root = mkdtempSync(join(tmpdir(), "agent-eval-ci-report-files-"));
+    const discoveryPath = join(root, "discovery.json");
+    const intentPath = join(root, "intent.json");
+    const out = join(root, "summary.md");
+    try {
+      writeJson(discoveryPath, suiteArtifact({ workloadConcurrency: 2 }));
+      writeJson(
+        intentPath,
+        suiteArtifact({
+          workloadConcurrency: 4,
+          status: "dry-run",
+          dryRun: true,
+          logicalToolCalls: 0,
+          callsByTool: [],
+          cumulativeAgentTimeMs: null,
+          tokens: {
+            uncachedInputTokens: null,
+            cachedInputTokens: null,
+            cacheWriteInputTokens: null,
+            outputTokens: null,
+            reasoningOutputTokens: null,
+          },
+          cost: { kind: "unknown", usd: null, uncertainty: "unknown" },
+          codexVersions: [],
+        }),
+      );
+      const result = runAgentEvalCiReportCli([
+        "--suite",
+        `discovery=${discoveryPath}`,
+        "--suite",
+        `intent=${intentPath}`,
+        "--run-url",
+        "https://github.example/runs/1",
+        "--out",
+        out,
+      ]);
+      expect(result.failed).toBe(false);
+      const markdown = readFileSync(out, "utf8");
+      expect(markdown).toContain("| discovery | PASS |");
+      expect(markdown).toContain("| intent | DRY-RUN |");
+      expect(markdown).toContain("schema v3");
+      expect(markdown).toContain("| 2 |");
+      expect(markdown).toContain("| 4 |");
+      expect(markdown).not.toMatch(/baseline|delta/i);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/agent-eval-ci-report.ts
+++ b/scripts/agent-eval-ci-report.ts
@@ -202,24 +202,30 @@ export function formatAgentEvalCiReport(
       : []),
     "| Scenario | Status | Cells | Wall time | Cumulative time | Logical calls | Tokens | Cost | Concurrency | Codex CLI | Warnings |",
     "| --- | --- | ---: | ---: | ---: | ---: | --- | --- | ---: | --- | ---: |",
-    ...options.suites.map((suite, index) =>
-      formatSuiteRow(suite, assessments[index]!),
-    ),
+    ...options.suites.map((suite, index) => {
+      const assessment = assessments[index];
+      assert(assessment, "missing suite assessment");
+      return formatSuiteRow(suite, assessment);
+    }),
     "",
-    ...options.suites.flatMap((suite, index) => [
-      `## ${suite.label}`,
-      `- Identity: ${suite.artifact ? formatIdentity(suite.artifact) : "unknown"}`,
-      ...(suite.artifact
-        ? [
-            `- Suite status: ${suite.artifact.status}`,
-            `- Suite scenarios: ${suite.artifact.matrix.scenarios.join(", ")}`,
-            `- Workloads: ${suite.artifact.selectedWorkloads.length}`,
-          ]
-        : []),
-      ...formatToolCalls(suite.artifact),
-      ...formatWarnings(suite, assessments[index]!),
-      "",
-    ]),
+    ...options.suites.flatMap((suite, index) => {
+      const assessment = assessments[index];
+      assert(assessment, "missing suite assessment");
+      return [
+        `## ${suite.label}`,
+        `- Identity: ${suite.artifact ? formatIdentity(suite.artifact) : "unknown"}`,
+        ...(suite.artifact
+          ? [
+              `- Suite status: ${suite.artifact.status}`,
+              `- Suite scenarios: ${suite.artifact.matrix.scenarios.join(", ")}`,
+              `- Workloads: ${suite.artifact.selectedWorkloads.length}`,
+            ]
+          : []),
+        ...formatToolCalls(suite.artifact),
+        ...formatWarnings(suite, assessment),
+        "",
+      ];
+    }),
   ];
   return { markdown: `${lines.join("\n")}\n`, failed };
 }
@@ -233,10 +239,7 @@ export function parseAgentEvalCiReportArgs(
   let out: string | undefined;
   for (let index = 0; index < args.length; index += 1) {
     const flag = args[index];
-    assert(
-      flag !== undefined && flag.startsWith("--"),
-      `unexpected argument: ${flag}`,
-    );
+    assert(flag?.startsWith("--"), `unexpected argument: ${flag}`);
     if (flag === "--suite") {
       const value = args[++index];
       assert(

--- a/scripts/agent-eval-ci-report.ts
+++ b/scripts/agent-eval-ci-report.ts
@@ -1,0 +1,309 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import {
+  type AgentEvalSuiteArtifact,
+  loadSuiteArtifact,
+} from "./agent-eval-suite.ts";
+
+export interface AgentEvalCiSuiteInput {
+  label: string;
+  artifact: AgentEvalSuiteArtifact | null;
+  path?: string;
+  error?: string;
+}
+
+export interface AgentEvalCiReportResult {
+  markdown: string;
+  failed: boolean;
+}
+
+interface AgentEvalCiSuiteAssessment {
+  failed: boolean;
+  reasons: string[];
+}
+
+export interface AgentEvalCiReportOptions {
+  suites: readonly AgentEvalCiSuiteInput[];
+  runUrl?: string;
+}
+
+export interface AgentEvalCiReportCliCommand {
+  suites: Array<{ label: string; path: string }>;
+  runUrl?: string;
+  out: string;
+}
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+function formatNumber(value: number | null | undefined): string {
+  return value === null || value === undefined ? "unknown" : String(value);
+}
+
+function formatDuration(value: number | null | undefined): string {
+  if (value === null || value === undefined) return "unknown";
+  if (value < 1_000) return `${value} ms`;
+  return `${(value / 1_000).toFixed(1)} s`;
+}
+
+function formatCost(artifact: AgentEvalSuiteArtifact): string {
+  if (artifact.cost.usd === null) {
+    return `unknown (${artifact.cost.uncertainty})`;
+  }
+  return `$${artifact.cost.usd.toFixed(4)} (${artifact.cost.uncertainty})`;
+}
+
+function formatTokens(artifact: AgentEvalSuiteArtifact): string {
+  const { tokens } = artifact;
+  return [
+    `in=${formatNumber(tokens.uncachedInputTokens)}`,
+    `cached=${formatNumber(tokens.cachedInputTokens)}`,
+    `write=${formatNumber(tokens.cacheWriteInputTokens)}`,
+    `out=${formatNumber(tokens.outputTokens)}`,
+    `reasoning=${formatNumber(tokens.reasoningOutputTokens)}`,
+  ].join(" ");
+}
+
+function formatIdentity(artifact: AgentEvalSuiteArtifact): string {
+  const harness = artifact.measurementGit.sha ?? "unknown";
+  return [
+    `schema v${artifact.schemaVersion}`,
+    `harness ${harness}`,
+    `${artifact.matrix.agent}:${artifact.matrix.model}/${artifact.matrix.reasoningEffort}`,
+    `${artifact.matrix.surface}/${artifact.matrix.server}`,
+  ].join("; ");
+}
+
+function formatToolCalls(artifact: AgentEvalSuiteArtifact | null): string[] {
+  if (artifact === null) return ["- Tool calls: unknown"];
+  if (artifact.callsByTool === null) {
+    const missing = artifact.missingToolTelemetryCellIds.length;
+    return [
+      `- Tool calls: unknown (missing telemetry for ${missing} cell${missing === 1 ? "" : "s"})`,
+    ];
+  }
+  if (artifact.callsByTool.length === 0) return ["- Tool calls: none"];
+  const calls = [...artifact.callsByTool].toSorted(
+    (left, right) =>
+      left.surface.localeCompare(right.surface) ||
+      left.tool.localeCompare(right.tool),
+  );
+  return [
+    "- Tool calls:",
+    ...calls.map(
+      (call) =>
+        `  - \`${call.surface}/${call.tool}\`: total ${call.total} (started ${call.started}, completed ${call.completed}, failed ${call.failed}, unknown ${call.unknown})`,
+    ),
+  ];
+}
+
+function invalidWarning(warning: string): boolean {
+  return /cli fallback|isolation|validation violation|descriptor profile read guidance|external guidance read|missing (?:required )?(?:evidence|artifact)|required evidence missing|\btimeout(?:ed)?\b/i.test(
+    warning,
+  );
+}
+
+function assessSuite(input: AgentEvalCiSuiteInput): AgentEvalCiSuiteAssessment {
+  if (input.artifact === null) {
+    return {
+      failed: true,
+      reasons: [input.error ?? "suite artifact is missing or unparseable"],
+    };
+  }
+  const artifact = input.artifact;
+  const reasons: string[] = [];
+  if (artifact.status === "partial" || artifact.status === "failed") {
+    reasons.push(`suite status is ${artifact.status}`);
+  }
+  const failedShards = artifact.shards.filter(
+    (shard) => shard.status === "failed",
+  );
+  if (failedShards.length > 0) {
+    reasons.push(
+      `failed scenario shards: ${failedShards.map((shard) => shard.scenario).join(", ")}`,
+    );
+  }
+  const invalidCells = artifact.cells.filter(
+    (cell) => cell.status !== "success",
+  );
+  if (invalidCells.length > 0) {
+    reasons.push(
+      `invalid workload cells: ${invalidCells.map((cell) => `${cell.id}=${cell.status}`).join(", ")}`,
+    );
+  }
+  if (
+    artifact.totals.failedExecutions > 0 ||
+    artifact.totals.missingExecutions > 0 ||
+    artifact.totals.unknownExecutions > 0
+  ) {
+    reasons.push(
+      `invalid execution totals: failed=${artifact.totals.failedExecutions} missing=${artifact.totals.missingExecutions} unknown=${artifact.totals.unknownExecutions}`,
+    );
+  }
+  const invalidWarnings = artifact.warnings.filter(invalidWarning);
+  reasons.push(
+    ...invalidWarnings.map((warning) => `invalid warning: ${warning}`),
+  );
+  return { failed: reasons.length > 0, reasons };
+}
+
+function formatStatus(
+  artifact: AgentEvalSuiteArtifact | null,
+  failed: boolean,
+): string {
+  if (failed) return "FAIL";
+  if (artifact?.status === "dry-run") return "DRY-RUN";
+  return "PASS";
+}
+
+function formatSuiteRow(
+  input: AgentEvalCiSuiteInput,
+  assessment: AgentEvalCiSuiteAssessment,
+): string {
+  if (input.artifact === null) {
+    return `| ${input.label} | FAIL | unknown | unknown | unknown | unknown | unknown | unknown | unknown | unknown | ${input.error ?? "suite artifact is missing or unparseable"} |`;
+  }
+  const artifact = input.artifact;
+  const successful = artifact.totals.successfulExecutions;
+  const expected = artifact.totals.expectedExecutions;
+  const warnings =
+    artifact.warnings.length > 0 ? String(artifact.warnings.length) : "none";
+  return `| ${input.label} | ${formatStatus(artifact, assessment.failed)} | ${successful}/${expected} | ${formatDuration(artifact.wallTimeMs)} | ${formatDuration(artifact.cumulativeAgentTimeMs)} | ${formatNumber(artifact.logicalToolCalls)} | ${formatTokens(artifact)} | ${formatCost(artifact)} | ${artifact.workloadConcurrency} | ${artifact.codexVersions.length > 0 ? artifact.codexVersions.join(", ") : "unknown"} | ${warnings} |`;
+}
+
+function formatWarnings(
+  input: AgentEvalCiSuiteInput,
+  assessment: AgentEvalCiSuiteAssessment,
+): string[] {
+  const warnings = input.artifact?.warnings ?? [];
+  const diagnostics = assessment.reasons;
+  if (warnings.length === 0 && diagnostics.length === 0) return [];
+  return [
+    `### ${input.label} warnings`,
+    ...warnings.map((warning) => `- ${warning}`),
+    ...diagnostics
+      .filter((reason) => !warnings.some((warning) => reason.endsWith(warning)))
+      .map((reason) => `- ${reason}`),
+  ];
+}
+
+export function formatAgentEvalCiReport(
+  options: AgentEvalCiReportOptions,
+): AgentEvalCiReportResult {
+  assert(options.suites.length > 0, "at least one suite is required");
+  const assessments = options.suites.map(assessSuite);
+  const failed = assessments.some((assessment) => assessment.failed);
+  const lines = [
+    "# Agent eval CI report",
+    "",
+    ...(options.runUrl
+      ? [`Evidence: [workflow run](<${options.runUrl}>)`, ""]
+      : []),
+    "| Scenario | Status | Cells | Wall time | Cumulative time | Logical calls | Tokens | Cost | Concurrency | Codex CLI | Warnings |",
+    "| --- | --- | ---: | ---: | ---: | ---: | --- | --- | ---: | --- | ---: |",
+    ...options.suites.map((suite, index) =>
+      formatSuiteRow(suite, assessments[index]!),
+    ),
+    "",
+    ...options.suites.flatMap((suite, index) => [
+      `## ${suite.label}`,
+      `- Identity: ${suite.artifact ? formatIdentity(suite.artifact) : "unknown"}`,
+      ...(suite.artifact
+        ? [
+            `- Suite status: ${suite.artifact.status}`,
+            `- Suite scenarios: ${suite.artifact.matrix.scenarios.join(", ")}`,
+            `- Workloads: ${suite.artifact.selectedWorkloads.length}`,
+          ]
+        : []),
+      ...formatToolCalls(suite.artifact),
+      ...formatWarnings(suite, assessments[index]!),
+      "",
+    ]),
+  ];
+  return { markdown: `${lines.join("\n")}\n`, failed };
+}
+
+export function parseAgentEvalCiReportArgs(
+  args: readonly string[],
+): AgentEvalCiReportCliCommand {
+  const suites: Array<{ label: string; path: string }> = [];
+  const labels = new Set<string>();
+  let runUrl: string | undefined;
+  let out: string | undefined;
+  for (let index = 0; index < args.length; index += 1) {
+    const flag = args[index];
+    assert(
+      flag !== undefined && flag.startsWith("--"),
+      `unexpected argument: ${flag}`,
+    );
+    if (flag === "--suite") {
+      const value = args[++index];
+      assert(
+        value !== undefined && value.length > 0 && !value.startsWith("--"),
+        "--suite requires a value",
+      );
+      const separator = value.indexOf("=");
+      assert(
+        separator > 0 && separator < value.length - 1,
+        "--suite must use <label>=<path>",
+      );
+      const label = value.slice(0, separator);
+      const path = value.slice(separator + 1);
+      assert(!labels.has(label), `duplicate suite label: ${label}`);
+      labels.add(label);
+      suites.push({ label, path });
+      continue;
+    }
+    assert(flag === "--run-url" || flag === "--out", `unknown flag: ${flag}`);
+    const value = args[++index];
+    assert(
+      value !== undefined && value.length > 0 && !value.startsWith("--"),
+      `${flag} requires a value`,
+    );
+    if (flag === "--run-url") {
+      assert(runUrl === undefined, "duplicate argument: --run-url");
+      runUrl = value;
+    } else {
+      assert(out === undefined, "duplicate argument: --out");
+      out = value;
+    }
+  }
+  assert(suites.length > 0, "at least one --suite is required");
+  assert(out !== undefined, "--out requires a value");
+  return { suites, ...(runUrl ? { runUrl } : {}), out };
+}
+
+export function runAgentEvalCiReportCli(
+  args: readonly string[],
+): AgentEvalCiReportResult {
+  const command = parseAgentEvalCiReportArgs(args);
+  const suites = command.suites.map((suite): AgentEvalCiSuiteInput => {
+    try {
+      return { ...suite, artifact: loadSuiteArtifact(suite.path) };
+    } catch (error) {
+      return {
+        ...suite,
+        artifact: null,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  });
+  const result = formatAgentEvalCiReport({ suites, runUrl: command.runUrl });
+  mkdirSync(dirname(command.out), { recursive: true });
+  writeFileSync(command.out, result.markdown);
+  return result;
+}
+
+async function main(): Promise<void> {
+  const result = runAgentEvalCiReportCli(process.argv.slice(2));
+  process.stdout.write(result.markdown);
+  if (result.failed) process.exitCode = 1;
+}
+
+if (import.meta.main) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}

--- a/scripts/agent-eval-ci-report.ts
+++ b/scripts/agent-eval-ci-report.ts
@@ -116,6 +116,9 @@ function assessSuite(input: AgentEvalCiSuiteInput): AgentEvalCiSuiteAssessment {
   if (artifact.status === "partial" || artifact.status === "failed") {
     reasons.push(`suite status is ${artifact.status}`);
   }
+  if (artifact.totals.expectedExecutions === 0) {
+    reasons.push("suite has no expected executions");
+  }
   const failedShards = artifact.shards.filter(
     (shard) => shard.status === "failed",
   );

--- a/scripts/agent-eval-suite.test.ts
+++ b/scripts/agent-eval-suite.test.ts
@@ -467,6 +467,34 @@ describe("agent eval suites", () => {
     ]);
   });
 
+  it("rejects an empty suite selection before spawning a child", async () => {
+    const fixture = createSuiteExecutionFixture();
+    const outDir = mkdtempSync(join(tmpdir(), "agent-eval-suite-empty-"));
+    let executorCalls = 0;
+    try {
+      await expect(
+        runAgentEvalSuite({
+          suite: "canary",
+          repoRoot: fixture.root,
+          targetRoot: fixture.targetRoot,
+          outDir,
+          manifestPath: fixture.manifestPath,
+          workloadsDir: fixture.workloadsDir,
+          reportingPath: fixture.reportingPath,
+          schemaPath: fixture.schemaPath,
+          shardExecutor: async () => {
+            executorCalls += 1;
+            return { status: "success" };
+          },
+        }),
+      ).rejects.toThrow("suite canary has no selected workloads");
+      expect(executorCalls).toBe(0);
+    } finally {
+      rmSync(fixture.root, { recursive: true, force: true });
+      rmSync(outDir, { recursive: true, force: true });
+    }
+  });
+
   it("parses strict run, pair, compare, and help CLI forms", () => {
     expect(
       parseAgentEvalSuiteCliArgs([
@@ -720,6 +748,18 @@ describe("agent eval suites", () => {
         path: "eval/agentic/workloads/canary-a.md",
         safety: "stable",
         suites: ["canary", "smoke", "stable-full"],
+      },
+      {
+        id: "stateful-a",
+        path: "eval/agentic/workloads/stateful-a.md",
+        safety: "stateful",
+        suites: ["stateful-manual"],
+      },
+      {
+        id: "experimental-a",
+        path: "eval/agentic/workloads/experimental-a.md",
+        safety: "experimental",
+        suites: ["experimental"],
       },
     ]);
     const capture = async (

--- a/scripts/agent-eval-suite.test.ts
+++ b/scripts/agent-eval-suite.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import {
   existsSync,
   mkdirSync,
@@ -333,6 +333,7 @@ async function generatePairSuite(
     "discovery",
     "full",
   ],
+  workloadConcurrency = 1,
 ): Promise<AgentEvalSuiteArtifact> {
   return runAgentEvalSuite({
     suite: "stable-full",
@@ -344,6 +345,7 @@ async function generatePairSuite(
     reportingPath: fixture.reportingPath,
     schemaPath: fixture.schemaPath,
     dryRun,
+    workloadConcurrency,
     scenarios,
     shardExecutor: async (options) => {
       writeShardArtifacts(
@@ -475,6 +477,8 @@ describe("agent eval suites", () => {
         "discovery",
         "--scenario",
         "intent",
+        "--concurrency",
+        "3",
         "--dry-run",
         "--out",
         "runs",
@@ -485,6 +489,7 @@ describe("agent eval suites", () => {
       mode: "run",
       suite: "canary",
       scenarios: ["discovery", "intent"],
+      workloadConcurrency: 3,
       dryRun: true,
       outDir: "runs",
       targetRoot: "../target",
@@ -520,6 +525,9 @@ describe("agent eval suites", () => {
       outDir: "comparison",
     });
     expect(parseAgentEvalSuiteCliArgs(["--help"])).toEqual({ mode: "help" });
+    expect(
+      parseAgentEvalSuiteCliArgs(["run", "--suite", "canary"]),
+    ).toMatchObject({ workloadConcurrency: 1 });
     expect(AGENT_EVAL_SUITE_USAGE).toContain(
       "Defaults: canary discovery + intent; other suites intent only.",
     );
@@ -560,6 +568,11 @@ describe("agent eval suites", () => {
         "--scenario",
         "intent",
       ],
+      ["run", "--suite", "canary", "--concurrency", "0"],
+      ["run", "--suite", "canary", "--concurrency", "-1"],
+      ["run", "--suite", "canary", "--concurrency", "1.5"],
+      ["run", "--suite", "canary", "--concurrency", "not-a-number"],
+      ["run", "--suite", "canary", "--concurrency"],
       ["run", "--suite", "canary", "--unknown"],
       ["--help", "--help"],
     ]) {
@@ -767,9 +780,12 @@ describe("agent eval suites", () => {
         matrix: Record<string, unknown>;
         shards: Array<Record<string, unknown>>;
         cells: Array<Record<string, unknown>>;
+        workloadConcurrency?: unknown;
       };
+      const currentV1 = { ...current };
+      delete currentV1.workloadConcurrency;
       const v1 = {
-        ...current,
+        ...currentV1,
         schemaVersion: 1,
         matrix: {
           agent: current.matrix.agent,
@@ -830,7 +846,8 @@ describe("agent eval suites", () => {
         });
       }
       const parsed = parseSuiteArtifact(v1);
-      expect(parsed.schemaVersion).toBe(2);
+      expect(parsed.schemaVersion).toBe(3);
+      expect(parsed.workloadConcurrency).toBe(1);
       expect(parsed.matrix.scenarios).toEqual(["discovery", "full"]);
       expect(parsed.cells.map((cell) => cell.scenario)).toEqual([
         "discovery",
@@ -883,7 +900,7 @@ describe("agent eval suites", () => {
     }
   });
 
-  it("emits v2 scenario identities and excludes intent hash mismatches from cohorts", async () => {
+  it("emits v3 scenario identities and excludes intent hash mismatches from cohorts", async () => {
     const baseline = createPairExecutionFixture();
     const candidate = createPairExecutionFixture();
     const baselineOutDir = mkdtempSync(
@@ -942,6 +959,71 @@ describe("agent eval suites", () => {
       rmSync(baselineOutDir, { recursive: true, force: true });
       rmSync(candidateOutDir, { recursive: true, force: true });
       rmSync(outputDir, { recursive: true, force: true });
+    }
+  });
+
+  it("normalizes v2 workload concurrency and keeps it out of comparison identity", async () => {
+    const fixture = createPairExecutionFixture();
+    const v2OutDir = mkdtempSync(join(tmpdir(), "agent-eval-suite-v2-"));
+    const baselineOutDir = mkdtempSync(
+      join(tmpdir(), "agent-eval-suite-concurrency-base-"),
+    );
+    const candidateOutDir = mkdtempSync(
+      join(tmpdir(), "agent-eval-suite-concurrency-candidate-"),
+    );
+    try {
+      await generatePairSuite(fixture, v2OutDir);
+      const v2Path = join(v2OutDir, "suite.json");
+      const v2 = JSON.parse(readFileSync(v2Path, "utf8")) as Record<
+        string,
+        unknown
+      >;
+      delete v2.workloadConcurrency;
+      v2.schemaVersion = 2;
+      const parsedV2 = parseSuiteArtifact(v2);
+      expect(parsedV2.schemaVersion).toBe(3);
+      expect(parsedV2.workloadConcurrency).toBe(1);
+
+      await generatePairSuite(
+        fixture,
+        baselineOutDir,
+        (record) => ({ ...record, durationMs: 1000 }),
+        () => true,
+        true,
+        ["intent"],
+        1,
+      );
+      await generatePairSuite(
+        fixture,
+        candidateOutDir,
+        (record) => ({ ...record, durationMs: 2000 }),
+        () => true,
+        true,
+        ["intent"],
+        2,
+      );
+      const comparison = buildSuiteComparison(
+        loadImportedSuite(join(baselineOutDir, "suite.json")),
+        loadImportedSuite(join(candidateOutDir, "suite.json")),
+        {
+          mode: "offline",
+          comparisonId: randomUUID(),
+          startedAt: "2026-08-28T10:00:00.000Z",
+          completedAt: "2026-08-28T10:00:01.000Z",
+        },
+      );
+      expect(comparison.compatibility.directDeltasSuppressed).toBe(false);
+      expect(comparison.aggregates.durationMs.delta).toBe(1000);
+      expect(
+        comparison.compatibility.dimensions.some(
+          (dimension) => dimension.name === "workloadConcurrency",
+        ),
+      ).toBe(false);
+    } finally {
+      rmSync(fixture.root, { recursive: true, force: true });
+      rmSync(v2OutDir, { recursive: true, force: true });
+      rmSync(baselineOutDir, { recursive: true, force: true });
+      rmSync(candidateOutDir, { recursive: true, force: true });
     }
   });
 
@@ -1231,8 +1313,10 @@ describe("agent eval suites", () => {
         reportingPath: fixture.reportingPath,
         schemaPath: fixture.schemaPath,
         dryRun: true,
+        workloadConcurrency: 2,
         scenarios: ["discovery", "intent"],
         shardExecutor: async (options) => {
+          expect(options.workloadConcurrency).toBe(2);
           starts.push(options.scenario);
           if (starts.length === 2) notifyStarts();
           await barrier;
@@ -1253,6 +1337,7 @@ describe("agent eval suites", () => {
         AGENT_EVAL_SUITE_MATRIX.reasoningEffort,
       );
       expect([...artifact.matrix.scenarios]).toEqual(["discovery", "intent"]);
+      expect(artifact.workloadConcurrency).toBe(2);
       expect(artifact.selectedWorkloads.map((workload) => workload.id)).toEqual(
         ["stable-a", "stable-z"],
       );

--- a/scripts/agent-eval-suite.ts
+++ b/scripts/agent-eval-suite.ts
@@ -412,6 +412,7 @@ export interface AgentEvalSuiteRunOptions {
   reportingPath?: string;
   schemaPath?: string;
   dryRun?: boolean;
+  workloadConcurrency?: number;
   scenarios?: readonly AgentEvalSuiteScenario[];
   shardExecutor?: AgentEvalSuiteShardExecutor;
 }
@@ -429,6 +430,7 @@ export interface AgentEvalSuiteShardOptions {
   reportingPath: string;
   schemaPath: string;
   dryRun: boolean;
+  workloadConcurrency: number;
   experimentalTools: boolean;
   workloads: AgentEvalSuiteWorkload[];
   workloadPaths: string[];
@@ -551,7 +553,7 @@ const suiteTotalsSchema = z.object({
 });
 
 export const agentEvalSuiteArtifactSchema = z.object({
-  schemaVersion: z.literal(2),
+  schemaVersion: z.literal(3),
   suiteId: z.string().uuid(),
   suiteName: suiteNameSchema,
   status: z.enum(["success", "partial", "failed", "dry-run"]),
@@ -577,6 +579,7 @@ export const agentEvalSuiteArtifactSchema = z.object({
   cells: z.array(suiteCellSchema),
   wallTimeMs: z.number().int().nonnegative(),
   cumulativeAgentTimeMs: z.number().int().nonnegative().nullable(),
+  workloadConcurrency: z.number().int().positive(),
   totals: suiteTotalsSchema,
   logicalToolCalls: z.number().int().nonnegative().nullable(),
   tokens: suiteTokenTotalsSchema,
@@ -590,6 +593,13 @@ export const agentEvalSuiteArtifactSchema = z.object({
 export type AgentEvalSuiteArtifact = z.infer<
   typeof agentEvalSuiteArtifactSchema
 >;
+
+const suiteV2ArtifactSchema = agentEvalSuiteArtifactSchema
+  .omit({ schemaVersion: true, workloadConcurrency: true })
+  .extend({
+    schemaVersion: z.literal(2),
+    workloadConcurrency: z.number().int().positive().optional(),
+  });
 
 const suiteV1ShardSchema = z.object({
   profile: suiteProfileSchema,
@@ -693,7 +703,8 @@ function normalizeV1SuiteArtifact(
   });
   return agentEvalSuiteArtifactSchema.parse({
     ...value,
-    schemaVersion: 2,
+    schemaVersion: 3,
+    workloadConcurrency: 1,
     matrix: {
       ...value.matrix,
       scenarios,
@@ -712,9 +723,21 @@ function normalizeV1SuiteArtifact(
   });
 }
 
+function normalizeV2SuiteArtifact(
+  value: z.infer<typeof suiteV2ArtifactSchema>,
+): AgentEvalSuiteArtifact {
+  return agentEvalSuiteArtifactSchema.parse({
+    ...value,
+    schemaVersion: 3,
+    workloadConcurrency: value.workloadConcurrency ?? 1,
+  });
+}
+
 export function parseSuiteArtifact(value: unknown): AgentEvalSuiteArtifact {
   const current = agentEvalSuiteArtifactSchema.safeParse(value);
   if (current.success) return current.data;
+  const v2 = suiteV2ArtifactSchema.safeParse(value);
+  if (v2.success) return normalizeV2SuiteArtifact(v2.data);
   const legacy = suiteV1ArtifactSchema.safeParse(value);
   if (legacy.success) return normalizeV1SuiteArtifact(legacy.data);
   throw new Error(`Invalid suite artifact: ${formatZodIssues(current.error)}`);
@@ -847,6 +870,7 @@ interface SuitePreflight {
   workloadPaths: string[];
   reportingPath: string;
   schemaPath: string;
+  workloadConcurrency: number;
   measurementGit: GitMetadata;
   targetGit: GitMetadata;
   contentIdentity: z.infer<typeof suiteContentIdentitySchema>;
@@ -1211,7 +1235,7 @@ function buildSuiteArtifact(
         ? "dry-run"
         : "success";
   return parseSuiteArtifact({
-    schemaVersion: 2,
+    schemaVersion: 3,
     suiteId: randomUUID(),
     suiteName: preflight.suite,
     status,
@@ -1263,6 +1287,7 @@ function buildSuiteArtifact(
     ),
     wallTimeMs,
     cumulativeAgentTimeMs: executionDurations,
+    workloadConcurrency: preflight.workloadConcurrency,
     totals: {
       expectedExecutions: cells.length,
       observedExecutions,
@@ -1290,6 +1315,11 @@ function buildSuiteArtifact(
 async function suitePreflight(
   options: AgentEvalSuiteRunOptions,
 ): Promise<SuitePreflight> {
+  const workloadConcurrency = options.workloadConcurrency ?? 1;
+  assert(
+    Number.isInteger(workloadConcurrency) && workloadConcurrency > 0,
+    "workloadConcurrency must be a positive integer",
+  );
   const repoRoot = resolve(options.repoRoot);
   const targetRoot = resolve(repoRoot, options.targetRoot ?? repoRoot);
   const outDir = resolve(repoRoot, options.outDir);
@@ -1359,6 +1389,7 @@ async function suitePreflight(
     workloadPaths,
     reportingPath,
     schemaPath,
+    workloadConcurrency,
     measurementGit,
     targetGit,
     contentIdentity,
@@ -1392,6 +1423,8 @@ async function productionShardExecutor(
     options.reportingPath,
     "--schema",
     options.schemaPath,
+    "--concurrency",
+    String(options.workloadConcurrency),
   ];
   if (options.experimentalTools) args.push("--experimental-tools");
   if (options.dryRun) args.push("--dry-run");
@@ -1439,6 +1472,7 @@ export async function runAgentEvalSuite(
       experimentalTools: preflight.suite === "experimental",
       workloads: preflight.workloads,
       workloadPaths: preflight.workloadPaths,
+      workloadConcurrency: preflight.workloadConcurrency,
       matrix: AGENT_EVAL_SUITE_MATRIX,
     };
   });
@@ -1500,6 +1534,7 @@ export function formatSuiteReport(artifact: AgentEvalSuiteArtifact): string {
   const lines = [
     `Agent eval suite: ${artifact.status} ${artifact.suiteName} ${artifact.measurementRoot}`,
     `matrix=${artifact.matrix.agent}:${artifact.matrix.model}/${artifact.matrix.reasoningEffort} scenarios=${artifact.matrix.scenarios.join(",")} workloads=${artifact.selectedWorkloads.length}`,
+    `workloadConcurrency=${artifact.workloadConcurrency}`,
     `agentCliVersions=${artifact.codexVersions.length > 0 ? artifact.codexVersions.join(",") : "unknown"}`,
     `totals executions=${artifact.totals.expectedExecutions} observed=${artifact.totals.observedExecutions} succeeded=${artifact.totals.successfulExecutions} failed=${artifact.totals.failedExecutions} missing=${artifact.totals.missingExecutions} wallTimeMs=${artifact.wallTimeMs} cumulativeAgentTimeMs=${artifact.cumulativeAgentTimeMs ?? "unknown"}`,
     `tokens uncachedInput=${artifact.tokens.uncachedInputTokens ?? "unknown"} cachedInput=${artifact.tokens.cachedInputTokens ?? "unknown"} cacheWriteInput=${artifact.tokens.cacheWriteInputTokens ?? "unknown"} output=${artifact.tokens.outputTokens ?? "unknown"} reasoning=${artifact.tokens.reasoningOutputTokens ?? "unknown"}`,
@@ -3191,6 +3226,7 @@ export interface AgentEvalSuitePairOptions {
   reportingPath?: string;
   schemaPath?: string;
   dryRun?: boolean;
+  workloadConcurrency?: number;
   scenarios?: readonly AgentEvalSuiteScenario[];
   shardExecutor?: AgentEvalSuiteShardExecutor;
 }
@@ -3228,6 +3264,7 @@ export async function runAgentEvalSuitePair(
     reportingPath: options.reportingPath,
     schemaPath: options.schemaPath,
     dryRun: options.dryRun,
+    workloadConcurrency: options.workloadConcurrency,
     scenarios: options.scenarios,
     shardExecutor: options.shardExecutor,
   };
@@ -3450,6 +3487,7 @@ export type AgentEvalSuiteCliCommand =
       outDir?: string;
       targetRoot?: string;
       dryRun: boolean;
+      workloadConcurrency: number;
     }
   | {
       mode: "pair";
@@ -3458,6 +3496,7 @@ export type AgentEvalSuiteCliCommand =
       baselineRoot: string;
       outDir?: string;
       dryRun: boolean;
+      workloadConcurrency: number;
     }
   | {
       mode: "compare";
@@ -3467,8 +3506,8 @@ export type AgentEvalSuiteCliCommand =
     };
 
 export const AGENT_EVAL_SUITE_USAGE = `Usage:
-  bun run agent:e2e:suite run --suite <name> [--scenario <discovery|intent|full>]... [--dry-run] [--out <dir>] [--target-root <path>]
-  bun run agent:e2e:suite pair --suite <name> --baseline-root <path> [--scenario <discovery|intent|full>]... [--dry-run] [--out <dir>]
+  bun run agent:e2e:suite run --suite <name> [--scenario <discovery|intent|full>]... [--concurrency <positive integer>] [--dry-run] [--out <dir>] [--target-root <path>]
+  bun run agent:e2e:suite pair --suite <name> --baseline-root <path> [--scenario <discovery|intent|full>]... [--concurrency <positive integer>] [--dry-run] [--out <dir>]
   bun run agent:e2e:suite compare --baseline-suite <path> --candidate-suite <path> [--out <dir>]
 
 Suites: ${AGENT_EVAL_SUITE_NAMES.join(", ")}
@@ -3477,8 +3516,22 @@ Defaults: canary discovery + intent; other suites intent only. Explicit --scenar
 `;
 
 const CLI_OPTIONS_BY_MODE: Record<AgentEvalSuiteCliMode, readonly string[]> = {
-  run: ["--suite", "--scenario", "--out", "--target-root", "--dry-run"],
-  pair: ["--suite", "--baseline-root", "--scenario", "--out", "--dry-run"],
+  run: [
+    "--suite",
+    "--scenario",
+    "--concurrency",
+    "--out",
+    "--target-root",
+    "--dry-run",
+  ],
+  pair: [
+    "--suite",
+    "--baseline-root",
+    "--scenario",
+    "--concurrency",
+    "--out",
+    "--dry-run",
+  ],
   compare: ["--baseline-suite", "--candidate-suite", "--out"],
 };
 
@@ -3489,6 +3542,15 @@ function isCliMode(value: string): value is AgentEvalSuiteCliMode {
 function assertCliValue(value: string | undefined, flag: string): string {
   assert(value !== undefined && value.length > 0, `${flag} requires a value`);
   return value;
+}
+
+function parsePositiveInteger(value: string, flag: string): number {
+  const parsed = Number(value);
+  assert(
+    Number.isInteger(parsed) && parsed > 0,
+    `${flag} must be a positive integer`,
+  );
+  return parsed;
 }
 
 function assertSuiteName(value: string): AgentEvalSuiteName {
@@ -3567,6 +3629,10 @@ export function parseAgentEvalSuiteCliArgs(
     return typeof value === "string" ? value : undefined;
   };
   const dryRun = values.has("--dry-run");
+  const workloadConcurrency = parsePositiveInteger(
+    getValue("--concurrency") ?? "1",
+    "--concurrency",
+  );
   if (rawMode === "run") {
     return {
       mode: rawMode,
@@ -3575,6 +3641,7 @@ export function parseAgentEvalSuiteCliArgs(
       outDir: getValue("--out"),
       targetRoot: getValue("--target-root"),
       dryRun,
+      workloadConcurrency,
     };
   }
   if (rawMode === "pair") {
@@ -3588,6 +3655,7 @@ export function parseAgentEvalSuiteCliArgs(
       ),
       outDir: getValue("--out"),
       dryRun,
+      workloadConcurrency,
     };
   }
   assert(!dryRun, "--dry-run is not valid for compare");
@@ -3636,6 +3704,7 @@ export async function runAgentEvalSuiteCli(
       targetRoot: command.targetRoot,
       outDir,
       dryRun: command.dryRun,
+      workloadConcurrency: command.workloadConcurrency,
       scenarios: command.scenarios,
     });
     return `${formatSuiteReport(artifact)}suite artifact: ${join(outDir, "suite.json")}\n`;
@@ -3648,6 +3717,7 @@ export async function runAgentEvalSuiteCli(
       baselineRoot: command.baselineRoot,
       outDir,
       dryRun: command.dryRun,
+      workloadConcurrency: command.workloadConcurrency,
       scenarios: command.scenarios,
     });
     return `${formatSuiteReport(result.baselineSuite)}${formatSuiteReport(result.candidateSuite)}${formatComparisonReport(result.comparison)}artifacts:\n  baseline suite: ${result.baselineSuitePath}\n  candidate suite: ${result.candidateSuitePath}\n  comparison: ${result.comparisonPath}\n`;

--- a/scripts/agent-eval-suite.ts
+++ b/scripts/agent-eval-suite.ts
@@ -323,13 +323,15 @@ export function selectSuiteWorkloads(
   if (!AGENT_EVAL_SUITE_NAMES.includes(suite)) {
     throw new Error(`unknown suite name: ${suite}`);
   }
-  return manifest.workloads
+  const workloads = manifest.workloads
     .filter((workload) => workload.suites.includes(suite))
     .toSorted(
       (left, right) =>
         compareStrings(left.id, right.id) ||
         compareStrings(left.path, right.path),
     );
+  assert(workloads.length > 0, `suite ${suite} has no selected workloads`);
+  return workloads;
 }
 
 export const AGENT_EVAL_SUITE_PROFILES = ["descriptors", "full"] as const;

--- a/scripts/agent-eval.test.ts
+++ b/scripts/agent-eval.test.ts
@@ -936,6 +936,9 @@ describe("agent eval harness", () => {
     );
     expect(codexConfig).toContain('env_vars = ["GITHITS_API_TOKEN"]');
     expect(codexConfig).not.toContain("secret-token");
+    expect(codexConfig.indexOf("env_vars =")).toBeLessThan(
+      codexConfig.indexOf("[mcp_servers.githits.env]"),
+    );
 
     const codexArgs = buildCodexConfigArgs(
       {

--- a/scripts/agent-eval.test.ts
+++ b/scripts/agent-eval.test.ts
@@ -2540,6 +2540,8 @@ describe("agent eval harness", () => {
         "eval/agentic/workloads/express-router.md",
         "--timeout",
         "12",
+        "--concurrency",
+        "3",
         "--dry-run",
       ],
       repoRoot,
@@ -2551,10 +2553,135 @@ describe("agent eval harness", () => {
     expect(options.surface).toBe("skills");
     expect(options.publishedPackage).toBe("githits@0.4.2");
     expect(options.timeoutSeconds).toBe(12);
+    expect(options.workloadConcurrency).toBe(3);
     expect(options.dryRun).toBe(true);
     expect(options.workloads).toEqual([
       resolve(repoRoot, "eval/agentic/workloads/express-router.md"),
     ]);
+  });
+
+  it("defaults concurrency to one and rejects invalid values before execution", () => {
+    const repoRoot = join(tmpdir(), "githits-cli");
+    expect(parseArgs(["--dry-run"], repoRoot).workloadConcurrency).toBe(1);
+    for (const value of ["0", "-1", "1.5", "not-a-number"]) {
+      expect(() =>
+        parseArgs(["--concurrency", value, "--dry-run"], repoRoot),
+      ).toThrow("--concurrency must be a positive integer");
+    }
+    expect(() => parseArgs(["--concurrency", "--dry-run"], repoRoot)).toThrow(
+      "--concurrency requires a value",
+    );
+  });
+
+  it("runs workloads within the selected bound, preserves input order, and continues after ordinary failures", async () => {
+    const fixtureRoot = mkdtempSync(join(tmpdir(), "agent-eval-concurrency-"));
+    const outDir = join(fixtureRoot, "run");
+    const workloads = ["workload-a", "workload-b", "workload-c", "workload-d"];
+    for (const id of workloads) {
+      writeFileSync(join(fixtureRoot, `${id}.md`), `# ${id}\n`);
+    }
+    const reportingPath = join(fixtureRoot, "REPORTING.md");
+    writeFileSync(reportingPath, "status\nanswer\nconfidence\n");
+    let active = 0;
+    let maxActive = 0;
+    let calls = 0;
+    try {
+      const options = parseArgs(
+        [
+          "--agent",
+          "opencode",
+          "--concurrency",
+          "2",
+          "--out",
+          outDir,
+          "--reporting",
+          reportingPath,
+          ...workloads.flatMap((id) => [
+            "--workload",
+            join(fixtureRoot, `${id}.md`),
+          ]),
+        ],
+        process.cwd(),
+      );
+      await runAgentEval(options, {
+        baseEnv: { PATH: "/bin" },
+        assertAgentAvailable: async () => {},
+        collectAgentVersions: async () => [
+          "opencode-test",
+          undefined,
+          "opencode-test",
+        ],
+        runCommand: async () => {
+          const call = calls;
+          calls += 1;
+          active += 1;
+          maxActive = Math.max(maxActive, active);
+          await new Promise((resolve) =>
+            setTimeout(resolve, call === 0 ? 15 : 2),
+          );
+          active -= 1;
+          return {
+            stdout: JSON.stringify({
+              status: "success",
+              answer: `answer-${call}`,
+              confidence: "high",
+            }),
+            stderr: "",
+            exitCode: call === 1 ? 1 : 0,
+            timedOut: false,
+          };
+        },
+      });
+      const run = JSON.parse(
+        readFileSync(join(outDir, "run.json"), "utf8"),
+      ) as {
+        workloadConcurrency: number;
+        workloads: Array<{ id: string; status: string }>;
+      };
+      expect(maxActive).toBe(2);
+      expect(calls).toBe(4);
+      expect(run.workloadConcurrency).toBe(2);
+      expect(run.workloads.map((workload) => workload.id)).toEqual(workloads);
+      expect(run.workloads.map((workload) => workload.status)).toEqual([
+        "success",
+        "failed",
+        "success",
+        "success",
+      ]);
+    } finally {
+      rmSync(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps rejecting when a workload executor unexpectedly throws", async () => {
+    const outDir = mkdtempSync(join(tmpdir(), "agent-eval-concurrency-error-"));
+    try {
+      const options = parseArgs(
+        [
+          "--agent",
+          "opencode",
+          "--concurrency",
+          "2",
+          "--out",
+          outDir,
+          "--workload",
+          "eval/agentic/workloads/express-router.md",
+        ],
+        process.cwd(),
+      );
+      await expect(
+        runAgentEval(options, {
+          baseEnv: { PATH: "/bin" },
+          assertAgentAvailable: async () => {},
+          collectAgentVersions: async () => [undefined, undefined, undefined],
+          runCommand: async () => {
+            throw new Error("unexpected executor failure");
+          },
+        }),
+      ).rejects.toThrow("unexpected executor failure");
+    } finally {
+      rmSync(outDir, { recursive: true, force: true });
+    }
   });
 
   it("accepts the experimental flag only for local MCP evals", () => {

--- a/scripts/agent-eval.test.ts
+++ b/scripts/agent-eval.test.ts
@@ -777,36 +777,36 @@ describe("agent eval harness", () => {
   });
 
   it("builds Codex TOML config from the same MCP command", () => {
-    expect(
-      buildCodexConfig(
-        {
-          server: "local",
-          repoRoot: "/repo/githits-cli",
-          publishedPackage: "githits@latest",
-        },
-        {},
-      ),
-    ).toBe(
+    const config = buildCodexConfig(
+      {
+        server: "local",
+        repoRoot: "/repo/githits-cli",
+        publishedPackage: "githits@latest",
+      },
+      {},
+    );
+    expect(config).toBe(
       '[mcp_servers.githits]\ncommand = "bun"\nargs = ["run","--cwd","/repo/githits-cli","dev","mcp","start"]\n',
     );
+    expect(config).not.toContain("env_vars");
   });
 
   it("builds Codex config override args", () => {
-    expect(
-      buildCodexConfigArgs(
-        {
-          server: "published",
-          repoRoot: "/repo/githits-cli",
-          publishedPackage: "githits@0.4.2",
-        },
-        {},
-      ),
-    ).toEqual([
+    const args = buildCodexConfigArgs(
+      {
+        server: "published",
+        repoRoot: "/repo/githits-cli",
+        publishedPackage: "githits@0.4.2",
+      },
+      {},
+    );
+    expect(args).toEqual([
       "-c",
       'mcp_servers.githits.command="npx"',
       "-c",
       'mcp_servers.githits.args=["-y","githits@0.4.2","mcp","start"]',
     ]);
+    expect(args).not.toContain("mcp_servers.githits.env_vars");
   });
 
   it("builds OpenCode project config from the same MCP command", () => {
@@ -925,6 +925,30 @@ describe("agent eval harness", () => {
     ).toContain(
       'mcp_servers.githits.env.PKGSEER_URL="https://pkgseer-backend-dev.fly.dev"',
     );
+
+    const codexConfig = buildCodexConfig(
+      {
+        server: "local",
+        repoRoot: "/repo/githits-cli",
+        publishedPackage: "githits@latest",
+      },
+      env,
+    );
+    expect(codexConfig).toContain('env_vars = ["GITHITS_API_TOKEN"]');
+    expect(codexConfig).not.toContain("secret-token");
+
+    const codexArgs = buildCodexConfigArgs(
+      {
+        server: "local",
+        repoRoot: "/repo/githits-cli",
+        publishedPackage: "githits@latest",
+      },
+      env,
+    );
+    expect(codexArgs).toContain(
+      'mcp_servers.githits.env_vars=["GITHITS_API_TOKEN"]',
+    );
+    expect(codexArgs.join(" ")).not.toContain("secret-token");
   });
 
   it("passes host auth roots only to the MCP child for both guidance profiles", () => {
@@ -3403,6 +3427,16 @@ describe("agent eval harness", () => {
         expect(content).not.toContain(hostConfig);
         expect(content).not.toContain(hostAppdata);
       }
+      const codexConfig = readFileSync(
+        join(workloadDir, "codex-config.toml"),
+        "utf8",
+      );
+      expect(codexConfig).toContain('env_vars = ["GITHITS_API_TOKEN"]');
+      expect(codexConfig).not.toContain(apiToken);
+      expect(observedCommand?.join(" ")).toContain(
+        'mcp_servers.githits.env_vars=["GITHITS_API_TOKEN"]',
+      );
+      expect(observedCommand?.join(" ")).not.toContain(apiToken);
       const stdout = readFileSync(join(workloadDir, "stdout.json"), "utf8");
       const stderr = readFileSync(join(workloadDir, "stderr.txt"), "utf8");
       const final = JSON.parse(

--- a/scripts/agent-eval.ts
+++ b/scripts/agent-eval.ts
@@ -711,6 +711,14 @@ function effectiveMcpConfigRoots(
   return roots;
 }
 
+function buildCodexMcpEnvVars(
+  baseEnv: NodeJS.ProcessEnv,
+): string[] | undefined {
+  return baseEnv.GITHITS_API_TOKEN === undefined
+    ? undefined
+    : ["GITHITS_API_TOKEN"];
+}
+
 export function buildCodexConfig(
   options: Pick<
     AgentEvalOptions,
@@ -724,6 +732,7 @@ export function buildCodexConfig(
   baseEnv: NodeJS.ProcessEnv = process.env,
 ): string {
   const command = buildMcpCommand(options, baseEnv);
+  const envVars = buildCodexMcpEnvVars(baseEnv);
   const lines = options.reasoningEffort
     ? [
         `model_reasoning_effort = ${JSON.stringify(options.reasoningEffort)}`,
@@ -735,6 +744,7 @@ export function buildCodexConfig(
     `command = ${JSON.stringify(command.command)}`,
     `args = ${JSON.stringify(command.args)}`,
   );
+  if (envVars) lines.push(`env_vars = ${JSON.stringify(envVars)}`);
   if (command.env && Object.keys(command.env).length > 0) {
     lines.push("", "[mcp_servers.githits.env]");
     for (const [key, value] of Object.entries(command.env)) {
@@ -758,12 +768,16 @@ export function buildCodexConfigArgs(
   baseEnv: NodeJS.ProcessEnv = process.env,
 ): string[] {
   const command = buildMcpCommand(options, baseEnv);
+  const envVars = buildCodexMcpEnvVars(baseEnv);
   const args = [
     "-c",
     `mcp_servers.githits.command=${JSON.stringify(command.command)}`,
     "-c",
     `mcp_servers.githits.args=${JSON.stringify(command.args)}`,
   ];
+  if (envVars) {
+    args.push("-c", `mcp_servers.githits.env_vars=${JSON.stringify(envVars)}`);
+  }
   if (options.reasoningEffort) {
     args.push(
       "-c",

--- a/scripts/agent-eval.ts
+++ b/scripts/agent-eval.ts
@@ -81,6 +81,7 @@ export interface AgentEvalOptions {
   reasoningEffort?: CodexReasoningEffort;
   experimentalTools: boolean;
   workloads: string[];
+  workloadConcurrency: number;
   outDir: string;
   timeoutSeconds: number;
   publishedPackage: string;
@@ -374,6 +375,7 @@ export function parseArgs(
     intentProfile: "neutral",
     experimentalTools: false,
     workloads: [],
+    workloadConcurrency: 1,
     outDir: defaultOutDir(repoRoot),
     timeoutSeconds: 300,
     publishedPackage: "githits@latest",
@@ -465,6 +467,18 @@ export function parseArgs(
         const value = argv[++i];
         assert(value, "--workload requires a path");
         options.workloads.push(value);
+        break;
+      }
+      case "--concurrency": {
+        const value = argv[++i];
+        assert(
+          value !== undefined && !value.startsWith("--"),
+          "--concurrency requires a value",
+        );
+        options.workloadConcurrency = parsePositiveInteger(
+          value,
+          "--concurrency",
+        );
         break;
       }
       case "--out": {
@@ -598,6 +612,7 @@ Options:
   --surface mcp|skills            GitHits access surface under test (default: mcp)
   --server local|published        GitHits source mode: local checkout or published package (default: local)
   --workload <path>               Workload markdown path, repeatable
+  --concurrency <positive integer> Maximum workloads to run concurrently (default: 1)
   --out <dir>                     Output directory
   --target-root <path>             Target checkout under test (default: measurement root)
   --timeout <seconds>             Per-workload timeout (default: 300)
@@ -2552,10 +2567,39 @@ async function runWorkload(
   }
 }
 
+async function runWorkloadsWithConcurrency(
+  workloads: readonly string[],
+  concurrency: number,
+  execute: (workload: string) => Promise<WorkloadRunExecution>,
+): Promise<WorkloadRunExecution[]> {
+  const results = new Array<WorkloadRunExecution>(workloads.length);
+  let nextIndex = 0;
+  const worker = async (): Promise<void> => {
+    while (nextIndex < workloads.length) {
+      const index = nextIndex;
+      nextIndex += 1;
+      const workload = workloads[index];
+      assert(workload, "missing workload");
+      results[index] = await execute(workload);
+    }
+  };
+  const workers = Array.from(
+    { length: Math.min(concurrency, workloads.length) },
+    () => worker(),
+  );
+  await Promise.all(workers);
+  return results;
+}
+
 export async function runAgentEval(
   options: AgentEvalOptions,
   dependencies: AgentEvalDependencies = DEFAULT_AGENT_EVAL_DEPENDENCIES,
 ): Promise<void> {
+  assert(
+    Number.isInteger(options.workloadConcurrency) &&
+      options.workloadConcurrency > 0,
+    "workloadConcurrency must be a positive integer",
+  );
   validateScenarioScope(options);
   assert(
     existsSync(options.schemaPath),
@@ -2608,10 +2652,11 @@ export async function runAgentEval(
     versionsPromise,
   ]);
 
-  const workloadExecutions: WorkloadRunExecution[] = [];
-  for (const workload of options.workloads) {
-    workloadExecutions.push(
-      await runWorkload(
+  const workloadExecutions = await runWorkloadsWithConcurrency(
+    options.workloads,
+    options.workloadConcurrency,
+    (workload) =>
+      runWorkload(
         options,
         workload,
         options.outDir,
@@ -2623,8 +2668,7 @@ export async function runAgentEval(
         dependencies.runCommand ?? runWithTimeout,
         guidanceBlock,
       ),
-    );
-  }
+  );
   const completedAt = new Date().toISOString();
   const workloadResults = workloadExecutions.map(
     (execution) => execution.metadata,
@@ -2648,6 +2692,7 @@ export async function runAgentEval(
     publishedPackage: options.publishedPackage,
     dryRun: options.dryRun,
     timeoutSeconds: options.timeoutSeconds,
+    workloadConcurrency: options.workloadConcurrency,
     repoRoot: options.repoRoot,
     measurementRoot: options.repoRoot,
     targetRoot: effectiveTargetRoot(options),


### PR DESCRIPTION
## Summary

- add bounded workload concurrency and schema-v3 execution metadata
- add a concise CI report with tool-call, token, cost, duration, and failure evidence
- run Luna discovery and intent scenarios daily, manually, or from an exact same-repository PR label event
- securely forward `GITHITS_API_TOKEN` to Codex MCP by variable name without persisting its value
- keep Braintrust persistence and baseline comparison out of this increment

## Validation

- 3,634 repository tests pass
- 124 focused harness tests and 60 focused suite/reporter tests pass
- typecheck, format, lint, build, actionlint, and diff checks pass
- Luna preflight complete
- Opus review clean after findings were fixed

## Live validation

- [Exact-head Agent Evals run 33381601980](https://github.com/githits-com/githits-cli/actions/runs/33381601980) passed at `dc63675`: discovery 2/2 and intent 21/21, MCP-only tool use, no warnings
- [First corrected runtime run 33380560726](https://github.com/githits-com/githits-cli/actions/runs/33380560726) passed at `16fd964` and provided the recorded timing, token, and cost evidence
- An earlier red run exposed missing Codex MCP token forwarding and CLI fallback; the root cause is fixed and covered by tests

Scheduled/manual default-branch validation remains pending merge because the workflow does not exist on `main` yet.