### PR TITLE
Persist agent eval metrics in Braintrust

### DIFF
--- a/.agents/skills/braintrust-agent-evals/SKILL.md
+++ b/.agents/skills/braintrust-agent-evals/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: braintrust-agent-evals
+description: Inspect, query, compare, or explicitly export GitHits agent-eval history in Braintrust using the repository's verified workflow.
+---
+
+# Braintrust agent evals
+
+Use this skill for read-only inspection of the GitHits agent-eval history in the
+Braintrust project `githits-cli-agent-evals`, or when the user explicitly asks
+to export a validated local suite. The normalized exporter stores one row per
+scenario/workload cell; see
+[`docs/implementation/agentic-eval-metrics.md`](../../../docs/implementation/agentic-eval-metrics.md)
+for the field contract.
+
+## Safety and interpretation
+
+- Read-only is the default. Never delete experiments or upload raw stdout,
+  stderr, environment/configuration, provider events, or arbitrary artifacts.
+- Never read or print `BRAINTRUST_API_KEY`, `.bt/`, Keychain contents, or any
+  credential/environment value. CI scopes the key only to its exporter step.
+- Do not treat an agent's self-reported confidence as result quality. This
+  phase has no scorer or quality score.
+- A failed or partial cell can be valid history when its normalized evidence is
+  complete; distinguish that from a rejected suite or failed preflight.
+
+## Inspect experiments
+
+Use the exercised project-option placement for list/view:
+
+```bash
+bt experiments --json --project githits-cli-agent-evals list
+bt experiments --json --project githits-cli-agent-evals view <experiment-name>
+```
+
+Use the experiment ID returned by the view result for a bounded field query:
+
+```bash
+bt sql --json --non-interactive "SELECT input, output, metrics, metadata, tags FROM experiment('<experiment-id>') LIMIT 23"
+```
+
+The query is the verified path for prompts, neutral answers, hashes, statuses,
+token/cost/duration metrics, and tool telemetry. Open an experiment permalink
+when row-level UI inspection is useful.
+
+The exercised comparison syntax is:
+
+```bash
+bt experiments --json --project githits-cli-agent-evals compare <experiment-a> <experiment-b>
+```
+
+It currently succeeds but reports only generic Braintrust trace metrics, which
+are zero for this exporter and do not expose the custom eval telemetry. Do not
+use that output as the eval comparison; use bounded SQL and the experiment UI
+until the comparison behavior is investigated.
+
+## Validate or explicitly export
+
+Credential-free validation maps complete suite artifacts without initializing
+Braintrust:
+
+```bash
+bun run agent:e2e:braintrust \
+  --suite discovery=.agent-eval/suites/<discovery>/suite.json \
+  --suite intent=.agent-eval/suites/<intent>/suite.json \
+  --project githits-cli-agent-evals \
+  --validate-only
+```
+
+An authenticated local subscription export uses the saved `bt` profile to run
+the same official entrypoint. The exporter, not `bt`, owns the experiment
+options and safe result file:
+
+```bash
+bt eval --runner bun --no-auto-instrumentation scripts/agent-eval-braintrust.ts -- \
+  --suite discovery=.agent-eval/suites/<discovery>/suite.json \
+  --suite intent=.agent-eval/suites/<intent>/suite.json \
+  --project githits-cli-agent-evals \
+  --experiment local-<name> \
+  --source local \
+  --result-out .agent-eval/braintrust-result.json
+```
+
+The suite preflight rejects dry-run suites, duplicate cells, mixed identity or
+schema contracts, and missing/unsafe child evidence before network setup. It
+does not reject a failed cell that retains complete report, metrics, workload,
+and contained prompt evidence. The result file is nonsecret and contains only
+schema version, mode, project, experiment, row count, suite summaries, and an
+export URL when applicable; it never contains row bodies, prompts, answers,
+artifact paths, or credentials. Do not create or upload a new experiment unless
+the user explicitly requests that export.

--- a/.agents/skills/braintrust-agent-evals/SKILL.md
+++ b/.agents/skills/braintrust-agent-evals/SKILL.md
@@ -84,6 +84,9 @@ discovery. The first main run is a one-time bootstrap; PR and default-local
 exports fail before initialization when no main baseline exists. Explicit
 local `--base-experiment` takes precedence and skips discovery. No live
 readback has yet proven later-main, PR, and local linkage under the new names.
+For exports, use the returned experiment name from the SDK readback; it can
+differ from a reused explicit local name if Braintrust de-duplicates it.
+Validate-only reports the requested or generated name.
 
 The exercised comparison syntax is:
 

--- a/.agents/skills/braintrust-agent-evals/SKILL.md
+++ b/.agents/skills/braintrust-agent-evals/SKILL.md
@@ -7,8 +7,8 @@ description: Inspect, query, compare, or explicitly export GitHits agent-eval hi
 
 Use this skill for read-only inspection of the GitHits agent-eval history in the
 Braintrust project `githits-cli-agent-evals`, or when the user explicitly asks
-to export a validated local suite. The normalized exporter stores one row per
-scenario/workload cell; see
+to export a validated local suite. The normalized exporter stores one top-level
+eval span per scenario/workload cell plus structural tool children; see
 [`docs/implementation/agentic-eval-metrics.md`](../../../docs/implementation/agentic-eval-metrics.md)
 for the field contract.
 
@@ -35,23 +35,23 @@ bt experiments --json --project githits-cli-agent-evals view <experiment-name>
 Use the experiment ID returned by the view result for a bounded field query:
 
 ```bash
-bt sql --json --non-interactive "SELECT input, output, metrics, metadata, tags FROM experiment('<experiment-id>') LIMIT 23"
+bt sql --json --non-interactive "SELECT input, output, metrics, metadata, tags FROM experiment('<experiment-id>') WHERE span_attributes.type = 'eval' LIMIT 23"
+bt sql --json --non-interactive "SELECT name, span_attributes.type, metrics, metadata FROM experiment('<experiment-id>') WHERE span_attributes.type = 'tool' LIMIT 100"
 ```
 
-The query is the verified path for prompts, neutral answers, hashes, statuses,
-native token/cost/duration metrics, and tool telemetry. A local export from the
-accepted discovery/intent artifacts produced experiment
-`poc-33381601980-native-root` (ID
-`dfa37c74-0b31-4b48-aeb1-a2698a03cecc`) read back 23 rows with native duration,
-prompt/completion/cache/reasoning token buckets, total `tokens`, and
-`estimated_cost`; bounded totals were `prompt_tokens=2,861,042`,
-`completion_tokens=20,942`, `tokens=2,881,984`, and
-`estimated_cost=0.23660003`, with duration from 8.53 to 207.317 seconds.
-Native structural tool views remain unresolved: root `tool_calls=119` and
-`tool_errors=2` compare as zero because Braintrust derives them from structural
-tool child spans. Per-call timestamps are unavailable, so do not fabricate
-child timing; GitHits-specific/custom telemetry remains accurate. Open an
-experiment permalink when row-level UI inspection is useful.
+The eval-root query is the verified path for prompts, neutral answers, hashes,
+statuses, native token/cost/duration metrics, and root metadata. Query tool
+children separately for native tool counts/errors and exact lifecycle timing.
+An unfiltered `count(*)` includes both eval roots and tool children, so it is not
+the workload-row count. A local proof experiment
+`poc-native-tool-spans-v2-20260831` (ID
+`e8480301-6622-4a06-a37b-0ebd0e42bb64`,
+<https://www.braintrust.dev/app/GitHits/p/githits-cli-agent-evals/experiments/poc-native-tool-spans-v2-20260831>)
+read back two eval roots and 10 tool children. Native comparison reported
+`tool_calls` average `5.0` and
+`tool_errors` `0`; child durations totaled 30.970 seconds and ranged from
+0.006 to 10.400 seconds. Native token and cost fields remain populated. Open
+the experiment permalink when row-level UI inspection is useful.
 
 The exercised comparison syntax is:
 
@@ -62,10 +62,11 @@ bt experiments --json --project githits-cli-agent-evals compare <experiment-a> <
 The prior custom-only experiments succeeded but reported only generic
 Braintrust trace metrics, which were zero and did not expose their custom eval
 telemetry. Treat that only as historical evidence about the older rows. The
-native-root readback verifies native duration, token, and cost fields, while
-standard tool comparison remains unresolved for the structural-span reason
-above. Use bounded SQL and the experiment UI for GitHits-specific/custom
-telemetry; do not fabricate child timing.
+preceding native-root experiment is also historical: it set root
+`tool_calls=119` and `tool_errors=2`, so comparison reported zero before
+structural children were implemented. Use bounded SQL and the experiment UI for
+GitHits-specific/custom telemetry; the current exporter uses exact
+harness-observed lifecycle boundaries and never fabricates timing.
 
 ## Validate or explicitly export
 
@@ -98,8 +99,12 @@ The suite preflight rejects dry-run suites, suites with no workload cells,
 duplicate cells, mixed identity or schema contracts, and missing/unsafe child
 evidence before network setup. It does not reject a failed cell that retains
 complete report, metrics, workload, and contained prompt evidence. The result
-file is nonsecret and contains only schema version, mode, project, experiment,
-row count, suite summaries, and an export URL when applicable; it never contains
-row bodies, prompts, answers,
-artifact paths, or credentials. Do not create or upload a new experiment unless
-the user explicitly requests that export.
+file is nonsecret and contains only its result-file schema version, mode,
+project, experiment, row count, suite summaries, and an export URL when
+applicable; experiment metadata records exporter schema/version 2. It never
+contains row bodies, prompts, answers, artifact paths, or credentials.
+Terminal tool-bearing rows lacking complete/valid observed lifecycle timing are
+rejected because they cannot produce accurate structural children; an observed
+started-only call remains an open child. Zero-tool legacy rows remain
+exportable. Do not create or upload a new experiment unless the user explicitly
+requests that export.

--- a/.agents/skills/braintrust-agent-evals/SKILL.md
+++ b/.agents/skills/braintrust-agent-evals/SKILL.md
@@ -39,8 +39,9 @@ bt sql --json --non-interactive "SELECT input, output, metrics, metadata, tags F
 ```
 
 The query is the verified path for prompts, neutral answers, hashes, statuses,
-token/cost/duration metrics, and tool telemetry. Open an experiment permalink
-when row-level UI inspection is useful.
+native token/cost/duration metrics, and tool telemetry. Native-first UI and
+comparison behavior still require a fresh export/readback. Open an experiment
+permalink when row-level UI inspection is useful.
 
 The exercised comparison syntax is:
 
@@ -48,10 +49,11 @@ The exercised comparison syntax is:
 bt experiments --json --project githits-cli-agent-evals compare <experiment-a> <experiment-b>
 ```
 
-It currently succeeds but reports only generic Braintrust trace metrics, which
-are zero for this exporter and do not expose the custom eval telemetry. Do not
-use that output as the eval comparison; use bounded SQL and the experiment UI
-until the comparison behavior is investigated.
+The prior custom-only experiments succeeded but reported only generic
+Braintrust trace metrics, which were zero and did not expose their custom eval
+telemetry. Do not treat that historical result as native-first comparison
+evidence; use bounded SQL and the experiment UI until a fresh native export is
+read back and the comparison behavior is investigated.
 
 ## Validate or explicitly export
 

--- a/.agents/skills/braintrust-agent-evals/SKILL.md
+++ b/.agents/skills/braintrust-agent-evals/SKILL.md
@@ -39,9 +39,19 @@ bt sql --json --non-interactive "SELECT input, output, metrics, metadata, tags F
 ```
 
 The query is the verified path for prompts, neutral answers, hashes, statuses,
-native token/cost/duration metrics, and tool telemetry. Native-first UI and
-comparison behavior still require a fresh export/readback. Open an experiment
-permalink when row-level UI inspection is useful.
+native token/cost/duration metrics, and tool telemetry. A local export from the
+accepted discovery/intent artifacts produced experiment
+`poc-33381601980-native-root` (ID
+`dfa37c74-0b31-4b48-aeb1-a2698a03cecc`) read back 23 rows with native duration,
+prompt/completion/cache/reasoning token buckets, total `tokens`, and
+`estimated_cost`; bounded totals were `prompt_tokens=2,861,042`,
+`completion_tokens=20,942`, `tokens=2,881,984`, and
+`estimated_cost=0.23660003`, with duration from 8.53 to 207.317 seconds.
+Native structural tool views remain unresolved: root `tool_calls=119` and
+`tool_errors=2` compare as zero because Braintrust derives them from structural
+tool child spans. Per-call timestamps are unavailable, so do not fabricate
+child timing; GitHits-specific/custom telemetry remains accurate. Open an
+experiment permalink when row-level UI inspection is useful.
 
 The exercised comparison syntax is:
 
@@ -51,9 +61,11 @@ bt experiments --json --project githits-cli-agent-evals compare <experiment-a> <
 
 The prior custom-only experiments succeeded but reported only generic
 Braintrust trace metrics, which were zero and did not expose their custom eval
-telemetry. Do not treat that historical result as native-first comparison
-evidence; use bounded SQL and the experiment UI until a fresh native export is
-read back and the comparison behavior is investigated.
+telemetry. Treat that only as historical evidence about the older rows. The
+native-root readback verifies native duration, token, and cost fields, while
+standard tool comparison remains unresolved for the structural-span reason
+above. Use bounded SQL and the experiment UI for GitHits-specific/custom
+telemetry; do not fabricate child timing.
 
 ## Validate or explicitly export
 

--- a/.agents/skills/braintrust-agent-evals/SKILL.md
+++ b/.agents/skills/braintrust-agent-evals/SKILL.md
@@ -138,10 +138,13 @@ The suite preflight rejects dry-run suites, suites with no workload cells,
 duplicate cells, mixed identity or schema contracts, and missing/unsafe child
 evidence before network setup. It does not reject a failed cell that retains
 complete report, metrics, workload, and contained prompt evidence. The result
-file is nonsecret and contains only its result-file schema version, mode,
-project, experiment, row count, suite summaries, and an export URL when
-applicable; experiment metadata records exporter schema/version 2. It never
-contains row bodies, prompts, answers, artifact paths, or credentials.
+file is nonsecret and uses result-file `schemaVersion: 2`; it contains only
+mode, project, experiment, row count, suite summaries, an export URL when
+applicable, and `baseExperiment`. In validate-only mode `baseExperiment: null`
+means unresolved/not queried; in export mode `null` means the required
+Braintrust readback returned no actual linked base. Experiment metadata records
+exporter schema/version 2. It never contains row bodies, prompts, answers,
+artifact paths, or credentials.
 Terminal tool-bearing rows lacking complete/valid observed lifecycle timing are
 rejected because they cannot produce accurate structural children; an observed
 started-only call remains an open child. Zero-tool legacy rows remain

--- a/.agents/skills/braintrust-agent-evals/SKILL.md
+++ b/.agents/skills/braintrust-agent-evals/SKILL.md
@@ -53,6 +53,19 @@ read back two eval roots and 10 tool children. Native comparison reported
 0.006 to 10.400 seconds. Native token and cost fields remain populated. Open
 the experiment permalink when row-level UI inspection is useful.
 
+The labeled CI path is proven by [run
+33424857668](https://github.com/githits-com/githits-cli/actions/runs/33424857668)
+at code SHA `7195ccc56b9ac9288dfb3d8de854f2f0e7ae7cf0`. Its experiment is
+`github-33424857668-1` (ID `182ee9db-0df3-40f4-8987-6eeb6d91a89b`), source
+`github`, exporter/schema 2, metrics schema 3: 23 eval spans and 116 tool
+children, exactly matching 116 MCP calls, with zero CLI calls and zero failed
+tool spans. Totals were 513.911 seconds eval duration, 126.458999872 seconds tool
+duration, 2,686,094 prompt tokens, 20,172 completion tokens, 2,706,266 total
+tokens, and estimated cost `$0.22819038`. Compare averages were duration
+`22.343956532685652`, estimated cost `$0.009921320869565216`, tool calls
+`5.043478260869565`, tool errors `0`, and total tokens `117663.73913043478`.
+The default-branch scheduled/manual activation remains pending merge.
+
 The exercised comparison syntax is:
 
 ```bash

--- a/.agents/skills/braintrust-agent-evals/SKILL.md
+++ b/.agents/skills/braintrust-agent-evals/SKILL.md
@@ -80,11 +80,12 @@ bt eval --runner bun --no-auto-instrumentation scripts/agent-eval-braintrust.ts 
   --result-out .agent-eval/braintrust-result.json
 ```
 
-The suite preflight rejects dry-run suites, duplicate cells, mixed identity or
-schema contracts, and missing/unsafe child evidence before network setup. It
-does not reject a failed cell that retains complete report, metrics, workload,
-and contained prompt evidence. The result file is nonsecret and contains only
-schema version, mode, project, experiment, row count, suite summaries, and an
-export URL when applicable; it never contains row bodies, prompts, answers,
+The suite preflight rejects dry-run suites, suites with no workload cells,
+duplicate cells, mixed identity or schema contracts, and missing/unsafe child
+evidence before network setup. It does not reject a failed cell that retains
+complete report, metrics, workload, and contained prompt evidence. The result
+file is nonsecret and contains only schema version, mode, project, experiment,
+row count, suite summaries, and an export URL when applicable; it never contains
+row bodies, prompts, answers,
 artifact paths, or credentials. Do not create or upload a new experiment unless
 the user explicitly requests that export.

--- a/.agents/skills/braintrust-agent-evals/SKILL.md
+++ b/.agents/skills/braintrust-agent-evals/SKILL.md
@@ -12,6 +12,14 @@ eval span per scenario/workload cell plus structural tool children; see
 [`docs/implementation/agentic-eval-metrics.md`](../../../docs/implementation/agentic-eval-metrics.md)
 for the field contract.
 
+The persistence unit is one exporter invocation = one experiment, one
+scenario/workload cell = one eval row, and one normalized logical tool call =
+one structural tool child. Current exporter-owned experiment names are
+`main-r<run-id>-a<attempt>`, `pr-<pr-number>-r<run-id>-a<attempt>`, and
+`local-<branch-slug>-<UTC-timestamp-with-milliseconds>-<short-sha>`. Historical
+`github-*` experiments predate this identity contract and should be treated as
+historical evidence, not as current names or baseline candidates.
+
 ## Safety and interpretation
 
 - Read-only is the default. Never delete experiments or upload raw stdout,
@@ -66,6 +74,17 @@ tokens, and estimated cost `$0.22819038`. Compare averages were duration
 `5.043478260869565`, tool errors `0`, and total tokens `117663.73913043478`.
 The default-branch scheduled/manual activation remains pending merge.
 
+For current comparisons, inspect experiment-level `metadata.channel` and
+`baseExperiment` in the safe exporter result or CI summary. A current main
+baseline has a `main-r...-a...` name and `channel: main`; PR and local exports
+resolve the newest such main experiment before initialization. The exporter
+reports the actual linked base `{id, name}` after `fetchBaseExperiment()`.
+Validate-only reports the base as unresolved/not queried and performs no
+discovery. The first main run is a one-time bootstrap; PR and default-local
+exports fail before initialization when no main baseline exists. Explicit
+local `--base-experiment` takes precedence and skips discovery. No live
+readback has yet proven later-main, PR, and local linkage under the new names.
+
 The exercised comparison syntax is:
 
 ```bash
@@ -103,10 +122,17 @@ bt eval --runner bun --no-auto-instrumentation scripts/agent-eval-braintrust.ts 
   --suite discovery=.agent-eval/suites/<discovery>/suite.json \
   --suite intent=.agent-eval/suites/<intent>/suite.json \
   --project githits-cli-agent-evals \
-  --experiment local-<name> \
   --source local \
   --result-out .agent-eval/braintrust-result.json
 ```
+
+This default local export lets the exporter derive its stable name and resolve
+the latest main baseline. Add `--branch <branch>` only when the evaluated suite
+is detached or has no branch; add `--base-experiment <main-r...-a...>` to use an
+explicit local main override. `--experiment <name>` is also a local-only
+override. GitHub workflow exports supply their channel, branch, PR number, run
+identity, and URL through environment-bound arguments and never pass
+`--experiment`.
 
 The suite preflight rejects dry-run suites, suites with no workload cells,
 duplicate cells, mixed identity or schema contracts, and missing/unsafe child

--- a/.github/workflows/agent-evals.yml
+++ b/.github/workflows/agent-evals.yml
@@ -18,9 +18,10 @@ jobs:
   scenario:
     name: ${{ matrix.label }} agent eval
     if: >-
-      github.event_name != 'pull_request' ||
+      (github.event_name != 'workflow_dispatch' || github.ref_name == 'main') &&
+      (github.event_name != 'pull_request' ||
       (github.event.label.name == 'agent-eval' &&
-      github.event.pull_request.head.repo.full_name == github.repository)
+      github.event.pull_request.head.repo.full_name == github.repository))
     runs-on: ubuntu-latest
     timeout-minutes: 40
     strategy:
@@ -108,6 +109,7 @@ jobs:
     name: Agent eval summary
     if: >-
       always() &&
+      (github.event_name != 'workflow_dispatch' || github.ref_name == 'main') &&
       (github.event_name != 'pull_request' ||
       (github.event.label.name == 'agent-eval' &&
       github.event.pull_request.head.repo.full_name == github.repository))
@@ -184,23 +186,43 @@ jobs:
         env:
           BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
           RESULT_OUT: ${{ runner.temp }}/agent-eval-braintrust-result.json
+          BRAINTRUST_EVENT_NAME: ${{ github.event_name }}
+          BRAINTRUST_CHANNEL: ${{ github.event_name == 'pull_request' && 'pr' || 'main' }}
+          BRAINTRUST_BRANCH: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
+          BRAINTRUST_PR_NUMBER: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || '' }}
+          BRAINTRUST_RUN_ID: ${{ github.run_id }}
+          BRAINTRUST_RUN_ATTEMPT: ${{ github.run_attempt }}
+          BRAINTRUST_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
-          bun run agent:e2e:braintrust \
-            --suite discovery="$RUNNER_TEMP/agent-eval-artifacts/discovery/suite.json" \
-            --suite intent="$RUNNER_TEMP/agent-eval-artifacts/intent/suite.json" \
-            --project "githits-cli-agent-evals" \
-            --experiment "github-${{ github.run_id }}-${{ github.run_attempt }}" \
-            --source github \
-            --run-id "${{ github.run_id }}" \
-            --run-attempt "${{ github.run_attempt }}" \
-            --run-url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+          braintrust_args=(
+            --suite "discovery=$RUNNER_TEMP/agent-eval-artifacts/discovery/suite.json"
+            --suite "intent=$RUNNER_TEMP/agent-eval-artifacts/intent/suite.json"
+            --project "githits-cli-agent-evals"
+            --source github
+            --channel "$BRAINTRUST_CHANNEL"
+            --branch "$BRAINTRUST_BRANCH"
+            --run-id "$BRAINTRUST_RUN_ID"
+            --run-attempt "$BRAINTRUST_RUN_ATTEMPT"
+            --run-url "$BRAINTRUST_RUN_URL"
             --result-out "$RESULT_OUT"
+          )
+          if [ "$BRAINTRUST_EVENT_NAME" = "pull_request" ]; then
+            braintrust_args+=(--pr-number "$BRAINTRUST_PR_NUMBER")
+          fi
+          bun run agent:e2e:braintrust "${braintrust_args[@]}"
           if [ -f "$RESULT_OUT" ]; then
-            experiment_url="$(node -e 'const fs = require("node:fs"); const result = JSON.parse(fs.readFileSync(process.argv[1], "utf8")); if (typeof result.url === "string") process.stdout.write(result.url);' "$RESULT_OUT")"
-            if [ -n "$experiment_url" ]; then
-              printf '\n[Braintrust experiment](%s)\n' "$experiment_url" >> "$GITHUB_STEP_SUMMARY"
-            fi
+            node -e '
+              const fs = require("node:fs");
+              const result = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+              const lines = [];
+              if (typeof result.experiment === "string") lines.push(`- Braintrust experiment: ${result.experiment}`);
+              if (typeof result.url === "string") lines.push(`- Braintrust link: ${result.url}`);
+              const base = result.baseExperiment;
+              if (base === null) lines.push("- Braintrust base: none (bootstrap/no base)");
+              else if (base && typeof base.id === "string" && typeof base.name === "string") lines.push(`- Braintrust base: ${base.name} (${base.id})`);
+              if (lines.length > 0) fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `\n${lines.join("\n")}\n`);
+            ' "$RESULT_OUT"
           fi
 
       - name: Finalize agent eval status

--- a/.github/workflows/agent-evals.yml
+++ b/.github/workflows/agent-evals.yml
@@ -151,6 +151,7 @@ jobs:
 
       - name: Render agent eval summary
         id: report
+        continue-on-error: true
         env:
           REPORT_OUT: ${{ runner.temp }}/agent-eval-summary.md
         run: |
@@ -175,3 +176,52 @@ jobs:
             } >> "$GITHUB_STEP_SUMMARY"
           fi
           exit "$report_status"
+
+      - name: Export agent eval metrics to Braintrust
+        id: braintrust
+        if: always()
+        continue-on-error: true
+        env:
+          BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
+          RESULT_OUT: ${{ runner.temp }}/agent-eval-braintrust-result.json
+        run: |
+          set -euo pipefail
+          bun run agent:e2e:braintrust \
+            --suite discovery="$RUNNER_TEMP/agent-eval-artifacts/discovery/suite.json" \
+            --suite intent="$RUNNER_TEMP/agent-eval-artifacts/intent/suite.json" \
+            --project "githits-cli-agent-evals" \
+            --experiment "github-${{ github.run_id }}-${{ github.run_attempt }}" \
+            --source github \
+            --run-id "${{ github.run_id }}" \
+            --run-attempt "${{ github.run_attempt }}" \
+            --run-url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --result-out "$RESULT_OUT"
+          if [ -f "$RESULT_OUT" ]; then
+            experiment_url="$(node -e 'const fs = require("node:fs"); const result = JSON.parse(fs.readFileSync(process.argv[1], "utf8")); if (typeof result.url === "string") process.stdout.write(result.url);' "$RESULT_OUT")"
+            if [ -n "$experiment_url" ]; then
+              printf '\n[Braintrust experiment](%s)\n' "$experiment_url" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          fi
+
+      - name: Finalize agent eval status
+        if: always()
+        env:
+          SCENARIO_RESULT: ${{ needs.scenario.result }}
+          REPORT_OUTCOME: ${{ steps.report.outcome }}
+          BRAINTRUST_OUTCOME: ${{ steps.braintrust.outcome }}
+        run: |
+          set -euo pipefail
+          failed_stages=()
+          if [ "$SCENARIO_RESULT" != "success" ]; then
+            failed_stages+=("scenario=$SCENARIO_RESULT")
+          fi
+          if [ "$REPORT_OUTCOME" != "success" ]; then
+            failed_stages+=("report=$REPORT_OUTCOME")
+          fi
+          if [ "$BRAINTRUST_OUTCOME" != "success" ]; then
+            failed_stages+=("braintrust=$BRAINTRUST_OUTCOME")
+          fi
+          if [ "${#failed_stages[@]}" -gt 0 ]; then
+            printf 'Agent eval failed stages: %s\n' "${failed_stages[*]}"
+            exit 1
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ coverage
 .claude
 .agent-eval/
 
+# Braintrust local state
+.bt/
+
 # logs
 logs
 _.log

--- a/bun.lock
+++ b/bun.lock
@@ -25,6 +25,7 @@
         "@biomejs/biome": "2.5.6",
         "@types/bun": "latest",
         "@types/semver": "^7.7.1",
+        "braintrust": "3.29.0",
         "bunup": "^0.16.32",
         "husky": "^9.1.7",
         "lint-staged": "17.3.0",
@@ -78,15 +79,83 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.6", "", { "os": "win32", "cpu": "x64" }, "sha512-WN05KwXnTO/2J45RQPvzZMXf7tZUIofHoR35xIPfCo7pQ2RFidxI8sfb5mGsaTxdMmEOzHzOPRCdA5/fCpc7xQ=="],
 
+    "@braintrust/bt-darwin-arm64": ["@braintrust/bt-darwin-arm64@0.12.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-mY6VW/3VwcOQOGN8sYHS6F0xzHTFwgZcNlj7zlQttI6OXOCGt/bhonGIqd03QBhxmj0M31ymSS7TqSeCK/RYIQ=="],
+
+    "@braintrust/bt-darwin-x64": ["@braintrust/bt-darwin-x64@0.12.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-woyRyDv2DfCF8+von+3X9f1cddAbFnKLSfCbEkrBQVc0ZsAM60as8nehYv7DkafJF/67yKFx/sUraV65sukesQ=="],
+
+    "@braintrust/bt-linux-arm64": ["@braintrust/bt-linux-arm64@0.12.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-J9/7f3EIMKmFmSSQHQnAQLpUgB8YJENrOlkABjlTprBgsIYVgz7tSH7yg2P3ur+2Jem7PpGnrDxHGh/UjRfjsg=="],
+
+    "@braintrust/bt-linux-x64": ["@braintrust/bt-linux-x64@0.12.0", "", { "os": "linux", "cpu": "x64" }, "sha512-HJFbUl3HYYY1Ivw8OYBeIMcIsU9r7+fC9BzLWB5FdH7881ToKee2wbbLZssMCxFbMVeUxzEo+SzGD/1Z9Gk9CA=="],
+
+    "@braintrust/bt-linux-x64-musl": ["@braintrust/bt-linux-x64-musl@0.12.0", "", { "os": "linux", "cpu": "x64" }, "sha512-KnLgENOoztBXcH+mLFJe4bYzi67kSOuELOQrm4Hler35GjgaBMI1fFLIUjKRPAmyT9VIhBMhy1ICfGEFLueMEQ=="],
+
+    "@braintrust/bt-win32-arm64": ["@braintrust/bt-win32-arm64@0.12.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-+7PkdBAmiqEJsWteGHP/Zs62F75PkHPA8m/ej4TOz/mHGKulUU0bZibw91KRqIB7J7jGi5ItvCiqkiGaLKLnyw=="],
+
+    "@braintrust/bt-win32-x64": ["@braintrust/bt-win32-x64@0.12.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Q0c+pVUGm82n/7N8QJ5s6j/G/Q0GFzqOaTipHjkmElLbAOOEcfRH/uljdtIPNBiEQcrzqirS0GmOgiFkeQ3Txg=="],
+
     "@bunup/dts": ["@bunup/dts@0.14.53", "", { "dependencies": { "@babel/parser": "^7.28.6", "coffi": "^0.1.37", "oxc-minify": "^0.93.0", "oxc-resolver": "^11.16.2", "oxc-transform": "^0.93.0", "picocolors": "^1.1.1", "std-env": "^3.10.0", "ts-import-resolver": "^0.1.23" }, "peerDependencies": { "typescript": ">=4.5.0" }, "optionalPeers": ["typescript"] }, "sha512-qyHgYEYxcghoChICEhuFKfA/EqqRA9WHOHLXcIkR9c70DgLAEXcOlkYhfBPmGxfMKJYL0X4VtQwst0/AMk9D3g=="],
 
     "@bunup/shared": ["@bunup/shared@0.16.31", "", { "peerDependencies": { "typescript": ">=4.5.0" }, "optionalPeers": ["typescript"] }, "sha512-h1dw669Uk68NCt1WvgqNfQoCcaK1RxLVAs3yQRCRaFxJiI9cqhU0EquVoGFM1g1BxzujGa7+bA9gt5JR0ZVLxA=="],
+
+    "@colors/colors": ["@colors/colors@1.5.0", "", {}, "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="],
 
     "@emnapi/core": ["@emnapi/core@1.8.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" } }, "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
 
     "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.1.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.1", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.28.1", "", { "os": "android", "cpu": "arm" }, "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.28.1", "", { "os": "android", "cpu": "arm64" }, "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.28.1", "", { "os": "android", "cpu": "x64" }, "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.28.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.28.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.28.1", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.28.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.28.1", "", { "os": "linux", "cpu": "arm" }, "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.28.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.28.1", "", { "os": "linux", "cpu": "ia32" }, "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.28.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.28.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.28.1", "", { "os": "linux", "cpu": "x64" }, "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.28.1", "", { "os": "none", "cpu": "x64" }, "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.28.1", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.28.1", "", { "os": "openbsd", "cpu": "x64" }, "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.28.1", "", { "os": "sunos", "cpu": "x64" }, "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.28.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A=="],
 
     "@githits/cli-workspace": ["@githits/cli-workspace@workspace:packages/cli"],
 
@@ -109,6 +178,16 @@
     "@inquirer/select": ["@inquirer/select@5.2.1", "", { "dependencies": { "@inquirer/ansi": "^2.0.7", "@inquirer/core": "^11.2.1", "@inquirer/figures": "^2.0.7", "@inquirer/type": "^4.0.7" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-FlDndEUww8m7BfukO2nJa25vhD+H5jxxCv4oGioKqzyWz3nPHhhw4LKdYRSlXuAx7DsdWia7iyaBPKKS95Evfw=="],
 
     "@inquirer/type": ["@inquirer/type@4.0.7", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g=="],
+
+    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
+
+    "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.6.0", "", {}, "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
@@ -139,6 +218,8 @@
     "@napi-rs/keyring-win32-x64-msvc": ["@napi-rs/keyring-win32-x64-msvc@2.0.0", "", { "os": "win32", "cpu": "x64" }, "sha512-POpEUTV6U+pb69cpuOgtLV4xhcyEWDWq+/9zdiZmNxTL1AenE0MllWrbepS+Hng4M7EarQ5TB3kX69ASqGwfIw=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.1", "", { "dependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1", "@tybys/wasm-util": "^0.10.1" } }, "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A=="],
+
+    "@next/env": ["@next/env@14.2.35", "", {}, "sha512-DuhvCtj4t9Gwrx80dmz2F4t/zKQ4ktN8WrMwOuVzkJfBilwAwGr6v16M5eI8yCuZ63H9TTuEU09Iu2HqkzFPVQ=="],
 
     "@oxc-minify/binding-android-arm64": ["@oxc-minify/binding-android-arm64@0.93.0", "", { "os": "android", "cpu": "arm64" }, "sha512-N3j/JoK4hXwQbnyOJoEltM8MEkddWV3XtfYimO6jsMjr5R6QdauKaSVeQHO/lSezB7SFkrMPqr6X7tBfghHiXA=="],
 
@@ -288,13 +369,31 @@
 
     "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
 
+    "@vercel/functions": ["@vercel/functions@1.6.0", "", { "peerDependencies": { "@aws-sdk/credential-provider-web-identity": "*" }, "optionalPeers": ["@aws-sdk/credential-provider-web-identity"] }, "sha512-R6FKQrYT5MZs5IE1SqeCJWxMuBdHawFcCZboKKw8p7s+6/mcd55Gx6tWmyKnQTyrSEA04NH73Tc9CbqpEle8RA=="],
+
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
-    "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
+    "acorn": ["acorn@8.18.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ=="],
+
+    "acorn-import-attributes": ["acorn-import-attributes@1.9.5", "", { "peerDependencies": { "acorn": "^8" } }, "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ=="],
+
+    "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
     "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "astring": ["astring@1.9.0", "", { "bin": { "astring": "bin/astring" } }, "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg=="],
+
+    "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
     "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
+
+    "brace-expansion": ["brace-expansion@5.0.9", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg=="],
+
+    "braintrust": ["braintrust@3.29.0", "", { "dependencies": { "@next/env": "^14.2.3", "@vercel/functions": "^1.0.2", "acorn": "^8.16.0", "acorn-import-attributes": "^1.9.5", "ajv": "^8.20.0", "argparse": "^2.0.1", "astring": "^1.9.0", "cjs-module-lexer": "^2.2.0", "cli-progress": "^3.12.0", "cli-table3": "^0.6.5", "cors": "^2.8.5", "dotenv": "^16.4.5", "esbuild": "0.28.1", "esquery": "^1.7.0", "eventsource-parser": "^1.1.2", "express": "^5.2.1", "http-errors": "^2.0.0", "meriyah": "^6.1.4", "minimatch": "^10.2.5", "module-details-from-path": "^1.0.4", "mustache": "^4.2.0", "pluralize": "^8.0.0", "semifies": "^1.0.0", "source-map": "^0.7.4", "termi-link": "^1.0.1", "unplugin": "^2.3.5", "uuid": "^11.1.1", "zod-to-json-schema": "^3.25.0" }, "optionalDependencies": { "@braintrust/bt-darwin-arm64": "0.12.0", "@braintrust/bt-darwin-x64": "0.12.0", "@braintrust/bt-linux-arm64": "0.12.0", "@braintrust/bt-linux-x64": "0.12.0", "@braintrust/bt-linux-x64-musl": "0.12.0", "@braintrust/bt-win32-arm64": "0.12.0", "@braintrust/bt-win32-x64": "0.12.0" }, "peerDependencies": { "zod": "^3.25.34 || ^4.0" }, "bin": { "bt": "bin/bt", "braintrust": "dist/cli.js" } }, "sha512-VM6HVz5ydoIgIuWO9Nv8TmLA1RIBCe9qxuGHN4l//TG9s3UjeNCl006TU4mg3xZOGx2qqCMUpI2RTgfdBfQiSw=="],
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
@@ -309,6 +408,12 @@
     "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
     "chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
+
+    "cjs-module-lexer": ["cjs-module-lexer@2.2.1", "", {}, "sha512-Ca8swihM+/4yKecYHY52kgJd300hi2lADU/a1RxNTRe+RJ9jvqQlESpbz9DnG9mowez8qwXHB8qYdIUw9e+F5Q=="],
+
+    "cli-progress": ["cli-progress@3.12.0", "", { "dependencies": { "string-width": "^4.2.3" } }, "sha512-tRkV3HJ1ASwm19THiiLIXLO7Im7wlTuKnvkYaTkyoAPefqjNg7W7DHKUlGRxy9vxDvbyCYQkQozvptuMkGCg8A=="],
+
+    "cli-table3": ["cli-table3@0.6.5", "", { "dependencies": { "string-width": "^4.2.0" }, "optionalDependencies": { "@colors/colors": "1.5.0" } }, "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ=="],
 
     "cli-width": ["cli-width@4.1.0", "", {}, "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ=="],
 
@@ -340,9 +445,13 @@
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
+    "dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
+
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
+    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
 
@@ -352,13 +461,19 @@
 
     "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
 
+    "esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
+
     "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
+    "esquery": ["esquery@1.7.0", "", { "dependencies": { "estraverse": "^5.1.0" } }, "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g=="],
+
+    "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
 
     "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
 
     "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
 
-    "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
+    "eventsource-parser": ["eventsource-parser@1.1.2", "", {}, "sha512-v0eOBUbiaFojBu2s2NPBfYUoRR9GjcDNvCXVaqEf5vVfpIAh9f8RCo4vXTP8c63QRKCFwoLpMpTdPwwhEKVgzA=="],
 
     "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
 
@@ -407,6 +522,8 @@
     "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
     "is-docker": ["is-docker@3.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="],
+
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 
     "is-in-ssh": ["is-in-ssh@1.0.0", "", {}, "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw=="],
 
@@ -458,11 +575,19 @@
 
     "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
 
+    "meriyah": ["meriyah@6.1.4", "", {}, "sha512-Sz8FzjzI0kN13GK/6MVEsVzMZEPvOhnmmI1lU5+/1cGOiK3QUahntrNNtdVeihrO7t9JpoH75iMNXg6R6uWflQ=="],
+
     "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
     "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
+    "minimatch": ["minimatch@10.2.6", "", { "dependencies": { "brace-expansion": "^5.0.8" } }, "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A=="],
+
+    "module-details-from-path": ["module-details-from-path@1.0.4", "", {}, "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w=="],
+
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "mustache": ["mustache@4.2.0", "", { "bin": { "mustache": "bin/mustache" } }, "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ=="],
 
     "mute-stream": ["mute-stream@3.0.0", "", {}, "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw=="],
 
@@ -496,6 +621,8 @@
 
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
+    "pluralize": ["pluralize@8.0.0", "", {}, "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="],
+
     "powershell-utils": ["powershell-utils@0.1.0", "", {}, "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A=="],
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
@@ -515,6 +642,8 @@
     "run-applescript": ["run-applescript@7.1.0", "", {}, "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q=="],
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "semifies": ["semifies@1.0.0", "", {}, "sha512-xXR3KGeoxTNWPD4aBvL5NUpMTT7WMANr3EWnaS190QVkY52lqqcVRD7Q05UVbBhiWDGWMlJEUam9m7uFFGVScw=="],
 
     "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
@@ -540,13 +669,21 @@
 
     "smol-toml": ["smol-toml@1.7.1", "", {}, "sha512-PPlsspAZ4jbMBu5DMFhfUGDQLu/vrL4SyBROVS37x8ynnVmFIs1VPBz1Co8Xks3TvpIaZXmU85y4DrQ+UyVFoQ=="],
 
+    "source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
+
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
 
     "string-argv": ["string-argv@0.3.2", "", {}, "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q=="],
 
+    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
     "strip-json-comments": ["strip-json-comments@5.0.3", "", {}, "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw=="],
+
+    "termi-link": ["termi-link@1.1.0", "", {}, "sha512-2qSN6TnomHgVLtk+htSWbaYs4Rd2MH/RU7VpHTy6MBstyNyWbM4yKd1DCYpE3fDg8dmGWojXCngNi/MHCzGuAA=="],
 
     "tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
 
@@ -568,7 +705,13 @@
 
     "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
 
+    "unplugin": ["unplugin@2.3.11", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "acorn": "^8.15.0", "picomatch": "^4.0.3", "webpack-virtual-modules": "^0.6.2" } }, "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww=="],
+
+    "uuid": ["uuid@11.1.1", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ=="],
+
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
+    "webpack-virtual-modules": ["webpack-virtual-modules@0.6.2", "", {}, "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
@@ -583,5 +726,13 @@
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
+
+    "@modelcontextprotocol/sdk/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
+
+    "@modelcontextprotocol/sdk/eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
+
+    "ajv-formats/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
+
+    "eventsource/eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
   }
 }

--- a/changes/agent-eval-braintrust.changed.md
+++ b/changes/agent-eval-braintrust.changed.md
@@ -3,4 +3,4 @@
 "@githits/mcp": none
 ---
 
-- **Braintrust agent-eval persistence** - Add maintainer-facing normalized eval export with harness-observed tool lifecycle timing and native structural Braintrust tool spans without changing public artifacts.
+- **Braintrust agent-eval persistence** - Add maintainer-facing normalized eval export with stable channel-aware experiment names, explicit latest-main baseline linkage, harness-observed tool lifecycle timing, and native structural Braintrust tool spans without changing public artifacts. The exporter records source/channel/branch/PR/SHA identity and reports the actual linked base experiment; the first main run remains a one-time bootstrap and PR/default-local exports fail before that baseline exists. This is maintainer tooling only and has `none` SemVer impact for both public artifacts.

--- a/changes/agent-eval-braintrust.changed.md
+++ b/changes/agent-eval-braintrust.changed.md
@@ -3,4 +3,4 @@
 "@githits/mcp": none
 ---
 
-- **Braintrust agent-eval persistence** - Add maintainer-facing normalized eval export and inspection guidance without changing public artifacts.
+- **Braintrust agent-eval persistence** - Add maintainer-facing normalized eval export with harness-observed tool lifecycle timing and native structural Braintrust tool spans without changing public artifacts.

--- a/changes/agent-eval-braintrust.changed.md
+++ b/changes/agent-eval-braintrust.changed.md
@@ -1,0 +1,6 @@
+---
+"githits": none
+"@githits/mcp": none
+---
+
+- **Braintrust agent-eval persistence** - Add maintainer-facing normalized eval export and inspection guidance without changing public artifacts.

--- a/docs/implementation/agentic-eval-metrics.md
+++ b/docs/implementation/agentic-eval-metrics.md
@@ -106,14 +106,29 @@ answers, prompt hashes, token buckets, duration, cost, and tool telemetry to
 the source artifacts. The first experiment permalink is
 <https://www.braintrust.dev/app/GitHits/p/githits-cli-agent-evals/experiments/poc-33381601980-top-level-spans>.
 
-The exercised comparison command,
+The native-first exporter was subsequently exercised locally against those
+accepted artifacts as experiment `poc-33381601980-native-root` (ID
+`dfa37c74-0b31-4b48-aeb1-a2698a03cecc`) with exactly 23 rows. Native
+comparison/readback populated `duration`, prompt/completion/cache/reasoning
+token buckets, total `tokens`, and `estimated_cost`. Across the 23 rows,
+bounded SQL totals were `prompt_tokens=2,861,042`,
+`completion_tokens=20,942`, `tokens=2,881,984`, and
+`estimated_cost=0.23660003`; recorded duration ranged from 8.53 to 207.317
+seconds. The export and readback were local operations over the accepted
+artifacts, not CI proof.
+
+The native-root rows contain `tool_calls=119` and `tool_errors=2`, but the
+exercised comparison command,
 `bt experiments --json --project githits-cli-agent-evals compare
 poc-33381601980-top-level-spans poc-33381601980-repeat`, was run against the
-prior custom-only rows. It succeeded but reported only generic Braintrust trace
-metrics, all zero, and did not expose that custom eval telemetry. This is a
-historical custom-only observation; native-first UI and comparison behavior is
-unproven until a native-root export is read back. Investigating that comparison
-path remains a Phase 5/PoC follow-up.
+prior custom-only rows and is therefore only a historical custom-only
+observation. A native-root comparison reports standard `tool_calls` and
+`tool_errors` as zero because Braintrust derives those metrics from structural
+tool child spans, not root-row numeric fields. The exporter currently lacks
+per-call timestamps and does not fabricate child timing; native structural tool
+views remain unresolved while GitHits-specific/custom telemetry remains
+accurate. Investigating that structural comparison path remains a Phase 5/PoC
+follow-up.
 
 ## Scenario and intent identity
 

--- a/docs/implementation/agentic-eval-metrics.md
+++ b/docs/implementation/agentic-eval-metrics.md
@@ -92,8 +92,9 @@ silently. The workflow does not select a baseline or fail on metric movement.
 ### Verified PoC and comparison limitation
 
 The accepted GitHub run `33381601980` at SHA
-`dc63675d7c0ee95a9594eac272982943dceef521` validated and exported both suites
-as exactly 23 rows (two discovery plus 21 intent). The experiments
+`dc63675d7c0ee95a9594eac272982943dceef521` supplied the discovery and intent
+suite artifacts. Those artifacts were exported locally through `bt eval` as
+exactly 23 rows (two discovery plus 21 intent). The experiments
 `poc-33381601980-top-level-spans` and `poc-33381601980-repeat` were read back
 with 23 rows. Bounded SQL and row inspection reconciled prompts, neutral
 answers, prompt hashes, token buckets, duration, cost, and tool telemetry to
@@ -107,8 +108,7 @@ only generic Braintrust trace metrics, all zero; it does not expose the custom
 eval telemetry. Built-in comparison is therefore not a validated trend path.
 The current verified path is bounded `bt sql`/row inspection plus the
 experiment UI. Investigating a comparison that understands custom eval metrics
-is a Phase 5/PoC follow-up. CI acceptance remains pending until a real labeled
-or manual workflow run exports and readbacks 23 rows.
+is a Phase 5/PoC follow-up.
 
 ## Scenario and intent identity
 

--- a/docs/implementation/agentic-eval-metrics.md
+++ b/docs/implementation/agentic-eval-metrics.md
@@ -168,6 +168,24 @@ proof, not CI proof. The preceding
 `poc-native-tool-spans-20260831` experiment proved counts and timestamps but
 had null child duration and is superseded by the v2 experiment.
 
+The qualifying labeled CI proof is GitHub run
+[33424857668](https://github.com/githits-com/githits-cli/actions/runs/33424857668)
+at code SHA `7195ccc56b9ac9288dfb3d8de854f2f0e7ae7cf0`. Discovery completed in
+40 seconds, intent in 2 minutes 32 seconds, and summary/export in 22 seconds,
+for about 3 minutes total. Its Braintrust experiment is
+`github-33424857668-1` (ID `182ee9db-0df3-40f4-8987-6eeb6d91a89b`), with source
+`github`, exporter/schema 2, and metrics schema 3. Readback reconciled 23 eval
+spans and 116 structural tool spans exactly to 116 MCP calls: zero CLI calls
+and zero failed tool spans. Totals were 513.911 seconds of eval duration,
+126.458999872 seconds of tool duration, 2,686,094 prompt tokens, 20,172
+completion tokens, 2,706,266 total tokens, and estimated cost `$0.22819038`.
+Standard Braintrust compare averages were duration
+`22.343956532685652`, estimated cost `$0.009921320869565216`, tool calls
+`5.043478260869565`, tool errors `0`, and total tokens
+`117663.73913043478`. This validates the labeled pull-request path; default-
+branch scheduled/manual activation remains pending merge. No paid rerun
+was made for this documentation-only closeout.
+
 ## Scenario and intent identity
 
 The harness has three closed MCP scenarios:

--- a/docs/implementation/agentic-eval-metrics.md
+++ b/docs/implementation/agentic-eval-metrics.md
@@ -8,10 +8,107 @@ and the console summary are review aids built from that artifact; they do not
 replace the raw terminal output or `tool-calls.json`.
 
 This is local maintainer tooling plus the repository's dedicated Luna CI
-workflow. It is not a persistent history service, deterministic CI gate, or
-quality judge. Named Luna suites, local paired/offline comparisons, and daily
-or explicitly authorized pull-request execution are implemented here;
-long-term export and answer-quality scoring remain later phases.
+workflow and its Braintrust persistence boundary. It is not a deterministic CI
+gate or quality judge. Named Luna suites, local paired/offline comparisons,
+daily or explicitly authorized pull-request execution, and normalized
+per-workload history are implemented here; answer-quality scoring remains a
+later phase.
+
+## Braintrust persistence contract
+
+`scripts/agent-eval-braintrust.ts` is a post-run mapper and exporter. It loads
+each labeled `suite.json` through `loadImportedSuite()`, rejects dry-run or
+incompatible inputs before network setup, and requires contained report,
+metrics, workload, and prompt evidence for every exported cell. Duplicate
+scenario/workload cells, mixed target or measurement Git identity, mixed
+agent/model/reasoning/surface/server identity, and incompatible reporting or
+result schemas are preflight errors. Failed or partial cells are retained when
+their child evidence is complete.
+
+The exact-pinned `braintrust` SDK is `3.29.0`. The earlier design assumption
+that `Experiment.log()` could accept a scoreless eval row was disproved by the
+installed SDK: its runtime requires non-empty `scores`. This phase has no
+quality scorer and does not fabricate scores. Instead, the production adapter
+initializes one experiment with `update: false`, artifact `repoInfo`, and
+automatic Git collection disabled, then starts one top-level `type: "eval"`
+span named by `cellId` for each row, ends it immediately, calls `flush()`, and
+then calls `summarize({ summarizeScores: false })` for the permalink. Agent
+execution is not traced or instrumented by this boundary.
+
+### Row and field mapping
+
+| Export field | Source and policy |
+| --- | --- |
+| `input` | Stable `{scenario, workloadId, workloadPath, prompt, promptSha256}`. Agent, model, CLI, Git, and run identity stay out so unchanged cells compare across attempts. |
+| `output` | Cell, process, report, and final status; exact neutral `answer` when present; optional confidence and discovery status. |
+| `error` | Generated status-only `eval_status:<status>` for non-success cells. Raw shard errors, stderr, provider errors, and validation paths are never copied. |
+| `metrics` | Named numeric duration, tool, token, and estimated-cost fields from normalized records. Known zero is preserved; `null`/unknown is omitted. |
+| `metadata` | Suite/cell/run, guidance/intent, agent/model/reasoning/CLI, target/measurement Git, schema/contract, cost/rate, warning/validation, and reconciled tool telemetry identity. |
+| `tags` | `tool:<surface>:<tool>` only for tools with known positive usage. |
+
+The metric names are `agent_duration_ms`, `logical_tool_calls`,
+`mcp_tool_calls`, `cli_tool_calls`, `tool_calls_started`,
+`tool_calls_completed`, `tool_calls_failed`, `tool_calls_unknown`,
+`raw_tool_events`, `uncached_input_tokens`, `cached_input_tokens`,
+`cache_write_input_tokens`, `output_tokens`, `reasoning_output_tokens`, and
+`estimated_cost_usd`. When tool telemetry reconciles, metadata also preserves
+the ordered normalized sequence and nested per-tool/status counts, including
+known zero status counts. When it does not reconcile, `toolTelemetryKnown` is
+false, tool-count/status metrics and per-tool counts/tags are omitted, and only
+known raw event count remains. Prompt bytes and SHA-256 are read only from the
+contained `prompt.md` referenced by the rebuilt report; no other raw artifact
+content is newly read.
+
+The CLI accepts repeated `--suite <label>=<suite.json>` inputs, strict local or
+GitHub identity, and `--validate-only`. Validation and result JSON are safe to
+print: they contain only project/experiment identity, suite summaries, row
+count, mode, and an export URL when available. The result never contains
+prompt, answer, row bodies, absolute paths, auth state, or keys. Local
+subscription export runs the official entrypoint through
+`bt eval --runner bun --no-auto-instrumentation`; CI invokes
+`bun run agent:e2e:braintrust` directly with `BRAINTRUST_API_KEY` scoped only to
+the exporter step.
+
+Authenticated readback uses the exercised command forms below. The project
+option placement for list/view is intentional; use the returned experiment ID
+for the bounded SQL query:
+
+```bash
+bt experiments --json --project githits-cli-agent-evals list
+bt experiments --json --project githits-cli-agent-evals view <experiment-name>
+bt sql --json --non-interactive "SELECT input, output, metrics, metadata, tags FROM experiment('<experiment-id>') LIMIT 23"
+```
+
+### CI sequencing and failure visibility
+
+The scenario jobs and unconditional 14-day artifact uploads run first. The
+summary job renders its report with `continue-on-error`, then the Braintrust
+export step runs with `if: always()` and `continue-on-error`. A final no-secret
+step checks the scenario result, report outcome, and exporter outcome and exits
+nonzero with each failed stage. Thus raw evidence and the concise report remain
+available during exporter outages, while persistence failure cannot pass
+silently. The workflow does not select a baseline or fail on metric movement.
+
+### Verified PoC and comparison limitation
+
+The accepted GitHub run `33381601980` at SHA
+`dc63675d7c0ee95a9594eac272982943dceef521` validated and exported both suites
+as exactly 23 rows (two discovery plus 21 intent). The experiments
+`poc-33381601980-top-level-spans` and `poc-33381601980-repeat` were read back
+with 23 rows. Bounded SQL and row inspection reconciled prompts, neutral
+answers, prompt hashes, token buckets, duration, cost, and tool telemetry to
+the source artifacts. The first experiment permalink is
+<https://www.braintrust.dev/app/GitHits/p/githits-cli-agent-evals/experiments/poc-33381601980-top-level-spans>.
+
+The exercised comparison command,
+`bt experiments --json --project githits-cli-agent-evals compare
+poc-33381601980-top-level-spans poc-33381601980-repeat`, succeeds but reports
+only generic Braintrust trace metrics, all zero; it does not expose the custom
+eval telemetry. Built-in comparison is therefore not a validated trend path.
+The current verified path is bounded `bt sql`/row inspection plus the
+experiment UI. Investigating a comparison that understands custom eval metrics
+is a Phase 5/PoC follow-up. CI acceptance remains pending until a real labeled
+or manual workflow run exports and readbacks 23 rows.
 
 ## Scenario and intent identity
 
@@ -678,8 +775,10 @@ artifacts that resolve outside the run directory.
 | `scripts/agent-eval-report.ts`       | Safe metrics loading, derived report fields, and console formatting                              |
 | `scripts/agent-eval-suite.ts`        | Named-suite manifest validation, Luna orchestration, paired comparison, and artifact containment |
 | `scripts/agent-eval-ci-report.ts`    | Schema-validated absolute CI Markdown report and failure classification                        |
+| `scripts/agent-eval-braintrust.ts`   | Validated suite mapping, Braintrust export, CLI entrypoint, and safe result output               |
 | `scripts/agent-eval-suite.test.ts`   | Suite, comparison, CLI, failure, and containment coverage                                        |
 | `scripts/agent-eval.test.ts`         | Runner, report, fallback, safety, and integration coverage                                       |
 | `scripts/agent-eval-metrics.test.ts` | Adapter and metrics-contract coverage                                                            |
 | `.github/workflows/agent-evals.yml`  | Daily, labeled-PR, and manual Luna execution plus unconditional summary                         |
 | `eval/agentic/README.md`             | User-facing harness usage, workload guidance, and limitations                                    |
+| `.agents/skills/braintrust-agent-evals/SKILL.md` | Internal read/query/export operating commands                                  |

--- a/docs/implementation/agentic-eval-metrics.md
+++ b/docs/implementation/agentic-eval-metrics.md
@@ -3,7 +3,7 @@
 ## Purpose
 
 The agentic eval runner preserves raw workload evidence and now derives a
-schema-versioned `metrics.json` artifact for local inspection. `report.json`
+schema-v3 `metrics.json` artifact for local inspection. `report.json`
 and the console summary are review aids built from that artifact; they do not
 replace the raw terminal output or `tool-calls.json`.
 
@@ -24,7 +24,8 @@ input must contribute at least one workload cell. Duplicate scenario/workload
 cells, mixed target or measurement Git identity, mixed
 agent/model/reasoning/surface/server identity, and incompatible reporting or
 result schemas are preflight errors. Failed or partial cells are retained when
-their child evidence is complete.
+their child evidence is complete; tool-bearing legacy cells upgraded with null
+timing are rejected because accurate structural spans cannot be created.
 
 The exact-pinned `braintrust` SDK is `3.29.0`. The earlier design assumption
 that `Experiment.log()` could accept a scoreless eval row was disproved by the
@@ -35,6 +36,9 @@ automatic Git collection disabled, then starts one top-level `type: "eval"`
 span named by `cellId` for each row, ends it immediately, calls `flush()`, and
 then calls `summarize({ summarizeScores: false })` for the permalink. Agent
 execution is not traced or instrumented by this boundary.
+The exporter metadata contract is schema/version 2; both values are retained
+in experiment metadata for regression attribution. The safe CLI result keeps
+its separate result-file schema version.
 
 ### Row and field mapping
 
@@ -48,8 +52,8 @@ execution is not traced or instrumented by this boundary.
 | `tags` | `tool:<surface>:<tool>` only for tools with known positive usage. |
 
 The mapper uses Braintrust-native metric names for values with a standard
-meaning: `duration` (seconds from recorded milliseconds), `tool_calls`,
-`tool_errors`, `prompt_tokens`, `prompt_cached_tokens`,
+meaning: `duration` (seconds from recorded milliseconds), `prompt_tokens`,
+`prompt_cached_tokens`,
 `prompt_cache_creation_tokens`, `completion_tokens`,
 `completion_reasoning_tokens`, `tokens`, and `estimated_cost`. The input token
 total comes from Codex `providerUsage.input_tokens`, which includes cached reads
@@ -59,10 +63,24 @@ remaining non-native metrics are `mcp_tool_calls`, `cli_tool_calls`,
 `raw_tool_events`. Known zeroes are preserved and unknown values are omitted.
 When tool telemetry reconciles, metadata also preserves the ordered normalized
 sequence and nested per-tool/status counts, including known zero status counts.
-When it does not reconcile, `toolTelemetryKnown` is false, tool-count/status
-metrics and per-tool counts/tags are omitted, and only known raw event count
-remains. Prompt bytes and SHA-256 are read only from the contained `prompt.md`
+When it does not reconcile, the exporter rejects a tool-bearing row rather than
+uploading incomplete native tool telemetry; a zero-tool row remains valid.
+Prompt bytes and SHA-256 are read only from the contained `prompt.md`
 referenced by the rebuilt report; no other raw artifact content is newly read.
+Raw `tool-calls.json` lifecycle events may retain their optional ISO
+`observedAt`; normalized timing is derived only from those harness receipt
+observations.
+
+Known logical tool calls are also represented structurally as Braintrust `tool`
+children under their top-level eval row. A completed or failed child uses the
+normalized tool name, exact harness-observed start/end seconds, and
+`event.metrics.duration` computed from those boundaries. A started-only child
+is left open and omits duration. Child event data contains only tool, surface,
+status, the `harness_stdout_observed` timing-source marker, and the generated
+`tool_status:failed` error for failed calls. Root `tool_calls` and
+`tool_errors` are intentionally absent because Braintrust derives those native
+metrics from structural children. The exporter rejects missing, invalid,
+reverse, or out-of-parent observed timing; it never fabricates a boundary.
 
 The CLI accepts repeated `--suite <label>=<suite.json>` inputs, strict local or
 GitHub identity, and `--validate-only`. Validation and result JSON are safe to
@@ -81,8 +99,13 @@ for the bounded SQL query:
 ```bash
 bt experiments --json --project githits-cli-agent-evals list
 bt experiments --json --project githits-cli-agent-evals view <experiment-name>
-bt sql --json --non-interactive "SELECT input, output, metrics, metadata, tags FROM experiment('<experiment-id>') LIMIT 23"
+bt sql --json --non-interactive "SELECT input, output, metrics, metadata, tags FROM experiment('<experiment-id>') WHERE span_attributes.type = 'eval' LIMIT 23"
+bt sql --json --non-interactive "SELECT name, span_attributes.type, metrics, metadata FROM experiment('<experiment-id>') WHERE span_attributes.type = 'tool' LIMIT 100"
 ```
+
+The exporter experiment contains one eval root per workload cell plus one
+structural tool child per normalized logical call. Filter `span_attributes.type`
+to count rows: an unfiltered `count(*)` includes both kinds of span.
 
 ### CI sequencing and failure visibility
 
@@ -94,7 +117,7 @@ nonzero with each failed stage. Thus raw evidence and the concise report remain
 available during exporter outages, while persistence failure cannot pass
 silently. The workflow does not select a baseline or fail on metric movement.
 
-### Verified PoC and comparison limitation
+### Verified PoC and historical migration evidence
 
 The accepted GitHub run `33381601980` at SHA
 `dc63675d7c0ee95a9594eac272982943dceef521` supplied the discovery and intent
@@ -106,8 +129,8 @@ answers, prompt hashes, token buckets, duration, cost, and tool telemetry to
 the source artifacts. The first experiment permalink is
 <https://www.braintrust.dev/app/GitHits/p/githits-cli-agent-evals/experiments/poc-33381601980-top-level-spans>.
 
-The native-first exporter was subsequently exercised locally against those
-accepted artifacts as experiment `poc-33381601980-native-root` (ID
+The superseded pre-structural exporter was subsequently exercised locally
+against those accepted artifacts as experiment `poc-33381601980-native-root` (ID
 `dfa37c74-0b31-4b48-aeb1-a2698a03cecc`) with exactly 23 rows. Native
 comparison/readback populated `duration`, prompt/completion/cache/reasoning
 token buckets, total `tokens`, and `estimated_cost`. Across the 23 rows,
@@ -117,18 +140,32 @@ bounded SQL totals were `prompt_tokens=2,861,042`,
 seconds. The export and readback were local operations over the accepted
 artifacts, not CI proof.
 
-The native-root rows contain `tool_calls=119` and `tool_errors=2`, but the
-exercised comparison command,
-`bt experiments --json --project githits-cli-agent-evals compare
-poc-33381601980-top-level-spans poc-33381601980-repeat`, was run against the
-prior custom-only rows and is therefore only a historical custom-only
-observation. A native-root comparison reports standard `tool_calls` and
-`tool_errors` as zero because Braintrust derives those metrics from structural
-tool child spans, not root-row numeric fields. The exporter currently lacks
-per-call timestamps and does not fabricate child timing; native structural tool
-views remain unresolved while GitHits-specific/custom telemetry remains
-accurate. Investigating that structural comparison path remains a Phase 5/PoC
-follow-up.
+The native-root rows contain `tool_calls=119` and `tool_errors=2` as root
+numeric fields. That experiment predates structural child export and is
+superseded for current native tool behavior: its standard comparison reported
+zero because Braintrust derives those metrics from structural tool children.
+The preceding custom-only comparison observation is likewise historical; keep
+both experiments only as provenance for the migration.
+
+The current local native structural proof used suite
+`.agent-eval/suites/native-tool-smoke-2` at target and measurement commit
+`4850299`. Its Luna-low intent canary ran with workload concurrency 2: 2/2
+workloads succeeded, with 10 logical MCP calls, zero CLI calls and failures,
+and complete harness-observed intervals for all 10 calls. Wall time was
+43.447 seconds, cumulative agent time 71.855 seconds, and estimated cost
+`$0.02070904`.
+
+The resulting experiment `poc-native-tool-spans-v2-20260831` (ID
+`e8480301-6622-4a06-a37b-0ebd0e42bb64`,
+<https://www.braintrust.dev/app/GitHits/p/githits-cli-agent-evals/experiments/poc-native-tool-spans-v2-20260831>)
+read back two eval roots and 10 structural tool children. Native comparison
+reported `tool_calls` average `5.0` and `tool_errors` `0`. Child SQL showed
+exact start/end observations and computed duration totaling 30.970 seconds,
+with individual durations from 0.006 to 10.400 seconds; eval duration totaled
+71.855 seconds. Native token and cost fields remain populated. This is local
+proof, not CI proof. The preceding
+`poc-native-tool-spans-20260831` experiment proved counts and timestamps but
+had null child duration and is superseded by the v2 experiment.
 
 ## Scenario and intent identity
 
@@ -639,7 +676,7 @@ persistent service history, Haiku execution, or quality judging.
 
 ## Metrics contract
 
-The current top-level artifact has `schemaVersion: 2`, `runId`, `startedAt`,
+The current top-level artifact has `schemaVersion: 3`, `runId`, `startedAt`,
 `completedAt`, `records`, `aggregates`, and de-duplicated `warnings`. Historical
 schema-v1 metrics remain readable through deterministic normalization at the
 loader boundary. For a valid v1 record, `descriptors` guidance becomes neutral
@@ -672,10 +709,13 @@ current Codex CLI does not expose a provider-resolved model, so Phase 1 writes
 `tools` contains raw event count, the current logical-call count, completed and
 failed counts, sorted unique normalized tool names, and ordered sequence
 entries. Sequence entries retain `mcp` or `cli`
-surface and normalized status (`started`, `completed`, `failed`, or `unknown`).
-The builder preserves duplicate raw observations and their order; Codex's
-derived sequence applies provider-ID pairing as described below. A persisted
-call with
+surface, normalized status (`started`, `completed`, `failed`, or `unknown`),
+and nullable harness-observed `startedAt`/`completedAt` ISO timestamps. These
+are receipt times for complete stdout JSONL lifecycle lines, not provider
+execution times. Existing schema-v1 and schema-v2 artifacts remain readable;
+their missing timing is upgraded to `null`. The builder preserves duplicate
+raw observations and their order; Codex's derived sequence applies provider-ID
+pairing as described below. A persisted call with
 `server: "githits-cli"` is `cli`; other persisted GitHits calls are `mcp`.
 
 The run aggregates sum only known record values. Token and cost totals are

--- a/docs/implementation/agentic-eval-metrics.md
+++ b/docs/implementation/agentic-eval-metrics.md
@@ -19,8 +19,9 @@ later phase.
 `scripts/agent-eval-braintrust.ts` is a post-run mapper and exporter. It loads
 each labeled `suite.json` through `loadImportedSuite()`, rejects dry-run or
 incompatible inputs before network setup, and requires contained report,
-metrics, workload, and prompt evidence for every exported cell. Duplicate
-scenario/workload cells, mixed target or measurement Git identity, mixed
+metrics, workload, and prompt evidence for every exported cell. Each suite
+input must contribute at least one workload cell. Duplicate scenario/workload
+cells, mixed target or measurement Git identity, mixed
 agent/model/reasoning/surface/server identity, and incompatible reporting or
 result schemas are preflight errors. Failed or partial cells are retained when
 their child evidence is complete.

--- a/docs/implementation/agentic-eval-metrics.md
+++ b/docs/implementation/agentic-eval-metrics.md
@@ -47,18 +47,22 @@ execution is not traced or instrumented by this boundary.
 | `metadata` | Suite/cell/run, guidance/intent, agent/model/reasoning/CLI, target/measurement Git, schema/contract, cost/rate, warning/validation, and reconciled tool telemetry identity. |
 | `tags` | `tool:<surface>:<tool>` only for tools with known positive usage. |
 
-The metric names are `agent_duration_ms`, `logical_tool_calls`,
-`mcp_tool_calls`, `cli_tool_calls`, `tool_calls_started`,
-`tool_calls_completed`, `tool_calls_failed`, `tool_calls_unknown`,
-`raw_tool_events`, `uncached_input_tokens`, `cached_input_tokens`,
-`cache_write_input_tokens`, `output_tokens`, `reasoning_output_tokens`, and
-`estimated_cost_usd`. When tool telemetry reconciles, metadata also preserves
-the ordered normalized sequence and nested per-tool/status counts, including
-known zero status counts. When it does not reconcile, `toolTelemetryKnown` is
-false, tool-count/status metrics and per-tool counts/tags are omitted, and only
-known raw event count remains. Prompt bytes and SHA-256 are read only from the
-contained `prompt.md` referenced by the rebuilt report; no other raw artifact
-content is newly read.
+The mapper uses Braintrust-native metric names for values with a standard
+meaning: `duration` (seconds from recorded milliseconds), `tool_calls`,
+`tool_errors`, `prompt_tokens`, `prompt_cached_tokens`,
+`prompt_cache_creation_tokens`, `completion_tokens`,
+`completion_reasoning_tokens`, `tokens`, and `estimated_cost`. The input token
+total comes from Codex `providerUsage.input_tokens`, which includes cached reads
+and cache creation; `tokens` is that total plus provider output tokens. The
+remaining non-native metrics are `mcp_tool_calls`, `cli_tool_calls`,
+`tool_calls_started`, `tool_calls_completed`, `tool_calls_unknown`, and
+`raw_tool_events`. Known zeroes are preserved and unknown values are omitted.
+When tool telemetry reconciles, metadata also preserves the ordered normalized
+sequence and nested per-tool/status counts, including known zero status counts.
+When it does not reconcile, `toolTelemetryKnown` is false, tool-count/status
+metrics and per-tool counts/tags are omitted, and only known raw event count
+remains. Prompt bytes and SHA-256 are read only from the contained `prompt.md`
+referenced by the rebuilt report; no other raw artifact content is newly read.
 
 The CLI accepts repeated `--suite <label>=<suite.json>` inputs, strict local or
 GitHub identity, and `--validate-only`. Validation and result JSON are safe to
@@ -104,12 +108,12 @@ the source artifacts. The first experiment permalink is
 
 The exercised comparison command,
 `bt experiments --json --project githits-cli-agent-evals compare
-poc-33381601980-top-level-spans poc-33381601980-repeat`, succeeds but reports
-only generic Braintrust trace metrics, all zero; it does not expose the custom
-eval telemetry. Built-in comparison is therefore not a validated trend path.
-The current verified path is bounded `bt sql`/row inspection plus the
-experiment UI. Investigating a comparison that understands custom eval metrics
-is a Phase 5/PoC follow-up.
+poc-33381601980-top-level-spans poc-33381601980-repeat`, was run against the
+prior custom-only rows. It succeeded but reported only generic Braintrust trace
+metrics, all zero, and did not expose that custom eval telemetry. This is a
+historical custom-only observation; native-first UI and comparison behavior is
+unproven until a native-root export is read back. Investigating that comparison
+path remains a Phase 5/PoC follow-up.
 
 ## Scenario and intent identity
 

--- a/docs/implementation/agentic-eval-metrics.md
+++ b/docs/implementation/agentic-eval-metrics.md
@@ -41,6 +41,52 @@ The exporter metadata contract is schema/version 2; both values are retained
 in experiment metadata for regression attribution. The safe CLI result keeps
 its separate result-file schema version.
 
+### Experiment identity and baseline linkage
+
+One exporter invocation is one immutable Braintrust experiment. Each
+scenario/workload cell is one eval row and each normalized logical tool call is
+one structural `tool` child beneath that row. The exporter owns stable names:
+`main-r<RUN_ID>-a<ATTEMPT>` for a main execution,
+`pr-<PR_NUMBER>-r<RUN_ID>-a<ATTEMPT>` for a pull request, and
+`local-<branch-slug>-<UTC-timestamp-with-milliseconds>-<short-sha>` for a
+local execution. Local branch slugs are lowercase, collapse each run of
+non-ASCII-alphanumeric characters to one hyphen, and trim hyphens. GitHub
+experiments use the workflow's real branch, full SHA, run ID, attempt, and PR
+number; local exports resolve the branch from the evaluated suite unless a
+detached suite requires `--branch`.
+
+The experiment metadata and allowlisted tags retain source (`local` or
+`github`), channel (`local`, `main`, or `pr`), branch, optional PR number, full
+SHA, run identity, and evaluated-target `repoInfo` including dirty state. The
+workflow passes `channel=main` for schedule/manual runs on `main` and
+`channel=pr` with the head branch and numeric PR number for the trusted
+same-repository label event. Manual dispatch on a non-main ref is rejected
+before either paid scenario job can start.
+
+Before initializing an export, the authenticated integration boundary pages
+through the newest-first project experiment list and selects the first object
+whose returned metadata channel is `main` and whose name matches
+`/^main-r\\d+-a\\d+$/`. Selection is client-side and uses the final object ID
+as the cursor while a page is full; no metadata filter is sent. A resolved ID
+is passed as `baseExperimentId`, and explicit local `--base-experiment` takes
+precedence and skips discovery. PR and default-local exports fail before
+experiment initialization when no main baseline exists. A main export is
+allowed as the one-time bootstrap; SDK 3.29.0 may choose an automatic
+ancestry for that first run because the public contract has no explicit
+no-base option, so the returned value is reported rather than treated as
+explicit linkage.
+
+After flush, the exporter calls `fetchBaseExperiment()` and includes only the
+actual safe `{id, name}` or `null` in the result. CI appends the experiment
+name/link and actual base name/ID (or explicit bootstrap/no-base text) to the
+step summary. Validate-only builds and prints the same identity/name without
+credentials, network access, or baseline discovery; its base is reported as
+unresolved/not queried. This identity and linkage behavior is deterministic
+and covered by the focused tests, but it has not yet been live-proven for a
+later main run linking to main, a PR linking to main, and a local run linking
+to main. Historical `github-*` experiments retain their old identity and
+null-linkage observations and are not evidence for this new contract.
+
 ### Row and field mapping
 
 | Export field | Source and policy |
@@ -84,11 +130,12 @@ metrics from structural children. The exporter rejects missing, invalid,
 reverse, or out-of-parent observed timing; it never fabricates a boundary.
 
 The CLI accepts repeated `--suite <label>=<suite.json>` inputs, strict local or
-GitHub identity, and `--validate-only`. Validation and result JSON are safe to
-print: they contain only project/experiment identity, suite summaries, row
-count, mode, and an export URL when available. The result never contains
-prompt, answer, row bodies, absolute paths, auth state, or keys. Local
-subscription export runs the official entrypoint through
+GitHub identity, channel-aware branch/PR fields, and `--validate-only`.
+Validation and result JSON are safe to print: they contain only
+project/experiment identity, suite summaries, row count, mode, an export URL
+when available, and the safe actual base `{id, name}` or `null`. The result
+never contains prompt, answer, row bodies, absolute paths, auth state, or keys.
+Local subscription export runs the official entrypoint through
 `bt eval --runner bun --no-auto-instrumentation`; CI invokes
 `bun run agent:e2e:braintrust` directly with `BRAINTRUST_API_KEY` scoped only to
 the exporter step.
@@ -116,7 +163,8 @@ export step runs with `if: always()` and `continue-on-error`. A final no-secret
 step checks the scenario result, report outcome, and exporter outcome and exits
 nonzero with each failed stage. Thus raw evidence and the concise report remain
 available during exporter outages, while persistence failure cannot pass
-silently. The workflow does not select a baseline or fail on metric movement.
+silently. The report does not select a baseline or fail on metric movement;
+the subsequent exporter resolves and records the native Braintrust base link.
 
 ### Verified PoC and historical migration evidence
 

--- a/docs/implementation/agentic-eval-metrics.md
+++ b/docs/implementation/agentic-eval-metrics.md
@@ -66,7 +66,7 @@ before either paid scenario job can start.
 Before initializing an export, the authenticated integration boundary pages
 through the newest-first project experiment list and selects the first object
 whose returned metadata channel is `main` and whose name matches
-`/^main-r\\d+-a\\d+$/`. Selection is client-side and uses the final object ID
+`/^main-r\d+-a\d+$/`. Selection is client-side and uses the final object ID
 as the cursor while a page is full; no metadata filter is sent. A resolved ID
 is passed as `baseExperimentId`, and explicit local `--base-experiment` takes
 precedence and skips discovery. PR and default-local exports fail before
@@ -75,6 +75,10 @@ allowed as the one-time bootstrap; SDK 3.29.0 may choose an automatic
 ancestry for that first run because the public contract has no explicit
 no-base option, so the returned value is reported rather than treated as
 explicit linkage.
+
+Main baseline selection intentionally does not exclude an experiment with the
+same evaluated SHA. Harness, model, or service drift is temporal and can occur
+without a source change; filtering same-SHA attempts would hide that signal.
 
 After flush, the exporter calls `fetchBaseExperiment()` and includes only the
 actual safe `{id, name}` or `null` in the result. CI appends the experiment
@@ -86,6 +90,10 @@ and covered by the focused tests, but it has not yet been live-proven for a
 later main run linking to main, a PR linking to main, and a local run linking
 to main. Historical `github-*` experiments retain their old identity and
 null-linkage observations and are not evidence for this new contract.
+For an export, the reported experiment name is the SDK's actual `Experiment.name`
+readback after flush, so it remains accurate if an explicit local name is
+reused and Braintrust de-duplicates it; validate-only reports the requested or
+generated name because no server experiment exists.
 
 ### Row and field mapping
 

--- a/docs/implementation/agentic-eval-metrics.md
+++ b/docs/implementation/agentic-eval-metrics.md
@@ -33,9 +33,10 @@ installed SDK: its runtime requires non-empty `scores`. This phase has no
 quality scorer and does not fabricate scores. Instead, the production adapter
 initializes one experiment with `update: false`, artifact `repoInfo`, and
 automatic Git collection disabled, then starts one top-level `type: "eval"`
-span named by `cellId` for each row, ends it immediately, calls `flush()`, and
-then calls `summarize({ summarizeScores: false })` for the permalink. Agent
-execution is not traced or instrumented by this boundary.
+span named by `cellId` for each row, creates and closes its validated structural
+tool children, closes the eval root, calls `flush()`, and then calls
+`summarize({ summarizeScores: false })` for the permalink. Agent execution is
+not traced or instrumented by this boundary.
 The exporter metadata contract is schema/version 2; both values are retained
 in experiment metadata for regression attribution. The safe CLI result keeps
 its separate result-file schema version.

--- a/docs/implementation/agentic-eval-metrics.md
+++ b/docs/implementation/agentic-eval-metrics.md
@@ -38,8 +38,8 @@ tool children, closes the eval root, calls `flush()`, and then calls
 `summarize({ summarizeScores: false })` for the permalink. Agent execution is
 not traced or instrumented by this boundary.
 The exporter metadata contract is schema/version 2; both values are retained
-in experiment metadata for regression attribution. The safe CLI result keeps
-its separate result-file schema version.
+in experiment metadata for regression attribution. The safe CLI result uses its
+separate result-file schema version 2.
 
 ### Experiment identity and baseline linkage
 
@@ -131,10 +131,13 @@ reverse, or out-of-parent observed timing; it never fabricates a boundary.
 
 The CLI accepts repeated `--suite <label>=<suite.json>` inputs, strict local or
 GitHub identity, channel-aware branch/PR fields, and `--validate-only`.
-Validation and result JSON are safe to print: they contain only
-project/experiment identity, suite summaries, row count, mode, an export URL
-when available, and the safe actual base `{id, name}` or `null`. The result
-never contains prompt, answer, row bodies, absolute paths, auth state, or keys.
+Validation and result JSON are safe to print: they use result-file schema
+version 2 and contain only project/experiment identity, suite summaries, row
+count, mode, an export URL when available, and the safe actual base
+`{id, name}` or `null`. In validate-only mode `baseExperiment: null` means
+unresolved/not queried; in export mode `null` means required Braintrust
+readback returned no actual linked base. The result never contains prompt,
+answer, row bodies, absolute paths, auth state, or keys.
 Local subscription export runs the official entrypoint through
 `bt eval --runner bun --no-auto-instrumentation`; CI invokes
 `bun run agent:e2e:braintrust` directly with `BRAINTRUST_API_KEY` scoped only to

--- a/docs/plans/systematic-agent-evals.md
+++ b/docs/plans/systematic-agent-evals.md
@@ -4,12 +4,13 @@
 
 - Overall: IN PROGRESS
 - Current phase: Phase 4 — Braintrust Persistence Proof Of Concept
-  (LABELED CI PATH COMPLETE; DEFAULT-BRANCH ACTIVATION PENDING MERGE)
+  (PERSISTENCE PROVEN; COMPARISON IDENTITY CORRECTION READY)
 - Previous work: Phase 2 correction is COMPLETE. Phase 3 is merged and its
   same-repository label path is live-validated; Phase 4's exporter, CI wiring,
   local Braintrust readback, and first qualifying labeled CI export/readback
-  are complete. Default-branch scheduled/manual activation remains pending
-  merge.
+  are complete. The exact-head run proved persistence again, but exposed null
+  branch and base-experiment identity. Stable naming and native main-baseline
+  linkage are now required before Phase 4 is complete.
 - Owner: repository maintainers
 - Last verified: 2026-08-31
 - Deployment: Phases 1 through 3 are merged to `main`. The Phase 3
@@ -17,9 +18,10 @@
   for its first default-branch execution. Phase 4's exact-pinned exporter and
   post-report CI step are implemented, with local and labeled CI
   persistence/readback proven. A push to `main` deliberately does not trigger
-  the workflow, and default-branch scheduled/manual activation remains
-  pending merge. Cadence changes remain deferred until persistent
-  evidence is visible.
+  the workflow. The next correction must preserve the verified persistence
+  shape while making main, pull-request, and local experiments discoverable
+  and natively comparable. Default-branch scheduled/manual activation remains
+  pending merge.
 
 ## Problem And Expected Outcome
 
@@ -622,12 +624,12 @@ The following must be resolved before Phase 6:
    clean GitHub-hosted jobs run the Luna discovery and intent suites daily or
    after an authorized PR label, retain raw evidence, and render a concise
    no-baseline summary. A push to `main` does not start a paid run.
-4. **Phase 4 — Braintrust persistence proof of concept (LABELED CI PATH
-   COMPLETE; DEFAULT-BRANCH ACTIVATION PENDING MERGE):** normalized Phase 3 records
-   become durable per-workload/per-agent history without making agent
-   execution dependent on Braintrust. Local and labeled CI export/readback
-   are proven; default-branch scheduled/manual activation remains pending
-   merge.
+4. **Phase 4 — Braintrust persistence proof of concept (PERSISTENCE PROVEN;
+   COMPARISON IDENTITY CORRECTION READY):** normalized Phase 3 records become
+   durable per-workload/per-agent history without making agent execution
+   dependent on Braintrust. Local and labeled CI export/readback are proven;
+   stable channel-aware names and native main-baseline linkage must still be
+   implemented and proven for main, pull-request, and local runs.
 5. **Phase 5 — broader discovery matrix (PLANNED):** the proven metrics, suite,
    CI, and persistence contracts add approved Codex/Claude agent-model cells to
    the neutral canary without changing Luna history.
@@ -1685,16 +1687,18 @@ None.
 
 ### Status
 
-LABELED CI PATH COMPLETE; DEFAULT-BRANCH SCHEDULED/MANUAL ACTIVATION PENDING
-MERGE.
+PERSISTENCE PROVEN; COMPARISON IDENTITY CORRECTION READY.
 Phase 3 is merged and its same-repository label path has clean runner evidence.
 The exact-pinned Braintrust exporter, post-report CI wiring, local
 persistence/readback proof, internal operations skill, and qualifying labeled
 CI export/readback are complete. The local and CI native structural proofs
 verify tool counts, exact observed boundaries, child duration, tokens, and
-cost. Default-branch scheduled/manual activation remains pending merge;
-no paid rerun was made for this documentation-only closeout. SDK tracing was
-deliberately not added.
+cost. Exact-head labeled run `33429755678` persisted the final PR head but
+confirmed that experiment `base_exp_id` and branch identity are null and that
+the opaque `github-<run>-<attempt>` name is insufficient for routine operation.
+Stable naming and native comparison linkage are required before Phase 4 is
+complete. Default-branch scheduled/manual activation remains pending merge.
+SDK tracing was deliberately not added.
 
 ### Expected Outcome
 
@@ -1708,6 +1712,14 @@ repository/harness identity, exact Codex CLI/model identity, and a link to the
 GitHub workflow evidence. Local and GitHub suite generation and concise
 reporting remain independent of Braintrust. No SDK tracing is inserted into
 Codex, the GitHits MCP server, or the harness execution path.
+
+One execution remains one immutable Braintrust experiment. Its workload and
+scenario cells remain the comparable eval rows, and logical tool calls remain
+structural children. Experiments use stable channel-aware names and complete Git
+identity so Braintrust can link pull-request, local, and later main executions
+to the latest preceding main experiment. This preserves Braintrust's run-snapshot
+model; it does not append executions as rows inside per-workload experiments or
+write eval data to the production Logs stream.
 
 ### Assumptions
 
@@ -1732,8 +1744,15 @@ Codex, the GitHits MCP server, or the harness execution path.
   the tool-bearing row. Exporter schema/version is 2, and schema-v1/v2 metrics
   remain readable with missing timing normalized to null.
 - One CI run attempt is one immutable experiment. GitHub `run_id` plus
-  `run_attempt` gives reruns distinct names, so no event-ID scheme, upsert,
-  retry, or duplicate-repair mechanism is required.
+  `run_attempt` gives reruns distinct names. The stable naming contract is
+  `main-r<RUN_ID>-a<ATTEMPT>` for main-branch schedule/manual executions and
+  `pr-<NUMBER>-r<RUN_ID>-a<ATTEMPT>` for labeled pull-request executions.
+  Local exports default to
+  `local-<branch-slug>-<UTC-timestamp-with-milliseconds>-<short-sha>`. Channel,
+  branch, pull request number when present, full SHA, and run URL remain
+  structured metadata/tags rather than being recoverable only from the display
+  name. No event-ID scheme, upsert, retry, or duplicate-repair mechanism is
+  required.
 - The existing `bt` OAuth profile is suitable for local read/query operations
   and for a `bt eval` wrapper that injects resolved authentication into its Bun
   child. CI uses only the repository secret `BRAINTRUST_API_KEY` and invokes the
@@ -1754,6 +1773,27 @@ then reads its permalink through `summarize({ summarizeScores: false })`. This
 is a resolved implementation contradiction, not a reason to alter the neutral
 metrics contract.
 
+### Resolved Braintrust storage-model question
+
+Braintrust documents an experiment as an immutable snapshot of one eval run and
+uses identical row `input` values to match test cases between experiments. The
+current execution-to-experiment and workload/scenario-to-row mapping follows
+that model. A per-workload experiment with executions appended as rows would
+invert the model, mix points in time inside one snapshot, and weaken native
+experiment comparison. The project Logs view is expected to remain empty
+because it represents production log streams, not experiment rows.
+
+The actual defect is comparison identity. Exact-head experiment
+`github-33429755678-1` (ID `917d0a9e-9eec-42f6-b888-a109705fca0c`) has commit
+`dd01bceee724f61f968f3024673b32824f30d0c8`, but its branch and `base_exp_id`
+are null. GitHub checks out the evaluated SHA detached, while the exporter
+currently relies on suite Git discovery and supplies no explicit base. The
+workflow owns event channel, source branch, pull-request number, run ID, and
+attempt; the exporter owns normalization into Braintrust experiment identity.
+Threading those existing workflow values across that boundary is the local
+fix, and the ownership remains correct; no new service or state store is
+needed.
+
 ### Unknowns Or Product Decisions
 
 No product choice blocks the implementation. The selected policy is:
@@ -1765,6 +1805,18 @@ No product choice blocks the implementation. The selected policy is:
   the exact prompt and neutral answer, not stdout, stderr, environment values,
   MCP payloads, or auth state;
 - quality: no scorer or `scores` value in this phase;
+- comparison: before creating the current experiment, the Braintrust boundary
+  pages through the public newest-first experiment-list API scoped to the
+  project and selects the first returned object whose
+  `metadata.channel = main` and name matches the `main-r...-a...` contract. The
+  API has no server-side metadata filter. The selected ID is supplied as
+  `baseExperimentId`, yielding the preceding main run for a new main execution
+  and the latest main run for pull-request/local execution. Local export also
+  accepts an explicit main experiment name as an override. The actual linked
+  base ID/name is returned in the nonsecret result and rendered in CI/local
+  output. A PR or default local export before the first main baseline fails
+  before experiment creation; it never substitutes another channel. The first
+  main execution is the one-time bootstrap described below;
 - export failure: preserve the GitHub summary/artifacts, then fail the final
   workflow status so missing persistence cannot be silent;
 - retention: Braintrust is the durable normalized history. GitHub raw artifacts
@@ -1812,6 +1864,20 @@ merge.
   experiment URLs. The installed 3.29.0 runtime requires non-empty scores for
   `Experiment.log()`, so the exporter uses scoreless top-level eval spans and
   does not fabricate quality scores.
+- The installed SDK defines an experiment as a snapshot of an application at a
+  point in time and states that experiments are compared by identical `input`.
+  The public Braintrust
+  [experiment-list endpoint](https://www.braintrust.dev/docs/api-reference/experiments/list-experiments)
+  is newest-first and supports project scoping and cursor pagination, but not a
+  metadata filter. The integration must select the latest main experiment from
+  returned metadata/name client-side. `baseExperimentId` pins that selection,
+  and `Experiment.fetchBaseExperiment()` returns the actual linked ID/name
+  without score summarization. The installed SDK's automatic ancestry is not
+  used after bootstrap: 3.29.0 computes it separately from `repoInfo`. It also
+  exposes no explicit "no base" option, so the first main bootstrap may retain
+  an SDK-selected legacy ancestor; this actual value is reported but is not
+  accepted as proof of explicit main linkage. Per-workload experiments and
+  production-log ingestion remain out of scope.
 - Braintrust [SQL](https://www.braintrust.dev/docs/reference/sql) and the
   `bt experiments`/`bt sql` commands can inspect and compare the persisted fields.
   The repository skill records only commands exercised against the PoC
@@ -1895,17 +1961,34 @@ Standard Braintrust compare averages were duration
 scheduled/manual activation remains pending merge. No paid rerun was
 made for this documentation-only closeout.
 
+The user then requested an exact-head PR run. GitHub run
+[33429755678](https://github.com/githits-com/githits-cli/actions/runs/33429755678)
+at final head `dd01bceee724f61f968f3024673b32824f30d0c8` passed: discovery took
+52 seconds, intent 2 minutes 44 seconds, and summary/export 22 seconds. Its
+experiment `github-33429755678-1` (ID
+`917d0a9e-9eec-42f6-b888-a109705fca0c`) contains 23 eval roots and 111 tool
+children, exactly matching 111 MCP calls and zero CLI calls. One failed
+`pkg_changelog` child is retained under
+`intent/package-vulnerability-rubygems`. Eval totals are 539.891 seconds,
+2,724,638 prompt tokens, 20,526 completion tokens, 2,745,164 total tokens, and
+estimated cost `$0.23155396`; tool duration totals 239.36799836158752 seconds.
+The experiment commit is correct, but branch and `base_exp_id` are null. This
+run proves final-head persistence and supplies the correction's failing live
+case; it does not satisfy native baseline linkage.
+
 ### Affected Components
 
 - `scripts/agent-eval-braintrust.ts` and focused tests for pure mapping, CLI
-  parsing, and an injected SDK boundary;
+  parsing, channel-aware naming, branch/base propagation, result reporting, and
+  an injected SDK boundary;
 - `scripts/agent-eval-report.ts` and focused tests to preserve the already
   emitted `prompt.md` path and neutral answer in contained `report.json`
   evidence;
 - `package.json`/`bun.lock` for one exact-pinned `braintrust` development
   dependency and exporter entrypoint;
 - `.github/workflows/agent-evals.yml` for a post-report export step, narrowly
-  scoped secret, nonsecret result link, and final status aggregation;
+  scoped secret, event-aware channel/branch/PR identity, nonsecret result link,
+  and final status aggregation;
 - `.gitignore` for `.bt/` local CLI state;
 - `eval/agentic/README.md` and
   `docs/implementation/agentic-eval-metrics.md` for durable operations and data
@@ -1938,22 +2021,37 @@ made for this documentation-only closeout.
 
 2. **Experiment and comparison identity**
 
-   Create one experiment per invocation. CI passes the deterministic name
-   `github-<run_id>-<run_attempt>`; local use defaults to a timestamped
-   `local-...` name but accepts explicit `--experiment`. Use `update: false` and
-   no base experiment. Braintrust's normal experiment comparison matches rows
-   by `input`; the input therefore contains scenario, workload ID/path, exact
-   effective prompt, and its SHA-256. Agent, model, CLI, git, and run identity
-   stay out of `input` so comparable runs retain the same test-case key. A
-   changed effective prompt deliberately becomes a different input rather than
-   producing a misleading direct comparison.
+   Create one experiment per invocation. Use the stable channel-aware names
+   defined above; local use still accepts explicit `--experiment`. Use
+   `update: false`. Resolve the newest experiment with
+   `metadata.channel = main` in the same project before initializing the current
+   experiment and pass its ID as `baseExperimentId`; an explicit local base name
+   takes precedence. Resolution scans the API's newest-first project pages and
+   filters returned experiment metadata/name client-side because the endpoint
+   has no metadata query parameter. A PR or default local export before the
+   first main baseline fails before experiment creation. The first main run is
+   allowed as a bootstrap; because SDK 3.29.0 has no explicit no-base option,
+   its readback may contain an automatically chosen legacy ancestor and must
+   report it rather than claiming `none`.
+   Braintrust's normal experiment comparison matches rows by `input`; the input
+   therefore contains scenario, workload ID/path, exact effective prompt, and
+   its SHA-256. Agent, model, CLI, git, and run identity stay out of `input` so
+   comparable runs retain the same test-case key. A changed effective prompt
+   deliberately becomes a different input rather than producing a misleading
+   direct comparison.
 
-   Experiment metadata records source (`local` or `github`), GitHub run ID and
+   Experiment metadata records source (`local` or `github`), channel (`local`,
+   `main`, or `pr`), branch, pull-request number when present, GitHub run ID and
    attempt when present, workflow/run URL, suite IDs/names/hashes, target and
    measurement SHAs/branches/dirty state, schema version, and exporter version.
-   Explicit `repoInfo` uses the evaluated target SHA while SDK automatic Git
-   collection is disabled, preventing the summary checkout or local dirty tree
-   from replacing artifact identity.
+   Explicit `repoInfo` uses the evaluated target SHA and supplied branch while SDK
+   automatic Git collection is disabled, preventing the summary checkout or
+   local dirty tree from replacing artifact identity. Project-level base
+   discovery and experiment publishing remain methods of the same injected
+   Braintrust integration boundary. Its production implementation uses the
+   SDK's public `login()` result and authenticated `apiConn()` for the list API,
+   so it does not read or expose credential values or introduce a second
+   client/service layer.
 
 3. **One allowlisted eval root plus structural tool children per workload/scenario**
 
@@ -2044,6 +2142,55 @@ made for this documentation-only closeout.
    routes schema/detail questions to the durable implementation document rather
    than duplicating the full field contract.
 
+7. **Stable experiment identity and native base linkage**
+
+   Preserve the run-level experiment and workload-row mapping. Add one pure
+   identity builder that accepts source channel, GitHub run/attempt, optional
+   pull-request number, branch, SHA, and current time for local defaults. It
+   emits the naming contract above plus allowlisted experiment metadata and
+   tags. Reject missing PR number/branch for a pull-request channel and missing
+   branch for GitHub main execution before network initialization. Continue to
+   allow an explicit `--experiment` override locally, but never silently append
+   to an existing experiment (`update` remains false).
+
+   Extend the exporter boundary with the real branch and optional explicit base
+   experiment. GitHub supplies `github.head_ref` for labeled pull requests and
+   `github.ref_name` for schedule/manual executions; local export uses the
+   suite's verified target branch or an explicit branch override when the suite
+   was produced from a detached checkout. Pass commit, branch, and dirty state
+   as `repoInfo`. Add workflow job guards that prevent a non-main
+   `workflow_dispatch` from starting paid scenario jobs; the identity builder
+   also rejects a GitHub main channel whose supplied branch is not `main`.
+
+   Before initializing the current experiment, page through the official
+   newest-first experiment-list API through the SDK's authenticated `apiConn()`,
+   scoped to this project. Select client-side only the first experiment whose
+   metadata channel is `main` and whose name matches the stable main-name
+   contract; the endpoint has no metadata-filter parameter. Pass the result as
+   `baseExperimentId`; an explicit local base name takes precedence. If no main
+   exists, reject PR and default local export before initialization. Allow a
+   main run to create the bootstrap experiment, while documenting that SDK
+   3.29.0 may automatically attach a legacy Git-ancestor base because it has no
+   explicit no-base option. Report that actual bootstrap link but do not count
+   it as explicit-link acceptance evidence. Do not use automatic ancestry after
+   bootstrap.
+
+   After publishing, call public `fetchBaseExperiment()` to return the actual
+   linked ID/name in the nonsecret result and render it in CI/local output as a
+   base or `none`. Keep discovery inside the injected Braintrust integration
+   boundary; do not add a mutable alias, rolling experiment, second client
+   abstraction, state store, or retry.
+
+   Unit tests cover all three name shapes, sanitization, required identity,
+   rerun uniqueness, main-only manual dispatch, newest-first pagination and
+   client-side main selection, rejection of PR/default-local pre-bootstrap,
+   main bootstrap behavior, explicit-local-base precedence, exact SDK init
+   options, `fetchBaseExperiment()` readback, and safe result output.
+   Workflow contract tests prove the event-specific channel/name/branch/PR
+   arguments and that a non-main manual dispatch cannot start paid jobs.
+   Existing mapping and tool span tests prove the persisted row shape is
+   unchanged.
+
 ### Ordered Implementation Steps
 
 1. Add focused failing tests for the pure suite-to-Braintrust mapping: stable
@@ -2078,12 +2225,26 @@ made for this documentation-only closeout.
    field semantics proven in step 3. Validate it with the skill validator. Run
    plugin generation/check and confirm the internal skill causes no
    public/generated skill changes.
-6. Run focused tests, exporter validate-only mode, `bun test`, typecheck, format, lint,
-   `bun run plugins:generate`, `bun run plugins:check`, and `bun run build`.
-   After merge and secret provisioning, manually dispatch one workflow and
-   verify the GitHub summary link plus 23 reconciled Braintrust rows before
-   calling the PoC complete. The later scheduled run should create a separate
-   experiment without code changes.
+6. **Ready correction:** Implement the pure channel-aware identity builder,
+   branch/base exporter arguments, paged newest-main resolution, complete
+   `repoInfo`, safe base-ID/name result, workflow event routing and manual-ref guard, CI
+   summary field, and local operator docs in
+   `scripts/agent-eval-braintrust.ts`, its focused tests,
+   `.github/workflows/agent-evals.yml`, `eval/agentic/README.md`,
+   `docs/implementation/agentic-eval-metrics.md`, and the internal Braintrust
+   skill. Preserve row inputs, outputs, metrics, and structural children.
+7. Run focused tests, exporter validate-only mode, `bun test`, typecheck,
+   format, lint, `bun run plugins:generate`, `bun run plugins:check`, and
+   `bun run build`. Re-run the labeled PR path to prove its new name, complete
+   branch and unchanged row/tool reconciliation. Because no stable main
+   baseline exists yet, this PR proof uses validate-only/network-stub coverage
+   rather than creating a misleading default-linked experiment. After merge,
+   use the first main execution to establish the baseline and report any
+   SDK-selected bootstrap link. Prove a later main execution links to that main
+   experiment, a subsequent PR links to the latest main experiment, and a local
+   canary export links to that main experiment through default resolution or
+   the explicit override. The bootstrap's base state is not acceptance evidence
+   for the three comparison cases.
 
 ### Acceptance Criteria
 
@@ -2096,6 +2257,19 @@ made for this documentation-only closeout.
 - Every row is filterable by workload, scenario, agent, exact CLI/model,
   reasoning, guidance, intent, target SHA, and used-tool tags. Structured
   metadata exposes ordered tools and per-tool/per-status counts.
+- Every persisted experiment has a unique, channel-aware name following
+  `main-r<RUN_ID>-a<ATTEMPT>`,
+  `pr-<NUMBER>-r<RUN_ID>-a<ATTEMPT>`, or
+  `local-<branch-slug>-<UTC-timestamp-with-milliseconds>-<short-sha>`. Channel,
+  branch, PR number when present, full SHA, run identity, and source remain
+  independently filterable metadata/tags.
+- A pull-request experiment can be opened with a native Braintrust base link to
+  the latest main experiment whose linked name matches `main-r...-a...`; a local
+  experiment can be compared to main through default latest-main resolution or
+  an explicit main-experiment override; and a later main experiment links to
+  the preceding main experiment. These three cases require live readback with
+  non-null `base_exp_id` and the expected linked main experiment name before
+  Phase 4 is complete.
 - Prompt, neutral answer, process/final status, self-reported confidence, native
   token buckets/duration/cost, and GitHits-specific tool counts reconcile to
   contained source artifacts. Unknown telemetry is absent/unknown; a verified
@@ -2104,8 +2278,10 @@ made for this documentation-only closeout.
   counts/errors, token, and cost fields; labeled CI readback verifies the same
   contract across 23 eval spans and 116 structural tool children.
 - The exporter keeps unchanged scenario/workload/prompt inputs stable across
-  workflow attempts, and no baseline is selected automatically or metric
-  movement fails the workflow. Root `tool_calls` and `tool_errors` are omitted;
+  workflow attempts so Braintrust matches workload rows across experiments.
+  Default latest-main baseline selection or an explicit local base affects
+  comparison only; metric movement does not fail the workflow. Root
+  `tool_calls` and `tool_errors` are omitted;
   Braintrust derives them from exact-timed structural tool children. The local
   v2 readback verifies those native metrics and bounded SQL verifies the
   GitHits-specific/custom sequence and status metadata. Labeled CI run

--- a/docs/plans/systematic-agent-evals.md
+++ b/docs/plans/systematic-agent-evals.md
@@ -3,19 +3,21 @@
 ## Status
 
 - Overall: IN PROGRESS
-- Current phase: Phase 3 — Parallel CI Execution And Concise Reporting
-  (IMPLEMENTED LOCALLY; SAME-REPOSITORY LABEL PATH LIVE-VALIDATED; SCHEDULED/MANUAL
-  PATH PENDING MERGE)
-- Previous work: Phase 2 correction is COMPLETE. Its discovery, intent, full,
-  scenario-aware comparison, metrics-compatibility, and Codex interactive
-  isolation contracts are locally validated; CI execution is Phase 3 and
-  Braintrust persistence is Phase 4.
+- Current phase: Phase 4 — Braintrust Persistence Proof Of Concept
+  (IMPLEMENTED LOCALLY; CI VALIDATION PENDING)
+- Previous work: Phase 2 correction is COMPLETE. Phase 3 is merged and its
+  same-repository label path is live-validated; Phase 4's exporter, CI wiring,
+  and local Braintrust readback are complete while the first qualifying CI
+  export/readback remains pending.
 - Owner: repository maintainers
 - Last verified: 2026-08-31
-- Deployment: Phases 1 and 2 merged to `main`; local maintainer tooling and the
-  Phase 3 workflow/report are implemented. Same-repository label-authorized
-  validation is live; scheduled/manual default-branch validation remains
-  pending merge. Braintrust persistence is a separate Phase 4 increment.
+- Deployment: Phases 1 through 3 are merged to `main`. The Phase 3
+  same-repository label path is live-validated; the scheduled path is waiting
+  for its first default-branch execution. Phase 4's exact-pinned exporter and
+  post-report CI step are implemented, with local 23-row persistence/readback
+  proven; qualifying CI validation remains pending. A push to `main`
+  deliberately does not trigger the workflow, and cadence changes remain
+  deferred until persistent evidence is visible.
 
 ## Problem And Expected Outcome
 
@@ -47,7 +49,7 @@ When this effort is complete:
   and normal Luna intent suite daily from `main`, or on an explicitly
   maintainer-authorized pull request, preserves raw artifacts, and renders a
   concise report without manufacturing a baseline comparison;
-- a later Braintrust integration persists the same normalized records for
+- the Braintrust integration persists the same normalized records for
   per-workload/per-agent history without changing the runner contract;
 - daily results are observational and alert on material drift without becoming
   a flaky merge gate; and
@@ -91,7 +93,7 @@ Out of scope for the initial phases:
   workload rubric and judge policy are approved;
 - a repository-owned database, queue, cache, lock, or dashboard;
 - baseline or `main` comparison inside the CI workflow;
-- Braintrust integration in the pipeline increment itself.
+- SDK tracing or a vendor-owned runner inside agent execution.
 
 ## Verified Current State And Evidence
 
@@ -110,19 +112,24 @@ Out of scope for the initial phases:
   one stateful onboarding workload, and three explicitly experimental-tool
   workloads.
 - `.agent-eval/` is gitignored. Each run now writes a normalized `metrics.json`
-  artifact, but no durable history exists.
+  artifact. The user created the Braintrust project
+  `githits-cli-agent-evals`, installed `bt` 0.18.0, and authenticated it with
+  `bt setup`; SDK instrumentation was intentionally skipped. The exact-pinned
+  exporter now persists normalized history without making agent execution
+  depend on Braintrust. Local `.bt/` state is repository-ignored and is not an
+  input to the eval harness.
 - `.github/workflows/main.yml` runs the reusable build/test workflow on pushes
   to `main`, and `.github/workflows/agent-evals.yml` now defines the scheduled,
   manual, and same-repository label-authorized Luna workflow. Repository
   administrators verified the required secret names `OPENAI_API_KEY` and
   `GITHITS_API_TOKEN` on 2026-08-31 without reading their values. The
-  same-repository label path is live-validated; default-branch scheduled/manual
-  execution remains pending merge before Phase 3 can be accepted as fully
-  complete.
+  same-repository label path is live-validated; the first default-branch
+  scheduled/manual execution has not happened yet.
 - The agentic eval documentation now distinguishes local human/agent-driven
-  inspection from the dedicated CI workflow. Deterministic smoke tests remain
-  merge gates, while scheduled live-agent evals are observational/advisory
-  until measured evidence supports a different policy.
+  inspection, the dedicated CI workflow, and Braintrust persistence.
+  Deterministic smoke tests remain merge gates, while scheduled live-agent
+  evals and their persistence are observational/advisory until qualifying CI
+  evidence supports a different policy.
 - The corrected Codex workload and interactive paths require a caller-supplied
   dedicated eval home containing authentication and Codex-managed runtime
   state, keep fresh per-workload OS homes, and reject root-level global
@@ -608,15 +615,17 @@ The following must be resolved before Phase 6:
    isolation, and Codex interactive isolation parity are implemented and
    validated; corrected discovery/intent evidence supersedes the two-profile
    behavior policy.
-3. **Phase 3 — parallel CI execution and concise reporting (IMPLEMENTED
-   LOCALLY; SAME-REPOSITORY LABEL PATH LIVE-VALIDATED; SCHEDULED/MANUAL PATH
-   PENDING MERGE):** clean GitHub-hosted jobs run the Luna discovery and intent
-   suites daily or after an authorized PR label, retain raw evidence, and
-   render a concise no-baseline summary. Do not mark this phase complete until
-   the scheduled/manual default-branch path is validated after merge.
-4. **Phase 4 — Braintrust persistence proof of concept (PLANNED):** normalized
-   Phase 3 records become durable per-workload/per-agent history without making
-   the runner dependent on Braintrust.
+3. **Phase 3 — parallel CI execution and concise reporting (MERGED;
+   SAME-REPOSITORY LABEL PATH LIVE-VALIDATED; FIRST SCHEDULED RUN PENDING):**
+   clean GitHub-hosted jobs run the Luna discovery and intent suites daily or
+   after an authorized PR label, retain raw evidence, and render a concise
+   no-baseline summary. A push to `main` does not start a paid run.
+4. **Phase 4 — Braintrust persistence proof of concept (IMPLEMENTED LOCALLY;
+   CI VALIDATION PENDING):** normalized Phase 3 records become durable
+   per-workload/per-agent history without making agent execution dependent on
+   Braintrust. The local export/readback proof and repository-internal
+   Braintrust operations skill are complete; a qualifying CI export/readback is
+   still required.
 5. **Phase 5 — broader discovery matrix (PLANNED):** the proven metrics, suite,
    CI, and persistence contracts add approved Codex/Claude agent-model cells to
    the neutral canary without changing Luna history.
@@ -1450,11 +1459,11 @@ captured below; Braintrust persistence is intentionally a later phase.
 
 ### Status
 
-IMPLEMENTED LOCALLY; SAME-REPOSITORY LABEL PATH LIVE-VALIDATED. The runner,
-schema-v3 suite artifacts, CI reporter, workflow, and operational documentation
-are complete and locally validated. The corrected label run passed its clean
-runner and summary checks; default-branch scheduled/manual execution remains
-pending merge, so Phase 3 deployment acceptance is not complete.
+MERGED; SAME-REPOSITORY LABEL PATH LIVE-VALIDATED. The runner, schema-v3 suite
+artifacts, CI reporter, workflow, and operational documentation are merged.
+The corrected label run passed its clean runner and summary checks; the first
+default-branch scheduled/manual execution has not happened yet. A push to
+`main` does not trigger this paid workflow.
 
 ### Live label-run evidence
 
@@ -1623,25 +1632,25 @@ None.
    status classification, including zero-call discovery, per-tool frequencies,
    unknown telemetry, partial/missing suites, CLI fallback, and isolation
    violations. Implement the pure formatter and thin CLI entrypoint.
-3. **Implemented locally; same-repository label path
-   live-validated:** Add the dedicated workflow with the three triggers, an explicit
+3. **Merged; same-repository label path live-validated:** Add the dedicated
+   workflow with the three triggers, an explicit
    `github.event.label.name == 'agent-eval'` job gate, same-repository label/SHA
    authorization, clean Codex home and API-key setup, the two scenario jobs,
    unconditional artifact upload/reporting, 14-day retention, and minimal
    permissions. Keep secret scope to the paid execution steps. The corrected
-   label run passed; default-branch scheduled/manual execution remains pending
-   merge.
+   label run passed; the first default-branch scheduled/manual execution is
+   pending.
 4. **Completed locally:** Update local/CI operational documentation, the durable implementation
    contract, and the required no-public-impact change fragment. Document label
    authorization, re-label behavior, exact suites/concurrency, expected
    duration/cost, secret names, and artifact/report locations.
-5. **Local and label evidence complete; scheduled/manual evidence pending
-   merge:** Run focused tests, all suite dry-runs at concurrency 1 and the CI-selected
+5. **Local and label evidence complete; first scheduled/manual evidence
+   pending:** Run focused tests, all suite dry-runs at concurrency 1 and the CI-selected
    values, `bun test`, typecheck, format, lint, build, and workflow syntax/action
    validation. The same-repository label path is live-validated with no global
-   skill/guidance reads or CLI fallbacks. After the change is merged, manually
-   dispatch the workflow and verify the scheduled/default-branch path before
-   treating Phase 3 deployment acceptance as complete.
+   skill/guidance reads or CLI fallbacks. Verify the scheduled/default-branch
+   path on its first run before treating Phase 3 deployment acceptance as
+   complete.
 
 ### Acceptance Criteria
 
@@ -1650,7 +1659,7 @@ None.
 - MET: A same-repository label run checks out the exact labeled head SHA and
   produces 2/2 discovery plus 21/21 intent records with concurrency 2/4
   captured in artifacts.
-- PENDING AFTER MERGE: A trusted manual run and a scheduled default-branch run
+- PENDING: A trusted manual run or scheduled default-branch run
   check out the exact intended SHA and produce 2/2 discovery plus 21/21 intent
   records, or explicit failed/missing records, with concurrency 2/4 captured in
   artifacts.
@@ -1674,49 +1683,345 @@ None.
 
 ### Status
 
-PLANNED. Reorient and detail after Phase 3 is merged and its first clean runner
-evidence is available.
+IMPLEMENTED LOCALLY; CI VALIDATION PENDING. Phase 3 is merged and its
+same-repository label path has clean runner evidence. The exact-pinned
+Braintrust exporter, post-report CI wiring, local persistence/readback proof,
+and internal operations skill are implemented. A real labeled or manually
+dispatched CI run must still export and read back 23 rows before Phase 4 is
+accepted as complete. SDK tracing was deliberately not added.
 
 ### Expected Outcome
 
-Braintrust persistently exposes each Luna workload/scenario execution and its
-tool-call frequencies, tools used, token buckets, duration, estimated cost,
-status, repository SHA, exact Codex CLI/model identity, and links to raw CI
-evidence. Local and GitHub suite generation remain fully functional when
-Braintrust is unavailable.
+Each completed Luna workflow attempt creates one immutable experiment in the
+Braintrust project `githits-cli-agent-evals`, with one top-level experiment row
+per scenario/workload cell. Braintrust exposes the exact effective prompt,
+answer/status evidence, tool-call frequencies and ordered sequence, token
+buckets, agent duration, estimated cost, repository/harness identity, exact
+Codex CLI/model identity, and a link to the GitHub workflow evidence. Local and
+GitHub suite generation and concise reporting remain independent of
+Braintrust. No SDK tracing is inserted into Codex, the GitHits MCP server, or
+the harness execution path.
 
 ### Assumptions
 
-- Phase 3's normalized records are sufficient input; Braintrust does not become
-  the source of truth for raw provider evidence.
-- The service can accept the existing versioned dimensions through a thin
-  mapping rather than forcing runner-specific instrumentation.
+- Phase 3 `suite.json`, contained child `metrics.json`/`report.json`, and raw
+  `prompt.md`/`final.json` evidence are the complete exporter input. Braintrust
+  does not become the source of truth for raw provider events.
+- The Braintrust experiment/event model accepts the existing dimensions through
+  a post-run mapping. The installed 3.29.0 SDK source confirms
+  `initExperiment()`, explicit experiment names, top-level `startSpan()` eval
+  rows with `input`, `output`, `error`, `metadata`, `metrics`, and `tags`,
+  explicit `flush()`, and `summarize({ summarizeScores: false })` permalink
+  retrieval. `update: true` continues an existing experiment, but the PoC does
+  not use it.
+- One CI run attempt is one immutable experiment. GitHub `run_id` plus
+  `run_attempt` gives reruns distinct names, so no event-ID scheme, upsert,
+  retry, or duplicate-repair mechanism is required.
+- The existing `bt` OAuth profile is suitable for local read/query operations
+  and for a `bt eval` wrapper that injects resolved authentication into its Bun
+  child. CI uses only the repository secret `BRAINTRUST_API_KEY` and invokes the
+  exporter directly; it does not install or depend on the global CLI.
+- Persisting the exact prompt and neutral answer now is required to make later
+  quality scoring possible after 14-day GitHub artifacts expire. Self-reported
+  confidence is diagnostic metadata, not a quality score.
+
+### Resolved SDK contract contradiction
+
+The initial plan assumed that `Experiment.log()` could represent a scoreless
+eval row. Runtime behavior in the installed Braintrust 3.29.0 package disproved
+that assumption: `Experiment.log()` requires non-empty `scores`. No quality
+judge or fabricated score is appropriate in this phase. The exporter therefore
+uses one top-level `type: "eval"` span per mapped cell, ends each span
+immediately, flushes the experiment, and then reads its permalink through
+`summarize({ summarizeScores: false })`. This is a resolved implementation
+contradiction, not a reason to alter the neutral metrics contract.
 
 ### Unknowns Or Product Decisions
 
-- Braintrust account/project ownership, available credits, authentication,
-  retention, and ingestion API/SDK.
-- Whether raw traces are uploaded or retained only in GitHub with durable links.
-- Dashboard grouping and whether exporter failure makes the advisory workflow
-  partial or failed.
+No product choice blocks the implementation. The selected policy is:
+
+- project: `githits-cli-agent-evals`;
+- ingestion: exact-pinned TypeScript `braintrust` SDK, currently verified as
+  3.29.0, through a downstream exporter;
+- raw traces: GitHub artifacts only; Braintrust receives normalized rows plus
+  the exact prompt and neutral answer, not stdout, stderr, environment values,
+  MCP payloads, or auth state;
+- quality: no scorer or `scores` value in this phase;
+- export failure: preserve the GitHub summary/artifacts, then fail the final
+  workflow status so missing persistence cannot be silent;
+- retention: Braintrust is the durable normalized history. GitHub raw artifacts
+  remain at 14 days until observed operations justify a change; and
+- cadence: unchanged in this phase. The existing schedule/manual/label triggers
+  remain; push-to-main behavior is reconsidered only after Braintrust evidence
+  is available.
+
+The built-in experiment comparison behavior is a known technical limitation,
+not a selected policy: its exercised output contains only generic all-zero trace
+metrics and omits the custom eval telemetry. Its investigation is deferred to a
+Phase 5 / PoC follow-up; bounded SQL and row/UI inspection remain the verified
+metrics path.
 
 ### Dependencies
 
-- Phase 3 accepted and merged.
-- Approved Braintrust proof-of-concept contract and credentials.
+- Phase 3's merge commit is `e1599b7`; planning was reoriented on current
+  `origin/main` commit `5a5fab7` after the non-overlapping 0.11.3 release merge.
+- The user-created Braintrust project `githits-cli-agent-evals` and local `bt`
+  authentication exist. This is user-provided verification; the plan does not
+  inspect `.bt/`, Keychain contents, or any credential value.
+- A repository administrator has provisioned the secret name
+  `BRAINTRUST_API_KEY` for CI. Its value is never read into an agent session;
+  qualifying CI export/readback remains pending.
+
+### Verified Braintrust Constraints
+
+- [`bt setup`](https://www.braintrust.dev/docs/reference/cli/setup) separates
+  authentication, optional skills/MCP setup, and optional SDK instrumentation.
+  Cancelling instrumentation does not undo authentication.
+- The [CLI authentication model](https://www.braintrust.dev/docs/reference/cli/quickstart)
+  uses an OAuth profile/keychain locally and `BRAINTRUST_API_KEY` in CI. The
+  official `bt` source passes resolved profile credentials to `bt eval` child
+  processes, which lets the same exporter run locally without reading or
+  copying Keychain material.
+- The [TypeScript SDK](https://www.braintrust.dev/docs/reference/libs/nodejs)
+  supports named experiments, explicit repository metadata, custom numeric
+  metrics, structured metadata, top-level eval spans, manual flush, and returned
+  experiment URLs. The installed 3.29.0 runtime requires non-empty scores for
+  `Experiment.log()`, so the exporter uses scoreless top-level eval spans and
+  does not fabricate quality scores.
+- Braintrust [SQL](https://www.braintrust.dev/docs/reference/sql) and the
+  `bt experiments`/`bt sql` commands can inspect and compare the persisted fields.
+  The repository skill records only commands exercised against the PoC
+  experiment. The built-in compare command currently returns only generic,
+  all-zero trace metrics rather than this custom telemetry; bounded SQL/query
+  and experiment UI inspection are the verified metrics path.
+
+### Verified PoC evidence
+
+The accepted GitHub run `33381601980` at SHA
+`dc63675d7c0ee95a9594eac272982943dceef521` validated and exported the discovery
+and intent suites as exactly 23 rows. The experiments
+`poc-33381601980-top-level-spans` and `poc-33381601980-repeat` each read back
+23 rows. Bounded SQL and row inspection reconciled prompts, neutral answers,
+prompt hashes, token buckets, duration, cost, and tool telemetry to the source
+artifacts. The first experiment permalink is:
+
+<https://www.braintrust.dev/app/GitHits/p/githits-cli-agent-evals/experiments/poc-33381601980-top-level-spans>
+
+The exercised command
+`bt experiments --json --project githits-cli-agent-evals compare
+poc-33381601980-top-level-spans poc-33381601980-repeat` succeeds but exposes
+only generic Braintrust trace metrics, all zero, and not the custom eval
+telemetry. This limitation does not invalidate persistence. It is a Phase 5 /
+PoC follow-up requiring investigation. CI acceptance remains pending until a
+real labeled or manually dispatched workflow exports and reads back 23 rows.
+
+### Affected Components
+
+- `scripts/agent-eval-braintrust.ts` and focused tests for pure mapping, CLI
+  parsing, and an injected SDK boundary;
+- `scripts/agent-eval-report.ts` and focused tests to preserve the already
+  emitted `prompt.md` path and neutral answer in contained `report.json`
+  evidence;
+- `package.json`/`bun.lock` for one exact-pinned `braintrust` development
+  dependency and exporter entrypoint;
+- `.github/workflows/agent-evals.yml` for a post-report export step, narrowly
+  scoped secret, nonsecret result link, and final status aggregation;
+- `.gitignore` for `.bt/` local CLI state;
+- `eval/agentic/README.md` and
+  `docs/implementation/agentic-eval-metrics.md` for durable operations and data
+  contracts;
+- `.agents/skills/braintrust-agent-evals/SKILL.md` as an internal-only
+  operations/query skill; and
+- one maintainer-facing change fragment with `none` impact for `githits` and
+  `@githits/mcp`.
+
+### Export Contract
+
+1. **Validated downstream input**
+
+   Reuse `loadImportedSuite()` for every repeatable
+   `--suite <label>=<suite.json>` input. This retains schema parsing, realpath
+   containment, canonical child basenames, metrics/report reconciliation, and
+   status validation. Before opening a network connection, reject dry-run
+   suites, duplicate scenario/workload cells, mixed target or measurement SHAs,
+   mixed agent/model/reasoning/surface/server identity, or incompatible
+   reporting/result-schema identity. Partial and failed suites with valid child
+   evidence remain exportable because failures are part of the history; a
+   missing or unparseable suite fails preflight and creates no experiment.
+
+   Extend the report's allowlisted workload artifacts with `prompt.md` and its
+   neutral final summary with `answer`. Existing report version 1 readers remain
+   compatible because both fields are additive and optional. The exporter
+   resolves prompt references inside the imported child run directory and
+   never loads raw stdout, stderr, environment/config files, or provider event
+   payloads.
+
+2. **Experiment and comparison identity**
+
+   Create one experiment per invocation. CI passes the deterministic name
+   `github-<run_id>-<run_attempt>`; local use defaults to a timestamped
+   `local-...` name but accepts explicit `--experiment`. Use `update: false` and
+   no base experiment. Braintrust's normal experiment comparison matches rows
+   by `input`; the input therefore contains scenario, workload ID/path, exact
+   effective prompt, and its SHA-256. Agent, model, CLI, git, and run identity
+   stay out of `input` so comparable runs retain the same test-case key. A
+   changed effective prompt deliberately becomes a different input rather than
+   producing a misleading direct comparison.
+
+   Experiment metadata records source (`local` or `github`), GitHub run ID and
+   attempt when present, workflow/run URL, suite IDs/names/hashes, target and
+   measurement SHAs/branches/dirty state, schema version, and exporter version.
+   Explicit `repoInfo` uses the evaluated target SHA while SDK automatic Git
+   collection is disabled, preventing the summary checkout or local dirty tree
+   from replacing artifact identity.
+
+3. **One allowlisted row per workload/scenario**
+
+   `output` contains process/cell/final status, neutral answer when present,
+   self-reported confidence, and discovery observation when available.
+   Failed cells use a generated status-only `error` label; raw error/stderr text
+   is not uploaded. `scores` is omitted.
+
+   Known numeric values map to custom metrics with stable names:
+   `agent_duration_ms`, `logical_tool_calls`, `mcp_tool_calls`,
+   `cli_tool_calls`, `tool_calls_started`, `tool_calls_completed`,
+   `tool_calls_failed`, `tool_calls_unknown`, `raw_tool_events`,
+   `uncached_input_tokens`, `cached_input_tokens`,
+   `cache_write_input_tokens`, `output_tokens`,
+   `reasoning_output_tokens`, and `estimated_cost_usd`. Known zero is logged as
+   zero. Unknown values are absent rather than coerced to zero. Custom names
+   avoid Braintrust reinterpreting the repository's rate estimate as
+   provider-reported billing.
+
+   Structured metadata contains cell/suite/run IDs, guidance/intent identity,
+   agent/model/reasoning/CLI identity, cost kind/uncertainty/rate snapshot,
+   normalized warnings/validation categories, `toolTelemetryKnown`, ordered
+   normalized tool sequence, and per-surface/per-tool total and status counts.
+   Each known used tool also adds a filter tag such as `tool:mcp:search`; the
+   nested counts remain authoritative. Tool telemetry that cannot reconcile is
+   `toolTelemetryKnown: false` with no tool-count metrics or fabricated empty
+   counts.
+
+4. **Thin SDK boundary and local authentication**
+
+   Keep record construction pure and inject only the minimal SDK publisher
+   needed by tests. Production initializes the exact project/experiment, starts
+   and immediately ends one top-level `type: "eval"` span per row in
+   deterministic suite/scenario/workload order, calls `flush()`, and writes a
+   small nonsecret result JSON containing project, experiment, URL, and
+   exported-row count. There is no agent execution, tracing wrapper, dataset,
+   scorer, queue, retry, lock, cache, or repository database.
+
+   The normal package command runs directly under Bun; `BRAINTRUST_API_KEY` is
+   required only when it performs a network export, matching CI. Local
+   OAuth-profile use runs the same file explicitly through
+   `bt eval --runner bun --no-auto-instrumentation ...`; the official `bt`
+   source supports the exported `btEvalMain` entrypoint, and the local
+   persistence/readback proof exercised this path without reading or copying
+   Keychain credentials. A credential-free `--validate-only` mode maps all rows
+   without initializing Braintrust and reports only identity/counts, not
+   prompts or answers.
+
+5. **CI sequencing and failure visibility**
+
+   Keep scenario execution and artifact upload unchanged. Mark the existing
+   report step `continue-on-error` so its summary is always appended. Run the
+   exporter afterward with `if: always()`, both downloaded suite paths, explicit
+   GitHub experiment identity, and `BRAINTRUST_API_KEY` scoped only to that
+   step. Append the returned Braintrust experiment link when available. A final
+   no-secret step fails if the scenario job, report step, or exporter step
+   failed. Thus an exporter outage cannot suppress raw evidence or the concise
+   report, but it cannot pass silently either. Do not retry ingestion.
+
+6. **Internal operations skill after live proof**
+
+   Create `.agents/skills/braintrust-agent-evals/SKILL.md` from the proven local
+   export/readback workflow. It is repository-internal and is not added to root
+   `skills/`, plugin manifests, generated assets, or public packages. Keep it
+   short and automatically discoverable for requests to inspect, compare, or
+   operate GitHits agent-eval history.
+
+   Document only exercised commands: selecting `githits-cli-agent-evals`,
+   listing/viewing/comparing experiments, running bounded SQL queries for token,
+   duration, tool, status, and cost fields, opening the returned permalink, and
+   invoking local export through the saved `bt` profile. The skill must prohibit
+   printing API keys, reading `.bt/` or Keychain contents, uploading raw
+   artifacts, deleting experiments, or treating confidence as quality. It
+   routes schema/detail questions to the durable implementation document rather
+   than duplicating the full field contract.
+
+### Ordered Implementation Steps
+
+1. Add focused failing tests for the pure suite-to-Braintrust mapping: stable
+   input identity, exact prompt/answer capture, deterministic ordering, all
+   numeric metrics, known-zero preservation, unknown omission, per-tool
+   frequency/sequence, failed cells, and allowlisted metadata only. Add the
+   additive prompt/answer report fields needed by those tests.
+2. **Implemented locally:** Implement exporter argument parsing, cross-suite
+   preflight, pure mapping, injected publisher, exact `braintrust` 3.29.0
+   development dependency, direct Bun entrypoint, `btEvalMain` profile wrapper,
+   validate-only output, explicit flush, and nonsecret result file. Verify
+   credential-free `--validate-only` mapping against complete Phase 3 artifacts
+   without running an agent.
+3. **Local persistence/readback proven:** Use the authenticated local `bt`
+   profile to export the accepted 23-cell evidence into
+   `githits-cli-agent-evals` under clearly named `poc-...` experiments. Read it
+   back with `bt experiments` and bounded `bt sql`; reconcile row count,
+   zero-tool discovery, tool-using cells, token buckets, duration, cost,
+   prompt, answer, exact Codex version, SHA, and permalink against source
+   artifacts. The built-in compare limitation is recorded for follow-up.
+4. **Implemented locally; CI validation pending:** Add the CI export/final-status
+   steps and document the provisioned `BRAINTRUST_API_KEY` secret name.
+   Unit-test the workflow contract, validate YAML/action references, and use
+   direct SDK execution in CI so the workflow does not install `bt`. A real
+   labeled or manual run must still export/read back 23 rows.
+5. **Implemented locally:** Update durable eval operations documentation and
+   create the internal `braintrust-agent-evals` skill from the commands and
+   field semantics proven in step 3. Validate it with the skill validator. Run
+   plugin generation/check and confirm the internal skill causes no
+   public/generated skill changes.
+6. Run focused tests, exporter validate-only mode, `bun test`, typecheck, format, lint,
+   `bun run plugins:generate`, `bun run plugins:check`, and `bun run build`.
+   After merge and secret provisioning, manually dispatch one workflow and
+   verify the GitHub summary link plus 23 reconciled Braintrust rows before
+   calling the PoC complete. The later scheduled run should create a separate
+   experiment without code changes.
 
 ### Acceptance Criteria
 
-- Braintrust shows durable records grouped by workload, agent, exact CLI/model,
-  reasoning, guidance, and intent, including per-tool call counts, token
-  buckets, duration, estimated cost/uncertainty, and failures.
-- Exported values reconcile to the source `suite.json`/`metrics.json` artifacts,
-  and missing telemetry remains unknown rather than zero.
-- Export failure never destroys raw GitHub evidence and cannot prevent local
-  suite/report generation.
-- No Braintrust credential appears in logs, artifacts, summaries, or records.
-- The proof of concept adds no repository database, queue, retry layer, or
-  runner replacement.
+- MET locally: PoC experiments in `githits-cli-agent-evals` have exactly 23
+  rows for the current two discovery plus 21 intent cells. PENDING for CI:
+  one real labeled or manually dispatched workflow experiment must be
+  exported/read back with the same 23-row reconciliation, including failed
+  cells when a run fails.
+- Every row is filterable by workload, scenario, agent, exact CLI/model,
+  reasoning, guidance, intent, target SHA, and used-tool tags. Structured
+  metadata exposes ordered tools and per-tool/per-status counts.
+- Prompt, neutral answer, process/final status, self-reported confidence, token
+  buckets, agent duration, estimated cost/uncertainty, and logical tool counts
+  reconcile to contained source artifacts. Unknown telemetry is absent/unknown;
+  a verified zero-tool discovery cell remains numeric zero.
+- The exporter keeps unchanged scenario/workload/prompt inputs stable across
+  workflow attempts, and no baseline is selected automatically or metric
+  movement fails the workflow. PENDING: the exercised `bt experiments compare`
+  command reports only generic all-zero trace metrics, so custom eval trend
+  comparison still requires the documented SQL/UI follow-up.
+- The existing GitHub concise report and 14-day raw artifact upload complete
+  even when export fails; the final workflow is red and names export as the
+  failed stage. Local suite/report generation works without Braintrust or its
+  credential.
+- `BRAINTRUST_API_KEY` is scoped only to the CI export step. No Braintrust,
+  GitHits, provider, Keychain, or local auth value appears in logs, artifacts,
+  summaries, records, tests, or the internal skill.
+- The internal skill can list, inspect, compare, and query the proven metrics
+  through the user's authenticated `bt` profile without reading credentials or
+  mutating/deleting experiments.
+- The Braintrust integration adds no tracing instrumentation, quality judge,
+  public skill, repository database, queue, retry, lock, cache, runner
+  replacement, or cadence change.
+- Braintrust ingestion itself makes no model call and adds no model-token cost;
+  exporter wall time and every run-variant Luna duration/cost value are measured
+  and persisted rather than pinned as an acceptance threshold.
 
 ## Phase 5 — Broader Discovery Matrix
 

--- a/docs/plans/systematic-agent-evals.md
+++ b/docs/plans/systematic-agent-evals.md
@@ -4,13 +4,14 @@
 
 - Overall: IN PROGRESS
 - Current phase: Phase 4 — Braintrust Persistence Proof Of Concept
-  (PERSISTENCE PROVEN; COMPARISON IDENTITY CORRECTION READY)
+  (IDENTITY/LINKAGE IMPLEMENTED LOCALLY; LIVE MAIN PROOF PENDING)
 - Previous work: Phase 2 correction is COMPLETE. Phase 3 is merged and its
   same-repository label path is live-validated; Phase 4's exporter, CI wiring,
   local Braintrust readback, and first qualifying labeled CI export/readback
   are complete. The exact-head run proved persistence again, but exposed null
   branch and base-experiment identity. Stable naming and native main-baseline
-  linkage are now required before Phase 4 is complete.
+  linkage are implemented locally and are now awaiting live main-baseline proof
+  before Phase 4 is complete.
 - Owner: repository maintainers
 - Last verified: 2026-08-31
 - Deployment: Phases 1 through 3 are merged to `main`. The Phase 3
@@ -18,10 +19,10 @@
   for its first default-branch execution. Phase 4's exact-pinned exporter and
   post-report CI step are implemented, with local and labeled CI
   persistence/readback proven. A push to `main` deliberately does not trigger
-  the workflow. The next correction must preserve the verified persistence
-  shape while making main, pull-request, and local experiments discoverable
-  and natively comparable. Default-branch scheduled/manual activation remains
-  pending merge.
+  the workflow. Stable channel-aware identity and explicit main-baseline
+  linkage are implemented locally, but no live export has yet proven
+  later-main, pull-request, and local readback linkage. Default-branch
+  scheduled/manual activation remains pending merge.
 
 ## Problem And Expected Outcome
 
@@ -624,12 +625,12 @@ The following must be resolved before Phase 6:
    clean GitHub-hosted jobs run the Luna discovery and intent suites daily or
    after an authorized PR label, retain raw evidence, and render a concise
    no-baseline summary. A push to `main` does not start a paid run.
-4. **Phase 4 — Braintrust persistence proof of concept (PERSISTENCE PROVEN;
-   COMPARISON IDENTITY CORRECTION READY):** normalized Phase 3 records become
-   durable per-workload/per-agent history without making agent execution
+4. **Phase 4 — Braintrust persistence proof of concept (IDENTITY/LINKAGE
+   IMPLEMENTED LOCALLY; LIVE MAIN PROOF PENDING):** normalized Phase 3 records
+   become durable per-workload/per-agent history without making agent execution
    dependent on Braintrust. Local and labeled CI export/readback are proven;
-   stable channel-aware names and native main-baseline linkage must still be
-   implemented and proven for main, pull-request, and local runs.
+   stable channel-aware names and native main-baseline linkage are implemented
+   locally, but still require live proof for main, pull-request, and local runs.
 5. **Phase 5 — broader discovery matrix (PLANNED):** the proven metrics, suite,
    CI, and persistence contracts add approved Codex/Claude agent-model cells to
    the neutral canary without changing Luna history.
@@ -1687,7 +1688,7 @@ None.
 
 ### Status
 
-PERSISTENCE PROVEN; COMPARISON IDENTITY CORRECTION READY.
+IDENTITY/LINKAGE IMPLEMENTED LOCALLY; LIVE MAIN PROOF PENDING.
 Phase 3 is merged and its same-repository label path has clean runner evidence.
 The exact-pinned Braintrust exporter, post-report CI wiring, local
 persistence/readback proof, internal operations skill, and qualifying labeled
@@ -1696,8 +1697,10 @@ verify tool counts, exact observed boundaries, child duration, tokens, and
 cost. Exact-head labeled run `33429755678` persisted the final PR head but
 confirmed that experiment `base_exp_id` and branch identity are null and that
 the opaque `github-<run>-<attempt>` name is insufficient for routine operation.
-Stable naming and native comparison linkage are required before Phase 4 is
-complete. Default-branch scheduled/manual activation remains pending merge.
+Stable naming and native comparison linkage are implemented locally. No live
+export/readback has yet proved later-main-to-main, PR-to-main, and
+local-to-main linkage, so Phase 4 remains incomplete. Default-branch
+scheduled/manual activation remains pending merge.
 SDK tracing was deliberately not added.
 
 ### Expected Outcome
@@ -2225,7 +2228,8 @@ case; it does not satisfy native baseline linkage.
    field semantics proven in step 3. Validate it with the skill validator. Run
    plugin generation/check and confirm the internal skill causes no
    public/generated skill changes.
-6. **Ready correction:** Implement the pure channel-aware identity builder,
+6. **Implemented locally; live main proof pending:** Implement the pure
+   channel-aware identity builder,
    branch/base exporter arguments, paged newest-main resolution, complete
    `repoInfo`, safe base-ID/name result, workflow event routing and manual-ref guard, CI
    summary field, and local operator docs in
@@ -2233,18 +2237,17 @@ case; it does not satisfy native baseline linkage.
    `.github/workflows/agent-evals.yml`, `eval/agentic/README.md`,
    `docs/implementation/agentic-eval-metrics.md`, and the internal Braintrust
    skill. Preserve row inputs, outputs, metrics, and structural children.
-7. Run focused tests, exporter validate-only mode, `bun test`, typecheck,
-   format, lint, `bun run plugins:generate`, `bun run plugins:check`, and
-   `bun run build`. Re-run the labeled PR path to prove its new name, complete
-   branch and unchanged row/tool reconciliation. Because no stable main
-   baseline exists yet, this PR proof uses validate-only/network-stub coverage
-   rather than creating a misleading default-linked experiment. After merge,
-   use the first main execution to establish the baseline and report any
-   SDK-selected bootstrap link. Prove a later main execution links to that main
-   experiment, a subsequent PR links to the latest main experiment, and a local
-   canary export links to that main experiment through default resolution or
-   the explicit override. The bootstrap's base state is not acceptance evidence
-   for the three comparison cases.
+   Deterministic evidence is 44 passing focused exporter/workflow tests and
+   `bun run typecheck` exit 0. No live Braintrust export/readback was run for
+   the new identity contract.
+7. Run the remaining non-live validation and, after merge, establish the first
+   main baseline. The bootstrap's base state is not acceptance evidence. Then
+   prove a later main execution links to that main experiment, a subsequent PR
+   links to the latest main experiment, and a local canary export links to that
+   main experiment through default resolution or the explicit override. Each
+   case requires live readback with the expected stable main name and non-null
+   `base_exp_id`; no CI paid run or default-branch run has occurred for this
+   contract yet.
 
 ### Acceptance Criteria
 
@@ -2257,19 +2260,22 @@ case; it does not satisfy native baseline linkage.
 - Every row is filterable by workload, scenario, agent, exact CLI/model,
   reasoning, guidance, intent, target SHA, and used-tool tags. Structured
   metadata exposes ordered tools and per-tool/per-status counts.
-- Every persisted experiment has a unique, channel-aware name following
+- MET locally (live proof pending): Every persisted experiment has a unique,
+  channel-aware name following
   `main-r<RUN_ID>-a<ATTEMPT>`,
   `pr-<NUMBER>-r<RUN_ID>-a<ATTEMPT>`, or
   `local-<branch-slug>-<UTC-timestamp-with-milliseconds>-<short-sha>`. Channel,
   branch, PR number when present, full SHA, run identity, and source remain
   independently filterable metadata/tags.
-- A pull-request experiment can be opened with a native Braintrust base link to
-  the latest main experiment whose linked name matches `main-r...-a...`; a local
-  experiment can be compared to main through default latest-main resolution or
-  an explicit main-experiment override; and a later main experiment links to
-  the preceding main experiment. These three cases require live readback with
-  non-null `base_exp_id` and the expected linked main experiment name before
-  Phase 4 is complete.
+- PENDING LIVE: A pull-request experiment must open with a native Braintrust
+  base link to the latest main experiment whose name matches `main-r...-a...`;
+  a local experiment must compare to main through default latest-main
+  resolution or an explicit main-experiment override; and a later main
+  experiment must link to the preceding main experiment. These three cases
+  require live readback with non-null `base_exp_id` and the expected linked
+  main experiment name before Phase 4 is complete. The deterministic local
+  implementation is covered by 44 focused tests and passing typecheck; no
+  live export/readback, CI paid run, or default-branch run has occurred for it.
 - Prompt, neutral answer, process/final status, self-reported confidence, native
   token buckets/duration/cost, and GitHits-specific tool counts reconcile to
   contained source artifacts. Unknown telemetry is absent/unknown; a verified

--- a/docs/plans/systematic-agent-evals.md
+++ b/docs/plans/systematic-agent-evals.md
@@ -8,16 +8,18 @@
 - Previous work: Phase 2 correction is COMPLETE. Phase 3 is merged and its
   same-repository label path is live-validated; Phase 4's exporter, CI wiring,
   and local Braintrust readback are complete while the first qualifying CI
-  export/readback remains pending.
+  export/readback remains pending because the required repository secret is not
+  currently visible/effective in the Actions context.
 - Owner: repository maintainers
 - Last verified: 2026-08-31
 - Deployment: Phases 1 through 3 are merged to `main`. The Phase 3
   same-repository label path is live-validated; the scheduled path is waiting
   for its first default-branch execution. Phase 4's exact-pinned exporter and
   post-report CI step are implemented, with local 23-row persistence/readback
-  proven; qualifying CI validation remains pending. A push to `main`
-  deliberately does not trigger the workflow, and cadence changes remain
-  deferred until persistent evidence is visible.
+  proven; qualifying CI validation remains blocked until the required
+  repository secret is visible/effective. A push to `main` deliberately does
+  not trigger the workflow, and cadence changes remain deferred until
+  persistent evidence is visible.
 
 ## Problem And Expected Outcome
 
@@ -1683,12 +1685,14 @@ None.
 
 ### Status
 
-IMPLEMENTED LOCALLY; CI VALIDATION PENDING. Phase 3 is merged and its
+IMPLEMENTED LOCALLY; CI VALIDATION BLOCKED. Phase 3 is merged and its
 same-repository label path has clean runner evidence. The exact-pinned
 Braintrust exporter, post-report CI wiring, local persistence/readback proof,
 and internal operations skill are implemented. A real labeled or manually
 dispatched CI run must still export and read back 23 rows before Phase 4 is
-accepted as complete. SDK tracing was deliberately not added.
+accepted as complete; that validation cannot begin until the repository
+`BRAINTRUST_API_KEY` secret is visible/effective in Actions. SDK tracing was
+deliberately not added.
 
 ### Expected Outcome
 
@@ -1768,9 +1772,13 @@ metrics path.
 - The user-created Braintrust project `githits-cli-agent-evals` and local `bt`
   authentication exist. This is user-provided verification; the plan does not
   inspect `.bt/`, Keychain contents, or any credential value.
-- A repository administrator has provisioned the secret name
-  `BRAINTRUST_API_KEY` for CI. Its value is never read into an agent session;
-  qualifying CI export/readback remains pending.
+- The user reported adding `BRAINTRUST_API_KEY`, but both
+  `gh secret list --repo githits-com/githits-cli --json name` and the
+  repository Actions-secrets API currently expose only `GITHITS_API_TOKEN` and
+  `OPENAI_API_KEY`; organization-secret visibility could not be checked because
+  that API returned 403. Secret values were never read. CI/labeled validation
+  remains blocked until `BRAINTRUST_API_KEY` is visible and effective in the
+  repository Actions context.
 
 ### Verified Braintrust Constraints
 
@@ -1971,7 +1979,8 @@ real labeled or manually dispatched workflow exports and reads back 23 rows.
    prompt, answer, exact Codex version, SHA, and permalink against source
    artifacts. The built-in compare limitation is recorded for follow-up.
 4. **Implemented locally; CI validation pending:** Add the CI export/final-status
-   steps and document the provisioned `BRAINTRUST_API_KEY` secret name.
+   steps and document the repository Actions visibility/effectiveness of the
+   `BRAINTRUST_API_KEY` secret.
    Unit-test the workflow contract, validate YAML/action references, and use
    direct SDK execution in CI so the workflow does not install `bt`. A real
    labeled or manual run must still export/read back 23 rows.

--- a/docs/plans/systematic-agent-evals.md
+++ b/docs/plans/systematic-agent-evals.md
@@ -4,22 +4,22 @@
 
 - Overall: IN PROGRESS
 - Current phase: Phase 4 — Braintrust Persistence Proof Of Concept
-  (IMPLEMENTED LOCALLY; CI VALIDATION PENDING)
+  (LABELED CI PATH COMPLETE; DEFAULT-BRANCH ACTIVATION PENDING MERGE)
 - Previous work: Phase 2 correction is COMPLETE. Phase 3 is merged and its
   same-repository label path is live-validated; Phase 4's exporter, CI wiring,
-  and local Braintrust readback are complete while the first qualifying CI
-  export/readback remains pending because the required repository secret is not
-  currently visible/effective in the Actions context.
+  local Braintrust readback, and first qualifying labeled CI export/readback
+  are complete. Default-branch scheduled/manual activation remains pending
+  merge.
 - Owner: repository maintainers
 - Last verified: 2026-08-31
 - Deployment: Phases 1 through 3 are merged to `main`. The Phase 3
   same-repository label path is live-validated; the scheduled path is waiting
   for its first default-branch execution. Phase 4's exact-pinned exporter and
-  post-report CI step are implemented, with local 23-row persistence/readback
-  proven; qualifying CI validation remains blocked until the required
-  repository secret is visible/effective. A push to `main` deliberately does
-  not trigger the workflow, and cadence changes remain deferred until
-  persistent evidence is visible.
+  post-report CI step are implemented, with local and labeled CI
+  persistence/readback proven. A push to `main` deliberately does not trigger
+  the workflow, and default-branch scheduled/manual activation remains
+  pending merge. Cadence changes remain deferred until persistent
+  evidence is visible.
 
 ## Problem And Expected Outcome
 
@@ -622,12 +622,12 @@ The following must be resolved before Phase 6:
    clean GitHub-hosted jobs run the Luna discovery and intent suites daily or
    after an authorized PR label, retain raw evidence, and render a concise
    no-baseline summary. A push to `main` does not start a paid run.
-4. **Phase 4 — Braintrust persistence proof of concept (IMPLEMENTED LOCALLY;
-   CI VALIDATION PENDING):** normalized Phase 3 records become durable
-   per-workload/per-agent history without making agent execution dependent on
-   Braintrust. The local export/readback proof and repository-internal
-   Braintrust operations skill are complete; a qualifying CI export/readback is
-   still required.
+4. **Phase 4 — Braintrust persistence proof of concept (LABELED CI PATH
+   COMPLETE; DEFAULT-BRANCH ACTIVATION PENDING MERGE):** normalized Phase 3 records
+   become durable per-workload/per-agent history without making agent
+   execution dependent on Braintrust. Local and labeled CI export/readback
+   are proven; default-branch scheduled/manual activation remains pending
+   merge.
 5. **Phase 5 — broader discovery matrix (PLANNED):** the proven metrics, suite,
    CI, and persistence contracts add approved Codex/Claude agent-model cells to
    the neutral canary without changing Luna history.
@@ -1685,15 +1685,16 @@ None.
 
 ### Status
 
-IMPLEMENTED LOCALLY; NATIVE STRUCTURAL PROOF COMPLETE LOCALLY; CI VALIDATION
-PENDING. Phase 3 is merged and its same-repository label path has clean runner
-evidence. The exact-pinned Braintrust exporter, post-report CI wiring, local
-persistence/readback proof, and internal operations skill are implemented. The
-fresh local native structural proof below verifies tool counts, exact observed
-boundaries, child duration, tokens, and cost. A fresh labeled or manually
-dispatched CI run must still export and read back the expected cells before
-Phase 4 is accepted as complete; default-branch scheduled/manual activation
-also remains pending after merge. SDK tracing was deliberately not added.
+LABELED CI PATH COMPLETE; DEFAULT-BRANCH SCHEDULED/MANUAL ACTIVATION PENDING
+MERGE.
+Phase 3 is merged and its same-repository label path has clean runner evidence.
+The exact-pinned Braintrust exporter, post-report CI wiring, local
+persistence/readback proof, internal operations skill, and qualifying labeled
+CI export/readback are complete. The local and CI native structural proofs
+verify tool counts, exact observed boundaries, child duration, tokens, and
+cost. Default-branch scheduled/manual activation remains pending merge;
+no paid rerun was made for this documentation-only closeout. SDK tracing was
+deliberately not added.
 
 ### Expected Outcome
 
@@ -1779,8 +1780,9 @@ telemetry. The current exporter records one structural `tool` child per known
 logical call, using exact harness-observed boundaries and computed duration for
 completed/failed calls. Native comparison now reports those child-derived
 `tool_calls` and `tool_errors`; bounded SQL remains the path for the exact
-GitHits-specific sequence and status counts. A fresh labeled CI export/readback
-and default-branch scheduled/manual activation remain pending.
+GitHits-specific sequence and status counts. The labeled CI export/readback is
+verified below; default-branch scheduled/manual activation remains pending
+merge.
 
 ### Dependencies
 
@@ -1789,13 +1791,10 @@ and default-branch scheduled/manual activation remain pending.
 - The user-created Braintrust project `githits-cli-agent-evals` and local `bt`
   authentication exist. This is user-provided verification; the plan does not
   inspect `.bt/`, Keychain contents, or any credential value.
-- The user reported adding `BRAINTRUST_API_KEY`, but both
-  `gh secret list --repo githits-com/githits-cli --json name` and the
-  repository Actions-secrets API currently expose only `GITHITS_API_TOKEN` and
-  `OPENAI_API_KEY`; organization-secret visibility could not be checked because
-  that API returned 403. Secret values were never read. CI/labeled validation
-  remains blocked until `BRAINTRUST_API_KEY` is visible and effective in the
-  repository Actions context.
+- `BRAINTRUST_API_KEY` is effective in the repository Actions context, as
+  verified by the labeled CI export/readback in run `33424857668`. Secret
+  values were never read. Default-branch scheduled/manual activation remains
+  pending merge.
 
 ### Verified Braintrust Constraints
 
@@ -1877,6 +1876,24 @@ with individual durations from 0.006 to 10.400 seconds; eval duration totaled
 proof, not CI proof. The preceding `poc-native-tool-spans-20260831` experiment
 proved counts and timestamps but had null child duration and is superseded by
 the v2 experiment.
+
+The qualifying labeled CI proof is GitHub run
+[33424857668](https://github.com/githits-com/githits-cli/actions/runs/33424857668)
+at code SHA `7195ccc56b9ac9288dfb3d8de854f2f0e7ae7cf0`. Discovery completed in
+40 seconds, intent in 2 minutes 32 seconds, and summary/export in 22 seconds,
+for about 3 minutes total. Its Braintrust experiment is
+`github-33424857668-1` (ID `182ee9db-0df3-40f4-8987-6eeb6d91a89b`), with source
+`github`, exporter/schema 2, and metrics schema 3. Readback reconciled 23 eval
+spans and 116 structural tool spans exactly to 116 MCP calls: zero CLI calls
+and zero failed tool spans. Totals were 513.911 seconds of eval duration,
+126.458999872 seconds of tool duration, 2,686,094 prompt tokens, 20,172
+completion tokens, 2,706,266 total tokens, and estimated cost `$0.22819038`.
+Standard Braintrust compare averages were duration
+`22.343956532685652`, estimated cost `$0.009921320869565216`, tool calls
+`5.043478260869565`, tool errors `0`, and total tokens
+`117663.73913043478`. This proves the labeled PR path; default-branch
+scheduled/manual activation remains pending merge. No paid rerun was
+made for this documentation-only closeout.
 
 ### Affected Components
 
@@ -2049,13 +2066,13 @@ the v2 experiment.
    permalink against source artifacts. The current proof is recorded below for
    `.agent-eval/suites/native-tool-smoke-2`; the earlier native-root experiment
    remains superseded historical evidence.
-4. **Implemented locally; CI validation pending:** Add the CI export/final-status
-   steps and document the repository Actions visibility/effectiveness of the
-   `BRAINTRUST_API_KEY` secret.
-   Unit-test the workflow contract, validate YAML/action references, and use
-   direct SDK execution in CI so the workflow does not install `bt`. A real
-   labeled or manual run must still export/read back the expected eval roots and
-   structural children.
+4. **Implemented and labeled-path validated; default-branch activation
+   pending:** The CI export/final-status steps and repository Actions
+   `BRAINTRUST_API_KEY` configuration are implemented. Workflow contract tests,
+   YAML/action-reference validation, and direct SDK execution in CI were
+   included in the implementation evidence. Run `33424857668` exported/read back
+   the expected 23 eval roots and 116 structural children; default-branch
+   scheduled/manual activation remains pending merge.
 5. **Implemented locally:** Update durable eval operations documentation and
    create the internal `braintrust-agent-evals` skill from the commands and
    field semantics proven in step 3. Validate it with the skill validator. Run
@@ -2070,12 +2087,12 @@ the v2 experiment.
 
 ### Acceptance Criteria
 
-- MET locally: the current native structural PoC has two eval roots and 10 tool
-  children for its two-cell canary, with native comparison showing
-  `tool_calls` average `5.0` and `tool_errors` `0`. PENDING for CI: one real
-  labeled or manually dispatched workflow experiment must be exported/read back
-  with its expected eval-root and child reconciliation, including failed cells
-  when a run fails.
+- MET: the local native structural PoC has two eval roots and 10 tool children
+  for its two-cell canary, and labeled CI run `33424857668` read back 23 eval
+  spans and 116 structural tool children. Native comparison showed
+  `tool_calls` average `5.0` locally and `5.043478260869565` in CI, with
+  `tool_errors` `0` in both. Default-branch scheduled/manual activation remains
+  pending merge.
 - Every row is filterable by workload, scenario, agent, exact CLI/model,
   reasoning, guidance, intent, target SHA, and used-tool tags. Structured
   metadata exposes ordered tools and per-tool/per-status counts.
@@ -2084,15 +2101,16 @@ the v2 experiment.
   contained source artifacts. Unknown telemetry is absent/unknown; a verified
   zero-tool discovery cell remains numeric zero. The local native structural
   proof verifies exact observed child boundaries, computed duration, native tool
-  counts/errors, token, and cost fields; a fresh CI export/readback remains
-  pending acceptance work.
+  counts/errors, token, and cost fields; labeled CI readback verifies the same
+  contract across 23 eval spans and 116 structural tool children.
 - The exporter keeps unchanged scenario/workload/prompt inputs stable across
   workflow attempts, and no baseline is selected automatically or metric
   movement fails the workflow. Root `tool_calls` and `tool_errors` are omitted;
   Braintrust derives them from exact-timed structural tool children. The local
   v2 readback verifies those native metrics and bounded SQL verifies the
-  GitHits-specific/custom sequence and status metadata. A fresh CI
-  export/readback remains pending.
+  GitHits-specific/custom sequence and status metadata. Labeled CI run
+  `33424857668` verifies the native structural counts and metrics; default-
+  branch scheduled/manual activation remains pending merge.
 - The existing GitHub concise report and 14-day raw artifact upload complete
   even when export fails; the final workflow is red and names export as the
   failed stage. Local suite/report generation works without Braintrust or its

--- a/docs/plans/systematic-agent-evals.md
+++ b/docs/plans/systematic-agent-evals.md
@@ -1685,29 +1685,28 @@ None.
 
 ### Status
 
-IMPLEMENTED LOCALLY; NATIVE-FIRST METRIC PROOF PARTIAL; CI VALIDATION BLOCKED. Phase 3
-is merged and its same-repository label path has clean runner evidence. The
-exact-pinned Braintrust exporter, post-report CI wiring, local persistence/
-readback proof, and internal operations skill are implemented. A local
-native-root experiment now verifies native duration, token, and cost
-readback/comparison. A real labeled or manually dispatched CI run must still
-export and read back 23 rows before Phase 4 is accepted as complete; that
-validation cannot begin until the repository `BRAINTRUST_API_KEY` secret is
-visible/effective in Actions. Native structural tool views remain unresolved,
-and fresh CI export/readback remain acceptance work. SDK tracing was
-deliberately not added.
+IMPLEMENTED LOCALLY; NATIVE STRUCTURAL PROOF COMPLETE LOCALLY; CI VALIDATION
+PENDING. Phase 3 is merged and its same-repository label path has clean runner
+evidence. The exact-pinned Braintrust exporter, post-report CI wiring, local
+persistence/readback proof, and internal operations skill are implemented. The
+fresh local native structural proof below verifies tool counts, exact observed
+boundaries, child duration, tokens, and cost. A fresh labeled or manually
+dispatched CI run must still export and read back the expected cells before
+Phase 4 is accepted as complete; default-branch scheduled/manual activation
+also remains pending after merge. SDK tracing was deliberately not added.
 
 ### Expected Outcome
 
 Each completed Luna workflow attempt creates one immutable experiment in the
-Braintrust project `githits-cli-agent-evals`, with one top-level experiment row
-per scenario/workload cell. Braintrust exposes the exact effective prompt,
-answer/status evidence, tool-call frequencies and ordered sequence, token
-buckets, agent duration, estimated cost, repository/harness identity, exact
-Codex CLI/model identity, and a link to the GitHub workflow evidence. Local and
-GitHub suite generation and concise reporting remain independent of
-Braintrust. No SDK tracing is inserted into Codex, the GitHits MCP server, or
-the harness execution path.
+Braintrust project `githits-cli-agent-evals`, with one top-level `type: "eval"`
+span per scenario/workload cell. Known logical calls also create safe
+structural `type: "tool"` children beneath their eval root. Braintrust exposes
+the exact effective prompt, answer/status evidence, native tool counts/errors,
+ordered GitHits tool sequence, token buckets, agent duration, estimated cost,
+repository/harness identity, exact Codex CLI/model identity, and a link to the
+GitHub workflow evidence. Local and GitHub suite generation and concise
+reporting remain independent of Braintrust. No SDK tracing is inserted into
+Codex, the GitHits MCP server, or the harness execution path.
 
 ### Assumptions
 
@@ -1722,13 +1721,15 @@ the harness execution path.
   retrieval. `update: true` continues an existing experiment, but the PoC does
   not use it.
 - The native-first mapper uses the pinned SDK's verified `duration`,
-  `tool_calls`, `tool_errors`, `prompt_tokens`, `prompt_cached_tokens`,
-  `prompt_cache_creation_tokens`, `completion_tokens`,
-  `completion_reasoning_tokens`, `tokens`, and `estimated_cost` keys. A local
-  native-root readback verifies duration, token, and cost fields in Braintrust
-  comparison/readback. Native structural tool views remain unresolved because
-  Braintrust derives standard tool metrics from structural tool child spans,
-  which this scoreless post-run exporter does not fabricate.
+  `prompt_tokens`, `prompt_cached_tokens`, `prompt_cache_creation_tokens`,
+  `completion_tokens`, `completion_reasoning_tokens`, `tokens`, and
+  `estimated_cost` keys on eval roots. Standard `tool_calls` and `tool_errors`
+  are derived from structural `tool` children; root rows intentionally omit
+  those keys. Completed/failed children use exact harness-observed lifecycle
+  boundaries and computed duration, while started-only children remain open and
+  omit duration. Missing, invalid, reverse, or out-of-parent boundaries reject
+  the tool-bearing row. Exporter schema/version is 2, and schema-v1/v2 metrics
+  remain readable with missing timing normalized to null.
 - One CI run attempt is one immutable experiment. GitHub `run_id` plus
   `run_attempt` gives reruns distinct names, so no event-ID scheme, upsert,
   retry, or duplicate-repair mechanism is required.
@@ -1773,13 +1774,12 @@ No product choice blocks the implementation. The selected policy is:
 The built-in experiment comparison behavior observed on prior custom-only rows
 is a historical limitation, not a native-first result: its exercised output
 contained only generic all-zero trace metrics and omitted the custom eval
-telemetry. The native-root readback now verifies native duration, token, and
-cost metrics, but standard `tool_calls` and `tool_errors` still compare as zero
-because Braintrust derives them from structural tool child spans. The exporter
-lacks per-call timestamps and must not fabricate child timing, so native
-structural tool views remain unresolved. GitHits-specific/custom telemetry is
-still accurate; investigate structural tool support as a Phase 5/PoC follow-up
-while bounded SQL and row/UI inspection remain the complete metrics path.
+telemetry. The current exporter records one structural `tool` child per known
+logical call, using exact harness-observed boundaries and computed duration for
+completed/failed calls. Native comparison now reports those child-derived
+`tool_calls` and `tool_errors`; bounded SQL remains the path for the exact
+GitHits-specific sequence and status counts. A fresh labeled CI export/readback
+and default-branch scheduled/manual activation remain pending.
 
 ### Dependencies
 
@@ -1815,13 +1815,12 @@ while bounded SQL and row/UI inspection remain the complete metrics path.
 - Braintrust [SQL](https://www.braintrust.dev/docs/reference/sql) and the
   `bt experiments`/`bt sql` commands can inspect and compare the persisted fields.
   The repository skill records only commands exercised against the PoC
-  experiment. The native-root readback verifies native duration, token, and
-  cost fields in comparison/readback. Its root `tool_calls` and `tool_errors`
-  are accurate in the rows but compare as zero because Braintrust derives those
-  standard metrics from structural tool child spans; per-call timestamps are
-  unavailable, so child timing is not fabricated. Bounded SQL/query and
-  experiment UI inspection remain the current complete metrics path for the
-  GitHits-specific/custom telemetry.
+  experiment. The current native structural readback verifies exact observed
+  child timing, computed duration, native tool counts/errors, and native token
+  and cost fields. Eval-root SQL must filter `span_attributes.type = 'eval'`;
+  tool-child SQL must filter `span_attributes.type = 'tool'`, because an
+  unfiltered count includes both span types. GitHits-specific sequence/status
+  metadata remains available through the bounded child/root queries.
 
 ### Verified PoC evidence
 
@@ -1835,8 +1834,8 @@ artifacts. The first experiment permalink is:
 
 <https://www.braintrust.dev/app/GitHits/p/githits-cli-agent-evals/experiments/poc-33381601980-top-level-spans>
 
-The native-first exporter was subsequently exercised locally against those
-accepted artifacts as experiment `poc-33381601980-native-root` (ID
+The superseded pre-structural exporter was subsequently exercised locally
+against those accepted artifacts as experiment `poc-33381601980-native-root` (ID
 `dfa37c74-0b31-4b48-aeb1-a2698a03cecc`) with exactly 23 rows. Native
 comparison/readback populated `duration`, prompt/completion/cache/reasoning
 token buckets, total `tokens`, and `estimated_cost`. Across the 23 rows,
@@ -1844,11 +1843,10 @@ bounded SQL totals were `prompt_tokens=2,861,042`,
 `completion_tokens=20,942`, `tokens=2,881,984`, and
 `estimated_cost=0.23660003`; recorded duration ranged from 8.53 to 207.317
 seconds. This was a local export/readback over the accepted artifacts, not CI
-proof. The native-root rows contain `tool_calls=119` and `tool_errors=2`, but
-the standard tool comparison reports both as zero because Braintrust derives
-them from structural tool child spans. The exporter lacks per-call timestamps
-and does not fabricate child timing; native structural tool views remain
-unresolved while GitHits-specific/custom telemetry remains accurate.
+proof. This native-root experiment is superseded historical evidence: its rows
+contain root `tool_calls=119` and `tool_errors=2`, and the standard comparison
+reports both as zero because structural tool children were not yet exported.
+Its lack of child timing is not the current exporter contract.
 
 The exercised custom-only command
 `bt experiments --json --project githits-cli-agent-evals compare
@@ -1858,6 +1856,26 @@ telemetry. This remains a historical observation about the prior custom-only
 rows; it does not describe the native-root experiment above. The labeled run
 `33413090610` is the current pre-native baseline; it is not native-first
 evidence.
+
+The current local native structural proof used suite
+`.agent-eval/suites/native-tool-smoke-2` at target and measurement commit
+`4850299`. Its Luna-low intent canary ran with workload concurrency 2: 2/2
+workloads succeeded, with 10 logical MCP calls, zero CLI calls and failures,
+and complete harness-observed intervals for all 10 calls. Wall time was
+43.447 seconds, cumulative agent time 71.855 seconds, and estimated cost
+`$0.02070904`.
+
+The resulting experiment `poc-native-tool-spans-v2-20260831` (ID
+`e8480301-6622-4a06-a37b-0ebd0e42bb64`,
+<https://www.braintrust.dev/app/GitHits/p/githits-cli-agent-evals/experiments/poc-native-tool-spans-v2-20260831>)
+read back two eval roots and 10 structural tool children. Native comparison
+reported `tool_calls` average `5.0` and `tool_errors` `0`. Child SQL showed
+exact observed start/end values and computed durations totaling 30.970 seconds,
+with individual durations from 0.006 to 10.400 seconds; eval duration totaled
+71.855 seconds. Native token and cost fields remain populated. This is local
+proof, not CI proof. The preceding `poc-native-tool-spans-20260831` experiment
+proved counts and timestamps but had null child duration and is superseded by
+the v2 experiment.
 
 ### Affected Components
 
@@ -1919,16 +1937,16 @@ evidence.
    collection is disabled, preventing the summary checkout or local dirty tree
    from replacing artifact identity.
 
-3. **One allowlisted row per workload/scenario**
+3. **One allowlisted eval root plus structural tool children per workload/scenario**
 
    `output` contains process/cell/final status, neutral answer when present,
    self-reported confidence, and discovery observation when available.
    Failed cells use a generated status-only `error` label; raw error/stderr text
    is not uploaded. `scores` is omitted.
 
-   Native numeric values use Braintrust's verified standard names: `duration`
-   (seconds from recorded milliseconds), `tool_calls`, `tool_errors`,
-   `prompt_tokens`, `prompt_cached_tokens`, `prompt_cache_creation_tokens`,
+   Native numeric values on the eval root use Braintrust's verified standard
+   names: `duration` (seconds from recorded milliseconds), `prompt_tokens`,
+   `prompt_cached_tokens`, `prompt_cache_creation_tokens`,
    `completion_tokens`, `completion_reasoning_tokens`, `tokens`, and
    `estimated_cost`. The provider input total includes cached reads and cache
    creation; `tokens` is that total plus provider output tokens. The remaining
@@ -1938,22 +1956,35 @@ evidence.
    absent rather than coerced to zero. Cost kind/uncertainty/rate metadata stays
    explicit because `estimated_cost` is still a rate-based estimate.
 
+   Known logical calls are represented as safe structural `type: "tool"` child
+   spans under the eval root. Completed/failed children use the normalized tool
+   name, exact harness-observed start/end times, and computed duration;
+   started-only children remain open and omit duration. Their event data is
+   limited to tool, surface, status, the `harness_stdout_observed` timing-source
+   marker, and a generated failure marker for failed calls. Root `tool_calls`
+   and `tool_errors` are omitted because Braintrust derives those native metrics
+   from the children. Missing, invalid, reverse, or out-of-parent boundaries
+   reject tool-bearing rows rather than fabricating an interval.
+
    Structured metadata contains cell/suite/run IDs, guidance/intent identity,
    agent/model/reasoning/CLI identity, cost kind/uncertainty/rate snapshot,
    normalized warnings/validation categories, `toolTelemetryKnown`, ordered
    normalized tool sequence, and per-surface/per-tool total and status counts.
    Each known used tool also adds a filter tag such as `tool:mcp:search`; the
-   nested counts remain authoritative. Tool telemetry that cannot reconcile is
-   `toolTelemetryKnown: false` with no tool-count metrics or fabricated empty
-   counts.
+   nested counts remain authoritative. A zero-tool row remains valid when
+   telemetry is known; tool-bearing rows whose telemetry or observed boundaries
+   cannot reconcile are rejected rather than uploaded with missing counts or
+   fabricated empty timing.
 
 4. **Thin SDK boundary and local authentication**
 
    Keep record construction pure and inject only the minimal SDK publisher
    needed by tests. Production initializes the exact project/experiment, starts
-   and immediately ends one top-level `type: "eval"` span per row in
-   deterministic suite/scenario/workload order, calls `flush()`, and writes a
-   small nonsecret result JSON containing project, experiment, URL, and
+   one top-level `type: "eval"` span per row in deterministic
+   suite/scenario/workload order, creates its validated structural `tool`
+   children, ends completed/failed children at their observed boundaries, leaves
+   started-only children open, ends each eval root, calls `flush()`, and writes
+   a small nonsecret result JSON containing project, experiment, URL, and
    exported-row count. There is no agent execution, tracing wrapper, dataset,
    scorer, queue, retry, lock, cache, or repository database.
 
@@ -2008,26 +2039,22 @@ evidence.
    validate-only output, explicit flush, and nonsecret result file. Verify
    credential-free `--validate-only` mapping against complete Phase 3 artifacts
    without running an agent.
-3. **Local native metric persistence/readback partially proven:** Use the authenticated local `bt`
-   profile to export the accepted 23-cell evidence into
+3. **Local native structural persistence/readback proven:** Use the authenticated
+   local `bt` profile to export the accepted evidence into
    `githits-cli-agent-evals` under clearly named `poc-...` experiments. Read it
-   back with `bt experiments` and bounded `bt sql`; reconcile row count,
-   zero-tool discovery, tool-using cells, native token buckets, duration, cost,
-   prompt, answer, exact Codex version, SHA, and permalink against source
-   artifacts. The native-root experiment has 23 rows and verifies duration,
-   token, and cost readback/comparison, with bounded totals of
-   `prompt_tokens=2,861,042`, `completion_tokens=20,942`,
-   `tokens=2,881,984`, `estimated_cost=0.23660003`, and duration from 8.53 to
-   207.317 seconds. Its root `tool_calls=119` and `tool_errors=2` compare as
-   zero because Braintrust expects structural tool child spans; per-call
-   timestamps are unavailable, so child timing is not fabricated. The
-   structural-tool limitation remains a follow-up.
+   back with `bt experiments` and bounded `bt sql`; reconcile eval-root count,
+   structural child count, zero-tool discovery, tool-using cells, native token
+   buckets, duration, cost, prompt, answer, exact Codex version, SHA, and
+   permalink against source artifacts. The current proof is recorded below for
+   `.agent-eval/suites/native-tool-smoke-2`; the earlier native-root experiment
+   remains superseded historical evidence.
 4. **Implemented locally; CI validation pending:** Add the CI export/final-status
    steps and document the repository Actions visibility/effectiveness of the
    `BRAINTRUST_API_KEY` secret.
    Unit-test the workflow contract, validate YAML/action references, and use
    direct SDK execution in CI so the workflow does not install `bt`. A real
-   labeled or manual run must still export/read back 23 rows.
+   labeled or manual run must still export/read back the expected eval roots and
+   structural children.
 5. **Implemented locally:** Update durable eval operations documentation and
    create the internal `braintrust-agent-evals` skill from the commands and
    field semantics proven in step 3. Validate it with the skill validator. Run
@@ -2042,27 +2069,29 @@ evidence.
 
 ### Acceptance Criteria
 
-- MET locally: PoC experiments in `githits-cli-agent-evals` have exactly 23
-  rows for the current two discovery plus 21 intent cells. PENDING for CI:
-  one real labeled or manually dispatched workflow experiment must be
-  exported/read back with the same 23-row reconciliation, including failed
-  cells when a run fails.
+- MET locally: the current native structural PoC has two eval roots and 10 tool
+  children for its two-cell canary, with native comparison showing
+  `tool_calls` average `5.0` and `tool_errors` `0`. PENDING for CI: one real
+  labeled or manually dispatched workflow experiment must be exported/read back
+  with its expected eval-root and child reconciliation, including failed cells
+  when a run fails.
 - Every row is filterable by workload, scenario, agent, exact CLI/model,
   reasoning, guidance, intent, target SHA, and used-tool tags. Structured
   metadata exposes ordered tools and per-tool/per-status counts.
 - Prompt, neutral answer, process/final status, self-reported confidence, native
   token buckets/duration/cost, and GitHits-specific tool counts reconcile to
   contained source artifacts. Unknown telemetry is absent/unknown; a verified
-  zero-tool discovery cell remains numeric zero. Native-root local readback is
-  verified for duration, token, and cost fields; structural native tool views
-  and a fresh CI export/readback remain pending acceptance work.
+  zero-tool discovery cell remains numeric zero. The local native structural
+  proof verifies exact observed child boundaries, computed duration, native tool
+  counts/errors, token, and cost fields; a fresh CI export/readback remains
+  pending acceptance work.
 - The exporter keeps unchanged scenario/workload/prompt inputs stable across
   workflow attempts, and no baseline is selected automatically or metric
-  movement fails the workflow. PENDING: native root `tool_calls` and
-  `tool_errors` compare as zero because Braintrust derives them from structural
-  tool child spans; per-call timestamps are unavailable, so structural child
-  timing is not fabricated. GitHits-specific/custom telemetry remains accurate
-  through bounded SQL/UI inspection.
+  movement fails the workflow. Root `tool_calls` and `tool_errors` are omitted;
+  Braintrust derives them from exact-timed structural tool children. The local
+  v2 readback verifies those native metrics and bounded SQL verifies the
+  GitHits-specific/custom sequence and status metadata. A fresh CI
+  export/readback remains pending.
 - The existing GitHub concise report and 14-day raw artifact upload complete
   even when export fails; the final workflow is red and names export as the
   failed stage. Local suite/report generation works without Braintrust or its

--- a/docs/plans/systematic-agent-evals.md
+++ b/docs/plans/systematic-agent-evals.md
@@ -1685,14 +1685,16 @@ None.
 
 ### Status
 
-IMPLEMENTED LOCALLY; CI VALIDATION BLOCKED. Phase 3 is merged and its
-same-repository label path has clean runner evidence. The exact-pinned
-Braintrust exporter, post-report CI wiring, local persistence/readback proof,
-and internal operations skill are implemented. A real labeled or manually
-dispatched CI run must still export and read back 23 rows before Phase 4 is
-accepted as complete; that validation cannot begin until the repository
-`BRAINTRUST_API_KEY` secret is visible/effective in Actions. SDK tracing was
-deliberately not added.
+IMPLEMENTED LOCALLY; NATIVE-FIRST PROOF PENDING; CI VALIDATION BLOCKED. Phase 3
+is merged and its same-repository label path has clean runner evidence. The
+exact-pinned Braintrust exporter, post-report CI wiring, local persistence/
+readback proof, and internal operations skill are implemented. A real labeled
+or manually dispatched CI run must still export and read back 23 rows before
+Phase 4 is accepted as complete; that validation cannot begin until the
+repository `BRAINTRUST_API_KEY` secret is visible/effective in Actions. The
+native-first mapper is implemented locally, but native-root readback and a
+fresh CI export/readback remain acceptance work. SDK tracing was deliberately
+not added.
 
 ### Expected Outcome
 
@@ -1718,6 +1720,12 @@ the harness execution path.
   explicit `flush()`, and `summarize({ summarizeScores: false })` permalink
   retrieval. `update: true` continues an existing experiment, but the PoC does
   not use it.
+- The native-first mapper uses the pinned SDK's verified `duration`,
+  `tool_calls`, `tool_errors`, `prompt_tokens`, `prompt_cached_tokens`,
+  `prompt_cache_creation_tokens`, `completion_tokens`,
+  `completion_reasoning_tokens`, `tokens`, and `estimated_cost` keys. Native
+  UI and comparison behavior remains unproven until a native-root export is
+  read back.
 - One CI run attempt is one immutable experiment. GitHub `run_id` plus
   `run_attempt` gives reruns distinct names, so no event-ID scheme, upsert,
   retry, or duplicate-repair mechanism is required.
@@ -1759,11 +1767,12 @@ No product choice blocks the implementation. The selected policy is:
   remain; push-to-main behavior is reconsidered only after Braintrust evidence
   is available.
 
-The built-in experiment comparison behavior is a known technical limitation,
-not a selected policy: its exercised output contains only generic all-zero trace
-metrics and omits the custom eval telemetry. Its investigation is deferred to a
-Phase 5 / PoC follow-up; bounded SQL and row/UI inspection remain the verified
-metrics path.
+The built-in experiment comparison behavior observed on prior custom-only rows
+is a known historical limitation, not a native-first result: its exercised
+output contained only generic all-zero trace metrics and omitted the custom eval
+telemetry. Native UI and comparison behavior remains unproven pending a fresh
+native export/readback. Its investigation is deferred to a Phase 5 / PoC
+follow-up; bounded SQL and row/UI inspection remain the current metrics path.
 
 ### Dependencies
 
@@ -1799,13 +1808,14 @@ metrics path.
 - Braintrust [SQL](https://www.braintrust.dev/docs/reference/sql) and the
   `bt experiments`/`bt sql` commands can inspect and compare the persisted fields.
   The repository skill records only commands exercised against the PoC
-  experiment. The built-in compare command currently returns only generic,
-  all-zero trace metrics rather than this custom telemetry; bounded SQL/query
-  and experiment UI inspection are the verified metrics path.
+  experiment. The built-in compare command previously returned only generic,
+  all-zero trace metrics rather than the custom-only telemetry; native-first UI
+  and comparison behavior remains unproven pending a fresh export/readback.
+  Bounded SQL/query and experiment UI inspection remain the current metrics path.
 
 ### Verified PoC evidence
 
-The accepted GitHub run `33381601980` at SHA
+The accepted pre-native GitHub run `33381601980` at SHA
 `dc63675d7c0ee95a9594eac272982943dceef521` validated and exported the discovery
 and intent suites as exactly 23 rows. The experiments
 `poc-33381601980-top-level-spans` and `poc-33381601980-repeat` each read back
@@ -1815,13 +1825,14 @@ artifacts. The first experiment permalink is:
 
 <https://www.braintrust.dev/app/GitHits/p/githits-cli-agent-evals/experiments/poc-33381601980-top-level-spans>
 
-The exercised command
+The exercised custom-only command
 `bt experiments --json --project githits-cli-agent-evals compare
 poc-33381601980-top-level-spans poc-33381601980-repeat` succeeds but exposes
 only generic Braintrust trace metrics, all zero, and not the custom eval
-telemetry. This limitation does not invalidate persistence. It is a Phase 5 /
-PoC follow-up requiring investigation. CI acceptance remains pending until a
-real labeled or manually dispatched workflow exports and reads back 23 rows.
+telemetry. This prior observation does not invalidate persistence, but it is not
+native-first proof. Native-root readback and a fresh CI export/readback remain
+acceptance work. The labeled run `33413090610` is the current pre-native
+baseline; it is not native-first evidence.
 
 ### Affected Components
 
@@ -1890,16 +1901,17 @@ real labeled or manually dispatched workflow exports and reads back 23 rows.
    Failed cells use a generated status-only `error` label; raw error/stderr text
    is not uploaded. `scores` is omitted.
 
-   Known numeric values map to custom metrics with stable names:
-   `agent_duration_ms`, `logical_tool_calls`, `mcp_tool_calls`,
-   `cli_tool_calls`, `tool_calls_started`, `tool_calls_completed`,
-   `tool_calls_failed`, `tool_calls_unknown`, `raw_tool_events`,
-   `uncached_input_tokens`, `cached_input_tokens`,
-   `cache_write_input_tokens`, `output_tokens`,
-   `reasoning_output_tokens`, and `estimated_cost_usd`. Known zero is logged as
-   zero. Unknown values are absent rather than coerced to zero. Custom names
-   avoid Braintrust reinterpreting the repository's rate estimate as
-   provider-reported billing.
+   Native numeric values use Braintrust's verified standard names: `duration`
+   (seconds from recorded milliseconds), `tool_calls`, `tool_errors`,
+   `prompt_tokens`, `prompt_cached_tokens`, `prompt_cache_creation_tokens`,
+   `completion_tokens`, `completion_reasoning_tokens`, `tokens`, and
+   `estimated_cost`. The provider input total includes cached reads and cache
+   creation; `tokens` is that total plus provider output tokens. The remaining
+   GitHits-specific metrics are `mcp_tool_calls`, `cli_tool_calls`,
+   `tool_calls_started`, `tool_calls_completed`, `tool_calls_unknown`, and
+   `raw_tool_events`. Known zero is logged as zero, and unknown values are
+   absent rather than coerced to zero. Cost kind/uncertainty/rate metadata stays
+   explicit because `estimated_cost` is still a rate-based estimate.
 
    Structured metadata contains cell/suite/run IDs, guidance/intent identity,
    agent/model/reasoning/CLI identity, cost kind/uncertainty/rate snapshot,
@@ -1971,11 +1983,11 @@ real labeled or manually dispatched workflow exports and reads back 23 rows.
    validate-only output, explicit flush, and nonsecret result file. Verify
    credential-free `--validate-only` mapping against complete Phase 3 artifacts
    without running an agent.
-3. **Local persistence/readback proven:** Use the authenticated local `bt`
+3. **Local pre-native persistence/readback proven:** Use the authenticated local `bt`
    profile to export the accepted 23-cell evidence into
    `githits-cli-agent-evals` under clearly named `poc-...` experiments. Read it
    back with `bt experiments` and bounded `bt sql`; reconcile row count,
-   zero-tool discovery, tool-using cells, token buckets, duration, cost,
+   zero-tool discovery, tool-using cells, native token buckets, duration, cost,
    prompt, answer, exact Codex version, SHA, and permalink against source
    artifacts. The built-in compare limitation is recorded for follow-up.
 4. **Implemented locally; CI validation pending:** Add the CI export/final-status
@@ -2006,10 +2018,11 @@ real labeled or manually dispatched workflow exports and reads back 23 rows.
 - Every row is filterable by workload, scenario, agent, exact CLI/model,
   reasoning, guidance, intent, target SHA, and used-tool tags. Structured
   metadata exposes ordered tools and per-tool/per-status counts.
-- Prompt, neutral answer, process/final status, self-reported confidence, token
-  buckets, agent duration, estimated cost/uncertainty, and logical tool counts
-  reconcile to contained source artifacts. Unknown telemetry is absent/unknown;
-  a verified zero-tool discovery cell remains numeric zero.
+- Prompt, neutral answer, process/final status, self-reported confidence, native
+  token buckets/duration/cost, and GitHits-specific tool counts reconcile to
+  contained source artifacts. Unknown telemetry is absent/unknown; a verified
+  zero-tool discovery cell remains numeric zero. Native-root local readback and
+  a fresh CI export/readback remain pending acceptance work.
 - The exporter keeps unchanged scenario/workload/prompt inputs stable across
   workflow attempts, and no baseline is selected automatically or metric
   movement fails the workflow. PENDING: the exercised `bt experiments compare`

--- a/docs/plans/systematic-agent-evals.md
+++ b/docs/plans/systematic-agent-evals.md
@@ -1685,16 +1685,17 @@ None.
 
 ### Status
 
-IMPLEMENTED LOCALLY; NATIVE-FIRST PROOF PENDING; CI VALIDATION BLOCKED. Phase 3
+IMPLEMENTED LOCALLY; NATIVE-FIRST METRIC PROOF PARTIAL; CI VALIDATION BLOCKED. Phase 3
 is merged and its same-repository label path has clean runner evidence. The
 exact-pinned Braintrust exporter, post-report CI wiring, local persistence/
-readback proof, and internal operations skill are implemented. A real labeled
-or manually dispatched CI run must still export and read back 23 rows before
-Phase 4 is accepted as complete; that validation cannot begin until the
-repository `BRAINTRUST_API_KEY` secret is visible/effective in Actions. The
-native-first mapper is implemented locally, but native-root readback and a
-fresh CI export/readback remain acceptance work. SDK tracing was deliberately
-not added.
+readback proof, and internal operations skill are implemented. A local
+native-root experiment now verifies native duration, token, and cost
+readback/comparison. A real labeled or manually dispatched CI run must still
+export and read back 23 rows before Phase 4 is accepted as complete; that
+validation cannot begin until the repository `BRAINTRUST_API_KEY` secret is
+visible/effective in Actions. Native structural tool views remain unresolved,
+and fresh CI export/readback remain acceptance work. SDK tracing was
+deliberately not added.
 
 ### Expected Outcome
 
@@ -1723,9 +1724,11 @@ the harness execution path.
 - The native-first mapper uses the pinned SDK's verified `duration`,
   `tool_calls`, `tool_errors`, `prompt_tokens`, `prompt_cached_tokens`,
   `prompt_cache_creation_tokens`, `completion_tokens`,
-  `completion_reasoning_tokens`, `tokens`, and `estimated_cost` keys. Native
-  UI and comparison behavior remains unproven until a native-root export is
-  read back.
+  `completion_reasoning_tokens`, `tokens`, and `estimated_cost` keys. A local
+  native-root readback verifies duration, token, and cost fields in Braintrust
+  comparison/readback. Native structural tool views remain unresolved because
+  Braintrust derives standard tool metrics from structural tool child spans,
+  which this scoreless post-run exporter does not fabricate.
 - One CI run attempt is one immutable experiment. GitHub `run_id` plus
   `run_attempt` gives reruns distinct names, so no event-ID scheme, upsert,
   retry, or duplicate-repair mechanism is required.
@@ -1768,11 +1771,15 @@ No product choice blocks the implementation. The selected policy is:
   is available.
 
 The built-in experiment comparison behavior observed on prior custom-only rows
-is a known historical limitation, not a native-first result: its exercised
-output contained only generic all-zero trace metrics and omitted the custom eval
-telemetry. Native UI and comparison behavior remains unproven pending a fresh
-native export/readback. Its investigation is deferred to a Phase 5 / PoC
-follow-up; bounded SQL and row/UI inspection remain the current metrics path.
+is a historical limitation, not a native-first result: its exercised output
+contained only generic all-zero trace metrics and omitted the custom eval
+telemetry. The native-root readback now verifies native duration, token, and
+cost metrics, but standard `tool_calls` and `tool_errors` still compare as zero
+because Braintrust derives them from structural tool child spans. The exporter
+lacks per-call timestamps and must not fabricate child timing, so native
+structural tool views remain unresolved. GitHits-specific/custom telemetry is
+still accurate; investigate structural tool support as a Phase 5/PoC follow-up
+while bounded SQL and row/UI inspection remain the complete metrics path.
 
 ### Dependencies
 
@@ -1808,10 +1815,13 @@ follow-up; bounded SQL and row/UI inspection remain the current metrics path.
 - Braintrust [SQL](https://www.braintrust.dev/docs/reference/sql) and the
   `bt experiments`/`bt sql` commands can inspect and compare the persisted fields.
   The repository skill records only commands exercised against the PoC
-  experiment. The built-in compare command previously returned only generic,
-  all-zero trace metrics rather than the custom-only telemetry; native-first UI
-  and comparison behavior remains unproven pending a fresh export/readback.
-  Bounded SQL/query and experiment UI inspection remain the current metrics path.
+  experiment. The native-root readback verifies native duration, token, and
+  cost fields in comparison/readback. Its root `tool_calls` and `tool_errors`
+  are accurate in the rows but compare as zero because Braintrust derives those
+  standard metrics from structural tool child spans; per-call timestamps are
+  unavailable, so child timing is not fabricated. Bounded SQL/query and
+  experiment UI inspection remain the current complete metrics path for the
+  GitHits-specific/custom telemetry.
 
 ### Verified PoC evidence
 
@@ -1825,14 +1835,29 @@ artifacts. The first experiment permalink is:
 
 <https://www.braintrust.dev/app/GitHits/p/githits-cli-agent-evals/experiments/poc-33381601980-top-level-spans>
 
+The native-first exporter was subsequently exercised locally against those
+accepted artifacts as experiment `poc-33381601980-native-root` (ID
+`dfa37c74-0b31-4b48-aeb1-a2698a03cecc`) with exactly 23 rows. Native
+comparison/readback populated `duration`, prompt/completion/cache/reasoning
+token buckets, total `tokens`, and `estimated_cost`. Across the 23 rows,
+bounded SQL totals were `prompt_tokens=2,861,042`,
+`completion_tokens=20,942`, `tokens=2,881,984`, and
+`estimated_cost=0.23660003`; recorded duration ranged from 8.53 to 207.317
+seconds. This was a local export/readback over the accepted artifacts, not CI
+proof. The native-root rows contain `tool_calls=119` and `tool_errors=2`, but
+the standard tool comparison reports both as zero because Braintrust derives
+them from structural tool child spans. The exporter lacks per-call timestamps
+and does not fabricate child timing; native structural tool views remain
+unresolved while GitHits-specific/custom telemetry remains accurate.
+
 The exercised custom-only command
 `bt experiments --json --project githits-cli-agent-evals compare
 poc-33381601980-top-level-spans poc-33381601980-repeat` succeeds but exposes
 only generic Braintrust trace metrics, all zero, and not the custom eval
-telemetry. This prior observation does not invalidate persistence, but it is not
-native-first proof. Native-root readback and a fresh CI export/readback remain
-acceptance work. The labeled run `33413090610` is the current pre-native
-baseline; it is not native-first evidence.
+telemetry. This remains a historical observation about the prior custom-only
+rows; it does not describe the native-root experiment above. The labeled run
+`33413090610` is the current pre-native baseline; it is not native-first
+evidence.
 
 ### Affected Components
 
@@ -1983,13 +2008,20 @@ baseline; it is not native-first evidence.
    validate-only output, explicit flush, and nonsecret result file. Verify
    credential-free `--validate-only` mapping against complete Phase 3 artifacts
    without running an agent.
-3. **Local pre-native persistence/readback proven:** Use the authenticated local `bt`
+3. **Local native metric persistence/readback partially proven:** Use the authenticated local `bt`
    profile to export the accepted 23-cell evidence into
    `githits-cli-agent-evals` under clearly named `poc-...` experiments. Read it
    back with `bt experiments` and bounded `bt sql`; reconcile row count,
    zero-tool discovery, tool-using cells, native token buckets, duration, cost,
    prompt, answer, exact Codex version, SHA, and permalink against source
-   artifacts. The built-in compare limitation is recorded for follow-up.
+   artifacts. The native-root experiment has 23 rows and verifies duration,
+   token, and cost readback/comparison, with bounded totals of
+   `prompt_tokens=2,861,042`, `completion_tokens=20,942`,
+   `tokens=2,881,984`, `estimated_cost=0.23660003`, and duration from 8.53 to
+   207.317 seconds. Its root `tool_calls=119` and `tool_errors=2` compare as
+   zero because Braintrust expects structural tool child spans; per-call
+   timestamps are unavailable, so child timing is not fabricated. The
+   structural-tool limitation remains a follow-up.
 4. **Implemented locally; CI validation pending:** Add the CI export/final-status
    steps and document the repository Actions visibility/effectiveness of the
    `BRAINTRUST_API_KEY` secret.
@@ -2021,13 +2053,16 @@ baseline; it is not native-first evidence.
 - Prompt, neutral answer, process/final status, self-reported confidence, native
   token buckets/duration/cost, and GitHits-specific tool counts reconcile to
   contained source artifacts. Unknown telemetry is absent/unknown; a verified
-  zero-tool discovery cell remains numeric zero. Native-root local readback and
-  a fresh CI export/readback remain pending acceptance work.
+  zero-tool discovery cell remains numeric zero. Native-root local readback is
+  verified for duration, token, and cost fields; structural native tool views
+  and a fresh CI export/readback remain pending acceptance work.
 - The exporter keeps unchanged scenario/workload/prompt inputs stable across
   workflow attempts, and no baseline is selected automatically or metric
-  movement fails the workflow. PENDING: the exercised `bt experiments compare`
-  command reports only generic all-zero trace metrics, so custom eval trend
-  comparison still requires the documented SQL/UI follow-up.
+  movement fails the workflow. PENDING: native root `tool_calls` and
+  `tool_errors` compare as zero because Braintrust derives them from structural
+  tool child spans; per-call timestamps are unavailable, so structural child
+  timing is not fabricated. GitHits-specific/custom telemetry remains accurate
+  through bounded SQL/UI inspection.
 - The existing GitHub concise report and 14-day raw artifact upload complete
   even when export fails; the final workflow is red and names export as the
   failed stage. Local suite/report generation works without Braintrust or its

--- a/docs/plans/systematic-agent-evals.md
+++ b/docs/plans/systematic-agent-evals.md
@@ -1747,10 +1747,11 @@ The initial plan assumed that `Experiment.log()` could represent a scoreless
 eval row. Runtime behavior in the installed Braintrust 3.29.0 package disproved
 that assumption: `Experiment.log()` requires non-empty `scores`. No quality
 judge or fabricated score is appropriate in this phase. The exporter therefore
-uses one top-level `type: "eval"` span per mapped cell, ends each span
-immediately, flushes the experiment, and then reads its permalink through
-`summarize({ summarizeScores: false })`. This is a resolved implementation
-contradiction, not a reason to alter the neutral metrics contract.
+uses one top-level `type: "eval"` span per mapped cell, publishes and closes
+its structural tool children, closes the eval root, flushes the experiment, and
+then reads its permalink through `summarize({ summarizeScores: false })`. This
+is a resolved implementation contradiction, not a reason to alter the neutral
+metrics contract.
 
 ### Unknowns Or Product Decisions
 

--- a/docs/plans/systematic-agent-evals.md
+++ b/docs/plans/systematic-agent-evals.md
@@ -2056,6 +2056,14 @@ case; it does not satisfy native baseline linkage.
    so it does not read or expose credential values or introduce a second
    client/service layer.
 
+   The nonsecret CLI result file is schema version 2 and includes the stable
+   experiment identity plus the actual `baseExperiment` `{id, name}` or null.
+   Validate-only uses null to mean unresolved/not queried because it performs
+   no discovery; export null means required Braintrust readback found no actual
+   linked base. `fetchBaseExperiment()` is required across the SDK adapter and
+   publisher boundary, so an unavailable capability fails rather than being
+   represented as no base.
+
 3. **One allowlisted eval root plus structural tool children per workload/scenario**
 
    `output` contains process/cell/final status, neutral answer when present,
@@ -2178,9 +2186,11 @@ case; it does not satisfy native baseline linkage.
    it as explicit-link acceptance evidence. Do not use automatic ancestry after
    bootstrap.
 
-   After publishing, call public `fetchBaseExperiment()` to return the actual
-   linked ID/name in the nonsecret result and render it in CI/local output as a
-   base or `none`. Keep discovery inside the injected Braintrust integration
+   After publishing, call required public `fetchBaseExperiment()` to return the
+   actual linked ID/name in the nonsecret result and render it in CI/local
+   output as a base or explicit no-base state. Validate-only's null is
+   unresolved/not queried; export null means readback found no actual linked
+   base. Keep discovery inside the injected Braintrust integration
    boundary; do not add a mutable alias, rolling experiment, second client
    abstraction, state store, or retry.
 

--- a/eval/agentic/README.md
+++ b/eval/agentic/README.md
@@ -20,7 +20,7 @@ The repository-local named-suite commands below are the local measurement
 workflow. They run the fixed Luna matrix and produce validated suite and
 comparison artifacts. The CI workflow composes the same commands for daily and
 explicitly authorized pull-request runs; it retains raw artifacts for diagnosis
-but does not provide long-term service history or judge answer quality.
+and exports normalized rows to Braintrust, but does not judge answer quality.
 
 ## What Is Under Test
 
@@ -335,9 +335,76 @@ descriptor shards/cells to `discovery` and full to `full`; missing, null, or
 other profiles are rejected rather than mapped to `intent`. Legacy child
 `metrics.json` files use the one-off v1 metrics normalizer.
 
-These local commands are diagnostic measurement tools. CI scheduling is
-implemented by `.github/workflows/agent-evals.yml`; persistent result history,
-service export, Haiku coverage, and quality judging remain later phases.
+These local commands are diagnostic measurement tools. CI scheduling and
+Braintrust export are implemented by `.github/workflows/agent-evals.yml`;
+Haiku coverage and quality judging remain later phases.
+
+## Braintrust persistence
+
+The exporter persists normalized suite evidence in the Braintrust project
+`githits-cli-agent-evals` using the exact `braintrust` SDK `3.29.0`. It creates
+one top-level eval row per scenario/workload cell and does not upload raw
+stdout, stderr, provider events, environment/configuration, or arbitrary
+artifacts. No quality score is fabricated; self-reported confidence remains
+diagnostic metadata.
+
+Validate downloaded or local suites without credentials or network access:
+
+```bash
+bun run agent:e2e:braintrust \
+  --suite discovery=.agent-eval/suites/<discovery>/suite.json \
+  --suite intent=.agent-eval/suites/<intent>/suite.json \
+  --project githits-cli-agent-evals \
+  --validate-only
+```
+
+Validation requires non-dry-run suites with complete contained child evidence.
+It rejects dry-run suites, duplicate scenario/workload cells, mixed identity or
+schema contracts, and missing/unsafe prompts. Failed or partial cells remain
+exportable when their report, metrics, workload, and prompt evidence are
+complete. Validate all suite inputs before an export; the command reports only
+safe identities and row counts in validate-only mode.
+
+For an explicitly requested local export using the authenticated `bt` profile,
+run the same official entrypoint through `bt eval`:
+
+```bash
+bt eval --runner bun --no-auto-instrumentation scripts/agent-eval-braintrust.ts -- \
+  --suite discovery=.agent-eval/suites/<discovery>/suite.json \
+  --suite intent=.agent-eval/suites/<intent>/suite.json \
+  --project githits-cli-agent-evals \
+  --experiment local-<name> \
+  --source local \
+  --result-out .agent-eval/braintrust-result.json
+```
+
+The result file is safe to retain and contains only schema version, mode,
+project, experiment, row count, suite summaries, and the export URL. It contains
+no prompt, answer, row body, artifact path, or credential. The direct command
+`bun run agent:e2e:braintrust` is also the CI path; CI scopes
+`BRAINTRUST_API_KEY` only to that export step and never installs or runs `bt`.
+The workflow renders the existing report and retains raw artifacts for 14 days
+before exporting; a final no-secret step names scenario, report, or Braintrust
+failure while preserving the earlier evidence.
+
+Inspect persisted history with the authenticated profile:
+
+```bash
+bt experiments --json --project githits-cli-agent-evals list
+bt experiments --json --project githits-cli-agent-evals view <experiment-name>
+bt sql --json --non-interactive "SELECT input, output, metrics, metadata, tags FROM experiment('<experiment-id>') LIMIT 23"
+```
+
+The exercised comparison command is:
+
+```bash
+bt experiments --json --project githits-cli-agent-evals compare <experiment-a> <experiment-b>
+```
+
+It currently reports only generic Braintrust trace metrics, all zero for these
+rows, and does not surface the custom eval telemetry. Use bounded SQL and the
+experiment UI for current metrics inspection; comparison behavior is a
+follow-up investigation, not a validated trend signal.
 
 ## Daily CI workflow
 
@@ -371,8 +438,9 @@ configuration are never copied into CI. The scenario directories are uploaded
 as `agent-eval-discovery` and `agent-eval-intent` artifacts for 14 days.
 
 The final summary job always runs for an authorized workflow, downloads both
-scenario artifacts without flattening them, and appends the concise report to
-`GITHUB_STEP_SUMMARY`. The local equivalent is:
+scenario artifacts without flattening them, appends the concise report to
+`GITHUB_STEP_SUMMARY`, and then exports the normalized 23-cell result to
+Braintrust. The local equivalent report command is:
 
 ```bash
 bun run agent:e2e:ci-report \
@@ -384,7 +452,9 @@ bun run agent:e2e:ci-report \
 The report is absolute: it links to the workflow run, shows schema/harness and
 Codex identity, successful/expected cells, wall and cumulative time, logical
 MCP/CLI calls, deterministic per-tool counts, token buckets, cost uncertainty,
-concurrency, and warnings. It never loads a baseline or calculates deltas.
+concurrency, and warnings. It never loads a baseline or calculates deltas. The
+subsequent Braintrust export uses the same validated suites and has no quality
+judge or baseline comparison.
 Missing or malformed suite evidence, zero selected workloads or zero expected
 executions, partial/failed/timeout execution, unknown or missing workload cells,
 CLI fallback, and isolation violations make the workflow fail only after the
@@ -392,8 +462,8 @@ report is rendered. A successful discovery run with zero GitHits calls and
 ordinary telemetry warnings remain advisory. The initial healthy two-job path
 is expected to take about 5–6 minutes and costs
 about $0.23 as a base-rate estimate, not a billing guarantee. The workflow
-does not judge answer quality or provide persistent history; those are later
-service work.
+does not judge answer quality. Braintrust persistence is observational; export
+failure preserves the report/artifacts and makes the final workflow status red.
 
 For ad hoc interactive testing with the same MCP/skills setup logic:
 
@@ -576,8 +646,8 @@ bun run agent:e2e:report .agent-eval/runs/<run>
 
 Named suites are available through `agent:e2e:suite`. Use
 `--scenario full` for a local/manual full-guidance run. Daily pipeline
-execution is provided by `.github/workflows/agent-evals.yml`; persistent result
-history, service export, and quality judging remain later phases.
+execution and persistent result export are provided by
+`.github/workflows/agent-evals.yml`; quality judging remains a later phase.
 
 For broad skill edits, run at least:
 

--- a/eval/agentic/README.md
+++ b/eval/agentic/README.md
@@ -343,31 +343,56 @@ Haiku coverage and quality judging remain later phases.
 
 The exporter persists normalized suite evidence in the Braintrust project
 `githits-cli-agent-evals` using the exact `braintrust` SDK `3.29.0`. It creates
-one top-level eval row per scenario/workload cell and does not upload raw
-stdout, stderr, provider events, environment/configuration, or arbitrary
-artifacts. No quality score is fabricated; self-reported confidence remains
-diagnostic metadata.
+one top-level `type: "eval"` span per scenario/workload cell and does not upload
+raw stdout, stderr, provider events, environment/configuration, or arbitrary
+artifacts. Known logical tool calls are safe structural `type: "tool"` child
+spans under that eval root. No quality score is fabricated; self-reported
+confidence remains diagnostic metadata.
+The exporter metadata contract is schema/version 2; both values are recorded
+in experiment metadata for regression attribution. The safe CLI result keeps
+its separate result-file schema version.
 
 The row mapper uses Braintrust-native metrics for duration (`duration`, in
-seconds), tool totals/errors (`tool_calls`, `tool_errors`), token totals and
-breakdowns (`tokens`, `prompt_tokens`, `prompt_cached_tokens`,
+seconds), token totals and breakdowns (`tokens`, `prompt_tokens`,
+`prompt_cached_tokens`,
 `prompt_cache_creation_tokens`, `completion_tokens`, and
 `completion_reasoning_tokens`), and rate-based cost (`estimated_cost`). It
 retains only the GitHits-specific `mcp_tool_calls`, `cli_tool_calls`,
 `tool_calls_started`, `tool_calls_completed`, `tool_calls_unknown`, and
-`raw_tool_events` metrics. A native-root local export from the accepted
-artifacts (`poc-33381601980-native-root`, Braintrust ID
+`raw_tool_events` metrics. The superseded pre-structural native-root export
+from the accepted artifacts (`poc-33381601980-native-root`, Braintrust ID
 `dfa37c74-0b31-4b48-aeb1-a2698a03cecc`, 23 rows) populated native duration,
 prompt/completion/cache/reasoning token buckets, total `tokens`, and estimated
 cost in readback/comparison. Bounded SQL totals were
 `prompt_tokens=2,861,042`, `completion_tokens=20,942`,
 `tokens=2,881,984`, and `estimated_cost=0.23660003`; duration ranged from 8.53
 to 207.317 seconds. This is local evidence, not CI proof. Native structural
-tool views remain unresolved: root rows contain `tool_calls=119` and
-`tool_errors=2`, while comparison reports both as zero because Braintrust
-derives those metrics from structural tool child spans. Per-call timestamps are
-not available, so the exporter does not fabricate child timing; GitHits-specific
-custom telemetry remains accurate. A fresh CI export/readback remains pending.
+tool views are populated by the current exporter: completed/failed child spans
+carry exact harness-observed start/end times and computed duration, while
+started-only children remain open without a fabricated duration. Root rows do
+not set `tool_calls` or `tool_errors`; Braintrust derives those native metrics
+from the structural children. A fresh labeled CI export/readback remains
+pending.
+
+The current local native structural proof used suite
+`.agent-eval/suites/native-tool-smoke-2` at target and measurement commit
+`4850299`. Its Luna-low intent canary ran with workload concurrency 2: 2/2
+workloads succeeded, with 10 logical MCP calls, zero CLI calls and failures,
+and complete harness-observed intervals for all 10 calls. Wall time was
+43.447 seconds, cumulative agent time 71.855 seconds, and estimated cost
+`$0.02070904`.
+
+The resulting experiment `poc-native-tool-spans-v2-20260831` (ID
+`e8480301-6622-4a06-a37b-0ebd0e42bb64`,
+<https://www.braintrust.dev/app/GitHits/p/githits-cli-agent-evals/experiments/poc-native-tool-spans-v2-20260831>)
+read back two eval roots and 10 structural tool children. Native comparison
+reported `tool_calls` average `5.0` and `tool_errors` `0`. Child SQL showed
+exact observed start/end values and computed durations totaling 30.970 seconds,
+with individual durations from 0.006 to 10.400 seconds; eval duration totaled
+71.855 seconds. Native token and cost fields remain populated. This is local
+proof, not CI proof. The preceding `poc-native-tool-spans-20260831` experiment
+proved counts and timestamps but had null child duration and is superseded by
+the v2 experiment.
 
 Validate downloaded or local suites without credentials or network access:
 
@@ -383,9 +408,10 @@ Validation requires non-dry-run suites with complete contained child evidence.
 It rejects dry-run suites, suites with no workload cells, duplicate
 scenario/workload cells, mixed identity or schema contracts, and missing/unsafe
 prompts. Failed or partial cells remain exportable when their report, metrics,
-workload, and prompt evidence are complete. Validate all suite inputs before an
-export; the command reports only safe identities and row counts in validate-only
-mode.
+workload, and prompt evidence are complete; tool-bearing legacy cells upgraded
+with null timing are rejected because accurate structural spans cannot be
+created. Validate all suite inputs before an export; the command reports only
+safe identities and row counts in validate-only mode.
 
 For an explicitly requested local export using the authenticated `bt` profile,
 run the same official entrypoint through `bt eval`:
@@ -414,8 +440,14 @@ Inspect persisted history with the authenticated profile:
 ```bash
 bt experiments --json --project githits-cli-agent-evals list
 bt experiments --json --project githits-cli-agent-evals view <experiment-name>
-bt sql --json --non-interactive "SELECT input, output, metrics, metadata, tags FROM experiment('<experiment-id>') LIMIT 23"
+bt sql --json --non-interactive "SELECT input, output, metrics, metadata, tags FROM experiment('<experiment-id>') WHERE span_attributes.type = 'eval' LIMIT 23"
+bt sql --json --non-interactive "SELECT name, span_attributes.type, metrics, metadata FROM experiment('<experiment-id>') WHERE span_attributes.type = 'tool' LIMIT 100"
 ```
+
+An exported experiment contains one eval root per workload cell plus one
+structural tool child per normalized logical call. Filter
+`span_attributes.type` when counting workload rows; an unfiltered `count(*)`
+includes both kinds of span.
 
 The exercised comparison command is:
 
@@ -425,13 +457,11 @@ bt experiments --json --project githits-cli-agent-evals compare <experiment-a> <
 
 The prior custom-only rows produced only generic Braintrust trace metrics, all
 zero, and did not surface their custom eval telemetry; that remains a historical
-observation about those older rows. The native-root readback verifies native
-duration, token, and cost fields, but its standard `tool_calls` and
-`tool_errors` compare as zero because Braintrust derives them from structural
-tool child spans. Per-call timestamps are unavailable, so child timing is not
-fabricated and native structural tool views remain unresolved. Use bounded SQL
-and the experiment UI for the accurate GitHits-specific/custom telemetry while
-that structural comparison behavior remains a follow-up investigation.
+observation about those older rows. The preceding native-root experiment is
+also historical: it set root `tool_calls=119` and `tool_errors=2`, so its
+comparison reported zero before structural child spans were implemented. Use
+the v2 experiment above for the current native tool comparison and bounded SQL
+for the exact GitHits-specific sequence/count metadata.
 
 ## Daily CI workflow
 
@@ -806,7 +836,7 @@ Each run writes:
   an external/descriptor guidance read or MCP CLI fallback, it writes redacted
   `isolation-violations.json` and marks the workload failed.
 
-Current one-off metrics are schema version 2. Run metadata and normalized
+Current one-off metrics are schema version 3. Run metadata and normalized
 records expose `scenario`, `intentProfile`, and `intentFragmentHash`; the latter
 is the SHA-256 hash of the exact intent fragment (`null` for `neutral`). The
 one-off report and human summary expose the same identity plus the exact
@@ -816,6 +846,16 @@ Valid schema-v1 metrics remain readable through deterministic normalization: his
 missing, null, or other profiles are rejected rather than mapped to `intent`.
 No historical descriptor/full record is inferred to have used the intent
 fragment.
+
+The harness records an ISO-8601 `observedAt` when each complete stdout JSONL
+lifecycle line is received. Schema-v3 normalization pairs valid observations
+for each logical call into nullable `startedAt` and `completedAt`; these are
+harness receipt times, not provider execution times. Existing schema-v1 and
+schema-v2 metrics remain readable with missing timing upgraded to `null`.
+Raw `tool-calls.json` lifecycle events may retain their optional `observedAt`.
+Accurate Braintrust export rejects terminal tool-bearing rows without complete,
+valid, ordered observed boundaries; observed started-only calls remain open,
+and zero-tool legacy rows remain exportable.
 
 `metrics.json` is authoritative for normalized usage and cost. For Codex it
 uses the final `turn.completed.usage` aggregate. `input_tokens` is inclusive of

--- a/eval/agentic/README.md
+++ b/eval/agentic/README.md
@@ -359,11 +359,12 @@ bun run agent:e2e:braintrust \
 ```
 
 Validation requires non-dry-run suites with complete contained child evidence.
-It rejects dry-run suites, duplicate scenario/workload cells, mixed identity or
-schema contracts, and missing/unsafe prompts. Failed or partial cells remain
-exportable when their report, metrics, workload, and prompt evidence are
-complete. Validate all suite inputs before an export; the command reports only
-safe identities and row counts in validate-only mode.
+It rejects dry-run suites, suites with no workload cells, duplicate
+scenario/workload cells, mixed identity or schema contracts, and missing/unsafe
+prompts. Failed or partial cells remain exportable when their report, metrics,
+workload, and prompt evidence are complete. Validate all suite inputs before an
+export; the command reports only safe identities and row counts in validate-only
+mode.
 
 For an explicitly requested local export using the authenticated `bt` profile,
 run the same official entrypoint through `bt eval`:

--- a/eval/agentic/README.md
+++ b/eval/agentic/README.md
@@ -348,6 +348,16 @@ stdout, stderr, provider events, environment/configuration, or arbitrary
 artifacts. No quality score is fabricated; self-reported confidence remains
 diagnostic metadata.
 
+The row mapper uses Braintrust-native metrics for duration (`duration`, in
+seconds), tool totals/errors (`tool_calls`, `tool_errors`), token totals and
+breakdowns (`tokens`, `prompt_tokens`, `prompt_cached_tokens`,
+`prompt_cache_creation_tokens`, `completion_tokens`, and
+`completion_reasoning_tokens`), and rate-based cost (`estimated_cost`). It
+retains only the GitHits-specific `mcp_tool_calls`, `cli_tool_calls`,
+`tool_calls_started`, `tool_calls_completed`, `tool_calls_unknown`, and
+`raw_tool_events` metrics. Native-root local proof and a fresh CI export/readback
+remain acceptance work.
+
 Validate downloaded or local suites without credentials or network access:
 
 ```bash
@@ -402,10 +412,11 @@ The exercised comparison command is:
 bt experiments --json --project githits-cli-agent-evals compare <experiment-a> <experiment-b>
 ```
 
-It currently reports only generic Braintrust trace metrics, all zero for these
-rows, and does not surface the custom eval telemetry. Use bounded SQL and the
-experiment UI for current metrics inspection; comparison behavior is a
-follow-up investigation, not a validated trend signal.
+The prior custom-only rows produced only generic Braintrust trace metrics, all
+zero, and did not surface their custom eval telemetry. That is a historical
+observation pending a native-first export/readback; native-root UI and
+comparison behavior are not yet proven. Use bounded SQL and the experiment UI
+while comparison behavior remains a follow-up investigation.
 
 ## Daily CI workflow
 

--- a/eval/agentic/README.md
+++ b/eval/agentic/README.md
@@ -459,10 +459,12 @@ Missing or malformed suite evidence, zero selected workloads or zero expected
 executions, partial/failed/timeout execution, unknown or missing workload cells,
 CLI fallback, and isolation violations make the workflow fail only after the
 report is rendered. A successful discovery run with zero GitHits calls and
-ordinary telemetry warnings remain advisory. The corrected live two-job path
-took about 2 minutes 42 seconds end to end and had a $0.2514 rate-based cost
-estimate; future runs can vary and this is not a billing guarantee. The
-workflow does not judge answer quality. Braintrust persistence is observational;
+ordinary telemetry warnings remain advisory. The two observed healthy workflow
+paths took about 2 minutes 42 seconds and 4 minutes 33 seconds end to end; this
+is an observed range, not a future-run guarantee. The 2-minute-42-second path
+had a $0.2514 rate-based cost estimate from the measured model rates; this is
+not a billing guarantee. The workflow does not judge answer quality. Braintrust
+persistence is observational;
 export failure preserves the report/artifacts and makes the final workflow
 status red.
 

--- a/eval/agentic/README.md
+++ b/eval/agentic/README.md
@@ -350,7 +350,7 @@ spans under that eval root. No quality score is fabricated; self-reported
 confidence remains diagnostic metadata.
 The exporter metadata contract is schema/version 2; both values are recorded
 in experiment metadata for regression attribution. The safe CLI result keeps
-its separate result-file schema version.
+its separate result-file schema version 2.
 
 One exporter invocation is one immutable experiment. A scenario/workload cell
 is one eval row, and each normalized logical tool call is one structural tool
@@ -481,10 +481,12 @@ the latest main baseline. Use `--branch <branch>` only for a detached suite;
 overrides. CI supplies its channel, branch, PR number, run ID, attempt, and URL
 through environment-bound arguments and does not pass `--experiment`.
 
-The result file is safe to retain and contains only schema version, mode,
-project, experiment, row count, suite summaries, export URL, and the actual
-base `{id, name}` or `null`. It contains no prompt, answer, row body, artifact
-path, or credential. The direct command
+The result file is safe to retain and uses result-file `schemaVersion: 2`; it
+contains only mode, project, experiment, row count, suite summaries, export
+URL, and the actual base `{id, name}` or `null`. In validate-only mode
+`baseExperiment: null` means unresolved/not queried; in export mode `null`
+means required Braintrust readback returned no actual linked base. It contains
+no prompt, answer, row body, artifact path, or credential. The direct command
 `bun run agent:e2e:braintrust` is also the CI path; CI scopes
 `BRAINTRUST_API_KEY` only to that export step and never installs or runs `bt`.
 The workflow renders the existing report and retains raw artifacts for 14 days

--- a/eval/agentic/README.md
+++ b/eval/agentic/README.md
@@ -383,6 +383,9 @@ contract is covered by focused tests, but has not yet been live-proven for a
 later main run linking to main, a PR linking to main, and a local run linking
 to main. Existing `github-*` experiments are historical records from the old
 identity contract and are not current baselines.
+For exports, the reported experiment name is the SDK's actual server name
+after flush, which may differ from a reused explicit local name when Braintrust
+de-duplicates it. Validate-only reports the requested or generated name.
 
 The row mapper uses Braintrust-native metrics for duration (`duration`, in
 seconds), token totals and breakdowns (`tokens`, `prompt_tokens`,

--- a/eval/agentic/README.md
+++ b/eval/agentic/README.md
@@ -352,6 +352,38 @@ The exporter metadata contract is schema/version 2; both values are recorded
 in experiment metadata for regression attribution. The safe CLI result keeps
 its separate result-file schema version.
 
+One exporter invocation is one immutable experiment. A scenario/workload cell
+is one eval row, and each normalized logical tool call is one structural tool
+child. The exporter owns stable names: `main-r<RUN_ID>-a<ATTEMPT>` for main,
+`pr-<PR_NUMBER>-r<RUN_ID>-a<ATTEMPT>` for trusted same-repository pull
+requests, and
+`local-<branch-slug>-<UTC-timestamp-with-milliseconds>-<short-sha>` for local
+exports. Local branch slugs are lowercase, collapse each run of
+non-ASCII-alphanumeric characters to one hyphen, and trim hyphens. Source,
+channel, branch, optional PR number, full SHA, run identity, and evaluated
+target dirty state are also retained in allowlisted metadata/tags and
+`repoInfo`.
+
+Before experiment initialization, the exporter scans the newest-first project
+pages through the same authenticated Braintrust integration boundary and picks
+the first returned object with `metadata.channel: main` and a
+`main-r...-a...` name. It filters client-side, paginating with the final object
+ID while a page is full; it does not send a metadata filter. That ID is passed
+as `baseExperimentId`. An explicit local `--base-experiment` takes precedence
+and skips discovery. PR and default-local exports fail before initialization if
+no main baseline exists. The first main run is a one-time bootstrap and may
+retain SDK automatic ancestry; the returned actual base is reported, but that
+bootstrap is not linkage acceptance evidence.
+
+After flush, the exporter calls `fetchBaseExperiment()` and reports the actual
+safe base `{id, name}` or `null` in the result. Validate-only builds and prints
+the same identity without credentials, network access, or baseline discovery;
+its base is unresolved/not queried. This deterministic identity/linkage
+contract is covered by focused tests, but has not yet been live-proven for a
+later main run linking to main, a PR linking to main, and a local run linking
+to main. Existing `github-*` experiments are historical records from the old
+identity contract and are not current baselines.
+
 The row mapper uses Braintrust-native metrics for duration (`duration`, in
 seconds), token totals and breakdowns (`tokens`, `prompt_tokens`,
 `prompt_cached_tokens`,
@@ -431,22 +463,28 @@ with null timing are rejected because accurate structural spans cannot be
 created. Validate all suite inputs before an export; the command reports only
 safe identities and row counts in validate-only mode.
 
-For an explicitly requested local export using the authenticated `bt` profile,
-run the same official entrypoint through `bt eval`:
+For a local export using the authenticated `bt` profile, run the same official
+entrypoint through `bt eval`:
 
 ```bash
 bt eval --runner bun --no-auto-instrumentation scripts/agent-eval-braintrust.ts -- \
   --suite discovery=.agent-eval/suites/<discovery>/suite.json \
   --suite intent=.agent-eval/suites/<intent>/suite.json \
   --project githits-cli-agent-evals \
-  --experiment local-<name> \
   --source local \
   --result-out .agent-eval/braintrust-result.json
 ```
 
+This default local export lets the exporter choose its stable name and resolve
+the latest main baseline. Use `--branch <branch>` only for a detached suite;
+`--experiment <name>` and `--base-experiment <main-r...-a...>` are local-only
+overrides. CI supplies its channel, branch, PR number, run ID, attempt, and URL
+through environment-bound arguments and does not pass `--experiment`.
+
 The result file is safe to retain and contains only schema version, mode,
-project, experiment, row count, suite summaries, and the export URL. It contains
-no prompt, answer, row body, artifact path, or credential. The direct command
+project, experiment, row count, suite summaries, export URL, and the actual
+base `{id, name}` or `null`. It contains no prompt, answer, row body, artifact
+path, or credential. The direct command
 `bun run agent:e2e:braintrust` is also the CI path; CI scopes
 `BRAINTRUST_API_KEY` only to that export step and never installs or runs `bt`.
 The workflow renders the existing report and retains raw artifacts for 14 days
@@ -529,7 +567,9 @@ Codex identity, successful/expected cells, wall and cumulative time, logical
 MCP/CLI calls, deterministic per-tool counts, token buckets, cost uncertainty,
 concurrency, and warnings. It never loads a baseline or calculates deltas. The
 subsequent Braintrust export uses the same validated suites and has no quality
-judge or baseline comparison.
+judge or metric-based failure gate; it resolves and records the native
+Braintrust base link after the report is rendered. The concise report remains
+absolute.
 Missing or malformed suite evidence, zero selected workloads or zero expected
 executions, partial/failed/timeout execution, unknown or missing workload cells,
 CLI fallback, and isolation violations make the workflow fail only after the

--- a/eval/agentic/README.md
+++ b/eval/agentic/README.md
@@ -355,8 +355,19 @@ breakdowns (`tokens`, `prompt_tokens`, `prompt_cached_tokens`,
 `completion_reasoning_tokens`), and rate-based cost (`estimated_cost`). It
 retains only the GitHits-specific `mcp_tool_calls`, `cli_tool_calls`,
 `tool_calls_started`, `tool_calls_completed`, `tool_calls_unknown`, and
-`raw_tool_events` metrics. Native-root local proof and a fresh CI export/readback
-remain acceptance work.
+`raw_tool_events` metrics. A native-root local export from the accepted
+artifacts (`poc-33381601980-native-root`, Braintrust ID
+`dfa37c74-0b31-4b48-aeb1-a2698a03cecc`, 23 rows) populated native duration,
+prompt/completion/cache/reasoning token buckets, total `tokens`, and estimated
+cost in readback/comparison. Bounded SQL totals were
+`prompt_tokens=2,861,042`, `completion_tokens=20,942`,
+`tokens=2,881,984`, and `estimated_cost=0.23660003`; duration ranged from 8.53
+to 207.317 seconds. This is local evidence, not CI proof. Native structural
+tool views remain unresolved: root rows contain `tool_calls=119` and
+`tool_errors=2`, while comparison reports both as zero because Braintrust
+derives those metrics from structural tool child spans. Per-call timestamps are
+not available, so the exporter does not fabricate child timing; GitHits-specific
+custom telemetry remains accurate. A fresh CI export/readback remains pending.
 
 Validate downloaded or local suites without credentials or network access:
 
@@ -413,10 +424,14 @@ bt experiments --json --project githits-cli-agent-evals compare <experiment-a> <
 ```
 
 The prior custom-only rows produced only generic Braintrust trace metrics, all
-zero, and did not surface their custom eval telemetry. That is a historical
-observation pending a native-first export/readback; native-root UI and
-comparison behavior are not yet proven. Use bounded SQL and the experiment UI
-while comparison behavior remains a follow-up investigation.
+zero, and did not surface their custom eval telemetry; that remains a historical
+observation about those older rows. The native-root readback verifies native
+duration, token, and cost fields, but its standard `tool_calls` and
+`tool_errors` compare as zero because Braintrust derives them from structural
+tool child spans. Per-call timestamps are unavailable, so child timing is not
+fabricated and native structural tool views remain unresolved. Use bounded SQL
+and the experiment UI for the accurate GitHits-specific/custom telemetry while
+that structural comparison behavior remains a follow-up investigation.
 
 ## Daily CI workflow
 

--- a/eval/agentic/README.md
+++ b/eval/agentic/README.md
@@ -371,8 +371,8 @@ tool views are populated by the current exporter: completed/failed child spans
 carry exact harness-observed start/end times and computed duration, while
 started-only children remain open without a fabricated duration. Root rows do
 not set `tool_calls` or `tool_errors`; Braintrust derives those native metrics
-from the structural children. A fresh labeled CI export/readback remains
-pending.
+from the structural children. The labeled CI proof is recorded below;
+default-branch scheduled/manual activation remains pending merge.
 
 The current local native structural proof used suite
 `.agent-eval/suites/native-tool-smoke-2` at target and measurement commit
@@ -393,6 +393,24 @@ with individual durations from 0.006 to 10.400 seconds; eval duration totaled
 proof, not CI proof. The preceding `poc-native-tool-spans-20260831` experiment
 proved counts and timestamps but had null child duration and is superseded by
 the v2 experiment.
+
+The qualifying labeled CI proof is GitHub run
+[33424857668](https://github.com/githits-com/githits-cli/actions/runs/33424857668)
+at code SHA `7195ccc56b9ac9288dfb3d8de854f2f0e7ae7cf0`. Discovery completed in
+40 seconds, intent in 2 minutes 32 seconds, and summary/export in 22 seconds,
+for about 3 minutes total. Its Braintrust experiment is
+`github-33424857668-1` (ID `182ee9db-0df3-40f4-8987-6eeb6d91a89b`), with source
+`github`, exporter/schema 2, and metrics schema 3. Readback reconciled 23 eval
+spans and 116 structural tool spans exactly to 116 MCP calls: zero CLI calls
+and zero failed tool spans. Totals were 513.911 seconds of eval duration,
+126.458999872 seconds of tool duration, 2,686,094 prompt tokens, 20,172
+completion tokens, 2,706,266 total tokens, and estimated cost `$0.22819038`.
+Standard Braintrust compare averages were duration
+`22.343956532685652`, estimated cost `$0.009921320869565216`, tool calls
+`5.043478260869565`, tool errors `0`, and total tokens
+`117663.73913043478`. This validates the labeled pull-request path; default-
+branch scheduled/manual activation remains pending merge. No paid rerun
+was made for this documentation-only closeout.
 
 Validate downloaded or local suites without credentials or network access:
 

--- a/eval/agentic/README.md
+++ b/eval/agentic/README.md
@@ -459,11 +459,12 @@ Missing or malformed suite evidence, zero selected workloads or zero expected
 executions, partial/failed/timeout execution, unknown or missing workload cells,
 CLI fallback, and isolation violations make the workflow fail only after the
 report is rendered. A successful discovery run with zero GitHits calls and
-ordinary telemetry warnings remain advisory. The initial healthy two-job path
-is expected to take about 5–6 minutes and costs
-about $0.23 as a base-rate estimate, not a billing guarantee. The workflow
-does not judge answer quality. Braintrust persistence is observational; export
-failure preserves the report/artifacts and makes the final workflow status red.
+ordinary telemetry warnings remain advisory. The corrected live two-job path
+took about 2 minutes 42 seconds end to end and had a $0.2514 rate-based cost
+estimate; future runs can vary and this is not a billing guarantee. The
+workflow does not judge answer quality. Braintrust persistence is observational;
+export failure preserves the report/artifacts and makes the final workflow
+status red.
 
 For ad hoc interactive testing with the same MCP/skills setup logic:
 

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "agent:e2e": "bun run scripts/agent-eval.ts",
     "agent:e2e:suite": "bun run scripts/agent-eval-suite.ts",
     "agent:e2e:report": "bun run scripts/agent-eval-report.ts",
+    "agent:e2e:braintrust": "bun run scripts/agent-eval-braintrust.ts",
     "agent:e2e:ci-report": "bun run scripts/agent-eval-ci-report.ts",
     "agent:session": "bun run scripts/agent-session.ts",
     "eval": "bun run eval/run.ts",

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "@biomejs/biome": "2.5.6",
     "@types/bun": "latest",
     "@types/semver": "^7.7.1",
+    "braintrust": "3.29.0",
     "bunup": "^0.16.32",
     "husky": "^9.1.7",
     "lint-staged": "17.3.0",

--- a/scripts/agent-eval-braintrust.test.ts
+++ b/scripts/agent-eval-braintrust.test.ts
@@ -2255,7 +2255,10 @@ describe("Agent eval workflow Braintrust integration", () => {
     expect(run).toContain("BRAINTRUST_BRANCH");
     expect(run).toContain("BRAINTRUST_PR_NUMBER");
     expect(run).toContain("braintrust_args+=(--pr-number");
-    expect(run).toContain('"${braintrust_args[@]}"');
+    const quotedArgsExpansion = ['"', "$", "{braintrust_args[@]}", '"'].join(
+      "",
+    );
+    expect(run).toContain(quotedArgsExpansion);
     expect(run).toContain("--source github");
     expect(run).toContain('--channel "$BRAINTRUST_CHANNEL"');
     expect(run).toContain('--branch "$BRAINTRUST_BRANCH"');

--- a/scripts/agent-eval-braintrust.test.ts
+++ b/scripts/agent-eval-braintrust.test.ts
@@ -12,17 +12,22 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { parse as parseYaml } from "yaml";
 import {
+  type BraintrustBaseExperiment,
   type BraintrustCliResult,
   type BraintrustEndSpanArgs,
+  type BraintrustExperimentInit,
+  type BraintrustIdentityInput,
   type BraintrustRowEvent,
   type BraintrustSpan,
   type BraintrustSuiteInput,
   btEvalMain,
+  buildBraintrustExperimentIdentity,
   buildBraintrustExperimentInit,
   createBraintrustPublisher,
   parseBraintrustArgs,
   preflightAndMapBraintrustRows,
   publishBraintrustRows,
+  resolveBraintrustMainExperiment,
   runBraintrustCli,
 } from "./agent-eval-braintrust.ts";
 import {
@@ -80,7 +85,11 @@ function createRecord(
     intentFragmentHash: options.intentFragmentHash,
     experimentalTools: false,
     publishedPackage: null,
-    targetGit: { branch: "main", sha: null, dirty: false },
+    targetGit: {
+      branch: "main",
+      sha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      dirty: false,
+    },
     startedAt: "2026-08-28T10:00:00.000Z",
     completedAt: "2026-08-28T10:00:01.000Z",
     durationMs: 1000,
@@ -212,7 +221,11 @@ async function createSuite(
         intentFragmentHash: options.intentFragmentHash,
         dryRun: options.dryRun,
         codexVersion: "codex-test",
-        git: { branch: "main", sha: null, dirty: false },
+        git: {
+          branch: "main",
+          sha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          dirty: false,
+        },
         workloads: [
           {
             id: workloadId,
@@ -243,6 +256,13 @@ async function createSuite(
       );
       return { runDir: options.outDir, status: "success" };
     },
+  });
+  mutateJson<AgentEvalSuiteArtifact>(join(outDir, "suite.json"), (artifact) => {
+    artifact.targetGit = {
+      branch: "main",
+      sha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      dirty: false,
+    };
   });
   return {
     root,
@@ -1084,6 +1104,262 @@ describe("Braintrust eval row mapping", () => {
   });
 });
 
+describe("Braintrust experiment identity", () => {
+  it("builds stable channel-aware experiment identity", () => {
+    const sha = "abcdef1234567890abcdef1234567890abcdef12";
+    expect(
+      buildBraintrustExperimentIdentity({
+        source: "github",
+        channel: "main",
+        branch: "main",
+        sha,
+        githubRunId: "123",
+        githubRunAttempt: "2",
+      }),
+    ).toEqual({
+      source: "github",
+      channel: "main",
+      branch: "main",
+      sha,
+      experiment: "main-r123-a2",
+      tags: ["source:github", "channel:main", "branch:main", `sha:${sha}`],
+    });
+    expect(
+      buildBraintrustExperimentIdentity({
+        source: "github",
+        channel: "pr",
+        branch: "Feature/One",
+        sha,
+        pullRequestNumber: "456",
+        githubRunId: "123",
+        githubRunAttempt: "2",
+      }).experiment,
+    ).toBe("pr-456-r123-a2");
+    expect(
+      buildBraintrustExperimentIdentity({
+        source: "local",
+        channel: "local",
+        branch: "Feature/One & two",
+        sha,
+        now: new Date("2026-08-31T20:24:22.123Z"),
+      }).experiment,
+    ).toBe("local-feature-one-two-20260831T202422123Z-abcdef12");
+
+    const invalid: BraintrustIdentityInput[] = [
+      {
+        source: "github",
+        channel: "local",
+        branch: "main",
+        sha,
+        githubRunId: "123",
+        githubRunAttempt: "2",
+      },
+      {
+        source: "github",
+        channel: "main",
+        branch: "feature",
+        sha,
+        githubRunId: "123",
+        githubRunAttempt: "2",
+      },
+      {
+        source: "github",
+        channel: "pr",
+        branch: "feature",
+        sha,
+        githubRunId: "123",
+        githubRunAttempt: "2",
+      },
+      {
+        source: "github",
+        channel: "main",
+        branch: "main",
+        sha,
+        githubRunId: "not-numeric",
+        githubRunAttempt: "2",
+      },
+      {
+        source: "local",
+        channel: "local",
+        branch: null,
+        sha,
+      },
+      {
+        source: "local",
+        channel: "local",
+        branch: "main",
+        sha: null,
+      },
+    ];
+    for (const input of invalid)
+      expect(() => buildBraintrustExperimentIdentity(input)).toThrow();
+  });
+});
+
+describe("Braintrust main baseline resolution", () => {
+  it("resolves the latest valid main experiment across pages", async () => {
+    const firstPage = Array.from({ length: 100 }, (_, index) => ({
+      id: `first-${index}`,
+      name: `other-${index}`,
+      metadata: { channel: "pr" },
+    }));
+    const secondPage = [
+      {
+        id: "invalid-main-name",
+        name: "main-r123",
+        metadata: { channel: "main" },
+      },
+      {
+        id: "latest-main",
+        name: "main-r123-a2",
+        metadata: { channel: "main" },
+      },
+    ];
+    const requests: unknown[] = [];
+    const sdk: import("./agent-eval-braintrust.ts").BraintrustSdk = {
+      async login() {
+        return {
+          apiConn() {
+            return {
+              async get_json(objectType, params) {
+                requests.push({ objectType, params });
+                return requests.length === 1
+                  ? { objects: firstPage }
+                  : { objects: secondPage };
+              },
+            };
+          },
+        };
+      },
+      initExperiment() {
+        throw new Error("initialization must not occur during resolution");
+      },
+    };
+
+    await expect(
+      resolveBraintrustMainExperiment("project", sdk),
+    ).resolves.toEqual({
+      id: "latest-main",
+      name: "main-r123-a2",
+    });
+    expect(requests).toEqual([
+      {
+        objectType: "v1/experiment",
+        params: { project_name: "project", limit: "100" },
+      },
+      {
+        objectType: "v1/experiment",
+        params: {
+          project_name: "project",
+          limit: "100",
+          starting_after: "first-99",
+        },
+      },
+    ]);
+    expect(JSON.stringify(requests)).not.toContain("metadata");
+  });
+});
+
+describe("Braintrust baseline precedence", () => {
+  it("enforces main baseline bootstrap and explicit local precedence", async () => {
+    const fixture = await createSuite();
+    const mapping = preflightAndMapBraintrustRows([
+      suiteInput("baseline", fixture.suitePath),
+    ]);
+    const makePublisher =
+      (initSeen: BraintrustExperimentInit[]) =>
+      (init: BraintrustExperimentInit) => {
+        initSeen.push(init);
+        return {
+          startSpan() {
+            return {
+              startSpan() {
+                return leafSpan();
+              },
+              end() {},
+            };
+          },
+          async flush() {},
+          async permalink() {
+            return undefined;
+          },
+        };
+      };
+    const resolver = async () => null;
+    await expect(
+      publishBraintrustRows(
+        mapping,
+        {
+          project: "project",
+          source: "github",
+          channel: "pr",
+          branch: "feature",
+          sha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          pullRequestNumber: "456",
+          githubRunId: "123",
+          githubRunAttempt: "2",
+        },
+        makePublisher([]),
+        resolver,
+      ),
+    ).rejects.toThrow("no main Braintrust baseline");
+
+    await expect(
+      publishBraintrustRows(
+        mapping,
+        {
+          project: "project",
+          source: "local",
+          channel: "local",
+          branch: "main",
+          sha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          now: new Date("2026-08-31T20:24:22.123Z"),
+        },
+        makePublisher([]),
+        resolver,
+      ),
+    ).rejects.toThrow("no main Braintrust baseline");
+
+    const mainInit: BraintrustExperimentInit[] = [];
+    await publishBraintrustRows(
+      mapping,
+      {
+        project: "project",
+        source: "github",
+        channel: "main",
+        branch: "main",
+        sha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        githubRunId: "123",
+        githubRunAttempt: "2",
+      },
+      makePublisher(mainInit),
+      resolver,
+    );
+    expect(mainInit[0]).toBeDefined();
+    expect(mainInit[0]).not.toHaveProperty("baseExperimentId");
+    expect(mainInit[0]!.experiment).toBe("main-r123-a2");
+
+    const localInit: BraintrustExperimentInit[] = [];
+    await publishBraintrustRows(
+      mapping,
+      {
+        project: "project",
+        source: "local",
+        channel: "local",
+        branch: "main",
+        sha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        experiment: "local-explicit",
+        baseExperiment: "main-r10-a1",
+      },
+      makePublisher(localInit),
+      async () => {
+        throw new Error("base discovery must be skipped");
+      },
+    );
+    expect(localInit[0]!.baseExperiment).toBe("main-r10-a1");
+  });
+});
+
 describe("Braintrust publisher boundary", () => {
   it("builds exact allowlisted experiment initialization options", async () => {
     const fixture = await createSuite();
@@ -1092,8 +1368,9 @@ describe("Braintrust publisher boundary", () => {
     ]);
     const init = buildBraintrustExperimentInit(mapping, {
       project: "githits-cli-agent-evals",
-      experiment: "github-123-2",
       source: "github",
+      channel: "main",
+      branch: "main",
       githubRunId: "123",
       githubRunAttempt: "2",
       githubRunUrl:
@@ -1102,10 +1379,19 @@ describe("Braintrust publisher boundary", () => {
 
     expect(init).toEqual({
       project: "githits-cli-agent-evals",
-      experiment: "github-123-2",
+      experiment: "main-r123-a2",
       update: false,
+      tags: [
+        "source:github",
+        "channel:main",
+        "branch:main",
+        "sha:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      ],
       metadata: {
         source: "github",
+        channel: "main",
+        branch: "main",
+        sha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         githubRunId: "123",
         githubRunAttempt: "2",
         githubRunUrl:
@@ -1240,6 +1526,7 @@ describe("Braintrust publisher boundary", () => {
       experiment: "local-test",
       url: "https://braintrust.dev/experiment/local-test",
       exportedRowCount: 2,
+      baseExperiment: null,
     });
     expect(JSON.stringify(result)).not.toContain(fixture.root);
     expect(JSON.stringify(result)).not.toContain("Prompt for");
@@ -1263,6 +1550,12 @@ describe("Braintrust publisher boundary", () => {
         expect(options).toEqual({
           experiment: "sdk-test",
           update: false,
+          tags: [
+            "source:local",
+            "channel:local",
+            "branch:main",
+            "sha:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          ],
           metadata: init.metadata,
           repoInfo: init.repoInfo,
           gitMetadataSettings: { collect: "none" },
@@ -1334,6 +1627,82 @@ describe("Braintrust publisher boundary", () => {
       "summary:false",
     ]);
     expect(result.url).toBe("https://braintrust.dev/experiment/sdk");
+  });
+
+  it("pins and reports the actual Braintrust base experiment", async () => {
+    const fixture = await createSuite();
+    const mapping = preflightAndMapBraintrustRows([
+      suiteInput("readback", fixture.suitePath),
+    ]);
+    const calls: string[] = [];
+    const sdk: import("./agent-eval-braintrust.ts").BraintrustSdk = {
+      initExperiment(project, options) {
+        calls.push(`init:${project}`);
+        expect(options.baseExperimentId).toBe("main-id");
+        return {
+          startSpan() {
+            return {
+              startSpan() {
+                return {
+                  startSpan() {
+                    throw new Error("unexpected nested span");
+                  },
+                  end() {
+                    return 0;
+                  },
+                };
+              },
+              end() {
+                return 0;
+              },
+            };
+          },
+          async flush() {
+            calls.push("flush");
+          },
+          async fetchBaseExperiment() {
+            calls.push("fetch-base");
+            return {
+              id: "main-id",
+              name: "main-r10-a1",
+              unused: "must-not-be-exported",
+            } as unknown as BraintrustBaseExperiment;
+          },
+          async summarize(options) {
+            calls.push(`summary:${options.summarizeScores}`);
+            return {
+              experimentUrl: "https://braintrust.dev/experiment/readback",
+            };
+          },
+        };
+      },
+    };
+    const result = await publishBraintrustRows(
+      mapping,
+      {
+        project: "project",
+        source: "local",
+        channel: "local",
+        branch: "main",
+        sha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        experiment: "local-readback",
+        baseExperimentId: "main-id",
+      },
+      (init) => createBraintrustPublisher(init, sdk),
+    );
+
+    expect(calls).toEqual([
+      "init:project",
+      "flush",
+      "fetch-base",
+      "summary:false",
+    ]);
+    expect(result).toMatchObject({
+      experiment: "local-readback",
+      url: "https://braintrust.dev/experiment/readback",
+      baseExperiment: { id: "main-id", name: "main-r10-a1" },
+    });
+    expect(JSON.stringify(result)).not.toContain("aaaaaaaa");
   });
 
   it("exports only a generated status error for failed rows", async () => {
@@ -1439,8 +1808,8 @@ describe("Braintrust CLI wrapper", () => {
     expect(options).toEqual({
       suites: [{ label: "canary", suitePath: "out/suite.json" }],
       project: "githits-cli-agent-evals",
-      experiment: "local-20260831T123456000Z",
       source: "local",
+      channel: "local",
       validateOnly: false,
     });
   });
@@ -1451,10 +1820,12 @@ describe("Braintrust CLI wrapper", () => {
       "daily=out/suite.json",
       "--project",
       "custom-project",
-      "--experiment",
-      "github-123-2",
       "--source",
       "github",
+      "--channel",
+      "main",
+      "--branch",
+      "main",
       "--run-id",
       "123",
       "--run-attempt",
@@ -1469,8 +1840,9 @@ describe("Braintrust CLI wrapper", () => {
     expect(options).toEqual({
       suites: [{ label: "daily", suitePath: "out/suite.json" }],
       project: "custom-project",
-      experiment: "github-123-2",
       source: "github",
+      channel: "main",
+      branch: "main",
       githubRunId: "123",
       githubRunAttempt: "2",
       githubRunUrl:
@@ -1643,11 +2015,16 @@ describe("Braintrust CLI wrapper", () => {
         `canary=${fixture.suitePath}`,
         "--experiment",
         "local-export",
+        "--base-experiment",
+        "main-r1-a1",
         "--result-out",
         resultPath,
       ],
       {
         env: { BRAINTRUST_API_KEY: "dummy-secret" },
+        baseResolver: async () => {
+          throw new Error("base discovery must be skipped");
+        },
         publisherFactory: async (init) => {
           calls.push(`init:${init.project}/${init.experiment}`);
           return {
@@ -1696,6 +2073,7 @@ describe("Braintrust CLI wrapper", () => {
       rowCount: 1,
       suites: result.suites,
       url: "https://braintrust.dev/experiment/local-export",
+      baseExperiment: null,
     });
     expect(JSON.parse(printed[0]!) as BraintrustCliResult).toEqual(result);
     const resultText = readFileSync(resultPath, "utf8");
@@ -1712,9 +2090,17 @@ describe("Braintrust CLI wrapper", () => {
     const calls: string[] = [];
     await expect(
       runBraintrustCli(
-        ["--suite", `canary=${fixture.suitePath}`, "--result-out", resultPath],
+        [
+          "--suite",
+          `canary=${fixture.suitePath}`,
+          "--base-experiment",
+          "main-r1-a1",
+          "--result-out",
+          resultPath,
+        ],
         {
           env: { BRAINTRUST_API_KEY: "dummy-secret" },
+          baseResolver: async () => null,
           publisherFactory: () => ({
             startSpan(args) {
               calls.push(`start:${args.name}`);

--- a/scripts/agent-eval-braintrust.test.ts
+++ b/scripts/agent-eval-braintrust.test.ts
@@ -11,12 +11,16 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  type BraintrustCliResult,
   type BraintrustRowEvent,
   type BraintrustSuiteInput,
+  btEvalMain,
   buildBraintrustExperimentInit,
   createBraintrustPublisher,
+  parseBraintrustArgs,
   preflightAndMapBraintrustRows,
   publishBraintrustRows,
+  runBraintrustCli,
 } from "./agent-eval-braintrust.ts";
 import {
   type AgentEvalRecordInput,
@@ -899,5 +903,317 @@ describe("Braintrust publisher boundary", () => {
       "start:discovery/workload-a",
       "end:discovery/workload-a",
     ]);
+  });
+});
+
+describe("Braintrust CLI wrapper", () => {
+  it("parses local defaults and a stable injected timestamp", () => {
+    const options = parseBraintrustArgs(
+      ["--suite", "canary=out/suite.json"],
+      new Date("2026-08-31T12:34:56.000Z"),
+    );
+
+    expect(options).toEqual({
+      suites: [{ label: "canary", suitePath: "out/suite.json" }],
+      project: "githits-cli-agent-evals",
+      experiment: "local-20260831T123456000Z",
+      source: "local",
+      validateOnly: false,
+    });
+  });
+
+  it("parses explicit GitHub identity and result options", () => {
+    const options = parseBraintrustArgs([
+      "--suite",
+      "daily=out/suite.json",
+      "--project",
+      "custom-project",
+      "--experiment",
+      "github-123-2",
+      "--source",
+      "github",
+      "--run-id",
+      "123",
+      "--run-attempt",
+      "2",
+      "--run-url",
+      "https://github.com/githits-com/githits-cli/actions/runs/123",
+      "--result-out",
+      "out/result.json",
+      "--validate-only",
+    ]);
+
+    expect(options).toEqual({
+      suites: [{ label: "daily", suitePath: "out/suite.json" }],
+      project: "custom-project",
+      experiment: "github-123-2",
+      source: "github",
+      githubRunId: "123",
+      githubRunAttempt: "2",
+      githubRunUrl:
+        "https://github.com/githits-com/githits-cli/actions/runs/123",
+      resultOut: "out/result.json",
+      validateOnly: true,
+    });
+  });
+
+  it("rejects malformed, duplicate, unknown, and incoherent options", () => {
+    const invalidArguments: readonly (readonly string[])[] = [
+      [],
+      ["--suite", "missing-separator"],
+      ["--suite", "=out/suite.json"],
+      ["--suite", "missing-path="],
+      ["--suite", "same=one.json", "--suite", "same=two.json"],
+      ["--suite", "one=one.json", "--unknown"],
+      ["--suite", "one=one.json", "--project"],
+      ["--suite", "one=one.json", "--project", "one", "--project", "two"],
+      ["--suite", "one=one.json", "--source", "other"],
+      ["--suite", "one=one.json", "--run-id", "123"],
+      [
+        "--suite",
+        "one=one.json",
+        "--source",
+        "github",
+        "--run-id",
+        "123",
+        "--run-attempt",
+        "1",
+        "--run-url",
+        "not-a-url",
+        "--experiment",
+        "github-123-1",
+      ],
+      [
+        "--suite",
+        "one=one.json",
+        "--source",
+        "github",
+        "--run-id",
+        "123",
+        "--run-attempt",
+        "1",
+        "--run-url",
+        "https://github.com/example/repo/actions/runs/123",
+      ],
+      [
+        "--suite",
+        "one=one.json",
+        "--source",
+        "github",
+        "--experiment",
+        "github-123-1",
+        "--run-id",
+        "123",
+        "--run-attempt",
+        "1",
+      ],
+    ];
+    for (const args of invalidArguments) {
+      expect(() => parseBraintrustArgs(args)).toThrow();
+    }
+  });
+
+  it("maps and reports validate-only without credentials or a publisher", async () => {
+    const fixture = await createSuite();
+    const resultPath = join(fixture.root, "validate-result.json");
+    let publisherCalled = false;
+    const printed: string[] = [];
+    const result = await runBraintrustCli(
+      [
+        "--suite",
+        `canary=${fixture.suitePath}`,
+        "--result-out",
+        resultPath,
+        "--validate-only",
+      ],
+      {
+        env: {},
+        publisherFactory: () => {
+          publisherCalled = true;
+          throw new Error("publisher must not be called");
+        },
+        print: (line) => printed.push(line),
+      },
+    );
+
+    expect(publisherCalled).toBe(false);
+    expect(result).toMatchObject({
+      schemaVersion: 1,
+      mode: "validate-only",
+      project: "githits-cli-agent-evals",
+      rowCount: 1,
+    });
+    expect(result.url).toBeUndefined();
+    expect(JSON.parse(printed[0]!) as BraintrustCliResult).toEqual(result);
+    const resultText = readFileSync(resultPath, "utf8");
+    expect(JSON.parse(resultText) as BraintrustCliResult).toEqual(result);
+    expect(resultText).not.toContain(fixture.root);
+    expect(resultText).not.toContain("Prompt for");
+    expect(resultText).not.toContain("Answer for");
+  });
+
+  it("completes all preflight before checking the API key or publisher", async () => {
+    let keyRead = false;
+    let publisherCalled = false;
+    const environment: Readonly<Record<string, string | undefined>> = {
+      get BRAINTRUST_API_KEY() {
+        keyRead = true;
+        return "dummy-secret";
+      },
+    };
+    let failure: unknown;
+    try {
+      await runBraintrustCli(
+        ["--suite", "missing=/does/not/exist/suite.json"],
+        {
+          env: environment,
+          publisherFactory: () => {
+            publisherCalled = true;
+            throw new Error("publisher must not be called");
+          },
+        },
+      );
+    } catch (error) {
+      failure = error;
+    }
+
+    expect(failure).toBeInstanceOf(Error);
+    expect(keyRead).toBe(false);
+    expect(publisherCalled).toBe(false);
+  });
+
+  it("rejects network mode without a key without exposing credential text", async () => {
+    const fixture = await createSuite();
+    const resultPath = join(fixture.root, "missing-key-result.json");
+    const printed: string[] = [];
+    let failure: unknown;
+    try {
+      await runBraintrustCli(
+        ["--suite", `canary=${fixture.suitePath}`, "--result-out", resultPath],
+        {
+          env: { BRAINTRUST_API_KEY: undefined },
+          publisherFactory: () => {
+            throw new Error("publisher must not be called");
+          },
+          print: (line) => printed.push(line),
+        },
+      );
+    } catch (error) {
+      failure = error;
+    }
+
+    expect(failure).toBeInstanceOf(Error);
+    expect(String(failure)).toContain("BRAINTRUST_API_KEY is required");
+    expect(String(failure)).not.toContain("dummy-secret");
+    expect(printed).toEqual([]);
+    expect(existsSync(resultPath)).toBe(false);
+  });
+
+  it("delegates network export and writes only the safe result", async () => {
+    const fixture = await createSuite();
+    const resultPath = join(fixture.root, "export-result.json");
+    const calls: string[] = [];
+    const printed: string[] = [];
+    const result = await runBraintrustCli(
+      [
+        "--suite",
+        `canary=${fixture.suitePath}`,
+        "--experiment",
+        "local-export",
+        "--result-out",
+        resultPath,
+      ],
+      {
+        env: { BRAINTRUST_API_KEY: "dummy-secret" },
+        publisherFactory: async (init) => {
+          calls.push(`init:${init.project}/${init.experiment}`);
+          return {
+            startSpan(args) {
+              calls.push(`start:${args.name}`);
+              return {
+                end() {
+                  calls.push(`end:${args.name}`);
+                },
+              };
+            },
+            async flush() {
+              calls.push("flush");
+            },
+            async permalink() {
+              calls.push("permalink");
+              return "https://braintrust.dev/experiment/local-export";
+            },
+          };
+        },
+        print: (line) => printed.push(line),
+      },
+    );
+
+    expect(calls).toEqual([
+      "init:githits-cli-agent-evals/local-export",
+      "start:discovery/workload-a",
+      "end:discovery/workload-a",
+      "flush",
+      "permalink",
+    ]);
+    expect(result).toEqual({
+      schemaVersion: 1,
+      mode: "export",
+      project: "githits-cli-agent-evals",
+      experiment: "local-export",
+      rowCount: 1,
+      suites: result.suites,
+      url: "https://braintrust.dev/experiment/local-export",
+    });
+    expect(JSON.parse(printed[0]!) as BraintrustCliResult).toEqual(result);
+    const resultText = readFileSync(resultPath, "utf8");
+    expect(JSON.parse(resultText) as BraintrustCliResult).toEqual(result);
+    expect(resultText).not.toContain("dummy-secret");
+    expect(resultText).not.toContain(fixture.root);
+    expect(resultText).not.toContain("Prompt for");
+    expect(resultText).not.toContain("Answer for");
+  });
+
+  it("propagates export failures without writing a success result or retrying", async () => {
+    const fixture = await createSuite();
+    const resultPath = join(fixture.root, "failed-result.json");
+    const calls: string[] = [];
+    await expect(
+      runBraintrustCli(
+        ["--suite", `canary=${fixture.suitePath}`, "--result-out", resultPath],
+        {
+          env: { BRAINTRUST_API_KEY: "dummy-secret" },
+          publisherFactory: () => ({
+            startSpan(args) {
+              calls.push(`start:${args.name}`);
+              return {
+                end() {
+                  calls.push(`end:${args.name}`);
+                  throw new Error("network export failed");
+                },
+              };
+            },
+            async flush() {
+              calls.push("flush");
+            },
+            async permalink() {
+              calls.push("permalink");
+              return "https://braintrust.dev/should-not-be-used";
+            },
+          }),
+        },
+      ),
+    ).rejects.toThrow("network export failed");
+    expect(calls).toEqual([
+      "start:discovery/workload-a",
+      "end:discovery/workload-a",
+    ]);
+    expect(existsSync(resultPath)).toBe(false);
+  });
+
+  it("exposes the official no-argument btEvalMain entrypoint", () => {
+    expect(typeof btEvalMain).toBe("function");
+    expect(btEvalMain.length).toBe(0);
+    expect(typeof runBraintrustCli).toBe("function");
   });
 });

--- a/scripts/agent-eval-braintrust.test.ts
+++ b/scripts/agent-eval-braintrust.test.ts
@@ -482,6 +482,20 @@ describe("Braintrust eval row mapping", () => {
     ).toThrow("tool-bearing row has unknown logical telemetry");
   });
 
+  it("rejects raw tool events without a logical tool sequence", async () => {
+    const fixture = await createSuite({ toolCalls: [] });
+    mutateMetrics(fixture, (metrics) => {
+      const record = firstMetricsRecord(metrics);
+      record.tools.rawEventCount = 1;
+    });
+
+    expect(() =>
+      preflightAndMapBraintrustRows([
+        suiteInput("raw-events-without-sequence", fixture.suitePath),
+      ]),
+    ).toThrow("tool-bearing row has empty logical tool sequence");
+  });
+
   it("maps ordered tool sequence, per-tool counts, and tags", async () => {
     const fixture = await createSuite();
     const row = preflightAndMapBraintrustRows([

--- a/scripts/agent-eval-braintrust.test.ts
+++ b/scripts/agent-eval-braintrust.test.ts
@@ -2155,7 +2155,7 @@ interface WorkflowStepContract {
 }
 
 interface WorkflowContract {
-  jobs: Record<string, { steps: WorkflowStepContract[] }>;
+  jobs: Record<string, { if?: string; steps: WorkflowStepContract[] }>;
 }
 
 function readAgentEvalWorkflow(): WorkflowContract {
@@ -2181,9 +2181,11 @@ function githubExpression(name: string): string {
 }
 
 describe("Agent eval workflow Braintrust integration", () => {
-  it("exports after reporting and aggregates final stage failures", () => {
+  it("routes stable Braintrust identity and guards non-main manual dispatch", () => {
     const workflow = readAgentEvalWorkflow();
+    const scenario = workflow.jobs.scenario;
     const summarySteps = readSummarySteps(workflow);
+    const summary = workflow.jobs.summary;
     const reportIndex = summarySteps.findIndex((step) => step.id === "report");
     const braintrustIndex = summarySteps.findIndex(
       (step) => step.id === "braintrust",
@@ -2194,6 +2196,17 @@ describe("Agent eval workflow Braintrust integration", () => {
     const report = summarySteps[reportIndex];
     const braintrust = summarySteps[braintrustIndex];
     const finalize = summarySteps[finalIndex];
+
+    expect(scenario?.if).toContain(
+      "github.event_name != 'workflow_dispatch' || github.ref_name == 'main'",
+    );
+    expect(summary?.if).toContain(
+      "github.event_name != 'workflow_dispatch' || github.ref_name == 'main'",
+    );
+    expect(scenario?.if).toContain("github.event.label.name == 'agent-eval'");
+    expect(scenario?.if).toContain(
+      "github.event.pull_request.head.repo.full_name == github.repository",
+    );
 
     expect(reportIndex).toBeGreaterThanOrEqual(0);
     expect(braintrustIndex).toBeGreaterThan(reportIndex);
@@ -2214,9 +2227,24 @@ describe("Agent eval workflow Braintrust integration", () => {
     expect(finalize?.run).toContain("report=");
     expect(finalize?.run).toContain("braintrust=");
     expect(finalize?.run).toContain("exit 1");
+
+    const run = braintrust?.run ?? "";
+    expect(run).toContain("BRAINTRUST_EVENT_NAME");
+    expect(run).toContain("BRAINTRUST_CHANNEL");
+    expect(run).toContain("BRAINTRUST_BRANCH");
+    expect(run).toContain("BRAINTRUST_PR_NUMBER");
+    expect(run).toContain("braintrust_args+=(--pr-number");
+    expect(run).toContain('"${braintrust_args[@]}"');
+    expect(run).toContain("--source github");
+    expect(run).toContain('--channel "$BRAINTRUST_CHANNEL"');
+    expect(run).toContain('--branch "$BRAINTRUST_BRANCH"');
+    expect(run).not.toContain("--experiment");
+    expect(run).not.toContain("github.head_ref");
+    expect(braintrust?.env?.BRAINTRUST_BRANCH).toContain("github.head_ref");
+    expect(braintrust?.env?.BRAINTRUST_CHANNEL).toContain("'pr'");
   });
 
-  it("uses the direct exporter command with one narrowly scoped secret", () => {
+  it("keeps Braintrust secret scope and reports actual base linkage", () => {
     const workflow = readAgentEvalWorkflow();
     const summarySteps = readSummarySteps(workflow);
     const braintrust = summarySteps.find((step) => step.id === "braintrust");
@@ -2224,27 +2252,26 @@ describe("Agent eval workflow Braintrust integration", () => {
 
     expect(run).toContain("bun run agent:e2e:braintrust");
     expect(run).toContain(
-      '--suite discovery="$RUNNER_TEMP/agent-eval-artifacts/discovery/suite.json"',
+      '--suite "discovery=$RUNNER_TEMP/agent-eval-artifacts/discovery/suite.json"',
     );
     expect(run).toContain(
-      '--suite intent="$RUNNER_TEMP/agent-eval-artifacts/intent/suite.json"',
+      '--suite "intent=$RUNNER_TEMP/agent-eval-artifacts/intent/suite.json"',
     );
     expect(run).toContain('--project "githits-cli-agent-evals"');
-    const githubRunId = githubExpression("github.run_id");
-    const githubRunAttempt = githubExpression("github.run_attempt");
-    const githubRepository = githubExpression("github.repository");
-    expect(run).toContain(
-      `--experiment "github-${githubRunId}-${githubRunAttempt}"`,
-    );
     expect(run).toContain("--source github");
-    expect(run).toContain(`--run-id "${githubRunId}"`);
-    expect(run).toContain(`--run-attempt "${githubRunAttempt}"`);
-    expect(run).toContain(
-      `--run-url "https://github.com/${githubRepository}/actions/runs/${githubRunId}"`,
-    );
+    expect(run).toContain('--run-id "$BRAINTRUST_RUN_ID"');
+    expect(run).toContain('--run-attempt "$BRAINTRUST_RUN_ATTEMPT"');
+    expect(run).toContain('--run-url "$BRAINTRUST_RUN_URL"');
     expect(run).toContain('--result-out "$RESULT_OUT"');
+    expect(run).toContain("result.experiment");
+    expect(run).toContain("result.baseExperiment");
     expect(run).toContain("result.url");
     expect(run).toContain("GITHUB_STEP_SUMMARY");
+    expect(run).toContain("bootstrap/no base");
+    expect(run).not.toContain("result.rows");
+    expect(run).not.toContain("result.prompt");
+    expect(run).not.toContain("result.answer");
+    expect(run).not.toContain("BRAINTRUST_API_KEY");
     expect(run).not.toContain("bt eval");
 
     const allSteps = Object.values(workflow.jobs).flatMap((job) => job.steps);
@@ -2259,6 +2286,13 @@ describe("Agent eval workflow Braintrust integration", () => {
     expect(braintrust?.env).toEqual({
       BRAINTRUST_API_KEY: braintrustApiKey,
       RESULT_OUT: `${runnerTemp}/agent-eval-braintrust-result.json`,
+      BRAINTRUST_EVENT_NAME: githubExpression("github.event_name"),
+      BRAINTRUST_CHANNEL: `${githubExpression("github.event_name == 'pull_request' && 'pr' || 'main'")}`,
+      BRAINTRUST_BRANCH: `${githubExpression("github.event_name == 'pull_request' && github.head_ref || github.ref_name")}`,
+      BRAINTRUST_PR_NUMBER: `${githubExpression("github.event_name == 'pull_request' && github.event.pull_request.number || ''")}`,
+      BRAINTRUST_RUN_ID: githubExpression("github.run_id"),
+      BRAINTRUST_RUN_ATTEMPT: githubExpression("github.run_attempt"),
+      BRAINTRUST_RUN_URL: `https://github.com/${githubExpression("github.repository")}/actions/runs/${githubExpression("github.run_id")}`,
     });
 
     const finalize = summarySteps.find(

--- a/scripts/agent-eval-braintrust.test.ts
+++ b/scripts/agent-eval-braintrust.test.ts
@@ -782,11 +782,12 @@ describe("Braintrust eval row mapping", () => {
 
     for (const testCase of cases) {
       const fixture = await createSuite({ toolCalls: testCase.toolCalls });
-      expect(() =>
+      const map = () =>
         preflightAndMapBraintrustRows([
           suiteInput(testCase.name, fixture.suitePath),
-        ]),
-      ).toThrow(testCase.message);
+        ]);
+      expect(map).toThrow("Braintrust preflight: discovery/workload-a:");
+      expect(map).toThrow(testCase.message);
     }
 
     const invalid = await createSuite();

--- a/scripts/agent-eval-braintrust.test.ts
+++ b/scripts/agent-eval-braintrust.test.ts
@@ -1280,6 +1280,9 @@ describe("Braintrust baseline precedence", () => {
             };
           },
           async flush() {},
+          async name() {
+            return init.experiment;
+          },
           async permalink() {
             return undefined;
           },
@@ -1482,6 +1485,9 @@ describe("Braintrust publisher boundary", () => {
           async flush() {
             calls.push("flush");
           },
+          async name() {
+            return init.experiment;
+          },
           async permalink() {
             calls.push("permalink");
             return "https://braintrust.dev/experiment/local-test";
@@ -1567,6 +1573,7 @@ describe("Braintrust publisher boundary", () => {
           gitMetadataSettings: { collect: "none" },
         });
         return {
+          name: Promise.resolve("sdk-test"),
           startSpan(args) {
             calls.push(`start:${args.name}`);
             expect(args.type).toBe("eval");
@@ -1649,6 +1656,7 @@ describe("Braintrust publisher boundary", () => {
         calls.push(`init:${project}`);
         expect(options.baseExperimentId).toBe("main-id");
         return {
+          name: Promise.resolve("server-created-name"),
           startSpan() {
             return {
               startSpan() {
@@ -1707,7 +1715,7 @@ describe("Braintrust publisher boundary", () => {
       "summary:false",
     ]);
     expect(result).toMatchObject({
-      experiment: "local-readback",
+      experiment: "server-created-name",
       url: "https://braintrust.dev/experiment/readback",
       baseExperiment: { id: "main-id", name: "main-r10-a1" },
     });
@@ -1738,6 +1746,9 @@ describe("Braintrust publisher boundary", () => {
           };
         },
         async flush() {},
+        async name() {
+          return "failed-row-test";
+        },
         async permalink() {
           return undefined;
         },
@@ -1792,6 +1803,9 @@ describe("Braintrust publisher boundary", () => {
           },
           async flush() {
             calls.push("flush");
+          },
+          async name() {
+            return "failure-test";
           },
           async permalink() {
             calls.push("permalink");
@@ -2060,6 +2074,9 @@ describe("Braintrust CLI wrapper", () => {
             async flush() {
               calls.push("flush");
             },
+            async name() {
+              return "local-export";
+            },
             async permalink() {
               calls.push("permalink");
               return "https://braintrust.dev/experiment/local-export";
@@ -2137,6 +2154,9 @@ describe("Braintrust CLI wrapper", () => {
             },
             async flush() {
               calls.push("flush");
+            },
+            async name() {
+              return "failure-test";
             },
             async permalink() {
               calls.push("permalink");

--- a/scripts/agent-eval-braintrust.test.ts
+++ b/scripts/agent-eval-braintrust.test.ts
@@ -9,7 +9,8 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
+import { parse as parseYaml } from "yaml";
 import {
   type BraintrustCliResult,
   type BraintrustRowEvent,
@@ -1215,5 +1216,126 @@ describe("Braintrust CLI wrapper", () => {
     expect(typeof btEvalMain).toBe("function");
     expect(btEvalMain.length).toBe(0);
     expect(typeof runBraintrustCli).toBe("function");
+  });
+});
+
+interface WorkflowStepContract {
+  name?: string;
+  id?: string;
+  if?: string;
+  "continue-on-error"?: boolean;
+  run?: string;
+  env?: Record<string, string>;
+}
+
+interface WorkflowContract {
+  jobs: Record<string, { steps: WorkflowStepContract[] }>;
+}
+
+function readAgentEvalWorkflow(): WorkflowContract {
+  const workflowPath = resolve(
+    process.cwd(),
+    ".github",
+    "workflows",
+    "agent-evals.yml",
+  );
+  return parseYaml(readFileSync(workflowPath, "utf8")) as WorkflowContract;
+}
+
+function readSummarySteps(workflow: WorkflowContract): WorkflowStepContract[] {
+  const summaryJob = workflow.jobs.summary;
+  if (!summaryJob) {
+    throw new Error("agent-evals workflow must define a summary job");
+  }
+  return summaryJob.steps;
+}
+
+describe("Agent eval workflow Braintrust integration", () => {
+  it("exports after reporting and aggregates final stage failures", () => {
+    const workflow = readAgentEvalWorkflow();
+    const summarySteps = readSummarySteps(workflow);
+    const reportIndex = summarySteps.findIndex((step) => step.id === "report");
+    const braintrustIndex = summarySteps.findIndex(
+      (step) => step.id === "braintrust",
+    );
+    const finalIndex = summarySteps.findIndex(
+      (step) => step.name === "Finalize agent eval status",
+    );
+    const report = summarySteps[reportIndex];
+    const braintrust = summarySteps[braintrustIndex];
+    const finalize = summarySteps[finalIndex];
+
+    expect(reportIndex).toBeGreaterThanOrEqual(0);
+    expect(braintrustIndex).toBeGreaterThan(reportIndex);
+    expect(finalIndex).toBeGreaterThan(braintrustIndex);
+    expect(report?.["continue-on-error"]).toBe(true);
+    expect(braintrust).toMatchObject({
+      id: "braintrust",
+      if: "always()",
+      "continue-on-error": true,
+    });
+    expect(finalize).toMatchObject({
+      if: "always()",
+    });
+    expect(finalize?.run).toContain("SCENARIO_RESULT");
+    expect(finalize?.run).toContain("REPORT_OUTCOME");
+    expect(finalize?.run).toContain("BRAINTRUST_OUTCOME");
+    expect(finalize?.run).toContain("scenario=");
+    expect(finalize?.run).toContain("report=");
+    expect(finalize?.run).toContain("braintrust=");
+    expect(finalize?.run).toContain("exit 1");
+  });
+
+  it("uses the direct exporter command with one narrowly scoped secret", () => {
+    const workflow = readAgentEvalWorkflow();
+    const summarySteps = readSummarySteps(workflow);
+    const braintrust = summarySteps.find((step) => step.id === "braintrust");
+    const run = braintrust?.run ?? "";
+
+    expect(run).toContain("bun run agent:e2e:braintrust");
+    expect(run).toContain(
+      '--suite discovery="$RUNNER_TEMP/agent-eval-artifacts/discovery/suite.json"',
+    );
+    expect(run).toContain(
+      '--suite intent="$RUNNER_TEMP/agent-eval-artifacts/intent/suite.json"',
+    );
+    expect(run).toContain('--project "githits-cli-agent-evals"');
+    expect(run).toContain(
+      '--experiment "github-${{ github.run_id }}-${{ github.run_attempt }}"',
+    );
+    expect(run).toContain("--source github");
+    expect(run).toContain('--run-id "${{ github.run_id }}"');
+    expect(run).toContain('--run-attempt "${{ github.run_attempt }}"');
+    expect(run).toContain(
+      '--run-url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"',
+    );
+    expect(run).toContain('--result-out "$RESULT_OUT"');
+    expect(run).toContain("result.url");
+    expect(run).toContain("GITHUB_STEP_SUMMARY");
+    expect(run).not.toContain("bt eval");
+
+    const allSteps = Object.values(workflow.jobs).flatMap((job) => job.steps);
+    const secretBindings = allSteps.flatMap((step) =>
+      Object.values(step.env ?? {}).filter((value) =>
+        value.includes("secrets.BRAINTRUST_API_KEY"),
+      ),
+    );
+    expect(secretBindings).toEqual(["${{ secrets.BRAINTRUST_API_KEY }}"]);
+    expect(braintrust?.env).toEqual({
+      BRAINTRUST_API_KEY: "${{ secrets.BRAINTRUST_API_KEY }}",
+      RESULT_OUT: "${{ runner.temp }}/agent-eval-braintrust-result.json",
+    });
+
+    const finalize = summarySteps.find(
+      (step) => step.name === "Finalize agent eval status",
+    );
+    expect(finalize?.env).toEqual({
+      SCENARIO_RESULT: "${{ needs.scenario.result }}",
+      REPORT_OUTCOME: "${{ steps.report.outcome }}",
+      BRAINTRUST_OUTCOME: "${{ steps.braintrust.outcome }}",
+    });
+    expect(Object.values(finalize?.env ?? {}).join(" ")).not.toContain(
+      "secrets.",
+    );
   });
 });

--- a/scripts/agent-eval-braintrust.test.ts
+++ b/scripts/agent-eval-braintrust.test.ts
@@ -530,6 +530,11 @@ describe("Braintrust eval row mapping", () => {
             surface: "mcp",
             timingSource: "harness_stdout_observed",
           },
+          metrics: {
+            duration:
+              Date.parse("2026-08-28T10:00:00.200Z") / 1000 -
+              Date.parse("2026-08-28T10:00:00.100Z") / 1000,
+          },
         },
         startTime: Date.parse("2026-08-28T10:00:00.100Z") / 1000,
         endTime: Date.parse("2026-08-28T10:00:00.200Z") / 1000,
@@ -588,6 +593,11 @@ describe("Braintrust eval row mapping", () => {
             surface: "mcp",
             timingSource: "harness_stdout_observed",
           },
+          metrics: {
+            duration:
+              Date.parse("2026-08-28T10:00:00.400Z") / 1000 -
+              Date.parse("2026-08-28T10:00:00.200Z") / 1000,
+          },
           error: "tool_status:failed",
         },
         startTime: Date.parse("2026-08-28T10:00:00.200Z") / 1000,
@@ -595,6 +605,52 @@ describe("Braintrust eval row mapping", () => {
       },
     ]);
     expect(JSON.stringify(row.toolSpans)).not.toContain("provider details");
+  });
+
+  it("preserves zero duration for equal observed boundaries", async () => {
+    const fixture = await createSuite({
+      toolCalls: [
+        {
+          tool: "search",
+          server: "githits",
+          providerCallId: "equal-completed",
+          status: "started",
+          observedAt: "2026-08-28T10:00:00.200Z",
+        },
+        {
+          tool: "search",
+          server: "githits",
+          providerCallId: "equal-completed",
+          status: "completed",
+          observedAt: "2026-08-28T10:00:00.200Z",
+        },
+        {
+          tool: "pkg-info",
+          server: "githits-cli",
+          providerCallId: "equal-failed",
+          status: "started",
+          observedAt: "2026-08-28T10:00:00.200Z",
+        },
+        {
+          tool: "pkg-info",
+          server: "githits-cli",
+          providerCallId: "equal-failed",
+          status: "failed",
+          observedAt: "2026-08-28T10:00:00.200Z",
+        },
+      ],
+    });
+    const row = preflightAndMapBraintrustRows([
+      suiteInput("equal-boundaries", fixture.suitePath),
+    ]).rows[0]!;
+
+    expect(row.toolSpans.map((span) => span.event.metrics?.duration)).toEqual([
+      0, 0,
+    ]);
+    expect(row.toolSpans.map((span) => span.startTime)).toEqual([
+      Date.parse("2026-08-28T10:00:00.200Z") / 1000,
+      Date.parse("2026-08-28T10:00:00.200Z") / 1000,
+    ]);
   });
 
   it("rejects incomplete, invalid, reverse, and outside-parent tool intervals", async () => {
@@ -1045,8 +1101,8 @@ describe("Braintrust publisher boundary", () => {
         suiteSchemaVersion: mapping.suites[0]!.suiteSchemaVersion,
         reportSchemaVersion: mapping.rows[0]!.metadata.reportSchemaVersion,
         metricsSchemaVersion: mapping.rows[0]!.metadata.metricsSchemaVersion,
-        exporterSchemaVersion: 1,
-        exporterVersion: "1",
+        exporterSchemaVersion: 2,
+        exporterVersion: "2",
       },
       repoInfo: {
         commit: mapping.rows[0]!.metadata.targetGit.sha,

--- a/scripts/agent-eval-braintrust.test.ts
+++ b/scripts/agent-eval-braintrust.test.ts
@@ -304,6 +304,52 @@ describe("Braintrust eval row mapping", () => {
     expect(row.output.discovery).toBeUndefined();
   });
 
+  it("uses the resolved model with a requested-model fallback", async () => {
+    const fixture = await createSuite();
+    mutateMetrics(fixture, (metrics) => {
+      firstMetricsRecord(metrics).resolvedModel = null;
+    });
+    const row = preflightAndMapBraintrustRows([
+      suiteInput("model", fixture.suitePath),
+    ]).rows[0]!;
+
+    expect(row.metadata.model).toBe(LUNA_MODEL);
+    expect(row.metadata.requestedModel).toBe(LUNA_MODEL);
+    expect(row.metadata.resolvedModel).toBeNull();
+  });
+
+  it("carries valid recorded span times without fabricating invalid ones", async () => {
+    const fixture = await createSuite();
+    const expectedStart = Date.parse("2026-08-28T10:00:00.000Z") / 1000;
+    const expectedEnd = Date.parse("2026-08-28T10:00:01.000Z") / 1000;
+    const validRow = preflightAndMapBraintrustRows([
+      suiteInput("valid-times", fixture.suitePath),
+    ]).rows[0]!;
+    expect(validRow.startTime).toBe(expectedStart);
+    expect(validRow.endTime).toBe(expectedEnd);
+
+    mutateMetrics(fixture, (metrics) => {
+      const record = firstMetricsRecord(metrics);
+      record.startedAt = "not-a-timestamp";
+    });
+    const invalidRow = preflightAndMapBraintrustRows([
+      suiteInput("invalid-times", fixture.suitePath),
+    ]).rows[0]!;
+    expect(invalidRow.startTime).toBeUndefined();
+    expect(invalidRow.endTime).toBeUndefined();
+
+    mutateMetrics(fixture, (metrics) => {
+      const record = firstMetricsRecord(metrics);
+      record.startedAt = "2026-08-28T10:00:02.000Z";
+      record.completedAt = "2026-08-28T10:00:01.000Z";
+    });
+    const reversedRow = preflightAndMapBraintrustRows([
+      suiteInput("reversed-times", fixture.suitePath),
+    ]).rows[0]!;
+    expect(reversedRow.startTime).toBeUndefined();
+    expect(reversedRow.endTime).toBeUndefined();
+  });
+
   it("orders rows by suite label, scenario, and workload", async () => {
     const zeta = await createSuite({ scenarios: ["full", "discovery"] });
     const alpha = await createSuite({
@@ -335,31 +381,48 @@ describe("Braintrust eval row mapping", () => {
     ]);
     const metrics = result.rows[0]!.metrics;
     expect(metrics).toMatchObject({
-      agent_duration_ms: 1000,
-      logical_tool_calls: 2,
+      duration: 1,
+      tool_calls: 2,
+      tool_errors: 0,
       mcp_tool_calls: 1,
       cli_tool_calls: 1,
       tool_calls_started: 1,
       tool_calls_completed: 1,
-      tool_calls_failed: 0,
       tool_calls_unknown: 0,
       raw_tool_events: 2,
-      uncached_input_tokens: 70,
-      cached_input_tokens: 20,
-      cache_write_input_tokens: 10,
-      output_tokens: 30,
-      reasoning_output_tokens: 4,
+      prompt_tokens: 100,
+      prompt_cached_tokens: 20,
+      prompt_cache_creation_tokens: 10,
+      completion_tokens: 30,
+      completion_reasoning_tokens: 4,
+      tokens: 130,
     });
-    expect(metrics.estimated_cost_usd).toBeGreaterThan(0);
+    expect(metrics.estimated_cost).toBeGreaterThan(0);
+    for (const removedMetric of [
+      "agent_duration_ms",
+      "logical_tool_calls",
+      "tool_calls_failed",
+      "uncached_input_tokens",
+      "cached_input_tokens",
+      "cache_write_input_tokens",
+      "output_tokens",
+      "reasoning_output_tokens",
+      "estimated_cost_usd",
+    ]) {
+      expect(Object.keys(metrics)).not.toContain(removedMetric);
+    }
 
     const zero = await createSuite({ toolCalls: [] });
     const zeroRow = preflightAndMapBraintrustRows([
       suiteInput("zero", zero.suitePath),
     ]).rows[0]!;
-    expect(zeroRow.metrics.logical_tool_calls).toBe(0);
+    expect(zeroRow.metrics.tool_calls).toBe(0);
+    expect(zeroRow.metrics.tool_errors).toBe(0);
     expect(zeroRow.metrics.mcp_tool_calls).toBe(0);
     expect(zeroRow.metrics.cli_tool_calls).toBe(0);
     expect(zeroRow.metrics.tool_calls_started).toBe(0);
+    expect(zeroRow.metrics.tool_calls_completed).toBe(0);
+    expect(zeroRow.metrics.tool_calls_unknown).toBe(0);
     expect(zeroRow.metadata.toolCounts).toEqual([]);
     expect(zeroRow.tags).toEqual([]);
   });
@@ -369,6 +432,7 @@ describe("Braintrust eval row mapping", () => {
     mutateMetrics(fixture, (metrics) => {
       const record = firstMetricsRecord(metrics);
       record.tools.logicalCallCount = null;
+      record.usage.providerUsage = null;
       record.usage.normalizedTokens.uncachedInputTokens = null;
       record.usage.normalizedTokens.cachedInputTokens = null;
       record.usage.normalizedTokens.cacheWriteInputTokens = null;
@@ -387,7 +451,7 @@ describe("Braintrust eval row mapping", () => {
     ]).rows[0]!;
 
     expect(row.metrics).toEqual({
-      agent_duration_ms: 1000,
+      duration: 1,
       raw_tool_events: 2,
     });
     expect(row.metadata.toolTelemetryKnown).toBe(false);
@@ -741,6 +805,8 @@ describe("Braintrust publisher boundary", () => {
     ]);
     const calls: string[] = [];
     const events: unknown[] = [];
+    const startTimes: Array<number | undefined> = [];
+    const endTimes: Array<number | undefined> = [];
     const result = await publishBraintrustRows(
       mapping,
       {
@@ -754,10 +820,17 @@ describe("Braintrust publisher boundary", () => {
           startSpan(args) {
             calls.push(`start:${args.name}`);
             events.push(args.event);
+            startTimes.push(args.startTime);
             expect(args.type).toBe("eval");
-            expect(Object.keys(args).sort()).toEqual(["event", "name", "type"]);
+            expect(Object.keys(args).sort()).toEqual([
+              "event",
+              "name",
+              "startTime",
+              "type",
+            ]);
             return {
-              end() {
+              end(endArgs) {
+                endTimes.push(endArgs?.endTime);
                 calls.push(`end:${args.name}`);
               },
             };
@@ -782,6 +855,10 @@ describe("Braintrust publisher boundary", () => {
       "flush",
       "permalink",
     ]);
+    const expectedStart = Date.parse("2026-08-28T10:00:00.000Z") / 1000;
+    const expectedEnd = Date.parse("2026-08-28T10:00:01.000Z") / 1000;
+    expect(startTimes).toEqual([expectedStart, expectedStart]);
+    expect(endTimes).toEqual([expectedEnd, expectedEnd]);
     expect(
       (events as Array<Record<string, unknown>>).map((event) =>
         Object.keys(event).sort(),
@@ -831,6 +908,9 @@ describe("Braintrust publisher boundary", () => {
           startSpan(args) {
             calls.push(`start:${args.name}`);
             expect(args.type).toBe("eval");
+            expect(args.startTime).toBe(
+              Date.parse("2026-08-28T10:00:00.000Z") / 1000,
+            );
             expect(Object.keys(args.event).sort()).toEqual([
               "input",
               "metadata",
@@ -839,7 +919,10 @@ describe("Braintrust publisher boundary", () => {
               "tags",
             ]);
             return {
-              end() {
+              end(endArgs) {
+                expect(endArgs).toEqual({
+                  endTime: Date.parse("2026-08-28T10:00:01.000Z") / 1000,
+                });
                 calls.push(`end:${args.name}`);
                 return 0;
               },

--- a/scripts/agent-eval-braintrust.test.ts
+++ b/scripts/agent-eval-braintrust.test.ts
@@ -13,7 +13,9 @@ import { join, resolve } from "node:path";
 import { parse as parseYaml } from "yaml";
 import {
   type BraintrustCliResult,
+  type BraintrustEndSpanArgs,
   type BraintrustRowEvent,
+  type BraintrustSpan,
   type BraintrustSuiteInput,
   btEvalMain,
   buildBraintrustExperimentInit,
@@ -101,8 +103,27 @@ function createRecord(
       LUNA_MODEL,
     ),
     toolCalls: suiteOptions.toolCalls ?? [
-      { tool: "search", server: "githits", status: "completed" },
-      { tool: "pkg-info", server: "githits-cli", status: "started" },
+      {
+        tool: "search",
+        server: "githits",
+        providerCallId: "search-1",
+        status: "started",
+        observedAt: "2026-08-28T10:00:00.100Z",
+      },
+      {
+        tool: "search",
+        server: "githits",
+        providerCallId: "search-1",
+        status: "completed",
+        observedAt: "2026-08-28T10:00:00.200Z",
+      },
+      {
+        tool: "pkg-info",
+        server: "githits-cli",
+        providerCallId: "pkg-info-1",
+        status: "started",
+        observedAt: "2026-08-28T10:00:00.500Z",
+      },
     ],
     artifacts: {},
   };
@@ -265,6 +286,17 @@ function firstMetricsRecord(
   return record;
 }
 
+function leafSpan(
+  end: (args?: BraintrustEndSpanArgs) => void = () => {},
+): BraintrustSpan {
+  return {
+    startSpan() {
+      throw new Error("test leaf spans cannot have children");
+    },
+    end,
+  };
+}
+
 describe("Braintrust eval row mapping", () => {
   it("keeps stable input identity separate from process identity", async () => {
     const fixture = await createSuite({ scenarios: ["full", "discovery"] });
@@ -332,22 +364,22 @@ describe("Braintrust eval row mapping", () => {
       const record = firstMetricsRecord(metrics);
       record.startedAt = "not-a-timestamp";
     });
-    const invalidRow = preflightAndMapBraintrustRows([
-      suiteInput("invalid-times", fixture.suitePath),
-    ]).rows[0]!;
-    expect(invalidRow.startTime).toBeUndefined();
-    expect(invalidRow.endTime).toBeUndefined();
+    expect(() =>
+      preflightAndMapBraintrustRows([
+        suiteInput("invalid-times", fixture.suitePath),
+      ]),
+    ).toThrow("no valid parent span interval");
 
     mutateMetrics(fixture, (metrics) => {
       const record = firstMetricsRecord(metrics);
       record.startedAt = "2026-08-28T10:00:02.000Z";
       record.completedAt = "2026-08-28T10:00:01.000Z";
     });
-    const reversedRow = preflightAndMapBraintrustRows([
-      suiteInput("reversed-times", fixture.suitePath),
-    ]).rows[0]!;
-    expect(reversedRow.startTime).toBeUndefined();
-    expect(reversedRow.endTime).toBeUndefined();
+    expect(() =>
+      preflightAndMapBraintrustRows([
+        suiteInput("reversed-times", fixture.suitePath),
+      ]),
+    ).toThrow("no valid parent span interval");
   });
 
   it("orders rows by suite label, scenario, and workload", async () => {
@@ -382,14 +414,12 @@ describe("Braintrust eval row mapping", () => {
     const metrics = result.rows[0]!.metrics;
     expect(metrics).toMatchObject({
       duration: 1,
-      tool_calls: 2,
-      tool_errors: 0,
       mcp_tool_calls: 1,
       cli_tool_calls: 1,
       tool_calls_started: 1,
       tool_calls_completed: 1,
       tool_calls_unknown: 0,
-      raw_tool_events: 2,
+      raw_tool_events: 3,
       prompt_tokens: 100,
       prompt_cached_tokens: 20,
       prompt_cache_creation_tokens: 10,
@@ -398,6 +428,8 @@ describe("Braintrust eval row mapping", () => {
       tokens: 130,
     });
     expect(metrics.estimated_cost).toBeGreaterThan(0);
+    expect(metrics).not.toHaveProperty("tool_calls");
+    expect(metrics).not.toHaveProperty("tool_errors");
     for (const removedMetric of [
       "agent_duration_ms",
       "logical_tool_calls",
@@ -416,8 +448,7 @@ describe("Braintrust eval row mapping", () => {
     const zeroRow = preflightAndMapBraintrustRows([
       suiteInput("zero", zero.suitePath),
     ]).rows[0]!;
-    expect(zeroRow.metrics.tool_calls).toBe(0);
-    expect(zeroRow.metrics.tool_errors).toBe(0);
+    expect(zeroRow.toolSpans).toEqual([]);
     expect(zeroRow.metrics.mcp_tool_calls).toBe(0);
     expect(zeroRow.metrics.cli_tool_calls).toBe(0);
     expect(zeroRow.metrics.tool_calls_started).toBe(0);
@@ -427,7 +458,7 @@ describe("Braintrust eval row mapping", () => {
     expect(zeroRow.tags).toEqual([]);
   });
 
-  it("omits unknown values while retaining raw events", async () => {
+  it("rejects tool-bearing rows with unknown logical telemetry", async () => {
     const fixture = await createSuite();
     mutateMetrics(fixture, (metrics) => {
       const record = firstMetricsRecord(metrics);
@@ -446,19 +477,9 @@ describe("Braintrust eval row mapping", () => {
       };
       metrics.aggregates.logicalToolCalls = null;
     });
-    const row = preflightAndMapBraintrustRows([
-      suiteInput("unknown", fixture.suitePath),
-    ]).rows[0]!;
-
-    expect(row.metrics).toEqual({
-      duration: 1,
-      raw_tool_events: 2,
-    });
-    expect(row.metadata.toolTelemetryKnown).toBe(false);
-    expect(row.metadata.toolSequence).toBeUndefined();
-    expect(row.metadata.toolCounts).toBeUndefined();
-    expect(row.tags).toEqual([]);
-    expect(row.metadata.costKind).toBe("unknown");
+    expect(() =>
+      preflightAndMapBraintrustRows([suiteInput("unknown", fixture.suitePath)]),
+    ).toThrow("tool-bearing row has unknown logical telemetry");
   });
 
   it("maps ordered tool sequence, per-tool counts, and tags", async () => {
@@ -468,8 +489,20 @@ describe("Braintrust eval row mapping", () => {
     ]).rows[0]!;
 
     expect(row.metadata.toolSequence).toEqual([
-      { tool: "search", surface: "mcp", status: "completed" },
-      { tool: "pkg-info", surface: "cli", status: "started" },
+      {
+        tool: "search",
+        surface: "mcp",
+        status: "completed",
+        startedAt: "2026-08-28T10:00:00.100Z",
+        completedAt: "2026-08-28T10:00:00.200Z",
+      },
+      {
+        tool: "pkg-info",
+        surface: "cli",
+        status: "started",
+        startedAt: "2026-08-28T10:00:00.500Z",
+        completedAt: null,
+      },
     ]);
     expect(row.metadata.toolCounts).toEqual([
       {
@@ -485,7 +518,250 @@ describe("Braintrust eval row mapping", () => {
         statusCounts: { started: 0, completed: 1, failed: 0, unknown: 0 },
       },
     ]);
+    expect(row.toolSpans).toEqual([
+      {
+        name: "search",
+        type: "tool",
+        event: {
+          input: { tool: "search", surface: "mcp" },
+          output: { status: "completed" },
+          metadata: {
+            tool: "search",
+            surface: "mcp",
+            timingSource: "harness_stdout_observed",
+          },
+        },
+        startTime: Date.parse("2026-08-28T10:00:00.100Z") / 1000,
+        endTime: Date.parse("2026-08-28T10:00:00.200Z") / 1000,
+      },
+      {
+        name: "pkg-info",
+        type: "tool",
+        event: {
+          input: { tool: "pkg-info", surface: "cli" },
+          output: { status: "started" },
+          metadata: {
+            tool: "pkg-info",
+            surface: "cli",
+            timingSource: "harness_stdout_observed",
+          },
+        },
+        startTime: Date.parse("2026-08-28T10:00:00.500Z") / 1000,
+      },
+    ]);
     expect(row.tags).toEqual(["tool:cli:pkg-info", "tool:mcp:search"]);
+  });
+
+  it("maps failed tools to native child errors without raw payloads", async () => {
+    const fixture = await createSuite({
+      toolCalls: [
+        {
+          tool: "search",
+          server: "githits",
+          providerCallId: "failed-search",
+          status: "started",
+          observedAt: "2026-08-28T10:00:00.200Z",
+        },
+        {
+          tool: "search",
+          server: "githits",
+          providerCallId: "failed-search",
+          status: "failed",
+          observedAt: "2026-08-28T10:00:00.400Z",
+          error: { message: "provider details" },
+        },
+      ],
+    });
+    const row = preflightAndMapBraintrustRows([
+      suiteInput("failed-tool", fixture.suitePath),
+    ]).rows[0]!;
+
+    expect(row.toolSpans).toEqual([
+      {
+        name: "search",
+        type: "tool",
+        event: {
+          input: { tool: "search", surface: "mcp" },
+          output: { status: "failed" },
+          metadata: {
+            tool: "search",
+            surface: "mcp",
+            timingSource: "harness_stdout_observed",
+          },
+          error: "tool_status:failed",
+        },
+        startTime: Date.parse("2026-08-28T10:00:00.200Z") / 1000,
+        endTime: Date.parse("2026-08-28T10:00:00.400Z") / 1000,
+      },
+    ]);
+    expect(JSON.stringify(row.toolSpans)).not.toContain("provider details");
+  });
+
+  it("rejects incomplete, invalid, reverse, and outside-parent tool intervals", async () => {
+    const cases: ReadonlyArray<{
+      name: string;
+      toolCalls: AgentEvalRecordInput["toolCalls"];
+      message: string;
+    }> = [
+      {
+        name: "missing-start",
+        toolCalls: [
+          {
+            tool: "search",
+            server: "githits",
+            providerCallId: "missing-start",
+            status: "completed",
+            observedAt: "2026-08-28T10:00:00.200Z",
+          },
+        ],
+        message: "no valid observed start time",
+      },
+      {
+        name: "missing-completion",
+        toolCalls: [
+          {
+            tool: "search",
+            server: "githits",
+            providerCallId: "missing-completion",
+            status: "started",
+            observedAt: "2026-08-28T10:00:00.200Z",
+          },
+          {
+            tool: "search",
+            server: "githits",
+            providerCallId: "missing-completion",
+            status: "completed",
+          },
+        ],
+        message: "no valid observed completion time",
+      },
+      {
+        name: "reverse",
+        toolCalls: [
+          {
+            tool: "search",
+            server: "githits",
+            providerCallId: "reverse",
+            status: "started",
+            observedAt: "2026-08-28T10:00:00.400Z",
+          },
+          {
+            tool: "search",
+            server: "githits",
+            providerCallId: "reverse",
+            status: "completed",
+            observedAt: "2026-08-28T10:00:00.200Z",
+          },
+        ],
+        message: "no valid observed start time",
+      },
+      {
+        name: "outside-start",
+        toolCalls: [
+          {
+            tool: "search",
+            server: "githits",
+            providerCallId: "outside-start",
+            status: "started",
+            observedAt: "2026-08-28T09:59:59.900Z",
+          },
+          {
+            tool: "search",
+            server: "githits",
+            providerCallId: "outside-start",
+            status: "completed",
+            observedAt: "2026-08-28T10:00:00.200Z",
+          },
+        ],
+        message: "starts outside the parent span interval",
+      },
+      {
+        name: "outside-end",
+        toolCalls: [
+          {
+            tool: "search",
+            server: "githits",
+            providerCallId: "outside-end",
+            status: "started",
+            observedAt: "2026-08-28T10:00:00.200Z",
+          },
+          {
+            tool: "search",
+            server: "githits",
+            providerCallId: "outside-end",
+            status: "completed",
+            observedAt: "2026-08-28T10:00:01.100Z",
+          },
+        ],
+        message: "ends outside the parent span interval",
+      },
+      {
+        name: "unknown-status",
+        toolCalls: [
+          {
+            tool: "search",
+            server: "githits",
+            providerCallId: "unknown-status",
+            status: "unknown",
+            observedAt: "2026-08-28T10:00:00.200Z",
+          },
+        ],
+        message: "has unknown status",
+      },
+    ];
+
+    for (const testCase of cases) {
+      const fixture = await createSuite({ toolCalls: testCase.toolCalls });
+      expect(() =>
+        preflightAndMapBraintrustRows([
+          suiteInput(testCase.name, fixture.suitePath),
+        ]),
+      ).toThrow(testCase.message);
+    }
+
+    const invalid = await createSuite();
+    mutateMetrics(invalid, (metrics) => {
+      const sequence = firstMetricsRecord(metrics).tools.sequence;
+      sequence[0]!.startedAt = "not-a-timestamp";
+    });
+    expect(() =>
+      preflightAndMapBraintrustRows([suiteInput("invalid", invalid.suitePath)]),
+    ).toThrow();
+  });
+
+  it("accepts legacy zero-tool suites and rejects legacy tool timing gaps", async () => {
+    const downgrade = (fixture: SuiteFixture, version: 1 | 2): void => {
+      mutateJson<Record<string, unknown>>(
+        join(fixture.shardPath, "metrics.json"),
+        (metrics) => {
+          metrics.schemaVersion = version;
+          const records = metrics.records as Array<Record<string, unknown>>;
+          for (const record of records) {
+            const tools = record.tools as Record<string, unknown>;
+            tools.sequence = (
+              tools.sequence as Array<Record<string, unknown>>
+            ).map(({ tool, surface, status }) => ({ tool, surface, status }));
+          }
+        },
+      );
+    };
+
+    for (const version of [1, 2] as const) {
+      const zero = await createSuite({ toolCalls: [] });
+      downgrade(zero, version);
+      const zeroRow = preflightAndMapBraintrustRows([
+        suiteInput(`legacy-zero-${version}`, zero.suitePath),
+      ]).rows[0]!;
+      expect(zeroRow.toolSpans).toEqual([]);
+
+      const toolBearing = await createSuite();
+      downgrade(toolBearing, version);
+      expect(() =>
+        preflightAndMapBraintrustRows([
+          suiteInput(`legacy-tools-${version}`, toolBearing.suitePath),
+        ]),
+      ).toThrow("no valid observed start time");
+    }
   });
 
   it("adds a status-only error for failed cells", async () => {
@@ -807,6 +1083,7 @@ describe("Braintrust publisher boundary", () => {
     const events: unknown[] = [];
     const startTimes: Array<number | undefined> = [];
     const endTimes: Array<number | undefined> = [];
+    const toolEndTimes: Array<number | undefined> = [];
     const result = await publishBraintrustRows(
       mapping,
       {
@@ -829,6 +1106,13 @@ describe("Braintrust publisher boundary", () => {
               "type",
             ]);
             return {
+              startSpan(childArgs) {
+                calls.push(`tool-start:${childArgs.name}`);
+                return leafSpan((endArgs) => {
+                  toolEndTimes.push(endArgs?.endTime);
+                  calls.push(`tool-end:${childArgs.name}`);
+                });
+              },
               end(endArgs) {
                 endTimes.push(endArgs?.endTime);
                 calls.push(`end:${args.name}`);
@@ -849,16 +1133,24 @@ describe("Braintrust publisher boundary", () => {
     expect(calls).toEqual([
       "init:githits-cli-agent-evals/local-test",
       "start:discovery/workload-a",
+      "tool-start:search",
+      "tool-end:search",
+      "tool-start:pkg-info",
       "end:discovery/workload-a",
       "start:full/workload-a",
+      "tool-start:search",
+      "tool-end:search",
+      "tool-start:pkg-info",
       "end:full/workload-a",
       "flush",
       "permalink",
     ]);
     const expectedStart = Date.parse("2026-08-28T10:00:00.000Z") / 1000;
     const expectedEnd = Date.parse("2026-08-28T10:00:01.000Z") / 1000;
+    const expectedSearchEnd = Date.parse("2026-08-28T10:00:00.200Z") / 1000;
     expect(startTimes).toEqual([expectedStart, expectedStart]);
     expect(endTimes).toEqual([expectedEnd, expectedEnd]);
+    expect(toolEndTimes).toEqual([expectedSearchEnd, expectedSearchEnd]);
     expect(
       (events as Array<Record<string, unknown>>).map((event) =>
         Object.keys(event).sort(),
@@ -919,6 +1211,18 @@ describe("Braintrust publisher boundary", () => {
               "tags",
             ]);
             return {
+              startSpan(childArgs) {
+                calls.push(`tool-start:${childArgs.name}`);
+                return {
+                  startSpan() {
+                    throw new Error("test leaf spans cannot have children");
+                  },
+                  end() {
+                    calls.push(`tool-end:${childArgs.name}`);
+                    return 0;
+                  },
+                };
+              },
               end(endArgs) {
                 expect(endArgs).toEqual({
                   endTime: Date.parse("2026-08-28T10:00:01.000Z") / 1000,
@@ -951,6 +1255,9 @@ describe("Braintrust publisher boundary", () => {
     expect(calls).toEqual([
       "init:githits-cli-agent-evals",
       "start:discovery/workload-a",
+      "tool-start:search",
+      "tool-end:search",
+      "tool-start:pkg-info",
       "end:discovery/workload-a",
       "flush",
       "summary:false",
@@ -974,7 +1281,12 @@ describe("Braintrust publisher boundary", () => {
       () => ({
         startSpan(args) {
           event = args.event;
-          return { end() {} };
+          return {
+            startSpan() {
+              return leafSpan();
+            },
+            end() {},
+          };
         },
         async flush() {},
         async permalink() {
@@ -1016,6 +1328,10 @@ describe("Braintrust publisher boundary", () => {
           startSpan(args) {
             calls.push(`start:${args.name}`);
             return {
+              startSpan(childArgs) {
+                calls.push(`tool-start:${childArgs.name}`);
+                return leafSpan(() => calls.push(`tool-end:${childArgs.name}`));
+              },
               end() {
                 calls.push(`end:${args.name}`);
                 throw new Error("publisher failure");
@@ -1034,6 +1350,9 @@ describe("Braintrust publisher boundary", () => {
     ).rejects.toThrow("publisher failure");
     expect(calls).toEqual([
       "start:discovery/workload-a",
+      "tool-start:search",
+      "tool-end:search",
+      "tool-start:pkg-info",
       "end:discovery/workload-a",
     ]);
   });
@@ -1264,6 +1583,12 @@ describe("Braintrust CLI wrapper", () => {
             startSpan(args) {
               calls.push(`start:${args.name}`);
               return {
+                startSpan(childArgs) {
+                  calls.push(`tool-start:${childArgs.name}`);
+                  return leafSpan(() =>
+                    calls.push(`tool-end:${childArgs.name}`),
+                  );
+                },
                 end() {
                   calls.push(`end:${args.name}`);
                 },
@@ -1285,6 +1610,9 @@ describe("Braintrust CLI wrapper", () => {
     expect(calls).toEqual([
       "init:githits-cli-agent-evals/local-export",
       "start:discovery/workload-a",
+      "tool-start:search",
+      "tool-end:search",
+      "tool-start:pkg-info",
       "end:discovery/workload-a",
       "flush",
       "permalink",
@@ -1320,6 +1648,12 @@ describe("Braintrust CLI wrapper", () => {
             startSpan(args) {
               calls.push(`start:${args.name}`);
               return {
+                startSpan(childArgs) {
+                  calls.push(`tool-start:${childArgs.name}`);
+                  return leafSpan(() =>
+                    calls.push(`tool-end:${childArgs.name}`),
+                  );
+                },
                 end() {
                   calls.push(`end:${args.name}`);
                   throw new Error("network export failed");
@@ -1339,6 +1673,9 @@ describe("Braintrust CLI wrapper", () => {
     ).rejects.toThrow("network export failed");
     expect(calls).toEqual([
       "start:discovery/workload-a",
+      "tool-start:search",
+      "tool-end:search",
+      "tool-start:pkg-info",
       "end:discovery/workload-a",
     ]);
     expect(existsSync(resultPath)).toBe(false);

--- a/scripts/agent-eval-braintrust.test.ts
+++ b/scripts/agent-eval-braintrust.test.ts
@@ -24,6 +24,7 @@ import {
   runBraintrustCli,
 } from "./agent-eval-braintrust.ts";
 import {
+  type AgentEvalMetrics,
   type AgentEvalRecordInput,
   adaptAgentUsage,
   buildAgentEvalMetrics,
@@ -234,8 +235,8 @@ function suiteInput(label: string, suitePath: string): BraintrustSuiteInput {
   return { label, suitePath };
 }
 
-function mutateJson(path: string, mutate: (value: any) => void): void {
-  const value = JSON.parse(readFileSync(path, "utf8"));
+function mutateJson<T>(path: string, mutate: (value: T) => void): void {
+  const value = JSON.parse(readFileSync(path, "utf8")) as T;
   mutate(value);
   writeJson(path, value);
 }
@@ -249,9 +250,19 @@ function mutateSuite(
 
 function mutateMetrics(
   fixture: SuiteFixture,
-  mutate: (metrics: any) => void,
+  mutate: (metrics: AgentEvalMetrics) => void,
 ): void {
   mutateJson(join(fixture.shardPath, "metrics.json"), mutate);
+}
+
+function firstMetricsRecord(
+  metrics: AgentEvalMetrics,
+): AgentEvalMetrics["records"][number] {
+  const record = metrics.records[0];
+  if (!record) {
+    throw new Error("test fixture must contain a metrics record");
+  }
+  return record;
 }
 
 describe("Braintrust eval row mapping", () => {
@@ -356,7 +367,7 @@ describe("Braintrust eval row mapping", () => {
   it("omits unknown values while retaining raw events", async () => {
     const fixture = await createSuite();
     mutateMetrics(fixture, (metrics) => {
-      const record = metrics.records[0];
+      const record = firstMetricsRecord(metrics);
       record.tools.logicalCallCount = null;
       record.usage.normalizedTokens.uncachedInputTokens = null;
       record.usage.normalizedTokens.cachedInputTokens = null;
@@ -431,7 +442,9 @@ describe("Braintrust eval row mapping", () => {
   it("keeps metadata allowlisted and warnings free of local roots", async () => {
     const fixture = await createSuite();
     mutateMetrics(fixture, (metrics) => {
-      metrics.records[0].warnings = ["provider warning at /tmp/private-output"];
+      firstMetricsRecord(metrics).warnings = [
+        "provider warning at /tmp/private-output",
+      ];
     });
     const row = preflightAndMapBraintrustRows([
       suiteInput("allowlisted", fixture.suitePath),
@@ -464,7 +477,7 @@ describe("Braintrust eval row mapping", () => {
       };
     });
     mutateMetrics(fixture, (metrics) => {
-      metrics.records[0].targetGit = {
+      firstMetricsRecord(metrics).targetGit = {
         branch: "feature",
         sha: "record-target",
         dirty: true,
@@ -485,7 +498,7 @@ describe("Braintrust eval row mapping", () => {
   it("labels a non-success record final status when final evidence is absent", async () => {
     const fixture = await createSuite();
     mutateMetrics(fixture, (metrics) => {
-      metrics.records[0].finalStatus = "failure";
+      firstMetricsRecord(metrics).finalStatus = "failure";
     });
     rmSync(join(fixture.workloadDir, "final.json"));
 
@@ -555,7 +568,7 @@ describe("Braintrust eval row mapping", () => {
     const normal = await createSuite();
     const other = await createSuite({ workloadId: "workload-b" });
     mutateMetrics(other, (metrics) => {
-      metrics.records[0].agent = "claude";
+      firstMetricsRecord(metrics).agent = "claude";
     });
     expect(() =>
       preflightAndMapBraintrustRows([
@@ -580,9 +593,12 @@ describe("Braintrust eval row mapping", () => {
     ).toThrow("metrics record");
 
     const missingWorkload = await createSuite();
-    mutateJson(join(missingWorkload.shardPath, "run.json"), (run) => {
-      run.workloads = [];
-    });
+    mutateJson<{ workloads: unknown[] }>(
+      join(missingWorkload.shardPath, "run.json"),
+      (run) => {
+        run.workloads = [];
+      },
+    );
     expect(() =>
       preflightAndMapBraintrustRows([
         suiteInput("missing-workload", missingWorkload.suitePath),
@@ -793,6 +809,7 @@ describe("Braintrust publisher boundary", () => {
             return {
               end() {
                 calls.push(`end:${args.name}`);
+                return 0;
               },
             };
           },
@@ -1250,6 +1267,10 @@ function readSummarySteps(workflow: WorkflowContract): WorkflowStepContract[] {
   return summaryJob.steps;
 }
 
+function githubExpression(name: string): string {
+  return `$${"{"}{ ${name} }}`;
+}
+
 describe("Agent eval workflow Braintrust integration", () => {
   it("exports after reporting and aggregates final stage failures", () => {
     const workflow = readAgentEvalWorkflow();
@@ -1300,14 +1321,17 @@ describe("Agent eval workflow Braintrust integration", () => {
       '--suite intent="$RUNNER_TEMP/agent-eval-artifacts/intent/suite.json"',
     );
     expect(run).toContain('--project "githits-cli-agent-evals"');
+    const githubRunId = githubExpression("github.run_id");
+    const githubRunAttempt = githubExpression("github.run_attempt");
+    const githubRepository = githubExpression("github.repository");
     expect(run).toContain(
-      '--experiment "github-${{ github.run_id }}-${{ github.run_attempt }}"',
+      `--experiment "github-${githubRunId}-${githubRunAttempt}"`,
     );
     expect(run).toContain("--source github");
-    expect(run).toContain('--run-id "${{ github.run_id }}"');
-    expect(run).toContain('--run-attempt "${{ github.run_attempt }}"');
+    expect(run).toContain(`--run-id "${githubRunId}"`);
+    expect(run).toContain(`--run-attempt "${githubRunAttempt}"`);
     expect(run).toContain(
-      '--run-url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"',
+      `--run-url "https://github.com/${githubRepository}/actions/runs/${githubRunId}"`,
     );
     expect(run).toContain('--result-out "$RESULT_OUT"');
     expect(run).toContain("result.url");
@@ -1315,24 +1339,26 @@ describe("Agent eval workflow Braintrust integration", () => {
     expect(run).not.toContain("bt eval");
 
     const allSteps = Object.values(workflow.jobs).flatMap((job) => job.steps);
+    const braintrustApiKey = githubExpression("secrets.BRAINTRUST_API_KEY");
+    const runnerTemp = githubExpression("runner.temp");
     const secretBindings = allSteps.flatMap((step) =>
       Object.values(step.env ?? {}).filter((value) =>
         value.includes("secrets.BRAINTRUST_API_KEY"),
       ),
     );
-    expect(secretBindings).toEqual(["${{ secrets.BRAINTRUST_API_KEY }}"]);
+    expect(secretBindings).toEqual([braintrustApiKey]);
     expect(braintrust?.env).toEqual({
-      BRAINTRUST_API_KEY: "${{ secrets.BRAINTRUST_API_KEY }}",
-      RESULT_OUT: "${{ runner.temp }}/agent-eval-braintrust-result.json",
+      BRAINTRUST_API_KEY: braintrustApiKey,
+      RESULT_OUT: `${runnerTemp}/agent-eval-braintrust-result.json`,
     });
 
     const finalize = summarySteps.find(
       (step) => step.name === "Finalize agent eval status",
     );
     expect(finalize?.env).toEqual({
-      SCENARIO_RESULT: "${{ needs.scenario.result }}",
-      REPORT_OUTCOME: "${{ steps.report.outcome }}",
-      BRAINTRUST_OUTCOME: "${{ steps.braintrust.outcome }}",
+      SCENARIO_RESULT: githubExpression("needs.scenario.result"),
+      REPORT_OUTCOME: githubExpression("steps.report.outcome"),
+      BRAINTRUST_OUTCOME: githubExpression("steps.braintrust.outcome"),
     });
     expect(Object.values(finalize?.env ?? {}).join(" ")).not.toContain(
       "secrets.",

--- a/scripts/agent-eval-braintrust.test.ts
+++ b/scripts/agent-eval-braintrust.test.ts
@@ -1,0 +1,633 @@
+import { describe, expect, it } from "bun:test";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  type BraintrustSuiteInput,
+  preflightAndMapBraintrustRows,
+} from "./agent-eval-braintrust.ts";
+import {
+  type AgentEvalRecordInput,
+  adaptAgentUsage,
+  buildAgentEvalMetrics,
+  LUNA_MODEL,
+} from "./agent-eval-metrics.ts";
+import { buildRunReportFromMetadata } from "./agent-eval-report.ts";
+import {
+  type AgentEvalSuiteArtifact,
+  type AgentEvalSuiteScenario,
+  type AgentEvalSuiteShardOptions,
+  runAgentEvalSuite,
+} from "./agent-eval-suite.ts";
+
+function writeJson(path: string, value: unknown): void {
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+interface SuiteFixture {
+  root: string;
+  suitePath: string;
+  shardPath: string;
+  workloadDir: string;
+}
+
+interface SuiteOptions {
+  scenarios?: readonly AgentEvalSuiteScenario[];
+  workloadId?: string;
+  processStatus?: "success" | "failed" | "timeout";
+  toolCalls?: AgentEvalRecordInput["toolCalls"];
+  dryRun?: boolean;
+}
+
+function createRecord(
+  options: AgentEvalSuiteShardOptions,
+  workloadId: string,
+  suiteOptions: SuiteOptions,
+): AgentEvalRecordInput {
+  return {
+    workloadId,
+    requestedModel: LUNA_MODEL,
+    resolvedModel: LUNA_MODEL,
+    agent: "codex",
+    agentVersion: "codex-test",
+    reasoningEffort: "low",
+    surface: "mcp",
+    server: "local",
+    guidanceProfile: options.guidanceProfile,
+    scenario: options.scenario,
+    intentProfile: options.intentProfile,
+    intentFragmentHash: options.intentFragmentHash,
+    experimentalTools: false,
+    publishedPackage: null,
+    targetGit: { branch: "main", sha: null, dirty: false },
+    startedAt: "2026-08-28T10:00:00.000Z",
+    completedAt: "2026-08-28T10:00:01.000Z",
+    durationMs: 1000,
+    processStatus: suiteOptions.processStatus ?? "success",
+    finalStatus:
+      suiteOptions.processStatus === "success" ? "success" : "failure",
+    exitCode: suiteOptions.processStatus === "success" ? 0 : 1,
+    timedOut: suiteOptions.processStatus === "timeout",
+    usage: adaptAgentUsage(
+      JSON.stringify({
+        type: "turn.completed",
+        usage: {
+          input_tokens: 100,
+          cached_input_tokens: 20,
+          cache_write_input_tokens: 10,
+          output_tokens: 30,
+          reasoning_output_tokens: 4,
+        },
+      }),
+      "codex",
+      LUNA_MODEL,
+    ),
+    toolCalls: suiteOptions.toolCalls ?? [
+      { tool: "search", server: "githits", status: "completed" },
+      { tool: "pkg-info", server: "githits-cli", status: "started" },
+    ],
+    artifacts: {},
+  };
+}
+
+async function createSuite(
+  suiteOptions: SuiteOptions = {},
+): Promise<SuiteFixture> {
+  const root = mkdtempSync(join(tmpdir(), "agent-eval-braintrust-suite-"));
+  const workloadsDir = join(root, "eval", "agentic", "workloads");
+  const workloadId = suiteOptions.workloadId ?? "workload-a";
+  const workloadPath = join(workloadsDir, `${workloadId}.md`);
+  const reportingPath = join(workloadsDir, "REPORTING.md");
+  const schemaPath = join(root, "eval", "agentic", "result.schema.json");
+  const manifestPath = join(root, "eval", "agentic", "suites.json");
+  const outDir = join(root, "out");
+  mkdirSync(workloadsDir, { recursive: true });
+  mkdirSync(join(root, "skills", "githits-mcp"), { recursive: true });
+  mkdirSync(join(root, "src", "commands", "init"), { recursive: true });
+  writeFileSync(workloadPath, `# ${workloadId}\n`);
+  writeFileSync(reportingPath, "# Reporting contract\n");
+  writeFileSync(schemaPath, "{}\n");
+  writeFileSync(
+    join(root, "skills", "githits-mcp", "SKILL.md"),
+    "# Target skill\n",
+  );
+  writeFileSync(
+    join(root, "src", "commands", "init", "guidance-assets.ts"),
+    'export const GITHITS_GUIDANCE_BLOCK = "Target guidance";\n',
+  );
+  writeJson(manifestPath, {
+    schemaVersion: 1,
+    workloads: [
+      {
+        id: workloadId,
+        path: `eval/agentic/workloads/${workloadId}.md`,
+        safety: "stable",
+        suites: ["canary", "smoke", "stable-full"],
+      },
+    ],
+  });
+
+  let shardPath = "";
+  let workloadDir = "";
+  await runAgentEvalSuite({
+    suite: "canary",
+    repoRoot: root,
+    targetRoot: root,
+    outDir,
+    manifestPath,
+    workloadsDir,
+    reportingPath,
+    schemaPath,
+    dryRun: suiteOptions.dryRun ?? false,
+    workloadConcurrency: 1,
+    scenarios: suiteOptions.scenarios ?? ["discovery"],
+    shardExecutor: async (options) => {
+      shardPath = options.outDir;
+      workloadDir = join(options.outDir, "workloads", workloadId);
+      mkdirSync(workloadDir, { recursive: true });
+      const record = createRecord(options, workloadId, suiteOptions);
+      writeFileSync(
+        join(workloadDir, "prompt.md"),
+        `Prompt for ${options.scenario}/${workloadId}.\n`,
+      );
+      writeJson(join(workloadDir, "tool-calls.json"), record.toolCalls);
+      writeJson(join(workloadDir, "final.json"), {
+        status:
+          suiteOptions.processStatus === "success" ? "success" : "failure",
+        answer: `Answer for ${options.scenario}/${workloadId}.`,
+        confidence: "high",
+      });
+      writeFileSync(join(workloadDir, "stderr.txt"), "");
+      const runMetadata = {
+        runId: `run-${options.scenario}`,
+        startedAt: "2026-08-28T10:00:00.000Z",
+        completedAt: "2026-08-28T10:00:01.000Z",
+        agent: "codex",
+        model: LUNA_MODEL,
+        reasoningEffort: "low",
+        surface: "mcp",
+        server: "local",
+        guidanceProfile: options.guidanceProfile,
+        scenario: options.scenario,
+        intentProfile: options.intentProfile,
+        intentFragmentHash: options.intentFragmentHash,
+        dryRun: options.dryRun,
+        codexVersion: "codex-test",
+        git: { branch: "main", sha: null, dirty: false },
+        workloads: [
+          {
+            id: workloadId,
+            status:
+              suiteOptions.processStatus === "timeout"
+                ? "timeout"
+                : suiteOptions.processStatus === "failed"
+                  ? "failed"
+                  : "success",
+            durationMs: 1000,
+            workloadDir,
+          },
+        ],
+      };
+      writeJson(join(options.outDir, "run.json"), runMetadata);
+      writeJson(
+        join(options.outDir, "metrics.json"),
+        buildAgentEvalMetrics({
+          runId: runMetadata.runId,
+          startedAt: runMetadata.startedAt,
+          completedAt: runMetadata.completedAt,
+          records: [record],
+        }),
+      );
+      writeJson(
+        join(options.outDir, "report.json"),
+        buildRunReportFromMetadata(options.outDir, runMetadata),
+      );
+      return { runDir: options.outDir, status: "success" };
+    },
+  });
+  return {
+    root,
+    suitePath: join(outDir, "suite.json"),
+    shardPath,
+    workloadDir,
+  };
+}
+
+function suiteInput(label: string, suitePath: string): BraintrustSuiteInput {
+  return { label, suitePath };
+}
+
+function mutateJson(path: string, mutate: (value: any) => void): void {
+  const value = JSON.parse(readFileSync(path, "utf8"));
+  mutate(value);
+  writeJson(path, value);
+}
+
+function mutateSuite(
+  fixture: SuiteFixture,
+  mutate: (artifact: AgentEvalSuiteArtifact) => void,
+): void {
+  mutateJson(fixture.suitePath, mutate);
+}
+
+function mutateMetrics(
+  fixture: SuiteFixture,
+  mutate: (metrics: any) => void,
+): void {
+  mutateJson(join(fixture.shardPath, "metrics.json"), mutate);
+}
+
+describe("Braintrust eval row mapping", () => {
+  it("keeps stable input identity separate from process identity", async () => {
+    const fixture = await createSuite({ scenarios: ["full", "discovery"] });
+    const result = preflightAndMapBraintrustRows([
+      suiteInput("local", fixture.suitePath),
+    ]);
+
+    expect(result.rows.map((row) => row.input.scenario)).toEqual([
+      "discovery",
+      "full",
+    ]);
+    expect(Object.keys(result.rows[0]!.input).sort()).toEqual([
+      "prompt",
+      "promptSha256",
+      "scenario",
+      "workloadId",
+      "workloadPath",
+    ]);
+    expect(result.rows[0]!.input.workloadPath).toBe(
+      "eval/agentic/workloads/workload-a.md",
+    );
+    expect(result.rows[0]!.metadata.agent).toBe("codex");
+    expect(result.rows[0]!.metadata.suiteLabel).toBe("local");
+  });
+
+  it("captures exact prompt and answer with a byte hash", async () => {
+    const fixture = await createSuite();
+    const result = preflightAndMapBraintrustRows([
+      suiteInput("canary", fixture.suitePath),
+    ]);
+    const row = result.rows[0]!;
+
+    expect(row.input.prompt).toBe("Prompt for discovery/workload-a.\n");
+    expect(row.input.promptSha256).toMatch(/^[a-f0-9]{64}$/);
+    expect(row.output.answer).toBe("Answer for discovery/workload-a.");
+    expect(row.output.confidence).toBe("high");
+    expect(row.output.discovery).toBeUndefined();
+  });
+
+  it("orders rows by suite label, scenario, and workload", async () => {
+    const zeta = await createSuite({ scenarios: ["full", "discovery"] });
+    const alpha = await createSuite({
+      scenarios: ["full", "discovery"],
+      workloadId: "workload-b",
+    });
+    const result = preflightAndMapBraintrustRows([
+      suiteInput("zeta", zeta.suitePath),
+      suiteInput("alpha", alpha.suitePath),
+    ]);
+
+    expect(
+      result.rows.map(
+        (row) =>
+          `${row.metadata.suiteLabel}/${row.input.scenario}/${row.input.workloadId}`,
+      ),
+    ).toEqual([
+      "alpha/discovery/workload-b",
+      "alpha/full/workload-b",
+      "zeta/discovery/workload-a",
+      "zeta/full/workload-a",
+    ]);
+  });
+
+  it("maps every named metric and preserves known zeroes", async () => {
+    const fixture = await createSuite();
+    const result = preflightAndMapBraintrustRows([
+      suiteInput("known", fixture.suitePath),
+    ]);
+    const metrics = result.rows[0]!.metrics;
+    expect(metrics).toMatchObject({
+      agent_duration_ms: 1000,
+      logical_tool_calls: 2,
+      mcp_tool_calls: 1,
+      cli_tool_calls: 1,
+      tool_calls_started: 1,
+      tool_calls_completed: 1,
+      tool_calls_failed: 0,
+      tool_calls_unknown: 0,
+      raw_tool_events: 2,
+      uncached_input_tokens: 70,
+      cached_input_tokens: 20,
+      cache_write_input_tokens: 10,
+      output_tokens: 30,
+      reasoning_output_tokens: 4,
+    });
+    expect(metrics.estimated_cost_usd).toBeGreaterThan(0);
+
+    const zero = await createSuite({ toolCalls: [] });
+    const zeroRow = preflightAndMapBraintrustRows([
+      suiteInput("zero", zero.suitePath),
+    ]).rows[0]!;
+    expect(zeroRow.metrics.logical_tool_calls).toBe(0);
+    expect(zeroRow.metrics.mcp_tool_calls).toBe(0);
+    expect(zeroRow.metrics.cli_tool_calls).toBe(0);
+    expect(zeroRow.metrics.tool_calls_started).toBe(0);
+    expect(zeroRow.metadata.toolCounts).toEqual([]);
+    expect(zeroRow.tags).toEqual([]);
+  });
+
+  it("omits unknown values while retaining raw events", async () => {
+    const fixture = await createSuite();
+    mutateMetrics(fixture, (metrics) => {
+      const record = metrics.records[0];
+      record.tools.logicalCallCount = null;
+      record.usage.normalizedTokens.uncachedInputTokens = null;
+      record.usage.normalizedTokens.cachedInputTokens = null;
+      record.usage.normalizedTokens.cacheWriteInputTokens = null;
+      record.usage.normalizedTokens.outputTokens = null;
+      record.usage.normalizedTokens.reasoningOutputTokens = null;
+      record.usage.cost = {
+        kind: "unknown",
+        usd: null,
+        uncertainty: "unknown",
+        rateSnapshot: null,
+      };
+      metrics.aggregates.logicalToolCalls = null;
+    });
+    const row = preflightAndMapBraintrustRows([
+      suiteInput("unknown", fixture.suitePath),
+    ]).rows[0]!;
+
+    expect(row.metrics).toEqual({
+      agent_duration_ms: 1000,
+      raw_tool_events: 2,
+    });
+    expect(row.metadata.toolTelemetryKnown).toBe(false);
+    expect(row.metadata.toolSequence).toBeUndefined();
+    expect(row.metadata.toolCounts).toBeUndefined();
+    expect(row.tags).toEqual([]);
+    expect(row.metadata.costKind).toBe("unknown");
+  });
+
+  it("maps ordered tool sequence, per-tool counts, and tags", async () => {
+    const fixture = await createSuite();
+    const row = preflightAndMapBraintrustRows([
+      suiteInput("tools", fixture.suitePath),
+    ]).rows[0]!;
+
+    expect(row.metadata.toolSequence).toEqual([
+      { tool: "search", surface: "mcp", status: "completed" },
+      { tool: "pkg-info", surface: "cli", status: "started" },
+    ]);
+    expect(row.metadata.toolCounts).toEqual([
+      {
+        surface: "cli",
+        tool: "pkg-info",
+        total: 1,
+        statusCounts: { started: 1, completed: 0, failed: 0, unknown: 0 },
+      },
+      {
+        surface: "mcp",
+        tool: "search",
+        total: 1,
+        statusCounts: { started: 0, completed: 1, failed: 0, unknown: 0 },
+      },
+    ]);
+    expect(row.tags).toEqual(["tool:cli:pkg-info", "tool:mcp:search"]);
+  });
+
+  it("adds a status-only error for failed cells", async () => {
+    const fixture = await createSuite({ processStatus: "failed" });
+    mutateSuite(fixture, (artifact) => {
+      artifact.warnings = ["discovery shard failed: provider secret details"];
+    });
+    const row = preflightAndMapBraintrustRows([
+      suiteInput("failed", fixture.suitePath),
+    ]).rows[0]!;
+
+    expect(row.output.cellStatus).toBe("failed");
+    expect(row.output.processStatus).toBe("failed");
+    expect(row.error).toBe("eval_status:failed");
+    expect(JSON.stringify(row)).not.toContain("provider");
+  });
+
+  it("keeps metadata allowlisted and warnings free of local roots", async () => {
+    const fixture = await createSuite();
+    mutateMetrics(fixture, (metrics) => {
+      metrics.records[0].warnings = ["provider warning at /tmp/private-output"];
+    });
+    const row = preflightAndMapBraintrustRows([
+      suiteInput("allowlisted", fixture.suitePath),
+    ]).rows[0]!;
+    const metadataText = JSON.stringify(row.metadata);
+
+    expect(metadataText).not.toContain(fixture.root);
+    expect(metadataText).not.toContain("stderr");
+    expect(metadataText).not.toContain("stdout");
+    expect(metadataText).not.toContain(
+      "provider warning at /tmp/private-output",
+    );
+    expect(metadataText).toContain("provider warning at <path>");
+    expect(row.metadata.reportingContractSha256).toMatch(/^[a-f0-9]{64}$/);
+    expect(row.metadata.resultSchemaSha256).toMatch(/^[a-f0-9]{64}$/);
+    expect(row.metadata.measurementGit).toEqual({
+      branch: null,
+      sha: null,
+      dirty: null,
+    });
+  });
+
+  it("uses the suite target Git identity over a record mismatch", async () => {
+    const fixture = await createSuite();
+    mutateSuite(fixture, (artifact) => {
+      artifact.targetGit = {
+        branch: "main",
+        sha: "suite-target",
+        dirty: false,
+      };
+    });
+    mutateMetrics(fixture, (metrics) => {
+      metrics.records[0].targetGit = {
+        branch: "feature",
+        sha: "record-target",
+        dirty: true,
+      };
+    });
+
+    const row = preflightAndMapBraintrustRows([
+      suiteInput("target", fixture.suitePath),
+    ]).rows[0]!;
+
+    expect(row.metadata.targetGit).toEqual({
+      branch: "main",
+      sha: "suite-target",
+      dirty: false,
+    });
+  });
+
+  it("labels a non-success record final status when final evidence is absent", async () => {
+    const fixture = await createSuite();
+    mutateMetrics(fixture, (metrics) => {
+      metrics.records[0].finalStatus = "failure";
+    });
+    rmSync(join(fixture.workloadDir, "final.json"));
+
+    const row = preflightAndMapBraintrustRows([
+      suiteInput("final-status", fixture.suitePath),
+    ]).rows[0]!;
+
+    expect(row.output.finalStatus).toBe("failure");
+    expect(row.output.answer).toBeUndefined();
+    expect(row.error).toBe("eval_status:failure");
+  });
+
+  it("rejects dry runs, duplicate labels, duplicate cells, and mixed identities", async () => {
+    const normal = await createSuite();
+    const dryRun = await createSuite({ dryRun: true });
+    expect(() =>
+      preflightAndMapBraintrustRows([suiteInput("dry", dryRun.suitePath)]),
+    ).toThrow("dry-run");
+    expect(() =>
+      preflightAndMapBraintrustRows([
+        suiteInput("same", normal.suitePath),
+        suiteInput("same", normal.suitePath),
+      ]),
+    ).toThrow("duplicate suite label");
+    expect(() =>
+      preflightAndMapBraintrustRows([
+        suiteInput("one", normal.suitePath),
+        suiteInput("two", normal.suitePath),
+      ]),
+    ).toThrow("duplicate scenario/workload cell");
+
+    const identityCases = [
+      [
+        "targetGit",
+        (artifact: AgentEvalSuiteArtifact) =>
+          (artifact.targetGit.sha = "different-target"),
+      ],
+      [
+        "measurementGit",
+        (artifact: AgentEvalSuiteArtifact) =>
+          (artifact.measurementGit.sha = "different-measurement"),
+      ],
+      [
+        "reportingContractSha256",
+        (artifact: AgentEvalSuiteArtifact) =>
+          (artifact.contentIdentity.reportingContract.sha256 = "a".repeat(64)),
+      ],
+      [
+        "resultSchemaSha256",
+        (artifact: AgentEvalSuiteArtifact) =>
+          (artifact.contentIdentity.resultSchema.sha256 = "b".repeat(64)),
+      ],
+    ] as const;
+    for (const [name, mutate] of identityCases) {
+      const other = await createSuite();
+      mutateSuite(other, mutate);
+      expect(() =>
+        preflightAndMapBraintrustRows([
+          suiteInput("base", normal.suitePath),
+          suiteInput(name, other.suitePath),
+        ]),
+      ).toThrow("mixed");
+    }
+  });
+
+  it("rejects mixed child agent identity", async () => {
+    const normal = await createSuite();
+    const other = await createSuite({ workloadId: "workload-b" });
+    mutateMetrics(other, (metrics) => {
+      metrics.records[0].agent = "claude";
+    });
+    expect(() =>
+      preflightAndMapBraintrustRows([
+        suiteInput("base", normal.suitePath),
+        suiteInput("other", other.suitePath),
+      ]),
+    ).toThrow("mixed agent/model/reasoning/surface/server identity");
+  });
+
+  it("rejects missing child evidence and unsafe prompts", async () => {
+    const missingRecord = await createSuite();
+    mutateMetrics(missingRecord, (metrics) => {
+      metrics.records = [];
+    });
+    mutateSuite(missingRecord, (artifact) => {
+      artifact.cells[0]!.status = "missing";
+    });
+    expect(() =>
+      preflightAndMapBraintrustRows([
+        suiteInput("missing-record", missingRecord.suitePath),
+      ]),
+    ).toThrow("metrics record");
+
+    const missingWorkload = await createSuite();
+    mutateJson(join(missingWorkload.shardPath, "run.json"), (run) => {
+      run.workloads = [];
+    });
+    expect(() =>
+      preflightAndMapBraintrustRows([
+        suiteInput("missing-workload", missingWorkload.suitePath),
+      ]),
+    ).toThrow("report workload");
+
+    const missingPrompt = await createSuite();
+    rmSync(join(missingPrompt.workloadDir, "prompt.md"));
+    expect(() =>
+      preflightAndMapBraintrustRows([
+        suiteInput("missing-prompt", missingPrompt.suitePath),
+      ]),
+    ).toThrow("prompt artifact");
+
+    const unsafePrompt = await createSuite();
+    const outsidePrompt = join(unsafePrompt.root, "outside-prompt.md");
+    writeFileSync(outsidePrompt, "outside\n");
+    rmSync(join(unsafePrompt.workloadDir, "prompt.md"));
+    symlinkSync(outsidePrompt, join(unsafePrompt.workloadDir, "prompt.md"));
+    expect(() =>
+      preflightAndMapBraintrustRows([
+        suiteInput("unsafe-prompt", unsafePrompt.suitePath),
+      ]),
+    ).toThrow("prompt artifact");
+
+    const missingMetrics = await createSuite();
+    rmSync(join(missingMetrics.shardPath, "metrics.json"));
+    expect(() =>
+      preflightAndMapBraintrustRows([
+        suiteInput("missing-metrics", missingMetrics.suitePath),
+      ]),
+    ).toThrow("metrics.json");
+  });
+
+  it("accepts failed cells when their evidence is complete", async () => {
+    const fixture = await createSuite({ processStatus: "failed" });
+    const result = preflightAndMapBraintrustRows([
+      suiteInput("partial", fixture.suitePath),
+    ]);
+
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0]!.output.cellStatus).toBe("failed");
+    expect(result.rows[0]!.input.prompt).toContain("Prompt for");
+  });
+
+  it("rejects invalid workload paths before exposing local roots", async () => {
+    const fixture = await createSuite();
+    mutateSuite(fixture, (artifact) => {
+      artifact.cells[0]!.workloadPath = "/private/workload.md";
+    });
+    expect(() =>
+      preflightAndMapBraintrustRows([
+        suiteInput("invalid-path", fixture.suitePath),
+      ]),
+    ).toThrow("workload path");
+  });
+});

--- a/scripts/agent-eval-braintrust.test.ts
+++ b/scripts/agent-eval-braintrust.test.ts
@@ -1283,6 +1283,9 @@ describe("Braintrust baseline precedence", () => {
           async permalink() {
             return undefined;
           },
+          async fetchBaseExperiment() {
+            return null;
+          },
         };
       };
     const resolver = async () => null;
@@ -1483,6 +1486,9 @@ describe("Braintrust publisher boundary", () => {
             calls.push("permalink");
             return "https://braintrust.dev/experiment/local-test";
           },
+          async fetchBaseExperiment() {
+            return null;
+          },
         };
       },
     );
@@ -1602,6 +1608,9 @@ describe("Braintrust publisher boundary", () => {
           async summarize(options) {
             calls.push(`summary:${options.summarizeScores}`);
             return { experimentUrl: "https://braintrust.dev/experiment/sdk" };
+          },
+          async fetchBaseExperiment() {
+            return null;
           },
         };
       },
@@ -1732,6 +1741,9 @@ describe("Braintrust publisher boundary", () => {
         async permalink() {
           return undefined;
         },
+        async fetchBaseExperiment() {
+          return null;
+        },
       }),
     );
 
@@ -1784,6 +1796,9 @@ describe("Braintrust publisher boundary", () => {
           async permalink() {
             calls.push("permalink");
             return "https://braintrust.dev/should-not-be-used";
+          },
+          async fetchBaseExperiment() {
+            return null;
           },
         }),
       ),
@@ -1933,7 +1948,7 @@ describe("Braintrust CLI wrapper", () => {
 
     expect(publisherCalled).toBe(false);
     expect(result).toMatchObject({
-      schemaVersion: 1,
+      schemaVersion: 2,
       mode: "validate-only",
       project: "githits-cli-agent-evals",
       rowCount: 1,
@@ -2049,6 +2064,9 @@ describe("Braintrust CLI wrapper", () => {
               calls.push("permalink");
               return "https://braintrust.dev/experiment/local-export";
             },
+            async fetchBaseExperiment() {
+              return { id: "main-id", name: "main-r1-a1" };
+            },
           };
         },
         print: (line) => printed.push(line),
@@ -2066,14 +2084,14 @@ describe("Braintrust CLI wrapper", () => {
       "permalink",
     ]);
     expect(result).toEqual({
-      schemaVersion: 1,
+      schemaVersion: 2,
       mode: "export",
       project: "githits-cli-agent-evals",
       experiment: "local-export",
       rowCount: 1,
       suites: result.suites,
       url: "https://braintrust.dev/experiment/local-export",
-      baseExperiment: null,
+      baseExperiment: { id: "main-id", name: "main-r1-a1" },
     });
     expect(JSON.parse(printed[0]!) as BraintrustCliResult).toEqual(result);
     const resultText = readFileSync(resultPath, "utf8");
@@ -2123,6 +2141,9 @@ describe("Braintrust CLI wrapper", () => {
             async permalink() {
               calls.push("permalink");
               return "https://braintrust.dev/should-not-be-used";
+            },
+            async fetchBaseExperiment() {
+              return null;
             },
           }),
         },

--- a/scripts/agent-eval-braintrust.test.ts
+++ b/scripts/agent-eval-braintrust.test.ts
@@ -11,8 +11,12 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  type BraintrustRowEvent,
   type BraintrustSuiteInput,
+  buildBraintrustExperimentInit,
+  createBraintrustPublisher,
   preflightAndMapBraintrustRows,
+  publishBraintrustRows,
 } from "./agent-eval-braintrust.ts";
 import {
   type AgentEvalRecordInput,
@@ -52,6 +56,7 @@ function createRecord(
   workloadId: string,
   suiteOptions: SuiteOptions,
 ): AgentEvalRecordInput {
+  const processStatus = suiteOptions.processStatus ?? "success";
   return {
     workloadId,
     requestedModel: LUNA_MODEL,
@@ -71,11 +76,10 @@ function createRecord(
     startedAt: "2026-08-28T10:00:00.000Z",
     completedAt: "2026-08-28T10:00:01.000Z",
     durationMs: 1000,
-    processStatus: suiteOptions.processStatus ?? "success",
-    finalStatus:
-      suiteOptions.processStatus === "success" ? "success" : "failure",
-    exitCode: suiteOptions.processStatus === "success" ? 0 : 1,
-    timedOut: suiteOptions.processStatus === "timeout",
+    processStatus,
+    finalStatus: processStatus === "success" ? "success" : "failure",
+    exitCode: processStatus === "success" ? 0 : 1,
+    timedOut: processStatus === "timeout",
     usage: adaptAgentUsage(
       JSON.stringify({
         type: "turn.completed",
@@ -629,5 +633,271 @@ describe("Braintrust eval row mapping", () => {
         suiteInput("invalid-path", fixture.suitePath),
       ]),
     ).toThrow("workload path");
+  });
+});
+
+describe("Braintrust publisher boundary", () => {
+  it("builds exact allowlisted experiment initialization options", async () => {
+    const fixture = await createSuite();
+    const mapping = preflightAndMapBraintrustRows([
+      suiteInput("github", fixture.suitePath),
+    ]);
+    const init = buildBraintrustExperimentInit(mapping, {
+      project: "githits-cli-agent-evals",
+      experiment: "github-123-2",
+      source: "github",
+      githubRunId: "123",
+      githubRunAttempt: "2",
+      githubRunUrl:
+        "https://github.com/githits-com/githits-cli/actions/runs/123",
+    });
+
+    expect(init).toEqual({
+      project: "githits-cli-agent-evals",
+      experiment: "github-123-2",
+      update: false,
+      metadata: {
+        source: "github",
+        githubRunId: "123",
+        githubRunAttempt: "2",
+        githubRunUrl:
+          "https://github.com/githits-com/githits-cli/actions/runs/123",
+        suites: mapping.suites,
+        targetGit: mapping.rows[0]!.metadata.targetGit,
+        measurementGit: mapping.rows[0]!.metadata.measurementGit,
+        suiteSchemaVersion: 3,
+        reportSchemaVersion: mapping.rows[0]!.metadata.reportSchemaVersion,
+        metricsSchemaVersion: mapping.rows[0]!.metadata.metricsSchemaVersion,
+        exporterSchemaVersion: 1,
+        exporterVersion: "1",
+      },
+      repoInfo: {
+        commit: mapping.rows[0]!.metadata.targetGit.sha,
+        branch: mapping.rows[0]!.metadata.targetGit.branch,
+        dirty: mapping.rows[0]!.metadata.targetGit.dirty,
+      },
+      gitMetadataSettings: { collect: "none" },
+    });
+    expect(JSON.stringify(init)).not.toContain(fixture.root);
+  });
+
+  it("starts and ends rows in order with exact event fields", async () => {
+    const fixture = await createSuite({ scenarios: ["full", "discovery"] });
+    const mapping = preflightAndMapBraintrustRows([
+      suiteInput("ordered", fixture.suitePath),
+    ]);
+    const calls: string[] = [];
+    const events: unknown[] = [];
+    const result = await publishBraintrustRows(
+      mapping,
+      {
+        project: "githits-cli-agent-evals",
+        experiment: "local-test",
+        source: "local",
+      },
+      async (init) => {
+        calls.push(`init:${init.project}/${init.experiment}`);
+        return {
+          startSpan(args) {
+            calls.push(`start:${args.name}`);
+            events.push(args.event);
+            expect(args.type).toBe("eval");
+            expect(Object.keys(args).sort()).toEqual(["event", "name", "type"]);
+            return {
+              end() {
+                calls.push(`end:${args.name}`);
+              },
+            };
+          },
+          async flush() {
+            calls.push("flush");
+          },
+          async permalink() {
+            calls.push("permalink");
+            return "https://braintrust.dev/experiment/local-test";
+          },
+        };
+      },
+    );
+
+    expect(calls).toEqual([
+      "init:githits-cli-agent-evals/local-test",
+      "start:discovery/workload-a",
+      "end:discovery/workload-a",
+      "start:full/workload-a",
+      "end:full/workload-a",
+      "flush",
+      "permalink",
+    ]);
+    expect(
+      (events as Array<Record<string, unknown>>).map((event) =>
+        Object.keys(event).sort(),
+      ),
+    ).toEqual([
+      ["input", "metadata", "metrics", "output", "tags"],
+      ["input", "metadata", "metrics", "output", "tags"],
+    ]);
+    expect(
+      (events as Array<Record<string, unknown>>).some(
+        (event) => "scores" in event || "expected" in event || "id" in event,
+      ),
+    ).toBe(false);
+    expect(result).toEqual({
+      project: "githits-cli-agent-evals",
+      experiment: "local-test",
+      url: "https://braintrust.dev/experiment/local-test",
+      exportedRowCount: 2,
+    });
+    expect(JSON.stringify(result)).not.toContain(fixture.root);
+    expect(JSON.stringify(result)).not.toContain("Prompt for");
+    expect(JSON.stringify(result)).not.toContain("Answer for");
+  });
+
+  it("uses the pinned SDK span and initialization contracts", async () => {
+    const fixture = await createSuite();
+    const mapping = preflightAndMapBraintrustRows([
+      suiteInput("sdk", fixture.suitePath),
+    ]);
+    const init = buildBraintrustExperimentInit(mapping, {
+      project: "githits-cli-agent-evals",
+      experiment: "sdk-test",
+      source: "local",
+    });
+    const calls: string[] = [];
+    const sdk: import("./agent-eval-braintrust.ts").BraintrustSdk = {
+      initExperiment(project, options) {
+        calls.push(`init:${project}`);
+        expect(options).toEqual({
+          experiment: "sdk-test",
+          update: false,
+          metadata: init.metadata,
+          repoInfo: init.repoInfo,
+          gitMetadataSettings: { collect: "none" },
+        });
+        return {
+          startSpan(args) {
+            calls.push(`start:${args.name}`);
+            expect(args.type).toBe("eval");
+            expect(Object.keys(args.event).sort()).toEqual([
+              "input",
+              "metadata",
+              "metrics",
+              "output",
+              "tags",
+            ]);
+            return {
+              end() {
+                calls.push(`end:${args.name}`);
+              },
+            };
+          },
+          async flush() {
+            calls.push("flush");
+          },
+          async summarize(options) {
+            calls.push(`summary:${options.summarizeScores}`);
+            return { experimentUrl: "https://braintrust.dev/experiment/sdk" };
+          },
+        };
+      },
+    };
+    const result = await publishBraintrustRows(
+      mapping,
+      {
+        project: "githits-cli-agent-evals",
+        experiment: "sdk-test",
+        source: "local",
+      },
+      (publisherInit) => createBraintrustPublisher(publisherInit, sdk),
+    );
+
+    expect(calls).toEqual([
+      "init:githits-cli-agent-evals",
+      "start:discovery/workload-a",
+      "end:discovery/workload-a",
+      "flush",
+      "summary:false",
+    ]);
+    expect(result.url).toBe("https://braintrust.dev/experiment/sdk");
+  });
+
+  it("exports only a generated status error for failed rows", async () => {
+    const fixture = await createSuite({ processStatus: "failed" });
+    const mapping = preflightAndMapBraintrustRows([
+      suiteInput("failed-row", fixture.suitePath),
+    ]);
+    let event: BraintrustRowEvent | undefined;
+    await publishBraintrustRows(
+      mapping,
+      {
+        project: "githits-cli-agent-evals",
+        experiment: "failed-row-test",
+        source: "local",
+      },
+      () => ({
+        startSpan(args) {
+          event = args.event;
+          return { end() {} };
+        },
+        async flush() {},
+        async permalink() {
+          return undefined;
+        },
+      }),
+    );
+
+    expect(event).toBeDefined();
+    expect(Object.keys(event!).sort()).toEqual([
+      "error",
+      "input",
+      "metadata",
+      "metrics",
+      "output",
+      "tags",
+    ]);
+    expect(event!.error).toBe("eval_status:failed");
+    expect("scores" in event!).toBe(false);
+    expect("expected" in event!).toBe(false);
+    expect("id" in event!).toBe(false);
+  });
+
+  it("does not retry a failed row and does not flush partial exports", async () => {
+    const fixture = await createSuite({ scenarios: ["discovery", "full"] });
+    const mapping = preflightAndMapBraintrustRows([
+      suiteInput("failure", fixture.suitePath),
+    ]);
+    const calls: string[] = [];
+    await expect(
+      publishBraintrustRows(
+        mapping,
+        {
+          project: "githits-cli-agent-evals",
+          experiment: "failure-test",
+          source: "local",
+        },
+        () => ({
+          startSpan(args) {
+            calls.push(`start:${args.name}`);
+            return {
+              end() {
+                calls.push(`end:${args.name}`);
+                throw new Error("publisher failure");
+              },
+            };
+          },
+          async flush() {
+            calls.push("flush");
+          },
+          async permalink() {
+            calls.push("permalink");
+            return "https://braintrust.dev/should-not-be-used";
+          },
+        }),
+      ),
+    ).rejects.toThrow("publisher failure");
+    expect(calls).toEqual([
+      "start:discovery/workload-a",
+      "end:discovery/workload-a",
+    ]);
   });
 });

--- a/scripts/agent-eval-braintrust.test.ts
+++ b/scripts/agent-eval-braintrust.test.ts
@@ -644,6 +644,22 @@ describe("Braintrust eval row mapping", () => {
     expect(result.rows[0]!.input.prompt).toContain("Prompt for");
   });
 
+  it("rejects a suite input that contributes no workload cells", async () => {
+    const fixture = await createSuite();
+    mutateSuite(fixture, (artifact) => {
+      artifact.selectedWorkloads = [];
+      artifact.contentIdentity.workloads = [];
+      artifact.cells = [];
+    });
+    mutateMetrics(fixture, (metrics) => {
+      metrics.records = [];
+    });
+
+    expect(() =>
+      preflightAndMapBraintrustRows([suiteInput("empty", fixture.suitePath)]),
+    ).toThrow("suite empty has no workload cells");
+  });
+
   it("rejects invalid workload paths before exposing local roots", async () => {
     const fixture = await createSuite();
     mutateSuite(fixture, (artifact) => {
@@ -686,7 +702,7 @@ describe("Braintrust publisher boundary", () => {
         suites: mapping.suites,
         targetGit: mapping.rows[0]!.metadata.targetGit,
         measurementGit: mapping.rows[0]!.metadata.measurementGit,
-        suiteSchemaVersion: 3,
+        suiteSchemaVersion: mapping.suites[0]!.suiteSchemaVersion,
         reportSchemaVersion: mapping.rows[0]!.metadata.reportSchemaVersion,
         metricsSchemaVersion: mapping.rows[0]!.metadata.metricsSchemaVersion,
         exporterSchemaVersion: 1,
@@ -700,6 +716,22 @@ describe("Braintrust publisher boundary", () => {
       gitMetadataSettings: { collect: "none" },
     });
     expect(JSON.stringify(init)).not.toContain(fixture.root);
+  });
+
+  it("uses the mapped suite schema version for experiment metadata", async () => {
+    const fixture = await createSuite();
+    const mapping = preflightAndMapBraintrustRows([
+      suiteInput("provenance", fixture.suitePath),
+    ]);
+    mapping.suites[0]!.suiteSchemaVersion = 37;
+
+    const init = buildBraintrustExperimentInit(mapping, {
+      project: "githits-cli-agent-evals",
+      experiment: "provenance-test",
+      source: "local",
+    });
+
+    expect(init.metadata.suiteSchemaVersion).toBe(37);
   });
 
   it("starts and ends rows in order with exact event fields", async () => {

--- a/scripts/agent-eval-braintrust.ts
+++ b/scripts/agent-eval-braintrust.ts
@@ -659,7 +659,13 @@ function buildToolSpanDescriptors(
     assert(!toolBearing, "tool-bearing row has unknown logical telemetry");
     return [];
   }
-  if (telemetry.sequence.length === 0) return [];
+  if (telemetry.sequence.length === 0) {
+    assert(
+      record.tools.rawEventCount === 0,
+      "tool-bearing row has empty logical tool sequence",
+    );
+    return [];
+  }
   assert(
     parentTimes.startTime !== undefined && parentTimes.endTime !== undefined,
     "tool-bearing row has no valid parent span interval",

--- a/scripts/agent-eval-braintrust.ts
+++ b/scripts/agent-eval-braintrust.ts
@@ -262,7 +262,7 @@ export type BraintrustPublisherFactory = (
 ) => BraintrustPublisher | Promise<BraintrustPublisher>;
 
 export interface BraintrustSdkSpan {
-  end(): void | number;
+  end(): number;
 }
 
 export interface BraintrustSdkExperiment {
@@ -333,8 +333,8 @@ function normalizeWarning(value: string): string {
 }
 
 function normalizeSuiteWarning(value: string): string {
-  const shardFailure = value.match(/^(.+ shard failed):/);
-  return normalizeWarning(shardFailure ? shardFailure[1]! : value);
+  const shardFailure = value.match(/^(.+ shard failed):/)?.[1];
+  return normalizeWarning(shardFailure ?? value);
 }
 
 function suiteIdentity(suite: AgentEvalImportedSuite): SuiteIdentity {
@@ -740,7 +740,9 @@ export function preflightAndMapBraintrustRows(
     labels.add(input.label);
     return { input, suite: loadImportedSuite(input.suitePath) };
   });
-  const expectedIdentity = suiteIdentity(loaded[0]!.suite);
+  const firstLoaded = loaded[0];
+  assert(firstLoaded, "at least one suite input is required");
+  const expectedIdentity = suiteIdentity(firstLoaded.suite);
   const seenCells = new Set<string>();
   for (const item of loaded) preflightSuite(item, expectedIdentity, seenCells);
 
@@ -947,10 +949,9 @@ export function parseBraintrustArgs(
 
   for (let index = 0; index < argv.length; index += 1) {
     const flag = argv[index];
-    cliAssert(
-      flag !== undefined && flag.startsWith("--"),
-      `unknown argument: ${flag ?? ""}`,
-    );
+    if (!flag?.startsWith("--")) {
+      cliAssert(false, `unknown argument: ${flag ?? ""}`);
+    }
     if (flag === "--validate-only") {
       cliAssert(!seenFlags.has(flag), `duplicate argument: ${flag}`);
       seenFlags.add(flag);

--- a/scripts/agent-eval-braintrust.ts
+++ b/scripts/agent-eval-braintrust.ts
@@ -652,23 +652,28 @@ function buildToolSpanDescriptors(
   record: AgentEvalRecord,
   telemetry: ReturnType<typeof toolTelemetry>,
   parentTimes: { startTime?: number; endTime?: number },
+  cellId: string,
 ): BraintrustToolSpanDescriptor[] {
+  const withCell = (message: string): string => `${cellId}: ${message}`;
   const toolBearing =
     record.tools.rawEventCount > 0 || telemetry.sequence.length > 0;
   if (!telemetry.known) {
-    assert(!toolBearing, "tool-bearing row has unknown logical telemetry");
+    assert(
+      !toolBearing,
+      withCell("tool-bearing row has unknown logical telemetry"),
+    );
     return [];
   }
   if (telemetry.sequence.length === 0) {
     assert(
       record.tools.rawEventCount === 0,
-      "tool-bearing row has empty logical tool sequence",
+      withCell("tool-bearing row has empty logical tool sequence"),
     );
     return [];
   }
   assert(
     parentTimes.startTime !== undefined && parentTimes.endTime !== undefined,
-    "tool-bearing row has no valid parent span interval",
+    withCell("tool-bearing row has no valid parent span interval"),
   );
   const parentStart = parentTimes.startTime;
   const parentEnd = parentTimes.endTime;
@@ -678,33 +683,39 @@ function buildToolSpanDescriptors(
     const endTime = observedUnixSeconds(call.completedAt);
     assert(
       call.status !== "unknown",
-      `tool call ${index + 1} has unknown status`,
+      withCell(`tool call ${index + 1} has unknown status`),
     );
     assert(
       startTime !== undefined,
-      `tool call ${index + 1} has no valid observed start time`,
+      withCell(`tool call ${index + 1} has no valid observed start time`),
     );
     assert(
       startTime >= parentStart && startTime <= parentEnd,
-      `tool call ${index + 1} starts outside the parent span interval`,
+      withCell(
+        `tool call ${index + 1} starts outside the parent span interval`,
+      ),
     );
     if (call.status === "started") {
       assert(
         call.completedAt === null,
-        `started tool call ${index + 1} has a terminal observed time`,
+        withCell(`started tool call ${index + 1} has a terminal observed time`),
       );
     } else {
       assert(
         endTime !== undefined,
-        `terminal tool call ${index + 1} has no valid observed completion time`,
+        withCell(
+          `terminal tool call ${index + 1} has no valid observed completion time`,
+        ),
       );
       assert(
         endTime >= startTime,
-        `tool call ${index + 1} has a reverse observed interval`,
+        withCell(`tool call ${index + 1} has a reverse observed interval`),
       );
       assert(
         endTime >= parentStart && endTime <= parentEnd,
-        `tool call ${index + 1} ends outside the parent span interval`,
+        withCell(
+          `tool call ${index + 1} ends outside the parent span interval`,
+        ),
       );
     }
     const event: BraintrustToolSpanEvent = {
@@ -834,7 +845,12 @@ function mapCell(
   const prompt = readPromptArtifact(report, workload);
   const telemetry = toolTelemetry(record, workload);
   const spanTimes = recordedSpanTimes(record);
-  const toolSpans = buildToolSpanDescriptors(record, telemetry, spanTimes);
+  const toolSpans = buildToolSpanDescriptors(
+    record,
+    telemetry,
+    spanTimes,
+    cell.id,
+  );
   const final = workload.finalReport;
   const finalStatus = record.finalStatus ?? final?.status;
   const output: BraintrustRowOutput = {

--- a/scripts/agent-eval-braintrust.ts
+++ b/scripts/agent-eval-braintrust.ts
@@ -1,5 +1,11 @@
 import { createHash } from "node:crypto";
-import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
+import {
+  existsSync,
+  readFileSync,
+  realpathSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { relative, resolve } from "node:path";
 import type { AgentEvalRecord } from "./agent-eval-metrics.ts";
 import {
@@ -226,6 +232,34 @@ export interface BraintrustExportResult {
   url?: string;
   exportedRowCount: number;
 }
+
+export interface BraintrustCliOptions extends BraintrustExportOptions {
+  suites: BraintrustSuiteInput[];
+  resultOut?: string;
+  validateOnly: boolean;
+}
+
+export interface BraintrustCliResult {
+  schemaVersion: 1;
+  mode: "validate-only" | "export";
+  project: string;
+  experiment: string;
+  rowCount: number;
+  suites: BraintrustSuiteSummary[];
+  url?: string;
+}
+
+export interface BraintrustCliRuntime {
+  now?: () => Date;
+  env?: Readonly<Record<string, string | undefined>>;
+  publisherFactory?: BraintrustPublisherFactory;
+  writeFile?: (path: string, contents: string) => void;
+  print?: (line: string) => void;
+}
+
+export type BraintrustPublisherFactory = (
+  init: BraintrustExperimentInit,
+) => BraintrustPublisher | Promise<BraintrustPublisher>;
 
 export interface BraintrustSdkSpan {
   end(): void | number;
@@ -822,11 +856,7 @@ export async function createBraintrustPublisher(
 export async function publishBraintrustRows(
   mapping: BraintrustMappingResult,
   options: BraintrustExportOptions,
-  publisherFactory: (
-    init: BraintrustExperimentInit,
-  ) =>
-    | BraintrustPublisher
-    | Promise<BraintrustPublisher> = createBraintrustPublisher,
+  publisherFactory: BraintrustPublisherFactory = createBraintrustPublisher,
 ): Promise<BraintrustExportResult> {
   const init = buildBraintrustExperimentInit(mapping, options);
   const publisher = await publisherFactory(init);
@@ -846,4 +876,257 @@ export async function publishBraintrustRows(
     ...(url !== undefined ? { url } : {}),
     exportedRowCount: mapping.rows.length,
   };
+}
+
+const DEFAULT_BRAINTRUST_PROJECT = "githits-cli-agent-evals";
+
+function cliAssert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(`Braintrust CLI: ${message}`);
+}
+
+function readCliValue(
+  argv: readonly string[],
+  index: number,
+  flag: string,
+): { value: string; nextIndex: number } {
+  const value = argv[index + 1];
+  cliAssert(
+    value !== undefined && value.trim().length > 0 && !value.startsWith("--"),
+    `${flag} requires a value`,
+  );
+  return { value, nextIndex: index + 1 };
+}
+
+function parseSuiteInput(value: string): BraintrustSuiteInput {
+  const separator = value.indexOf("=");
+  cliAssert(
+    separator > 0 && separator < value.length - 1,
+    "--suite requires <label>=<suite.json>",
+  );
+  const label = value.slice(0, separator);
+  const suitePath = value.slice(separator + 1);
+  cliAssert(label.trim().length > 0, "suite label must not be empty");
+  cliAssert(suitePath.trim().length > 0, "suite path must not be empty");
+  return { label, suitePath };
+}
+
+function localExperimentName(now: Date): string {
+  cliAssert(!Number.isNaN(now.getTime()), "current time is invalid");
+  return `local-${now.toISOString().replace(/[^0-9A-Za-z]/g, "")}`;
+}
+
+function validateRunUrl(value: string): void {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error("Braintrust CLI: --run-url must be an HTTP(S) URL");
+  }
+  cliAssert(
+    url.protocol === "http:" || url.protocol === "https:",
+    "--run-url must be an HTTP(S) URL",
+  );
+}
+
+export function parseBraintrustArgs(
+  argv: readonly string[],
+  now: Date = new Date(),
+): BraintrustCliOptions {
+  const suites: BraintrustSuiteInput[] = [];
+  const seenSuiteLabels = new Set<string>();
+  const seenFlags = new Set<string>();
+  let project = DEFAULT_BRAINTRUST_PROJECT;
+  let experiment: string | undefined;
+  let source: BraintrustExportOptions["source"] = "local";
+  let githubRunId: string | undefined;
+  let githubRunAttempt: string | undefined;
+  let githubRunUrl: string | undefined;
+  let resultOut: string | undefined;
+  let validateOnly = false;
+  let experimentWasExplicit = false;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const flag = argv[index];
+    cliAssert(
+      flag !== undefined && flag.startsWith("--"),
+      `unknown argument: ${flag ?? ""}`,
+    );
+    if (flag === "--validate-only") {
+      cliAssert(!seenFlags.has(flag), `duplicate argument: ${flag}`);
+      seenFlags.add(flag);
+      validateOnly = true;
+      continue;
+    }
+
+    cliAssert(
+      flag === "--suite" ||
+        flag === "--project" ||
+        flag === "--experiment" ||
+        flag === "--source" ||
+        flag === "--run-id" ||
+        flag === "--run-attempt" ||
+        flag === "--run-url" ||
+        flag === "--result-out",
+      `unknown flag: ${flag}`,
+    );
+    const parsed = readCliValue(argv, index, flag);
+    index = parsed.nextIndex;
+
+    if (flag === "--suite") {
+      const suite = parseSuiteInput(parsed.value);
+      cliAssert(
+        !seenSuiteLabels.has(suite.label),
+        `duplicate suite label: ${suite.label}`,
+      );
+      seenSuiteLabels.add(suite.label);
+      suites.push(suite);
+      continue;
+    }
+
+    cliAssert(!seenFlags.has(flag), `duplicate argument: ${flag}`);
+    seenFlags.add(flag);
+    switch (flag) {
+      case "--project":
+        project = parsed.value;
+        break;
+      case "--experiment":
+        experiment = parsed.value;
+        experimentWasExplicit = true;
+        break;
+      case "--source":
+        cliAssert(
+          parsed.value === "local" || parsed.value === "github",
+          "--source must be local or github",
+        );
+        source = parsed.value;
+        break;
+      case "--run-id":
+        githubRunId = parsed.value;
+        break;
+      case "--run-attempt":
+        githubRunAttempt = parsed.value;
+        break;
+      case "--run-url":
+        githubRunUrl = parsed.value;
+        validateRunUrl(parsed.value);
+        break;
+      case "--result-out":
+        resultOut = parsed.value;
+        break;
+    }
+  }
+
+  cliAssert(suites.length > 0, "at least one --suite is required");
+  const hasGithubMetadata =
+    githubRunId !== undefined ||
+    githubRunAttempt !== undefined ||
+    githubRunUrl !== undefined;
+  if (source === "local") {
+    cliAssert(!hasGithubMetadata, "GitHub run fields require --source github");
+  } else {
+    cliAssert(
+      githubRunId !== undefined &&
+        githubRunAttempt !== undefined &&
+        githubRunUrl !== undefined,
+      "--source github requires --run-id, --run-attempt, and --run-url",
+    );
+    cliAssert(
+      experimentWasExplicit,
+      "--source github requires an explicit --experiment",
+    );
+    cliAssert(
+      experiment === `github-${githubRunId}-${githubRunAttempt}`,
+      "GitHub experiment must be github-<run-id>-<run-attempt>",
+    );
+  }
+
+  return {
+    suites,
+    project,
+    experiment: experiment ?? localExperimentName(now),
+    source,
+    ...(githubRunId !== undefined ? { githubRunId } : {}),
+    ...(githubRunAttempt !== undefined ? { githubRunAttempt } : {}),
+    ...(githubRunUrl !== undefined ? { githubRunUrl } : {}),
+    ...(resultOut !== undefined ? { resultOut } : {}),
+    validateOnly,
+  };
+}
+
+function hasBraintrustApiKey(runtime: BraintrustCliRuntime): boolean {
+  const environment = runtime.env ?? process.env;
+  return (
+    typeof environment.BRAINTRUST_API_KEY === "string" &&
+    environment.BRAINTRUST_API_KEY.length > 0
+  );
+}
+
+function buildCliResult(
+  mode: BraintrustCliResult["mode"],
+  options: BraintrustCliOptions,
+  mapping: BraintrustMappingResult,
+  url: string | undefined,
+): BraintrustCliResult {
+  return {
+    schemaVersion: 1,
+    mode,
+    project: options.project,
+    experiment: options.experiment,
+    rowCount: mapping.rows.length,
+    suites: mapping.suites,
+    ...(url !== undefined ? { url } : {}),
+  };
+}
+
+function writeCliResult(
+  path: string,
+  result: BraintrustCliResult,
+  writeFile: (path: string, contents: string) => void,
+): void {
+  writeFile(path, `${JSON.stringify(result, null, 2)}\n`);
+}
+
+export async function runBraintrustCli(
+  argv: readonly string[],
+  runtime: BraintrustCliRuntime = {},
+): Promise<BraintrustCliResult> {
+  const options = parseBraintrustArgs(argv, runtime.now?.() ?? new Date());
+  const mapping = preflightAndMapBraintrustRows(options.suites);
+  let result: BraintrustCliResult;
+  if (options.validateOnly) {
+    result = buildCliResult("validate-only", options, mapping, undefined);
+  } else {
+    cliAssert(
+      hasBraintrustApiKey(runtime),
+      "BRAINTRUST_API_KEY is required for network export",
+    );
+    const exported = await publishBraintrustRows(
+      mapping,
+      options,
+      runtime.publisherFactory,
+    );
+    result = buildCliResult("export", options, mapping, exported.url);
+  }
+  if (options.resultOut !== undefined) {
+    writeCliResult(
+      options.resultOut,
+      result,
+      runtime.writeFile ?? ((path, contents) => writeFileSync(path, contents)),
+    );
+  }
+  (runtime.print ?? ((line) => process.stdout.write(`${line}\n`)))(
+    JSON.stringify(result),
+  );
+  return result;
+}
+
+export async function btEvalMain(): Promise<void> {
+  await runBraintrustCli(process.argv.slice(2));
+}
+
+if (import.meta.main) {
+  btEvalMain().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
 }

--- a/scripts/agent-eval-braintrust.ts
+++ b/scripts/agent-eval-braintrust.ts
@@ -47,21 +47,22 @@ export interface BraintrustRowOutput {
 
 export interface BraintrustRowMetrics {
   [key: string]: unknown;
-  agent_duration_ms?: number;
-  logical_tool_calls?: number;
+  duration?: number;
+  tool_calls?: number;
+  tool_errors?: number;
   mcp_tool_calls?: number;
   cli_tool_calls?: number;
   tool_calls_started?: number;
   tool_calls_completed?: number;
-  tool_calls_failed?: number;
   tool_calls_unknown?: number;
   raw_tool_events?: number;
-  uncached_input_tokens?: number;
-  cached_input_tokens?: number;
-  cache_write_input_tokens?: number;
-  output_tokens?: number;
-  reasoning_output_tokens?: number;
-  estimated_cost_usd?: number;
+  prompt_tokens?: number;
+  prompt_cached_tokens?: number;
+  prompt_cache_creation_tokens?: number;
+  completion_tokens?: number;
+  completion_reasoning_tokens?: number;
+  tokens?: number;
+  estimated_cost?: number;
 }
 
 export interface BraintrustGitIdentity {
@@ -118,6 +119,7 @@ export interface BraintrustRowMetadata {
   intentProfile: string;
   intentFragmentHash: string | null;
   agent: string;
+  model: string | null;
   requestedModel: string | null;
   resolvedModel: string | null;
   reasoningEffort: string | null;
@@ -147,6 +149,8 @@ export interface BraintrustRow {
   metrics: BraintrustRowMetrics;
   metadata: BraintrustRowMetadata;
   tags: string[];
+  startTime?: number;
+  endTime?: number;
   error?: string;
 }
 
@@ -218,10 +222,15 @@ export interface BraintrustStartSpanArgs {
   name: string;
   type: "eval";
   event: BraintrustRowEvent;
+  startTime?: number;
+}
+
+export interface BraintrustEndSpanArgs {
+  endTime?: number;
 }
 
 export interface BraintrustSpan {
-  end(): void | Promise<void>;
+  end(args?: BraintrustEndSpanArgs): void | Promise<void>;
 }
 
 export interface BraintrustPublisher {
@@ -266,7 +275,7 @@ export type BraintrustPublisherFactory = (
 ) => BraintrustPublisher | Promise<BraintrustPublisher>;
 
 export interface BraintrustSdkSpan {
-  end(): number;
+  end(args?: BraintrustEndSpanArgs): number;
 }
 
 export interface BraintrustSdkExperiment {
@@ -533,21 +542,41 @@ function rowMetrics(
   telemetry: ReturnType<typeof toolTelemetry>,
 ): BraintrustRowMetrics {
   const metrics: BraintrustRowMetrics = {};
-  knownMetric(metrics, "agent_duration_ms", record.durationMs);
-  knownMetric(metrics, "raw_tool_events", record.tools.rawEventCount);
-  const tokens = record.usage.normalizedTokens;
-  knownMetric(metrics, "uncached_input_tokens", tokens.uncachedInputTokens);
-  knownMetric(metrics, "cached_input_tokens", tokens.cachedInputTokens);
   knownMetric(
     metrics,
-    "cache_write_input_tokens",
-    tokens.cacheWriteInputTokens,
+    "duration",
+    record.durationMs === null ? null : record.durationMs / 1000,
   );
-  knownMetric(metrics, "output_tokens", tokens.outputTokens);
-  knownMetric(metrics, "reasoning_output_tokens", tokens.reasoningOutputTokens);
-  knownMetric(metrics, "estimated_cost_usd", record.usage.cost.usd);
+  knownMetric(metrics, "raw_tool_events", record.tools.rawEventCount);
+  const providerUsage = record.usage.providerUsage;
+  if (providerUsage) {
+    knownMetric(metrics, "prompt_tokens", providerUsage.input_tokens);
+    knownMetric(
+      metrics,
+      "prompt_cached_tokens",
+      providerUsage.cached_input_tokens,
+    );
+    knownMetric(
+      metrics,
+      "prompt_cache_creation_tokens",
+      providerUsage.cache_write_input_tokens,
+    );
+    knownMetric(metrics, "completion_tokens", providerUsage.output_tokens);
+    knownMetric(
+      metrics,
+      "completion_reasoning_tokens",
+      providerUsage.reasoning_output_tokens,
+    );
+    knownMetric(
+      metrics,
+      "tokens",
+      providerUsage.input_tokens + providerUsage.output_tokens,
+    );
+  }
+  knownMetric(metrics, "estimated_cost", record.usage.cost.usd);
   if (telemetry.known) {
-    knownMetric(metrics, "logical_tool_calls", record.tools.logicalCallCount);
+    knownMetric(metrics, "tool_calls", record.tools.logicalCallCount);
+    knownMetric(metrics, "tool_errors", telemetry.statusCounts.failed);
     knownMetric(metrics, "mcp_tool_calls", telemetry.mcpCalls);
     knownMetric(metrics, "cli_tool_calls", telemetry.cliCalls);
     knownMetric(metrics, "tool_calls_started", telemetry.statusCounts.started);
@@ -556,10 +585,26 @@ function rowMetrics(
       "tool_calls_completed",
       telemetry.statusCounts.completed,
     );
-    knownMetric(metrics, "tool_calls_failed", telemetry.statusCounts.failed);
     knownMetric(metrics, "tool_calls_unknown", telemetry.statusCounts.unknown);
   }
   return metrics;
+}
+
+function recordedSpanTimes(record: AgentEvalRecord): {
+  startTime?: number;
+  endTime?: number;
+} {
+  if (record.startedAt === null || record.completedAt === null) return {};
+  const startTime = Date.parse(record.startedAt) / 1000;
+  const endTime = Date.parse(record.completedAt) / 1000;
+  if (
+    !Number.isFinite(startTime) ||
+    !Number.isFinite(endTime) ||
+    endTime < startTime
+  ) {
+    return {};
+  }
+  return { startTime, endTime };
 }
 
 function rowMetadata(
@@ -603,6 +648,7 @@ function rowMetadata(
     intentProfile: record.intentProfile,
     intentFragmentHash: record.intentFragmentHash,
     agent: record.agent,
+    model: record.resolvedModel ?? record.requestedModel,
     requestedModel: record.requestedModel,
     resolvedModel: record.resolvedModel,
     reasoningEffort: record.reasoningEffort,
@@ -664,6 +710,7 @@ function mapCell(
   );
   const prompt = readPromptArtifact(report, workload);
   const telemetry = toolTelemetry(record, workload);
+  const spanTimes = recordedSpanTimes(record);
   const final = workload.finalReport;
   const finalStatus = record.finalStatus ?? final?.status;
   const output: BraintrustRowOutput = {
@@ -710,6 +757,7 @@ function mapCell(
       telemetry,
     ),
     tags: telemetry.tags,
+    ...spanTimes,
     ...(status ? { error: `eval_status:${status}` } : {}),
   };
 }
@@ -857,8 +905,8 @@ export async function createBraintrustPublisher(
     startSpan(args): BraintrustSpan {
       const span = experiment.startSpan(args);
       return {
-        end: () => {
-          span.end();
+        end: (endArgs) => {
+          span.end(endArgs);
         },
       };
     },
@@ -880,8 +928,11 @@ export async function publishBraintrustRows(
       name: row.metadata.cellId,
       type: "eval",
       event: rowEvent(row),
+      ...(row.startTime !== undefined ? { startTime: row.startTime } : {}),
     });
-    await span.end();
+    await span.end(
+      row.endTime !== undefined ? { endTime: row.endTime } : undefined,
+    );
   }
   await publisher.flush();
   const url = await publisher.permalink();

--- a/scripts/agent-eval-braintrust.ts
+++ b/scripts/agent-eval-braintrust.ts
@@ -37,6 +37,7 @@ export interface BraintrustRowOutput {
 }
 
 export interface BraintrustRowMetrics {
+  [key: string]: unknown;
   agent_duration_ms?: number;
   logical_tool_calls?: number;
   mcp_tool_calls?: number;
@@ -95,6 +96,7 @@ export interface BraintrustToolSequenceEntry {
 }
 
 export interface BraintrustRowMetadata {
+  [key: string]: unknown;
   suiteLabel: string;
   suiteId: string;
   suiteName: string;
@@ -152,6 +154,101 @@ export interface BraintrustMappingResult {
   rows: BraintrustRow[];
   suites: BraintrustSuiteSummary[];
 }
+
+export interface BraintrustExportOptions {
+  project: string;
+  experiment: string;
+  source: "local" | "github";
+  githubRunId?: string;
+  githubRunAttempt?: string;
+  githubRunUrl?: string;
+}
+
+export interface BraintrustRowEvent {
+  input: BraintrustRowInput;
+  output: BraintrustRowOutput;
+  error?: string;
+  metrics: BraintrustRowMetrics;
+  metadata: BraintrustRowMetadata;
+  tags: string[];
+}
+
+export interface BraintrustExperimentMetadata {
+  [key: string]: unknown;
+  source: BraintrustExportOptions["source"];
+  githubRunId?: string;
+  githubRunAttempt?: string;
+  githubRunUrl?: string;
+  suites: BraintrustSuiteSummary[];
+  targetGit: BraintrustGitIdentity;
+  measurementGit: BraintrustGitIdentity;
+  suiteSchemaVersion: number;
+  reportSchemaVersion: number;
+  metricsSchemaVersion: number;
+  exporterSchemaVersion: number;
+  exporterVersion: string;
+}
+
+export interface BraintrustExperimentInit {
+  project: string;
+  experiment: string;
+  update: false;
+  metadata: BraintrustExperimentMetadata;
+  repoInfo: {
+    commit: string | null;
+    branch: string | null;
+    dirty: boolean | null;
+  };
+  gitMetadataSettings: {
+    collect: "none";
+  };
+}
+
+export interface BraintrustStartSpanArgs {
+  name: string;
+  type: "eval";
+  event: BraintrustRowEvent;
+}
+
+export interface BraintrustSpan {
+  end(): void | Promise<void>;
+}
+
+export interface BraintrustPublisher {
+  startSpan(args: BraintrustStartSpanArgs): BraintrustSpan;
+  flush(): Promise<void>;
+  permalink(): Promise<string | undefined>;
+}
+
+export interface BraintrustExportResult {
+  project: string;
+  experiment: string;
+  url?: string;
+  exportedRowCount: number;
+}
+
+export interface BraintrustSdkSpan {
+  end(): void | number;
+}
+
+export interface BraintrustSdkExperiment {
+  startSpan(args: BraintrustStartSpanArgs): BraintrustSdkSpan;
+  flush(): Promise<void>;
+  summarize(options: { summarizeScores: false }): Promise<{
+    experimentUrl?: string;
+  }>;
+}
+
+export interface BraintrustSdk {
+  initExperiment(
+    project: string,
+    options: Omit<BraintrustExperimentInit, "project">,
+  ): BraintrustSdkExperiment;
+}
+
+const BRAINTRUST_SUITE_SCHEMA_VERSION = 3;
+const BRAINTRUST_EXPORTER_SCHEMA_VERSION = 1;
+const BRAINTRUST_EXPORTER_VERSION = "1";
 
 interface LoadedBraintrustSuite {
   input: BraintrustSuiteInput;
@@ -634,5 +731,119 @@ export function preflightAndMapBraintrustRows(
         workloadCount: suite.artifact.selectedWorkloads.length,
       }))
       .sort((left, right) => compareStrings(left.label, right.label)),
+  };
+}
+
+function rowEvent(row: BraintrustRow): BraintrustRowEvent {
+  return {
+    input: row.input,
+    output: row.output,
+    ...(row.error ? { error: row.error } : {}),
+    metrics: row.metrics,
+    metadata: row.metadata,
+    tags: row.tags,
+  };
+}
+
+export function buildBraintrustExperimentInit(
+  mapping: BraintrustMappingResult,
+  options: BraintrustExportOptions,
+): BraintrustExperimentInit {
+  const firstRow = mapping.rows[0];
+  assert(firstRow, "cannot build experiment metadata without mapped rows");
+  const { metadata } = firstRow;
+  const experimentMetadata: BraintrustExperimentMetadata = {
+    source: options.source,
+    ...(options.githubRunId !== undefined
+      ? { githubRunId: options.githubRunId }
+      : {}),
+    ...(options.githubRunAttempt !== undefined
+      ? { githubRunAttempt: options.githubRunAttempt }
+      : {}),
+    ...(options.githubRunUrl !== undefined
+      ? { githubRunUrl: options.githubRunUrl }
+      : {}),
+    suites: mapping.suites,
+    targetGit: metadata.targetGit,
+    measurementGit: metadata.measurementGit,
+    suiteSchemaVersion: BRAINTRUST_SUITE_SCHEMA_VERSION,
+    reportSchemaVersion: metadata.reportSchemaVersion,
+    metricsSchemaVersion: metadata.metricsSchemaVersion,
+    exporterSchemaVersion: BRAINTRUST_EXPORTER_SCHEMA_VERSION,
+    exporterVersion: BRAINTRUST_EXPORTER_VERSION,
+  };
+  return {
+    project: options.project,
+    experiment: options.experiment,
+    update: false,
+    metadata: experimentMetadata,
+    repoInfo: {
+      commit: metadata.targetGit.sha,
+      branch: metadata.targetGit.branch,
+      dirty: metadata.targetGit.dirty,
+    },
+    gitMetadataSettings: { collect: "none" },
+  };
+}
+
+export async function createBraintrustPublisher(
+  init: BraintrustExperimentInit,
+  injectedSdk?: BraintrustSdk,
+): Promise<BraintrustPublisher> {
+  const sdkOptions: Omit<BraintrustExperimentInit, "project"> = {
+    experiment: init.experiment,
+    update: init.update,
+    metadata: init.metadata,
+    repoInfo: init.repoInfo,
+    gitMetadataSettings: init.gitMetadataSettings,
+  };
+  let experiment: BraintrustSdkExperiment;
+  if (injectedSdk) {
+    experiment = injectedSdk.initExperiment(init.project, sdkOptions);
+  } else {
+    const braintrust = await import("braintrust");
+    experiment = braintrust.initExperiment(init.project, sdkOptions);
+  }
+  return {
+    startSpan(args): BraintrustSpan {
+      const span = experiment.startSpan(args);
+      return {
+        end: () => {
+          span.end();
+        },
+      };
+    },
+    flush: () => experiment.flush(),
+    permalink: async () =>
+      (await experiment.summarize({ summarizeScores: false })).experimentUrl,
+  };
+}
+
+export async function publishBraintrustRows(
+  mapping: BraintrustMappingResult,
+  options: BraintrustExportOptions,
+  publisherFactory: (
+    init: BraintrustExperimentInit,
+  ) =>
+    | BraintrustPublisher
+    | Promise<BraintrustPublisher> = createBraintrustPublisher,
+): Promise<BraintrustExportResult> {
+  const init = buildBraintrustExperimentInit(mapping, options);
+  const publisher = await publisherFactory(init);
+  for (const row of mapping.rows) {
+    const span = publisher.startSpan({
+      name: row.metadata.cellId,
+      type: "eval",
+      event: rowEvent(row),
+    });
+    await span.end();
+  }
+  await publisher.flush();
+  const url = await publisher.permalink();
+  return {
+    project: options.project,
+    experiment: options.experiment,
+    ...(url !== undefined ? { url } : {}),
+    exportedRowCount: mapping.rows.length,
   };
 }

--- a/scripts/agent-eval-braintrust.ts
+++ b/scripts/agent-eval-braintrust.ts
@@ -305,6 +305,7 @@ function safeBaseExperiment(value: unknown): BraintrustBaseExperiment | null {
 export interface BraintrustPublisher {
   startSpan(args: BraintrustStartSpanArgs): BraintrustSpan;
   flush(): Promise<void>;
+  name(): Promise<string>;
   permalink(): Promise<string | undefined>;
   fetchBaseExperiment(): Promise<BraintrustBaseExperiment | null>;
 }
@@ -355,6 +356,7 @@ export interface BraintrustSdkSpan {
 export interface BraintrustSdkExperiment {
   startSpan(args: BraintrustStartSpanArgs): BraintrustSdkSpan;
   flush(): Promise<void>;
+  name: Promise<string>;
   summarize(options: { summarizeScores: false }): Promise<{
     experimentUrl?: string;
   }>;
@@ -1310,6 +1312,7 @@ export async function createBraintrustPublisher(
       return wrapSpan(experiment.startSpan(args));
     },
     flush: () => experiment.flush(),
+    name: () => experiment.name,
     permalink: async () =>
       (await experiment.summarize({ summarizeScores: false })).experimentUrl,
     fetchBaseExperiment: async () =>
@@ -1456,10 +1459,11 @@ export async function publishBraintrustRows(
   }
   await publisher.flush();
   const baseExperiment = await publisher.fetchBaseExperiment();
+  const experiment = await publisher.name();
   const url = await publisher.permalink();
   return {
     project: resolvedOptions.project,
-    experiment: init.experiment,
+    experiment,
     ...(url !== undefined ? { url } : {}),
     exportedRowCount: mapping.rows.length,
     baseExperiment,

--- a/scripts/agent-eval-braintrust.ts
+++ b/scripts/agent-eval-braintrust.ts
@@ -286,7 +286,7 @@ export interface BraintrustBaseExperiment {
 }
 
 function safeBaseExperiment(value: unknown): BraintrustBaseExperiment | null {
-  if (value === null || value === undefined) return null;
+  if (value === null) return null;
   assert(
     typeof value === "object" && value !== null,
     "Braintrust base experiment response is invalid",
@@ -306,7 +306,7 @@ export interface BraintrustPublisher {
   startSpan(args: BraintrustStartSpanArgs): BraintrustSpan;
   flush(): Promise<void>;
   permalink(): Promise<string | undefined>;
-  fetchBaseExperiment?(): Promise<BraintrustBaseExperiment | null>;
+  fetchBaseExperiment(): Promise<BraintrustBaseExperiment | null>;
 }
 
 export interface BraintrustExportResult {
@@ -314,7 +314,7 @@ export interface BraintrustExportResult {
   experiment: string;
   url?: string;
   exportedRowCount: number;
-  baseExperiment?: BraintrustBaseExperiment | null;
+  baseExperiment: BraintrustBaseExperiment | null;
 }
 
 export interface BraintrustCliOptions extends BraintrustExportOptions {
@@ -324,14 +324,14 @@ export interface BraintrustCliOptions extends BraintrustExportOptions {
 }
 
 export interface BraintrustCliResult {
-  schemaVersion: 1;
+  schemaVersion: 2;
   mode: "validate-only" | "export";
   project: string;
   experiment: string;
   rowCount: number;
   suites: BraintrustSuiteSummary[];
   url?: string;
-  baseExperiment?: BraintrustBaseExperiment | null;
+  baseExperiment: BraintrustBaseExperiment | null;
 }
 
 export interface BraintrustCliRuntime {
@@ -358,7 +358,7 @@ export interface BraintrustSdkExperiment {
   summarize(options: { summarizeScores: false }): Promise<{
     experimentUrl?: string;
   }>;
-  fetchBaseExperiment?(): Promise<BraintrustBaseExperiment | null>;
+  fetchBaseExperiment(): Promise<BraintrustBaseExperiment | null>;
 }
 
 export interface BraintrustSdkApiConnection {
@@ -1312,10 +1312,8 @@ export async function createBraintrustPublisher(
     flush: () => experiment.flush(),
     permalink: async () =>
       (await experiment.summarize({ summarizeScores: false })).experimentUrl,
-    fetchBaseExperiment: async () => {
-      const base = await experiment.fetchBaseExperiment?.();
-      return safeBaseExperiment(base);
-    },
+    fetchBaseExperiment: async () =>
+      safeBaseExperiment(await experiment.fetchBaseExperiment()),
   };
 }
 
@@ -1457,7 +1455,7 @@ export async function publishBraintrustRows(
     );
   }
   await publisher.flush();
-  const baseExperiment = (await publisher.fetchBaseExperiment?.()) ?? null;
+  const baseExperiment = await publisher.fetchBaseExperiment();
   const url = await publisher.permalink();
   return {
     project: resolvedOptions.project,
@@ -1712,7 +1710,7 @@ function buildCliResult(
   baseExperiment: BraintrustBaseExperiment | null,
 ): BraintrustCliResult {
   return {
-    schemaVersion: 1,
+    schemaVersion: 2,
     mode,
     project: options.project,
     experiment,
@@ -1768,7 +1766,7 @@ export async function runBraintrustCli(
       mapping,
       exported.experiment,
       exported.url,
-      exported.baseExperiment ?? null,
+      exported.baseExperiment,
     );
   }
   if (options.resultOut !== undefined) {

--- a/scripts/agent-eval-braintrust.ts
+++ b/scripts/agent-eval-braintrust.ts
@@ -203,8 +203,15 @@ export interface BraintrustMappingResult {
 
 export interface BraintrustExportOptions {
   project: string;
-  experiment: string;
+  experiment?: string;
   source: "local" | "github";
+  channel?: "local" | "main" | "pr";
+  branch?: string | null;
+  sha?: string | null;
+  pullRequestNumber?: string;
+  baseExperiment?: string;
+  baseExperimentId?: string;
+  now?: Date;
   githubRunId?: string;
   githubRunAttempt?: string;
   githubRunUrl?: string;
@@ -222,6 +229,10 @@ export interface BraintrustRowEvent {
 export interface BraintrustExperimentMetadata {
   [key: string]: unknown;
   source: BraintrustExportOptions["source"];
+  channel?: "local" | "main" | "pr";
+  branch?: string;
+  sha?: string;
+  pullRequestNumber?: string;
   githubRunId?: string;
   githubRunAttempt?: string;
   githubRunUrl?: string;
@@ -239,6 +250,9 @@ export interface BraintrustExperimentInit {
   project: string;
   experiment: string;
   update: false;
+  baseExperiment?: string;
+  baseExperimentId?: string;
+  tags?: string[];
   metadata: BraintrustExperimentMetadata;
   repoInfo: {
     commit: string | null;
@@ -266,10 +280,33 @@ export interface BraintrustSpan {
   end(args?: BraintrustEndSpanArgs): void | Promise<void>;
 }
 
+export interface BraintrustBaseExperiment {
+  id: string;
+  name: string;
+}
+
+function safeBaseExperiment(value: unknown): BraintrustBaseExperiment | null {
+  if (value === null || value === undefined) return null;
+  assert(
+    typeof value === "object" && value !== null,
+    "Braintrust base experiment response is invalid",
+  );
+  const candidate = value as { id?: unknown; name?: unknown };
+  assert(
+    typeof candidate.id === "string" &&
+      candidate.id.length > 0 &&
+      typeof candidate.name === "string" &&
+      candidate.name.length > 0,
+    "Braintrust base experiment response is invalid",
+  );
+  return { id: candidate.id, name: candidate.name };
+}
+
 export interface BraintrustPublisher {
   startSpan(args: BraintrustStartSpanArgs): BraintrustSpan;
   flush(): Promise<void>;
   permalink(): Promise<string | undefined>;
+  fetchBaseExperiment?(): Promise<BraintrustBaseExperiment | null>;
 }
 
 export interface BraintrustExportResult {
@@ -277,6 +314,7 @@ export interface BraintrustExportResult {
   experiment: string;
   url?: string;
   exportedRowCount: number;
+  baseExperiment?: BraintrustBaseExperiment | null;
 }
 
 export interface BraintrustCliOptions extends BraintrustExportOptions {
@@ -293,12 +331,14 @@ export interface BraintrustCliResult {
   rowCount: number;
   suites: BraintrustSuiteSummary[];
   url?: string;
+  baseExperiment?: BraintrustBaseExperiment | null;
 }
 
 export interface BraintrustCliRuntime {
   now?: () => Date;
   env?: Readonly<Record<string, string | undefined>>;
   publisherFactory?: BraintrustPublisherFactory;
+  baseResolver?: (project: string) => Promise<BraintrustBaseExperiment | null>;
   writeFile?: (path: string, contents: string) => void;
   print?: (line: string) => void;
 }
@@ -318,9 +358,23 @@ export interface BraintrustSdkExperiment {
   summarize(options: { summarizeScores: false }): Promise<{
     experimentUrl?: string;
   }>;
+  fetchBaseExperiment?(): Promise<BraintrustBaseExperiment | null>;
+}
+
+export interface BraintrustSdkApiConnection {
+  get_json(
+    objectType: string,
+    params?: Record<string, string | string[] | undefined>,
+    retries?: number,
+  ): Promise<unknown>;
+}
+
+export interface BraintrustSdkState {
+  apiConn(): BraintrustSdkApiConnection;
 }
 
 export interface BraintrustSdk {
+  login?(): Promise<BraintrustSdkState>;
   initExperiment(
     project: string,
     options: Omit<BraintrustExperimentInit, "project">,
@@ -352,8 +406,151 @@ interface PromptArtifact {
   sha256: string;
 }
 
+export type BraintrustChannel = "local" | "main" | "pr";
+
+export interface BraintrustExperimentIdentity {
+  source: BraintrustExportOptions["source"];
+  channel: BraintrustChannel;
+  branch: string;
+  sha: string;
+  pullRequestNumber?: string;
+  experiment: string;
+  tags: string[];
+}
+
+export interface BraintrustIdentityInput {
+  source: BraintrustExportOptions["source"];
+  channel?: BraintrustChannel;
+  branch: string | null | undefined;
+  sha: string | null | undefined;
+  pullRequestNumber?: string;
+  githubRunId?: string;
+  githubRunAttempt?: string;
+  experiment?: string;
+  now?: Date;
+}
+
 function assert(condition: unknown, message: string): asserts condition {
   if (!condition) throw new Error(`Braintrust preflight: ${message}`);
+}
+
+function assertNonEmptyIdentity(
+  value: string | null | undefined,
+  field: string,
+): string {
+  assert(
+    typeof value === "string" && value.trim().length > 0,
+    `${field} is required`,
+  );
+  return value;
+}
+
+function assertPositiveInteger(
+  value: string | undefined,
+  field: string,
+): string {
+  assert(
+    typeof value === "string" && /^[1-9]\d*$/.test(value),
+    `${field} must be a positive integer`,
+  );
+  return value;
+}
+
+function branchSlug(branch: string): string {
+  const slug = branch.replace(/[^A-Za-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+  assert(
+    slug.length > 0,
+    "branch must contain an ASCII alphanumeric character",
+  );
+  return slug.toLowerCase();
+}
+
+function buildIdentityTags(identity: {
+  source: BraintrustExportOptions["source"];
+  channel: BraintrustChannel;
+  branch: string;
+  sha: string;
+  pullRequestNumber?: string;
+}): string[] {
+  return [
+    `source:${identity.source}`,
+    `channel:${identity.channel}`,
+    `branch:${identity.branch}`,
+    `sha:${identity.sha}`,
+    ...(identity.pullRequestNumber !== undefined
+      ? [`pr:${identity.pullRequestNumber}`]
+      : []),
+  ];
+}
+
+export function buildBraintrustExperimentIdentity(
+  input: BraintrustIdentityInput,
+): BraintrustExperimentIdentity {
+  const channel =
+    input.channel ?? (input.source === "local" ? "local" : "main");
+  assert(
+    (input.source === "local" && channel === "local") ||
+      (input.source === "github" && (channel === "main" || channel === "pr")),
+    `source ${input.source} is incompatible with channel ${channel}`,
+  );
+  const branch = assertNonEmptyIdentity(input.branch, "branch");
+  const sha = assertNonEmptyIdentity(input.sha, "SHA");
+
+  let experiment: string;
+  const identity = {
+    source: input.source,
+    channel,
+    branch,
+    sha,
+    ...(input.pullRequestNumber !== undefined
+      ? { pullRequestNumber: input.pullRequestNumber }
+      : {}),
+  };
+  if (input.source === "github") {
+    assert(
+      input.experiment === undefined,
+      "--experiment is only permitted for local exports",
+    );
+    const runId = assertPositiveInteger(input.githubRunId, "GitHub run ID");
+    const attempt = assertPositiveInteger(
+      input.githubRunAttempt,
+      "GitHub run attempt",
+    );
+    if (channel === "main") {
+      assert(branch === "main", "GitHub main channel requires branch main");
+      assert(
+        input.pullRequestNumber === undefined,
+        "GitHub main channel must not have a pull-request number",
+      );
+      experiment = `main-r${runId}-a${attempt}`;
+    } else {
+      const pullRequestNumber = assertPositiveInteger(
+        input.pullRequestNumber,
+        "pull-request number",
+      );
+      experiment = `pr-${pullRequestNumber}-r${runId}-a${attempt}`;
+    }
+  } else {
+    assert(
+      input.pullRequestNumber === undefined &&
+        input.githubRunId === undefined &&
+        input.githubRunAttempt === undefined,
+      "GitHub identity fields require source github",
+    );
+    const now = input.now ?? new Date();
+    assert(!Number.isNaN(now.getTime()), "current time is invalid");
+    experiment =
+      input.experiment ??
+      `local-${branchSlug(branch)}-${now
+        .toISOString()
+        .replace(/[^0-9A-Za-z]/g, "")}-${sha.slice(0, 8)}`;
+    assertNonEmptyIdentity(experiment, "experiment");
+  }
+  return {
+    ...identity,
+    experiment,
+    tags: buildIdentityTags(identity),
+  };
 }
 
 function uniqueSorted(values: readonly string[]): string[] {
@@ -990,8 +1187,53 @@ export function buildBraintrustExperimentInit(
   const firstSuite = mapping.suites[0];
   assert(firstSuite, "cannot build experiment metadata without mapped suites");
   const { metadata } = firstRow;
-  const experimentMetadata: BraintrustExperimentMetadata = {
+  const branch =
+    options.branch !== undefined
+      ? options.branch
+      : options.source === "github"
+        ? null
+        : metadata.targetGit.branch;
+  const sha = options.sha !== undefined ? options.sha : metadata.targetGit.sha;
+  if (options.source === "local") {
+    assert(
+      options.githubRunId === undefined &&
+        options.githubRunAttempt === undefined &&
+        options.githubRunUrl === undefined,
+      "GitHub run fields require source github",
+    );
+  }
+  const identity = buildBraintrustExperimentIdentity({
     source: options.source,
+    channel: options.channel,
+    branch,
+    sha,
+    pullRequestNumber: options.pullRequestNumber,
+    githubRunId: options.githubRunId,
+    githubRunAttempt: options.githubRunAttempt,
+    experiment: options.experiment,
+    now: options.now,
+  });
+  if (options.baseExperiment !== undefined) {
+    assert(
+      options.source === "local",
+      "explicit base experiment is only permitted for local exports",
+    );
+    assertNonEmptyIdentity(options.baseExperiment, "base experiment");
+  }
+  if (
+    options.baseExperiment === undefined &&
+    options.baseExperimentId !== undefined
+  ) {
+    assertNonEmptyIdentity(options.baseExperimentId, "base experiment ID");
+  }
+  const experimentMetadata: BraintrustExperimentMetadata = {
+    source: identity.source,
+    channel: identity.channel,
+    branch: identity.branch,
+    sha: identity.sha,
+    ...(identity.pullRequestNumber !== undefined
+      ? { pullRequestNumber: identity.pullRequestNumber }
+      : {}),
     ...(options.githubRunId !== undefined
       ? { githubRunId: options.githubRunId }
       : {}),
@@ -1012,12 +1254,20 @@ export function buildBraintrustExperimentInit(
   };
   return {
     project: options.project,
-    experiment: options.experiment,
+    experiment: identity.experiment,
     update: false,
+    ...(options.baseExperiment !== undefined
+      ? { baseExperiment: options.baseExperiment }
+      : {}),
+    ...(options.baseExperiment === undefined &&
+    options.baseExperimentId !== undefined
+      ? { baseExperimentId: options.baseExperimentId }
+      : {}),
+    tags: identity.tags,
     metadata: experimentMetadata,
     repoInfo: {
-      commit: metadata.targetGit.sha,
-      branch: metadata.targetGit.branch,
+      commit: identity.sha,
+      branch: identity.branch,
       dirty: metadata.targetGit.dirty,
     },
     gitMetadataSettings: { collect: "none" },
@@ -1031,6 +1281,13 @@ export async function createBraintrustPublisher(
   const sdkOptions: Omit<BraintrustExperimentInit, "project"> = {
     experiment: init.experiment,
     update: init.update,
+    ...(init.baseExperiment !== undefined
+      ? { baseExperiment: init.baseExperiment }
+      : {}),
+    ...(init.baseExperimentId !== undefined
+      ? { baseExperimentId: init.baseExperimentId }
+      : {}),
+    tags: init.tags,
     metadata: init.metadata,
     repoInfo: init.repoInfo,
     gitMetadataSettings: init.gitMetadataSettings,
@@ -1055,15 +1312,127 @@ export async function createBraintrustPublisher(
     flush: () => experiment.flush(),
     permalink: async () =>
       (await experiment.summarize({ summarizeScores: false })).experimentUrl,
+    fetchBaseExperiment: async () => {
+      const base = await experiment.fetchBaseExperiment?.();
+      return safeBaseExperiment(base);
+    },
   };
+}
+
+const BRAINTRUST_EXPERIMENT_PAGE_SIZE = "100";
+
+interface BraintrustListedExperiment {
+  id: string;
+  name: string;
+  metadata?: Record<string, unknown> | null;
+}
+
+function listedExperiments(value: unknown): BraintrustListedExperiment[] {
+  assert(
+    typeof value === "object" && value !== null && "objects" in value,
+    "Braintrust experiment list response is invalid",
+  );
+  const objects = (value as { objects?: unknown }).objects;
+  assert(
+    Array.isArray(objects),
+    "Braintrust experiment list response is invalid",
+  );
+  return objects.map((candidate) => {
+    assert(
+      typeof candidate === "object" && candidate !== null,
+      "Braintrust experiment list item is invalid",
+    );
+    const item = candidate as {
+      id?: unknown;
+      name?: unknown;
+      metadata?: unknown;
+    };
+    assert(
+      typeof item.id === "string" &&
+        item.id.length > 0 &&
+        typeof item.name === "string",
+      "Braintrust experiment list item is invalid",
+    );
+    return {
+      id: item.id,
+      name: item.name,
+      ...(item.metadata !== undefined
+        ? {
+            metadata: (item.metadata ?? null) as Record<string, unknown> | null,
+          }
+        : {}),
+    };
+  });
+}
+
+export async function resolveBraintrustMainExperiment(
+  project: string,
+  injectedSdk?: BraintrustSdk,
+): Promise<BraintrustBaseExperiment | null> {
+  const sdk =
+    injectedSdk ?? ((await import("braintrust")) as unknown as BraintrustSdk);
+  assert(typeof sdk.login === "function", "Braintrust login is unavailable");
+  const state = await sdk.login();
+  const api = state.apiConn();
+  let startingAfter: string | undefined;
+  while (true) {
+    const page = listedExperiments(
+      await api.get_json(
+        "v1/experiment",
+        {
+          project_name: project,
+          limit: BRAINTRUST_EXPERIMENT_PAGE_SIZE,
+          ...(startingAfter !== undefined
+            ? { starting_after: startingAfter }
+            : {}),
+        },
+        0,
+      ),
+    );
+    for (const experiment of page) {
+      if (
+        experiment.metadata?.channel === "main" &&
+        /^main-r\d+-a\d+$/.test(experiment.name)
+      ) {
+        return safeBaseExperiment(experiment);
+      }
+    }
+    if (page.length < Number(BRAINTRUST_EXPERIMENT_PAGE_SIZE)) return null;
+    const final = page[page.length - 1];
+    assert(final, "Braintrust experiment list page is empty");
+    startingAfter = final.id;
+  }
 }
 
 export async function publishBraintrustRows(
   mapping: BraintrustMappingResult,
   options: BraintrustExportOptions,
   publisherFactory: BraintrustPublisherFactory = createBraintrustPublisher,
+  baseResolver?: (project: string) => Promise<BraintrustBaseExperiment | null>,
 ): Promise<BraintrustExportResult> {
-  const init = buildBraintrustExperimentInit(mapping, options);
+  let resolvedOptions = options;
+  const channel =
+    options.channel ?? (options.source === "local" ? "local" : "main");
+  if (options.baseExperiment !== undefined) {
+    cliAssert(
+      options.source === "local",
+      "explicit base experiment is only permitted for local exports",
+    );
+  } else if (
+    options.baseExperimentId === undefined &&
+    baseResolver !== undefined
+  ) {
+    const base = safeBaseExperiment(await baseResolver(options.project));
+    cliAssert(
+      base !== null || channel === "main",
+      `no main Braintrust baseline exists for ${channel} export`,
+    );
+    resolvedOptions = {
+      ...options,
+      ...(base !== null ? { baseExperimentId: base.id } : {}),
+    };
+  }
+  const init = buildBraintrustExperimentInit(mapping, resolvedOptions);
   const publisher = await publisherFactory(init);
   for (const row of mapping.rows) {
     const span = publisher.startSpan({
@@ -1088,12 +1457,14 @@ export async function publishBraintrustRows(
     );
   }
   await publisher.flush();
+  const baseExperiment = (await publisher.fetchBaseExperiment?.()) ?? null;
   const url = await publisher.permalink();
   return {
-    project: options.project,
-    experiment: options.experiment,
+    project: resolvedOptions.project,
+    experiment: init.experiment,
     ...(url !== undefined ? { url } : {}),
     exportedRowCount: mapping.rows.length,
+    baseExperiment,
   };
 }
 
@@ -1129,11 +1500,6 @@ function parseSuiteInput(value: string): BraintrustSuiteInput {
   return { label, suitePath };
 }
 
-function localExperimentName(now: Date): string {
-  cliAssert(!Number.isNaN(now.getTime()), "current time is invalid");
-  return `local-${now.toISOString().replace(/[^0-9A-Za-z]/g, "")}`;
-}
-
 function validateRunUrl(value: string): void {
   let url: URL;
   try {
@@ -1151,12 +1517,17 @@ export function parseBraintrustArgs(
   argv: readonly string[],
   now: Date = new Date(),
 ): BraintrustCliOptions {
+  cliAssert(!Number.isNaN(now.getTime()), "current time is invalid");
   const suites: BraintrustSuiteInput[] = [];
   const seenSuiteLabels = new Set<string>();
   const seenFlags = new Set<string>();
   let project = DEFAULT_BRAINTRUST_PROJECT;
   let experiment: string | undefined;
   let source: BraintrustExportOptions["source"] = "local";
+  let channel: BraintrustChannel | undefined;
+  let branch: string | null | undefined;
+  let pullRequestNumber: string | undefined;
+  let baseExperiment: string | undefined;
   let githubRunId: string | undefined;
   let githubRunAttempt: string | undefined;
   let githubRunUrl: string | undefined;
@@ -1181,6 +1552,10 @@ export function parseBraintrustArgs(
         flag === "--project" ||
         flag === "--experiment" ||
         flag === "--source" ||
+        flag === "--channel" ||
+        flag === "--branch" ||
+        flag === "--pr-number" ||
+        flag === "--base-experiment" ||
         flag === "--run-id" ||
         flag === "--run-attempt" ||
         flag === "--run-url" ||
@@ -1218,6 +1593,24 @@ export function parseBraintrustArgs(
         );
         source = parsed.value;
         break;
+      case "--channel":
+        cliAssert(
+          parsed.value === "local" ||
+            parsed.value === "main" ||
+            parsed.value === "pr",
+          "--channel must be local, main, or pr",
+        );
+        channel = parsed.value;
+        break;
+      case "--branch":
+        branch = parsed.value;
+        break;
+      case "--pr-number":
+        pullRequestNumber = parsed.value;
+        break;
+      case "--base-experiment":
+        baseExperiment = parsed.value;
+        break;
       case "--run-id":
         githubRunId = parsed.value;
         break;
@@ -1241,6 +1634,14 @@ export function parseBraintrustArgs(
     githubRunUrl !== undefined;
   if (source === "local") {
     cliAssert(!hasGithubMetadata, "GitHub run fields require --source github");
+    cliAssert(
+      channel === undefined || channel === "local",
+      "local source requires local channel",
+    );
+    cliAssert(
+      pullRequestNumber === undefined,
+      "pull-request number requires a GitHub pull-request channel",
+    );
   } else {
     cliAssert(
       githubRunId !== undefined &&
@@ -1249,20 +1650,43 @@ export function parseBraintrustArgs(
       "--source github requires --run-id, --run-attempt, and --run-url",
     );
     cliAssert(
-      experimentWasExplicit,
-      "--source github requires an explicit --experiment",
+      !experimentWasExplicit,
+      "--experiment is only permitted for local exports",
     );
     cliAssert(
-      experiment === `github-${githubRunId}-${githubRunAttempt}`,
-      "GitHub experiment must be github-<run-id>-<run-attempt>",
+      typeof branch === "string" && branch.trim().length > 0,
+      "GitHub source requires --branch",
+    );
+    cliAssert(
+      channel === "main" || channel === "pr",
+      "GitHub source requires --channel main or pr",
+    );
+    if (channel === "pr") {
+      cliAssert(
+        pullRequestNumber !== undefined && /^[1-9]\d*$/.test(pullRequestNumber),
+        "pull-request channel requires a positive numeric --pr-number",
+      );
+    } else {
+      cliAssert(
+        pullRequestNumber === undefined,
+        "main channel must not have --pr-number",
+      );
+    }
+    cliAssert(
+      baseExperiment === undefined,
+      "--base-experiment is only permitted for local exports",
     );
   }
 
   return {
     suites,
     project,
-    experiment: experiment ?? localExperimentName(now),
     source,
+    channel: channel ?? (source === "local" ? "local" : "main"),
+    ...(experiment !== undefined ? { experiment } : {}),
+    ...(branch !== undefined ? { branch } : {}),
+    ...(pullRequestNumber !== undefined ? { pullRequestNumber } : {}),
+    ...(baseExperiment !== undefined ? { baseExperiment } : {}),
     ...(githubRunId !== undefined ? { githubRunId } : {}),
     ...(githubRunAttempt !== undefined ? { githubRunAttempt } : {}),
     ...(githubRunUrl !== undefined ? { githubRunUrl } : {}),
@@ -1283,16 +1707,19 @@ function buildCliResult(
   mode: BraintrustCliResult["mode"],
   options: BraintrustCliOptions,
   mapping: BraintrustMappingResult,
+  experiment: string,
   url: string | undefined,
+  baseExperiment: BraintrustBaseExperiment | null,
 ): BraintrustCliResult {
   return {
     schemaVersion: 1,
     mode,
     project: options.project,
-    experiment: options.experiment,
+    experiment,
     rowCount: mapping.rows.length,
     suites: mapping.suites,
     ...(url !== undefined ? { url } : {}),
+    baseExperiment,
   };
 }
 
@@ -1308,11 +1735,21 @@ export async function runBraintrustCli(
   argv: readonly string[],
   runtime: BraintrustCliRuntime = {},
 ): Promise<BraintrustCliResult> {
-  const options = parseBraintrustArgs(argv, runtime.now?.() ?? new Date());
-  const mapping = preflightAndMapBraintrustRows(options.suites);
+  const now = runtime.now?.() ?? new Date();
+  const parsedOptions = parseBraintrustArgs(argv, now);
+  const mapping = preflightAndMapBraintrustRows(parsedOptions.suites);
+  const options: BraintrustCliOptions = { ...parsedOptions, now };
+  const init = buildBraintrustExperimentInit(mapping, options);
   let result: BraintrustCliResult;
   if (options.validateOnly) {
-    result = buildCliResult("validate-only", options, mapping, undefined);
+    result = buildCliResult(
+      "validate-only",
+      options,
+      mapping,
+      init.experiment,
+      undefined,
+      null,
+    );
   } else {
     cliAssert(
       hasBraintrustApiKey(runtime),
@@ -1322,8 +1759,17 @@ export async function runBraintrustCli(
       mapping,
       options,
       runtime.publisherFactory,
+      runtime.baseResolver ??
+        ((project) => resolveBraintrustMainExperiment(project)),
     );
-    result = buildCliResult("export", options, mapping, exported.url);
+    result = buildCliResult(
+      "export",
+      options,
+      mapping,
+      exported.experiment,
+      exported.url,
+      exported.baseExperiment ?? null,
+    );
   }
   if (options.resultOut !== undefined) {
     writeCliResult(

--- a/scripts/agent-eval-braintrust.ts
+++ b/scripts/agent-eval-braintrust.ts
@@ -48,8 +48,6 @@ export interface BraintrustRowOutput {
 export interface BraintrustRowMetrics {
   [key: string]: unknown;
   duration?: number;
-  tool_calls?: number;
-  tool_errors?: number;
   mcp_tool_calls?: number;
   cli_tool_calls?: number;
   tool_calls_started?: number;
@@ -103,6 +101,36 @@ export interface BraintrustToolSequenceEntry {
   tool: string;
   surface: "mcp" | "cli";
   status: "started" | "completed" | "failed" | "unknown";
+  startedAt: string | null;
+  completedAt: string | null;
+}
+
+export interface BraintrustToolSpanEvent {
+  input: {
+    tool: string;
+    surface: "mcp" | "cli";
+  };
+  output: {
+    status: "started" | "completed" | "failed";
+  };
+  metadata: {
+    tool: string;
+    surface: "mcp" | "cli";
+    timingSource: "harness_stdout_observed";
+  };
+  error?: "tool_status:failed";
+}
+
+export interface BraintrustToolSpanStartArgs {
+  name: string;
+  type: "tool";
+  event: BraintrustToolSpanEvent;
+  startTime: number;
+}
+
+export interface BraintrustToolSpanDescriptor
+  extends BraintrustToolSpanStartArgs {
+  endTime?: number;
 }
 
 export interface BraintrustRowMetadata {
@@ -149,6 +177,7 @@ export interface BraintrustRow {
   metrics: BraintrustRowMetrics;
   metadata: BraintrustRowMetadata;
   tags: string[];
+  toolSpans: BraintrustToolSpanDescriptor[];
   startTime?: number;
   endTime?: number;
   error?: string;
@@ -230,6 +259,7 @@ export interface BraintrustEndSpanArgs {
 }
 
 export interface BraintrustSpan {
+  startSpan(args: BraintrustToolSpanStartArgs): BraintrustSpan;
   end(args?: BraintrustEndSpanArgs): void | Promise<void>;
 }
 
@@ -275,6 +305,7 @@ export type BraintrustPublisherFactory = (
 ) => BraintrustPublisher | Promise<BraintrustPublisher>;
 
 export interface BraintrustSdkSpan {
+  startSpan(args: BraintrustToolSpanStartArgs): BraintrustSdkSpan;
   end(args?: BraintrustEndSpanArgs): number;
 }
 
@@ -520,6 +551,8 @@ function toolTelemetry(
       tool: call.tool,
       surface: call.surface,
       status: call.status,
+      startedAt: call.startedAt,
+      completedAt: call.completedAt,
     })),
     counts,
     tags: counts.map((entry) => `tool:${entry.surface}:${entry.tool}`),
@@ -575,8 +608,6 @@ function rowMetrics(
   }
   knownMetric(metrics, "estimated_cost", record.usage.cost.usd);
   if (telemetry.known) {
-    knownMetric(metrics, "tool_calls", record.tools.logicalCallCount);
-    knownMetric(metrics, "tool_errors", telemetry.statusCounts.failed);
     knownMetric(metrics, "mcp_tool_calls", telemetry.mcpCalls);
     knownMetric(metrics, "cli_tool_calls", telemetry.cliCalls);
     knownMetric(metrics, "tool_calls_started", telemetry.statusCounts.started);
@@ -605,6 +636,86 @@ function recordedSpanTimes(record: AgentEvalRecord): {
     return {};
   }
   return { startTime, endTime };
+}
+
+function observedUnixSeconds(value: string | null): number | undefined {
+  if (value === null) return undefined;
+  const milliseconds = Date.parse(value);
+  if (!Number.isFinite(milliseconds)) return undefined;
+  return milliseconds / 1000;
+}
+
+function buildToolSpanDescriptors(
+  record: AgentEvalRecord,
+  telemetry: ReturnType<typeof toolTelemetry>,
+  parentTimes: { startTime?: number; endTime?: number },
+): BraintrustToolSpanDescriptor[] {
+  const toolBearing =
+    record.tools.rawEventCount > 0 || telemetry.sequence.length > 0;
+  if (!telemetry.known) {
+    assert(!toolBearing, "tool-bearing row has unknown logical telemetry");
+    return [];
+  }
+  if (telemetry.sequence.length === 0) return [];
+  assert(
+    parentTimes.startTime !== undefined && parentTimes.endTime !== undefined,
+    "tool-bearing row has no valid parent span interval",
+  );
+  const parentStart = parentTimes.startTime;
+  const parentEnd = parentTimes.endTime;
+
+  return telemetry.sequence.map((call, index) => {
+    const startTime = observedUnixSeconds(call.startedAt);
+    const endTime = observedUnixSeconds(call.completedAt);
+    assert(
+      call.status !== "unknown",
+      `tool call ${index + 1} has unknown status`,
+    );
+    assert(
+      startTime !== undefined,
+      `tool call ${index + 1} has no valid observed start time`,
+    );
+    assert(
+      startTime >= parentStart && startTime <= parentEnd,
+      `tool call ${index + 1} starts outside the parent span interval`,
+    );
+    if (call.status === "started") {
+      assert(
+        call.completedAt === null,
+        `started tool call ${index + 1} has a terminal observed time`,
+      );
+    } else {
+      assert(
+        endTime !== undefined,
+        `terminal tool call ${index + 1} has no valid observed completion time`,
+      );
+      assert(
+        endTime >= startTime,
+        `tool call ${index + 1} has a reverse observed interval`,
+      );
+      assert(
+        endTime >= parentStart && endTime <= parentEnd,
+        `tool call ${index + 1} ends outside the parent span interval`,
+      );
+    }
+    const event: BraintrustToolSpanEvent = {
+      input: { tool: call.tool, surface: call.surface },
+      output: { status: call.status },
+      metadata: {
+        tool: call.tool,
+        surface: call.surface,
+        timingSource: "harness_stdout_observed",
+      },
+      ...(call.status === "failed" ? { error: "tool_status:failed" } : {}),
+    };
+    return {
+      name: call.tool,
+      type: "tool",
+      event,
+      startTime,
+      ...(endTime !== undefined ? { endTime } : {}),
+    };
+  });
 }
 
 function rowMetadata(
@@ -711,6 +822,7 @@ function mapCell(
   const prompt = readPromptArtifact(report, workload);
   const telemetry = toolTelemetry(record, workload);
   const spanTimes = recordedSpanTimes(record);
+  const toolSpans = buildToolSpanDescriptors(record, telemetry, spanTimes);
   const final = workload.finalReport;
   const finalStatus = record.finalStatus ?? final?.status;
   const output: BraintrustRowOutput = {
@@ -757,6 +869,7 @@ function mapCell(
       telemetry,
     ),
     tags: telemetry.tags,
+    toolSpans,
     ...spanTimes,
     ...(status ? { error: `eval_status:${status}` } : {}),
   };
@@ -901,14 +1014,15 @@ export async function createBraintrustPublisher(
     const braintrust = await import("braintrust");
     experiment = braintrust.initExperiment(init.project, sdkOptions);
   }
+  const wrapSpan = (span: BraintrustSdkSpan): BraintrustSpan => ({
+    startSpan: (args) => wrapSpan(span.startSpan(args)),
+    end: (endArgs) => {
+      span.end(endArgs);
+    },
+  });
   return {
     startSpan(args): BraintrustSpan {
-      const span = experiment.startSpan(args);
-      return {
-        end: (endArgs) => {
-          span.end(endArgs);
-        },
-      };
+      return wrapSpan(experiment.startSpan(args));
     },
     flush: () => experiment.flush(),
     permalink: async () =>
@@ -930,6 +1044,17 @@ export async function publishBraintrustRows(
       event: rowEvent(row),
       ...(row.startTime !== undefined ? { startTime: row.startTime } : {}),
     });
+    for (const toolSpan of row.toolSpans) {
+      const child = span.startSpan({
+        name: toolSpan.name,
+        type: toolSpan.type,
+        event: toolSpan.event,
+        startTime: toolSpan.startTime,
+      });
+      if (toolSpan.endTime !== undefined) {
+        await child.end({ endTime: toolSpan.endTime });
+      }
+    }
     await span.end(
       row.endTime !== undefined ? { endTime: row.endTime } : undefined,
     );

--- a/scripts/agent-eval-braintrust.ts
+++ b/scripts/agent-eval-braintrust.ts
@@ -7,7 +7,10 @@ import {
   writeFileSync,
 } from "node:fs";
 import { relative, resolve } from "node:path";
-import type { AgentEvalRecord } from "./agent-eval-metrics.ts";
+import type {
+  AgentEvalMetrics,
+  AgentEvalRecord,
+} from "./agent-eval-metrics.ts";
 import {
   type AgentEvalReport,
   isContainedRelativePath,
@@ -152,6 +155,7 @@ export interface BraintrustSuiteSummary {
   suiteId: string;
   suiteName: string;
   suiteSha256: string;
+  suiteSchemaVersion: number;
   scenarioCount: number;
   workloadCount: number;
 }
@@ -280,7 +284,6 @@ export interface BraintrustSdk {
   ): BraintrustSdkExperiment;
 }
 
-const BRAINTRUST_SUITE_SCHEMA_VERSION = 3;
 const BRAINTRUST_EXPORTER_SCHEMA_VERSION = 1;
 const BRAINTRUST_EXPORTER_VERSION = "1";
 
@@ -379,6 +382,7 @@ function reportWorkloadFor(
   scenario: AgentEvalSuiteScenario,
   workloadId: string,
 ): {
+  metrics: AgentEvalMetrics;
   record: AgentEvalRecord;
   report: AgentEvalReport;
   workload: WorkloadReport;
@@ -395,7 +399,7 @@ function reportWorkloadFor(
     (candidate) => candidate.id === workloadId,
   );
   assert(workload, `missing ${scenario}/${workloadId} report workload`);
-  return { record, report: shard.report, workload };
+  return { metrics: shard.metrics, record, report: shard.report, workload };
 }
 
 function readPromptArtifact(
@@ -564,6 +568,7 @@ function rowMetadata(
   scenario: AgentEvalSuiteScenario,
   workloadId: string,
   cellId: string,
+  metrics: AgentEvalMetrics,
   record: AgentEvalRecord,
   report: AgentEvalReport,
   workload: WorkloadReport,
@@ -591,7 +596,7 @@ function rowMetadata(
     suiteName: suite.artifact.suiteName,
     suiteSha256: suite.sha256,
     cellId,
-    runId: suite.shards[scenario]?.metrics?.runId ?? "unknown",
+    runId: metrics.runId,
     scenario,
     workloadId,
     guidanceProfile: record.guidanceProfile ?? "unknown",
@@ -616,7 +621,7 @@ function rowMetadata(
       dirty: suite.artifact.measurementGit.dirty,
     },
     reportSchemaVersion: report.schemaVersion,
-    metricsSchemaVersion: suite.shards[scenario]?.metrics?.schemaVersion ?? 0,
+    metricsSchemaVersion: metrics.schemaVersion,
     reportingContractSha256:
       suite.artifact.contentIdentity.reportingContract.sha256,
     resultSchemaSha256: suite.artifact.contentIdentity.resultSchema.sha256,
@@ -639,7 +644,7 @@ function mapCell(
   suite: AgentEvalImportedSuite,
   cell: AgentEvalImportedSuite["artifact"]["cells"][number],
 ): BraintrustRow {
-  const { record, report, workload } = reportWorkloadFor(
+  const { metrics, record, report, workload } = reportWorkloadFor(
     suite,
     cell.scenario,
     cell.workloadId,
@@ -698,6 +703,7 @@ function mapCell(
       cell.scenario,
       cell.workloadId,
       cell.id,
+      metrics,
       record,
       report,
       workload,
@@ -717,6 +723,10 @@ function preflightSuite(
   assert(
     !suite.artifact.dryRun && suite.artifact.status !== "dry-run",
     `suite ${input.label} is a dry-run`,
+  );
+  assert(
+    suite.artifact.cells.length > 0,
+    `suite ${input.label} has no workload cells`,
   );
   assertSameIdentity(expectedIdentity, suiteIdentity(suite));
   for (const cell of suite.artifact.cells) {
@@ -763,6 +773,7 @@ export function preflightAndMapBraintrustRows(
         suiteId: suite.artifact.suiteId,
         suiteName: suite.artifact.suiteName,
         suiteSha256: suite.sha256,
+        suiteSchemaVersion: suite.artifact.schemaVersion,
         scenarioCount: suite.artifact.matrix.scenarios.length,
         workloadCount: suite.artifact.selectedWorkloads.length,
       }))
@@ -787,6 +798,8 @@ export function buildBraintrustExperimentInit(
 ): BraintrustExperimentInit {
   const firstRow = mapping.rows[0];
   assert(firstRow, "cannot build experiment metadata without mapped rows");
+  const firstSuite = mapping.suites[0];
+  assert(firstSuite, "cannot build experiment metadata without mapped suites");
   const { metadata } = firstRow;
   const experimentMetadata: BraintrustExperimentMetadata = {
     source: options.source,
@@ -802,7 +815,7 @@ export function buildBraintrustExperimentInit(
     suites: mapping.suites,
     targetGit: metadata.targetGit,
     measurementGit: metadata.measurementGit,
-    suiteSchemaVersion: BRAINTRUST_SUITE_SCHEMA_VERSION,
+    suiteSchemaVersion: firstSuite.suiteSchemaVersion,
     reportSchemaVersion: metadata.reportSchemaVersion,
     metricsSchemaVersion: metadata.metricsSchemaVersion,
     exporterSchemaVersion: BRAINTRUST_EXPORTER_SCHEMA_VERSION,

--- a/scripts/agent-eval-braintrust.ts
+++ b/scripts/agent-eval-braintrust.ts
@@ -1,0 +1,638 @@
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
+import { relative, resolve } from "node:path";
+import type { AgentEvalRecord } from "./agent-eval-metrics.ts";
+import {
+  type AgentEvalReport,
+  isContainedRelativePath,
+  type WorkloadReport,
+} from "./agent-eval-report.ts";
+import {
+  type AgentEvalImportedSuite,
+  type AgentEvalSuiteScenario,
+  loadImportedSuite,
+} from "./agent-eval-suite.ts";
+
+export interface BraintrustSuiteInput {
+  label: string;
+  suitePath: string;
+}
+
+export interface BraintrustRowInput {
+  scenario: AgentEvalSuiteScenario;
+  workloadId: string;
+  workloadPath: string;
+  prompt: string;
+  promptSha256: string;
+}
+
+export interface BraintrustRowOutput {
+  cellStatus: string;
+  processStatus: string;
+  reportStatus: string;
+  finalStatus?: string;
+  answer?: string;
+  confidence?: string;
+  discovery?: string;
+}
+
+export interface BraintrustRowMetrics {
+  agent_duration_ms?: number;
+  logical_tool_calls?: number;
+  mcp_tool_calls?: number;
+  cli_tool_calls?: number;
+  tool_calls_started?: number;
+  tool_calls_completed?: number;
+  tool_calls_failed?: number;
+  tool_calls_unknown?: number;
+  raw_tool_events?: number;
+  uncached_input_tokens?: number;
+  cached_input_tokens?: number;
+  cache_write_input_tokens?: number;
+  output_tokens?: number;
+  reasoning_output_tokens?: number;
+  estimated_cost_usd?: number;
+}
+
+export interface BraintrustGitIdentity {
+  branch: string | null;
+  sha: string | null;
+  dirty: boolean | null;
+}
+
+export interface BraintrustToolStatusCounts {
+  started: number;
+  completed: number;
+  failed: number;
+  unknown: number;
+}
+
+export interface BraintrustToolCount {
+  surface: "mcp" | "cli";
+  tool: string;
+  total: number;
+  statusCounts: BraintrustToolStatusCounts;
+}
+
+export interface BraintrustRateSnapshot {
+  model: string;
+  currency: string;
+  unit: string;
+  effectiveDate: string;
+  source: string;
+  rates: {
+    uncachedInputUsdPerMillion: number;
+    cachedInputUsdPerMillion: number;
+    cacheWriteInputUsdPerMillion: number;
+    outputUsdPerMillion: number;
+  };
+}
+
+export interface BraintrustToolSequenceEntry {
+  tool: string;
+  surface: "mcp" | "cli";
+  status: "started" | "completed" | "failed" | "unknown";
+}
+
+export interface BraintrustRowMetadata {
+  suiteLabel: string;
+  suiteId: string;
+  suiteName: string;
+  suiteSha256: string;
+  cellId: string;
+  runId: string;
+  scenario: AgentEvalSuiteScenario;
+  workloadId: string;
+  guidanceProfile: string;
+  intentProfile: string;
+  intentFragmentHash: string | null;
+  agent: string;
+  requestedModel: string | null;
+  resolvedModel: string | null;
+  reasoningEffort: string | null;
+  agentVersion: string | null;
+  surface: string;
+  server: string;
+  experimentalTools: boolean;
+  targetGit: BraintrustGitIdentity;
+  measurementGit: BraintrustGitIdentity;
+  reportSchemaVersion: number;
+  metricsSchemaVersion: number;
+  reportingContractSha256: string;
+  resultSchemaSha256: string;
+  costKind: string;
+  costUncertainty: string;
+  rateSnapshot?: BraintrustRateSnapshot;
+  warnings: string[];
+  validationCategories: string[];
+  toolTelemetryKnown: boolean;
+  toolSequence?: BraintrustToolSequenceEntry[];
+  toolCounts?: BraintrustToolCount[];
+}
+
+export interface BraintrustRow {
+  input: BraintrustRowInput;
+  output: BraintrustRowOutput;
+  metrics: BraintrustRowMetrics;
+  metadata: BraintrustRowMetadata;
+  tags: string[];
+  error?: string;
+}
+
+export interface BraintrustSuiteSummary {
+  label: string;
+  suiteId: string;
+  suiteName: string;
+  suiteSha256: string;
+  scenarioCount: number;
+  workloadCount: number;
+}
+
+export interface BraintrustMappingResult {
+  rows: BraintrustRow[];
+  suites: BraintrustSuiteSummary[];
+}
+
+interface LoadedBraintrustSuite {
+  input: BraintrustSuiteInput;
+  suite: AgentEvalImportedSuite;
+}
+
+interface SuiteIdentity {
+  targetSha: string | null;
+  measurementSha: string | null;
+  agent: string;
+  model: string;
+  reasoningEffort: string;
+  surface: string;
+  server: string;
+  reportingContractSha256: string;
+  resultSchemaSha256: string;
+}
+
+interface PromptArtifact {
+  value: string;
+  sha256: string;
+}
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(`Braintrust preflight: ${message}`);
+}
+
+function uniqueSorted(values: readonly string[]): string[] {
+  return [...new Set(values.filter((value) => value.length > 0))].sort();
+}
+
+function compareStrings(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function normalizeWarning(value: string): string {
+  return value
+    .trim()
+    .replace(
+      /(?:^|[\s:(])\/(?!\/)[^,\s)]+|(?:\/Users\/|\/private\/|\/tmp\/|\/var\/|\/home\/|[A-Za-z]:[\\/])[^,\s)]+/g,
+      (match) =>
+        match.startsWith("/") ||
+        match.startsWith("\\") ||
+        /^[A-Za-z]:[\\/]/.test(match)
+          ? "<path>"
+          : `${match[0]}<path>`,
+    );
+}
+
+function normalizeSuiteWarning(value: string): string {
+  const shardFailure = value.match(/^(.+ shard failed):/);
+  return normalizeWarning(shardFailure ? shardFailure[1]! : value);
+}
+
+function suiteIdentity(suite: AgentEvalImportedSuite): SuiteIdentity {
+  const { artifact } = suite;
+  return {
+    targetSha: artifact.targetGit.sha,
+    measurementSha: artifact.measurementGit.sha,
+    agent: artifact.matrix.agent,
+    model: artifact.matrix.model,
+    reasoningEffort: artifact.matrix.reasoningEffort,
+    surface: artifact.matrix.surface,
+    server: artifact.matrix.server,
+    reportingContractSha256: artifact.contentIdentity.reportingContract.sha256,
+    resultSchemaSha256: artifact.contentIdentity.resultSchema.sha256,
+  };
+}
+
+function assertSameIdentity(
+  expected: SuiteIdentity,
+  actual: SuiteIdentity,
+): void {
+  for (const field of [
+    "targetSha",
+    "measurementSha",
+    "agent",
+    "model",
+    "reasoningEffort",
+    "surface",
+    "server",
+    "reportingContractSha256",
+    "resultSchemaSha256",
+  ] as const) {
+    assert(
+      expected[field] === actual[field],
+      `mixed ${field} across suite inputs`,
+    );
+  }
+}
+
+function reportWorkloadFor(
+  suite: AgentEvalImportedSuite,
+  scenario: AgentEvalSuiteScenario,
+  workloadId: string,
+): {
+  record: AgentEvalRecord;
+  report: AgentEvalReport;
+  workload: WorkloadReport;
+} {
+  const shard = suite.shards[scenario];
+  assert(shard, `missing ${scenario} child shard`);
+  assert(shard.metrics, `missing ${scenario} child metrics evidence`);
+  assert(shard.report, `missing ${scenario} child report evidence`);
+  const record = shard.metrics.records.find(
+    (candidate) => candidate.workloadId === workloadId,
+  );
+  assert(record, `missing ${scenario}/${workloadId} metrics record`);
+  const workload = shard.report.workloads.find(
+    (candidate) => candidate.id === workloadId,
+  );
+  assert(workload, `missing ${scenario}/${workloadId} report workload`);
+  return { record, report: shard.report, workload };
+}
+
+function readPromptArtifact(
+  report: AgentEvalReport,
+  workload: WorkloadReport,
+): PromptArtifact {
+  const reference = workload.artifacts.prompt;
+  assert(
+    typeof reference === "string" &&
+      reference.length > 0 &&
+      !reference.includes("\\") &&
+      isContainedRelativePath(reference),
+    "prompt artifact reference is missing or unsafe",
+  );
+  assert(
+    typeof report.runDir === "string" && report.runDir.length > 0,
+    "child report run directory is missing",
+  );
+  try {
+    const runDir = realpathSync(resolve(report.runDir));
+    const candidate = resolve(runDir, reference);
+    assert(
+      existsSync(candidate) && statSync(candidate).isFile(),
+      "prompt artifact is unreadable",
+    );
+    const promptPath = realpathSync(candidate);
+    const candidateRelative = relative(runDir, promptPath).replaceAll(
+      "\\",
+      "/",
+    );
+    assert(
+      isContainedRelativePath(candidateRelative),
+      "prompt artifact escapes child run directory",
+    );
+    const bytes = readFileSync(promptPath);
+    return {
+      value: bytes.toString("utf8"),
+      sha256: createHash("sha256").update(bytes).digest("hex"),
+    };
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      error.message.startsWith("Braintrust preflight:")
+    )
+      throw error;
+    throw new Error(
+      "Braintrust preflight: prompt artifact is missing or unreadable",
+    );
+  }
+}
+
+function toolTelemetry(
+  record: AgentEvalRecord,
+  workload: WorkloadReport,
+): {
+  known: boolean;
+  sequence: BraintrustToolSequenceEntry[];
+  counts: BraintrustToolCount[];
+  tags: string[];
+  statusCounts: BraintrustToolStatusCounts;
+  mcpCalls: number;
+  cliCalls: number;
+} {
+  const sequence = record.tools.sequence;
+  const known =
+    workload.metrics.callsByTool !== null &&
+    record.tools.logicalCallCount !== null &&
+    record.tools.logicalCallCount === sequence.length;
+  if (!known) {
+    return {
+      known: false,
+      sequence: [],
+      counts: [],
+      tags: [],
+      statusCounts: { started: 0, completed: 0, failed: 0, unknown: 0 },
+      mcpCalls: 0,
+      cliCalls: 0,
+    };
+  }
+  const statusCounts: BraintrustToolStatusCounts = {
+    started: sequence.filter((call) => call.status === "started").length,
+    completed: sequence.filter((call) => call.status === "completed").length,
+    failed: sequence.filter((call) => call.status === "failed").length,
+    unknown: sequence.filter((call) => call.status === "unknown").length,
+  };
+  const counts = workload.metrics.callsByTool
+    ? workload.metrics.callsByTool
+        .filter((entry) => entry.total > 0)
+        .map((entry) => ({
+          surface: entry.surface,
+          tool: entry.tool,
+          total: entry.total,
+          statusCounts: {
+            started: entry.started,
+            completed: entry.completed,
+            failed: entry.failed,
+            unknown: entry.unknown,
+          },
+        }))
+        .sort(
+          (left, right) =>
+            compareStrings(left.surface, right.surface) ||
+            compareStrings(left.tool, right.tool),
+        )
+    : [];
+  return {
+    known: true,
+    sequence: sequence.map((call) => ({
+      tool: call.tool,
+      surface: call.surface,
+      status: call.status,
+    })),
+    counts,
+    tags: counts.map((entry) => `tool:${entry.surface}:${entry.tool}`),
+    statusCounts,
+    mcpCalls: sequence.filter((call) => call.surface === "mcp").length,
+    cliCalls: sequence.filter((call) => call.surface === "cli").length,
+  };
+}
+
+function knownMetric(
+  target: BraintrustRowMetrics,
+  key: keyof BraintrustRowMetrics,
+  value: number | null | undefined,
+): void {
+  if (value !== null && value !== undefined) target[key] = value;
+}
+
+function rowMetrics(
+  record: AgentEvalRecord,
+  telemetry: ReturnType<typeof toolTelemetry>,
+): BraintrustRowMetrics {
+  const metrics: BraintrustRowMetrics = {};
+  knownMetric(metrics, "agent_duration_ms", record.durationMs);
+  knownMetric(metrics, "raw_tool_events", record.tools.rawEventCount);
+  const tokens = record.usage.normalizedTokens;
+  knownMetric(metrics, "uncached_input_tokens", tokens.uncachedInputTokens);
+  knownMetric(metrics, "cached_input_tokens", tokens.cachedInputTokens);
+  knownMetric(
+    metrics,
+    "cache_write_input_tokens",
+    tokens.cacheWriteInputTokens,
+  );
+  knownMetric(metrics, "output_tokens", tokens.outputTokens);
+  knownMetric(metrics, "reasoning_output_tokens", tokens.reasoningOutputTokens);
+  knownMetric(metrics, "estimated_cost_usd", record.usage.cost.usd);
+  if (telemetry.known) {
+    knownMetric(metrics, "logical_tool_calls", record.tools.logicalCallCount);
+    knownMetric(metrics, "mcp_tool_calls", telemetry.mcpCalls);
+    knownMetric(metrics, "cli_tool_calls", telemetry.cliCalls);
+    knownMetric(metrics, "tool_calls_started", telemetry.statusCounts.started);
+    knownMetric(
+      metrics,
+      "tool_calls_completed",
+      telemetry.statusCounts.completed,
+    );
+    knownMetric(metrics, "tool_calls_failed", telemetry.statusCounts.failed);
+    knownMetric(metrics, "tool_calls_unknown", telemetry.statusCounts.unknown);
+  }
+  return metrics;
+}
+
+function rowMetadata(
+  input: BraintrustSuiteInput,
+  suite: AgentEvalImportedSuite,
+  scenario: AgentEvalSuiteScenario,
+  workloadId: string,
+  cellId: string,
+  record: AgentEvalRecord,
+  report: AgentEvalReport,
+  workload: WorkloadReport,
+  telemetry: ReturnType<typeof toolTelemetry>,
+): BraintrustRowMetadata {
+  const cost = record.usage.cost;
+  const warnings = uniqueSorted(
+    [
+      ...suite.artifact.warnings.map(normalizeSuiteWarning),
+      ...report.metricsWarnings,
+      ...report.warnings,
+      ...record.warnings,
+      ...workload.metrics.telemetryWarnings,
+      ...workload.warnings,
+    ]
+      .map(normalizeWarning)
+      .filter((warning) => warning.length > 0),
+  );
+  const validationCategories = uniqueSorted(
+    workload.validationViolations.map((violation) => violation.category),
+  );
+  return {
+    suiteLabel: input.label,
+    suiteId: suite.artifact.suiteId,
+    suiteName: suite.artifact.suiteName,
+    suiteSha256: suite.sha256,
+    cellId,
+    runId: suite.shards[scenario]?.metrics?.runId ?? "unknown",
+    scenario,
+    workloadId,
+    guidanceProfile: record.guidanceProfile ?? "unknown",
+    intentProfile: record.intentProfile,
+    intentFragmentHash: record.intentFragmentHash,
+    agent: record.agent,
+    requestedModel: record.requestedModel,
+    resolvedModel: record.resolvedModel,
+    reasoningEffort: record.reasoningEffort,
+    agentVersion: record.agentVersion,
+    surface: record.surface,
+    server: record.server,
+    experimentalTools: record.experimentalTools,
+    targetGit: {
+      branch: suite.artifact.targetGit.branch,
+      sha: suite.artifact.targetGit.sha,
+      dirty: suite.artifact.targetGit.dirty,
+    },
+    measurementGit: {
+      branch: suite.artifact.measurementGit.branch,
+      sha: suite.artifact.measurementGit.sha,
+      dirty: suite.artifact.measurementGit.dirty,
+    },
+    reportSchemaVersion: report.schemaVersion,
+    metricsSchemaVersion: suite.shards[scenario]?.metrics?.schemaVersion ?? 0,
+    reportingContractSha256:
+      suite.artifact.contentIdentity.reportingContract.sha256,
+    resultSchemaSha256: suite.artifact.contentIdentity.resultSchema.sha256,
+    costKind: cost.kind,
+    costUncertainty: cost.uncertainty,
+    ...(cost.kind === "base_rate_estimate"
+      ? { rateSnapshot: cost.rateSnapshot }
+      : {}),
+    warnings,
+    validationCategories,
+    toolTelemetryKnown: telemetry.known,
+    ...(telemetry.known
+      ? { toolSequence: telemetry.sequence, toolCounts: telemetry.counts }
+      : {}),
+  };
+}
+
+function mapCell(
+  input: BraintrustSuiteInput,
+  suite: AgentEvalImportedSuite,
+  cell: AgentEvalImportedSuite["artifact"]["cells"][number],
+): BraintrustRow {
+  const { record, report, workload } = reportWorkloadFor(
+    suite,
+    cell.scenario,
+    cell.workloadId,
+  );
+  assert(
+    isContainedRelativePath(cell.workloadPath) &&
+      !cell.workloadPath.includes("\\"),
+    `workload path is not a safe relative path: ${cell.workloadId}`,
+  );
+  assert(
+    record.agent === suite.artifact.matrix.agent &&
+      record.requestedModel === suite.artifact.matrix.model &&
+      record.reasoningEffort === suite.artifact.matrix.reasoningEffort &&
+      record.surface === suite.artifact.matrix.surface &&
+      record.server === suite.artifact.matrix.server,
+    `mixed agent/model/reasoning/surface/server identity in ${cell.id}`,
+  );
+  const prompt = readPromptArtifact(report, workload);
+  const telemetry = toolTelemetry(record, workload);
+  const final = workload.finalReport;
+  const finalStatus = record.finalStatus ?? final?.status;
+  const output: BraintrustRowOutput = {
+    cellStatus: cell.status,
+    processStatus: record.processStatus,
+    reportStatus: workload.status,
+    ...(finalStatus ? { finalStatus } : {}),
+    ...(final?.answer !== undefined ? { answer: final.answer } : {}),
+    ...(final?.confidence !== undefined
+      ? { confidence: final.confidence }
+      : {}),
+    ...(workload.discovery ? { discovery: workload.discovery.status } : {}),
+  };
+  const status =
+    cell.status !== "success"
+      ? cell.status
+      : record.processStatus !== "success"
+        ? record.processStatus
+        : workload.status !== "success"
+          ? workload.status
+          : finalStatus && finalStatus !== "success"
+            ? finalStatus
+            : undefined;
+  return {
+    input: {
+      scenario: cell.scenario,
+      workloadId: cell.workloadId,
+      workloadPath: cell.workloadPath,
+      prompt: prompt.value,
+      promptSha256: prompt.sha256,
+    },
+    output,
+    metrics: rowMetrics(record, telemetry),
+    metadata: rowMetadata(
+      input,
+      suite,
+      cell.scenario,
+      cell.workloadId,
+      cell.id,
+      record,
+      report,
+      workload,
+      telemetry,
+    ),
+    tags: telemetry.tags,
+    ...(status ? { error: `eval_status:${status}` } : {}),
+  };
+}
+
+function preflightSuite(
+  loaded: LoadedBraintrustSuite,
+  expectedIdentity: SuiteIdentity,
+  seenCells: Set<string>,
+): void {
+  const { input, suite } = loaded;
+  assert(
+    !suite.artifact.dryRun && suite.artifact.status !== "dry-run",
+    `suite ${input.label} is a dry-run`,
+  );
+  assertSameIdentity(expectedIdentity, suiteIdentity(suite));
+  for (const cell of suite.artifact.cells) {
+    const key = `${cell.scenario}\0${cell.workloadId}`;
+    assert(
+      !seenCells.has(key),
+      `duplicate scenario/workload cell: ${key.replace("\0", "/")}`,
+    );
+    seenCells.add(key);
+  }
+}
+
+export function preflightAndMapBraintrustRows(
+  inputs: readonly BraintrustSuiteInput[],
+): BraintrustMappingResult {
+  assert(inputs.length > 0, "at least one suite input is required");
+  const labels = new Set<string>();
+  const loaded = inputs.map((input) => {
+    assert(input.label.length > 0, "suite labels must not be empty");
+    assert(!labels.has(input.label), `duplicate suite label: ${input.label}`);
+    labels.add(input.label);
+    return { input, suite: loadImportedSuite(input.suitePath) };
+  });
+  const expectedIdentity = suiteIdentity(loaded[0]!.suite);
+  const seenCells = new Set<string>();
+  for (const item of loaded) preflightSuite(item, expectedIdentity, seenCells);
+
+  const rows = loaded.flatMap(({ input, suite }) =>
+    suite.artifact.cells.map((cell) => mapCell(input, suite, cell)),
+  );
+  rows.sort(
+    (left, right) =>
+      compareStrings(left.metadata.suiteLabel, right.metadata.suiteLabel) ||
+      compareStrings(left.input.scenario, right.input.scenario) ||
+      compareStrings(left.input.workloadId, right.input.workloadId),
+  );
+  return {
+    rows,
+    suites: loaded
+      .map(({ input, suite }) => ({
+        label: input.label,
+        suiteId: suite.artifact.suiteId,
+        suiteName: suite.artifact.suiteName,
+        suiteSha256: suite.sha256,
+        scenarioCount: suite.artifact.matrix.scenarios.length,
+        workloadCount: suite.artifact.selectedWorkloads.length,
+      }))
+      .sort((left, right) => compareStrings(left.label, right.label)),
+  };
+}

--- a/scripts/agent-eval-braintrust.ts
+++ b/scripts/agent-eval-braintrust.ts
@@ -118,6 +118,9 @@ export interface BraintrustToolSpanEvent {
     surface: "mcp" | "cli";
     timingSource: "harness_stdout_observed";
   };
+  metrics?: {
+    duration: number;
+  };
   error?: "tool_status:failed";
 }
 
@@ -324,8 +327,8 @@ export interface BraintrustSdk {
   ): BraintrustSdkExperiment;
 }
 
-const BRAINTRUST_EXPORTER_SCHEMA_VERSION = 1;
-const BRAINTRUST_EXPORTER_VERSION = "1";
+const BRAINTRUST_EXPORTER_SCHEMA_VERSION = 2;
+const BRAINTRUST_EXPORTER_VERSION = "2";
 
 interface LoadedBraintrustSuite {
   input: BraintrustSuiteInput;
@@ -706,6 +709,9 @@ function buildToolSpanDescriptors(
         surface: call.surface,
         timingSource: "harness_stdout_observed",
       },
+      ...(endTime !== undefined
+        ? { metrics: { duration: endTime - startTime } }
+        : {}),
       ...(call.status === "failed" ? { error: "tool_status:failed" } : {}),
     };
     return {

--- a/scripts/agent-eval-metrics.test.ts
+++ b/scripts/agent-eval-metrics.test.ts
@@ -352,6 +352,70 @@ describe("agent eval usage metrics", () => {
     ]);
   });
 
+  it("rejects Codex terminal-then-started lifecycle transitions", () => {
+    const baseRecord: AgentEvalRecordInput = {
+      ...identityRecord("descriptors"),
+      workloadId: "terminal-then-started",
+      agent: "codex",
+      usage: adaptAgentUsage(
+        codexUsageEvent({
+          input_tokens: 1,
+          cached_input_tokens: 0,
+          cache_write_input_tokens: 0,
+          output_tokens: 1,
+          reasoning_output_tokens: 0,
+        }),
+        "codex",
+        LUNA_MODEL,
+      ),
+      toolCalls: [],
+    };
+
+    for (const observedAt of ["2026-08-28T10:00:00.300Z", undefined] as const) {
+      const metrics = buildAgentEvalMetrics({
+        runId: `run-terminal-then-started-${observedAt ?? "missing"}`,
+        startedAt: "2026-08-28T10:00:00.000Z",
+        completedAt: "2026-08-28T10:00:01.000Z",
+        records: [
+          {
+            ...baseRecord,
+            toolCalls: [
+              {
+                tool: "search",
+                server: "githits",
+                providerCallId: "replayed-call",
+                status: "completed",
+                observedAt: "2026-08-28T10:00:00.200Z",
+              },
+              {
+                tool: "search",
+                server: "githits",
+                providerCallId: "replayed-call",
+                status: "started",
+                ...(observedAt === undefined ? {} : { observedAt }),
+              },
+            ],
+          },
+        ],
+      });
+
+      expect(metrics.records[0]?.tools).toMatchObject({
+        rawEventCount: 2,
+        logicalCallCount: 1,
+        completedCount: 0,
+      });
+      expect(metrics.records[0]?.tools.sequence).toEqual([
+        {
+          tool: "search",
+          surface: "mcp",
+          status: "started",
+          startedAt: null,
+          completedAt: null,
+        },
+      ]);
+    }
+  });
+
   it("normalizes inclusive Luna usage and does not double-count reasoning", () => {
     const metrics = adaptAgentUsage(
       codexUsageEvent({

--- a/scripts/agent-eval-metrics.test.ts
+++ b/scripts/agent-eval-metrics.test.ts
@@ -55,7 +55,7 @@ function identityRecord(
 }
 
 describe("agent eval usage metrics", () => {
-  it("emits schema-v2 scenario identity with a SHA-256 intent hash", () => {
+  it("emits schema-v3 scenario identity with a SHA-256 intent hash", () => {
     const neutral = buildAgentEvalMetrics({
       runId: "run-neutral",
       startedAt: "2026-08-28T10:00:00.000Z",
@@ -69,7 +69,7 @@ describe("agent eval usage metrics", () => {
       records: [identityRecord("descriptors", "githits")],
     });
 
-    expect(neutral.schemaVersion).toBe(2);
+    expect(neutral.schemaVersion).toBe(3);
     expect(neutral.records[0]).toMatchObject({
       scenario: "discovery",
       intentProfile: "neutral",
@@ -103,7 +103,7 @@ describe("agent eval usage metrics", () => {
     };
     const normalized = parseAgentEvalMetrics(legacy);
 
-    expect(normalized.schemaVersion).toBe(2);
+    expect(normalized.schemaVersion).toBe(3);
     expect(normalized.records.map((record) => record.scenario)).toEqual([
       "discovery",
       "full",
@@ -122,6 +122,234 @@ describe("agent eval usage metrics", () => {
       current.records.map((record) => record.warnings),
     );
     expect(normalized.aggregates).toEqual(current.aggregates);
+  });
+
+  it("upgrades schema-v2 tool sequences with unknown timing", () => {
+    const current = buildAgentEvalMetrics({
+      runId: "run-v2",
+      startedAt: "2026-08-28T10:00:00.000Z",
+      completedAt: "2026-08-28T10:00:02.000Z",
+      records: [identityRecord("descriptors")],
+    });
+    const prior = {
+      ...current,
+      schemaVersion: 2,
+      records: current.records.map((record) => ({
+        ...record,
+        tools: {
+          ...record.tools,
+          sequence: record.tools.sequence.map(({ tool, surface, status }) => ({
+            tool,
+            surface,
+            status,
+          })),
+        },
+      })),
+    };
+
+    const normalized = parseAgentEvalMetrics(prior);
+
+    expect(normalized.schemaVersion).toBe(3);
+    expect(normalized.records[0]?.tools.sequence).toEqual([
+      {
+        tool: "pkg_info",
+        surface: "mcp",
+        status: "completed",
+        startedAt: null,
+        completedAt: null,
+      },
+    ]);
+  });
+
+  it("pairs Codex lifecycle observations with harness-observed boundaries", () => {
+    const record: AgentEvalRecordInput = {
+      ...identityRecord("descriptors"),
+      workloadId: "codex-timing",
+      agent: "codex",
+      usage: adaptAgentUsage(
+        codexUsageEvent({
+          input_tokens: 1,
+          cached_input_tokens: 0,
+          cache_write_input_tokens: 0,
+          output_tokens: 1,
+          reasoning_output_tokens: 0,
+        }),
+        "codex",
+        LUNA_MODEL,
+      ),
+      toolCalls: [
+        {
+          tool: "search",
+          server: "githits",
+          providerCallId: "mcp-1",
+          status: "in_progress",
+          observedAt: "2026-08-28T10:00:00.100Z",
+        },
+        {
+          tool: "search",
+          server: "githits",
+          providerCallId: "mcp-1",
+          status: "completed",
+          observedAt: "2026-08-28T10:00:00.300Z",
+        },
+        {
+          tool: "search",
+          server: "githits",
+          providerCallId: "mcp-2",
+          status: "in_progress",
+          observedAt: "2026-08-28T10:00:00.400Z",
+        },
+        {
+          tool: "search",
+          server: "githits",
+          providerCallId: "mcp-2",
+          status: "failed",
+          observedAt: "2026-08-28T10:00:00.500Z",
+        },
+      ],
+    };
+
+    const metrics = buildAgentEvalMetrics({
+      runId: "run-codex-timing",
+      startedAt: "2026-08-28T10:00:00.000Z",
+      completedAt: "2026-08-28T10:00:01.000Z",
+      records: [record],
+    });
+
+    expect(metrics.records[0]?.tools).toMatchObject({
+      rawEventCount: 4,
+      logicalCallCount: 2,
+      completedCount: 1,
+      failedCount: 1,
+    });
+    expect(metrics.records[0]?.tools.sequence).toEqual([
+      {
+        tool: "search",
+        surface: "mcp",
+        status: "completed",
+        startedAt: "2026-08-28T10:00:00.100Z",
+        completedAt: "2026-08-28T10:00:00.300Z",
+      },
+      {
+        tool: "search",
+        surface: "mcp",
+        status: "failed",
+        startedAt: "2026-08-28T10:00:00.400Z",
+        completedAt: "2026-08-28T10:00:00.500Z",
+      },
+    ]);
+  });
+
+  it("keeps missing boundaries unknown and rejects invalid or reverse intervals", () => {
+    const createRecord = (
+      workloadId: string,
+      toolCalls: AgentEvalRecordInput["toolCalls"],
+    ): AgentEvalRecordInput => ({
+      ...identityRecord("descriptors"),
+      workloadId,
+      agent: "codex",
+      usage: adaptAgentUsage(
+        codexUsageEvent({
+          input_tokens: 1,
+          cached_input_tokens: 0,
+          cache_write_input_tokens: 0,
+          output_tokens: 1,
+          reasoning_output_tokens: 0,
+        }),
+        "codex",
+        LUNA_MODEL,
+      ),
+      toolCalls,
+    });
+
+    const metrics = buildAgentEvalMetrics({
+      runId: "run-timing-gaps",
+      startedAt: "2026-08-28T10:00:00.000Z",
+      completedAt: "2026-08-28T10:00:01.000Z",
+      records: [
+        createRecord("completed-only", [
+          {
+            tool: "search",
+            server: "githits",
+            providerCallId: "completed-only",
+            status: "completed",
+            observedAt: "2026-08-28T10:00:00.200Z",
+          },
+        ]),
+        createRecord("started-only", [
+          {
+            tool: "search",
+            server: "githits",
+            providerCallId: "started-only",
+            status: "started",
+            observedAt: "2026-08-28T10:00:00.200Z",
+          },
+        ]),
+        createRecord("reverse", [
+          {
+            tool: "search",
+            server: "githits",
+            providerCallId: "reverse",
+            status: "started",
+            observedAt: "2026-08-28T10:00:00.300Z",
+          },
+          {
+            tool: "search",
+            server: "githits",
+            providerCallId: "reverse",
+            status: "completed",
+            observedAt: "2026-08-28T10:00:00.100Z",
+          },
+        ]),
+        createRecord("invalid", [
+          {
+            tool: "search",
+            server: "githits",
+            providerCallId: "invalid",
+            status: "started",
+            observedAt: "not-a-timestamp",
+          },
+          {
+            tool: "search",
+            server: "githits",
+            providerCallId: "invalid",
+            status: "failed",
+            observedAt: "2026-08-28T10:00:00.400Z",
+          },
+        ]),
+      ],
+    });
+
+    expect(metrics.records.map((record) => record.tools.sequence[0])).toEqual([
+      {
+        tool: "search",
+        surface: "mcp",
+        status: "completed",
+        startedAt: null,
+        completedAt: "2026-08-28T10:00:00.200Z",
+      },
+      {
+        tool: "search",
+        surface: "mcp",
+        status: "started",
+        startedAt: "2026-08-28T10:00:00.200Z",
+        completedAt: null,
+      },
+      {
+        tool: "search",
+        surface: "mcp",
+        status: "completed",
+        startedAt: null,
+        completedAt: null,
+      },
+      {
+        tool: "search",
+        surface: "mcp",
+        status: "failed",
+        startedAt: null,
+        completedAt: "2026-08-28T10:00:00.400Z",
+      },
+    ]);
   });
 
   it("normalizes inclusive Luna usage and does not double-count reasoning", () => {
@@ -484,10 +712,34 @@ describe("agent eval usage metrics", () => {
       failedCount: 1,
       uniqueTools: ["pkg_info", "pkg_vulns", "search"],
       sequence: [
-        { tool: "pkg_info", surface: "mcp", status: "completed" },
-        { tool: "pkg_info", surface: "mcp", status: "completed" },
-        { tool: "search", surface: "cli", status: "completed" },
-        { tool: "pkg_vulns", surface: "mcp", status: "failed" },
+        {
+          tool: "pkg_info",
+          surface: "mcp",
+          status: "completed",
+          startedAt: null,
+          completedAt: null,
+        },
+        {
+          tool: "pkg_info",
+          surface: "mcp",
+          status: "completed",
+          startedAt: null,
+          completedAt: null,
+        },
+        {
+          tool: "search",
+          surface: "cli",
+          status: "completed",
+          startedAt: null,
+          completedAt: null,
+        },
+        {
+          tool: "pkg_vulns",
+          surface: "mcp",
+          status: "failed",
+          startedAt: null,
+          completedAt: null,
+        },
       ],
     });
     expect(metrics.aggregates).toMatchObject({
@@ -644,10 +896,34 @@ describe("agent eval usage metrics", () => {
       failedCount: 0,
       uniqueTools: ["search"],
       sequence: [
-        { tool: "search", surface: "cli", status: "completed" },
-        { tool: "search", surface: "mcp", status: "completed" },
-        { tool: "search", surface: "mcp", status: "completed" },
-        { tool: "search", surface: "mcp", status: "started" },
+        {
+          tool: "search",
+          surface: "cli",
+          status: "completed",
+          startedAt: null,
+          completedAt: null,
+        },
+        {
+          tool: "search",
+          surface: "mcp",
+          status: "completed",
+          startedAt: null,
+          completedAt: null,
+        },
+        {
+          tool: "search",
+          surface: "mcp",
+          status: "completed",
+          startedAt: null,
+          completedAt: null,
+        },
+        {
+          tool: "search",
+          surface: "mcp",
+          status: "started",
+          startedAt: null,
+          completedAt: null,
+        },
       ],
     });
     expect(JSON.stringify(metrics)).not.toContain("providerCallId");

--- a/scripts/agent-eval-metrics.test.ts
+++ b/scripts/agent-eval-metrics.test.ts
@@ -416,6 +416,83 @@ describe("agent eval usage metrics", () => {
     }
   });
 
+  it("rejects retained terminal timing after an unknown Codex lifecycle event", () => {
+    const baseRecord: AgentEvalRecordInput = {
+      ...identityRecord("descriptors"),
+      workloadId: "terminal-unknown-then-started",
+      agent: "codex",
+      usage: adaptAgentUsage(
+        codexUsageEvent({
+          input_tokens: 1,
+          cached_input_tokens: 0,
+          cache_write_input_tokens: 0,
+          output_tokens: 1,
+          reasoning_output_tokens: 0,
+        }),
+        "codex",
+        LUNA_MODEL,
+      ),
+      toolCalls: [],
+    };
+
+    for (const terminalStatus of ["completed", "failed"] as const) {
+      for (const observedAt of [
+        "2026-08-28T10:00:00.300Z",
+        undefined,
+      ] as const) {
+        const metrics = buildAgentEvalMetrics({
+          runId: `run-${terminalStatus}-unknown-then-started-${observedAt ?? "missing"}`,
+          startedAt: "2026-08-28T10:00:00.000Z",
+          completedAt: "2026-08-28T10:00:01.000Z",
+          records: [
+            {
+              ...baseRecord,
+              toolCalls: [
+                {
+                  tool: "search",
+                  server: "githits",
+                  providerCallId: "replayed-call",
+                  status: terminalStatus,
+                  observedAt: "2026-08-28T10:00:00.100Z",
+                },
+                {
+                  tool: "search",
+                  server: "githits",
+                  providerCallId: "replayed-call",
+                  status: "provider_update",
+                  observedAt: "2026-08-28T10:00:00.200Z",
+                },
+                {
+                  tool: "search",
+                  server: "githits",
+                  providerCallId: "replayed-call",
+                  status: "started",
+                  ...(observedAt === undefined ? {} : { observedAt }),
+                },
+              ],
+            },
+          ],
+        });
+
+        expect(metrics.records[0]?.tools).toMatchObject({
+          rawEventCount: 3,
+          logicalCallCount: 1,
+          completedCount: 0,
+          failedCount: 0,
+        });
+        expect(metrics.records[0]?.tools.sequence).toEqual([
+          {
+            tool: "search",
+            surface: "mcp",
+            status: "started",
+            startedAt: null,
+            completedAt: null,
+          },
+        ]);
+      }
+    }
+  });
+
   it("normalizes inclusive Luna usage and does not double-count reasoning", () => {
     const metrics = adaptAgentUsage(
       codexUsageEvent({

--- a/scripts/agent-eval-metrics.ts
+++ b/scripts/agent-eval-metrics.ts
@@ -729,17 +729,13 @@ function mergeCodexToolObservation(
   const previousStarted = parseObservedTimestamp(
     previous.startedAt ?? undefined,
   );
-  const previousCompleted = parseObservedTimestamp(
-    previous.completedAt ?? undefined,
-  );
-  if (current.status === "started" && currentObservedAt !== undefined) {
-    if (
-      previousCompleted !== undefined &&
-      currentObservedAt.milliseconds < previousCompleted.milliseconds
-    ) {
+  if (current.status === "started") {
+    if (previous.status === "completed" || previous.status === "failed") {
       return rejectToolTiming(merged);
     }
-    if (merged.startedAt === null) merged.startedAt = currentObservedAt.value;
+    if (currentObservedAt !== undefined && merged.startedAt === null) {
+      merged.startedAt = currentObservedAt.value;
+    }
   }
   if (
     (current.status === "completed" || current.status === "failed") &&

--- a/scripts/agent-eval-metrics.ts
+++ b/scripts/agent-eval-metrics.ts
@@ -730,7 +730,11 @@ function mergeCodexToolObservation(
     previous.startedAt ?? undefined,
   );
   if (current.status === "started") {
-    if (previous.status === "completed" || previous.status === "failed") {
+    if (
+      previous.status === "completed" ||
+      previous.status === "failed" ||
+      merged.completedAt !== null
+    ) {
       return rejectToolTiming(merged);
     }
     if (currentObservedAt !== undefined && merged.startedAt === null) {

--- a/scripts/agent-eval-metrics.ts
+++ b/scripts/agent-eval-metrics.ts
@@ -112,6 +112,7 @@ export interface PersistedToolCall {
   providerCallId?: string;
   status?: string;
   error?: unknown;
+  observedAt?: string;
 }
 
 export interface AgentEvalRecordInput {
@@ -191,10 +192,26 @@ const targetGitSchema = z.object({
   dirty: z.boolean().nullable(),
 });
 
-const toolSequenceEntrySchema = z.object({
+const legacyToolSequenceEntrySchema = z.object({
   tool: z.string(),
   surface: z.enum(["mcp", "cli"]),
   status: z.enum(["started", "completed", "failed", "unknown"]),
+});
+
+const observedTimestampSchema = z.string().datetime({ offset: true });
+
+const toolSequenceEntrySchema = legacyToolSequenceEntrySchema.extend({
+  startedAt: observedTimestampSchema.nullable(),
+  completedAt: observedTimestampSchema.nullable(),
+});
+
+const legacyToolsMetricsSchema = z.object({
+  rawEventCount: nonNegativeInteger,
+  logicalCallCount: nonNegativeInteger.nullable(),
+  completedCount: nonNegativeInteger,
+  failedCount: nonNegativeInteger,
+  uniqueTools: z.array(z.string()),
+  sequence: z.array(legacyToolSequenceEntrySchema),
 });
 
 const toolsMetricsSchema = z.object({
@@ -245,7 +262,7 @@ const legacyAgentEvalRecordSchema = z.object({
   exitCode: z.number().int().nullable(),
   timedOut: z.boolean().nullable(),
   usage: agentUsageMetricsSchema,
-  tools: toolsMetricsSchema,
+  tools: legacyToolsMetricsSchema,
   artifacts: z.record(z.string(), relativeArtifactPathSchema),
   warnings: z.array(z.string()),
 });
@@ -329,8 +346,40 @@ export const agentEvalRecordSchema = z
     }
   });
 
+const priorAgentEvalRecordSchema = z.object({
+  workloadId: z.string().min(1),
+  requestedModel: z.string().nullable(),
+  resolvedModel: z.string().nullable(),
+  agent: z.enum(["claude", "codex", "opencode"]),
+  agentVersion: z.string().nullable(),
+  reasoningEffort: z.string().nullable(),
+  surface: z.enum(["mcp", "skills"]),
+  server: z.enum(["local", "published"]),
+  guidanceProfile: z.enum(["descriptors", "full"]).nullable(),
+  scenario: scenarioSchema.nullable(),
+  intentProfile: intentProfileSchema,
+  intentFragmentHash: z
+    .string()
+    .regex(/^[a-f0-9]{64}$/)
+    .nullable(),
+  experimentalTools: z.boolean(),
+  publishedPackage: z.string().nullable(),
+  targetGit: targetGitSchema,
+  startedAt: z.string().nullable(),
+  completedAt: z.string().nullable(),
+  durationMs: nonNegativeInteger.nullable(),
+  processStatus: z.enum(["dry-run", "success", "failed", "timeout"]),
+  finalStatus: z.enum(["success", "failure", "inconclusive"]).nullable(),
+  exitCode: z.number().int().nullable(),
+  timedOut: z.boolean().nullable(),
+  usage: agentUsageMetricsSchema,
+  tools: legacyToolsMetricsSchema,
+  artifacts: z.record(z.string(), relativeArtifactPathSchema),
+  warnings: z.array(z.string()),
+});
+
 export const agentEvalMetricsSchema = z.object({
-  schemaVersion: z.literal(2),
+  schemaVersion: z.literal(3),
   runId: z.string().min(1),
   startedAt: z.string().min(1),
   completedAt: z.string().min(1),
@@ -341,6 +390,16 @@ export const agentEvalMetricsSchema = z.object({
 
 export type AgentEvalRecord = z.infer<typeof agentEvalRecordSchema>;
 export type AgentEvalMetrics = z.infer<typeof agentEvalMetricsSchema>;
+
+const priorAgentEvalMetricsSchema = z.object({
+  schemaVersion: z.literal(2),
+  runId: z.string().min(1),
+  startedAt: z.string().min(1),
+  completedAt: z.string().min(1),
+  records: z.array(priorAgentEvalRecordSchema),
+  aggregates: aggregateMetricsSchema,
+  warnings: z.array(z.string()),
+});
 
 const LONG_CONTEXT_INPUT_LIMIT = 272_000;
 
@@ -571,6 +630,26 @@ interface NormalizedToolObservation {
   tool: string;
   surface: "mcp" | "cli";
   status: NormalizedToolStatus;
+  startedAt: string | null;
+  completedAt: string | null;
+}
+
+interface ParsedObservedTimestamp {
+  value: string;
+  milliseconds: number;
+}
+
+function parseObservedTimestamp(
+  value: string | undefined,
+): ParsedObservedTimestamp | undefined {
+  if (
+    value === undefined ||
+    !observedTimestampSchema.safeParse(value).success
+  ) {
+    return undefined;
+  }
+  const milliseconds = Date.parse(value);
+  return Number.isFinite(milliseconds) ? { value, milliseconds } : undefined;
 }
 
 interface AgentEvalIdentity {
@@ -617,11 +696,64 @@ function normalizeAgentEvalIdentity(input: {
 function normalizeToolObservation(
   call: PersistedToolCall,
 ): NormalizedToolObservation {
+  const status = normalizeToolStatus(call.status, call.error);
+  const observedAt = parseObservedTimestamp(call.observedAt);
   return {
     tool: normalizeToolName(call.tool),
     surface: call.server === "githits-cli" ? "cli" : "mcp",
-    status: normalizeToolStatus(call.status, call.error),
+    status,
+    startedAt: status === "started" ? (observedAt?.value ?? null) : null,
+    completedAt:
+      status === "completed" || status === "failed"
+        ? (observedAt?.value ?? null)
+        : null,
   };
+}
+
+function rejectToolTiming(
+  observation: NormalizedToolObservation,
+): NormalizedToolObservation {
+  return { ...observation, startedAt: null, completedAt: null };
+}
+
+function mergeCodexToolObservation(
+  previous: NormalizedToolObservation,
+  current: NormalizedToolObservation,
+  currentObservedAt: ParsedObservedTimestamp | undefined,
+): NormalizedToolObservation {
+  const merged: NormalizedToolObservation = {
+    ...current,
+    startedAt: previous.startedAt,
+    completedAt: previous.completedAt,
+  };
+  const previousStarted = parseObservedTimestamp(
+    previous.startedAt ?? undefined,
+  );
+  const previousCompleted = parseObservedTimestamp(
+    previous.completedAt ?? undefined,
+  );
+  if (current.status === "started" && currentObservedAt !== undefined) {
+    if (
+      previousCompleted !== undefined &&
+      currentObservedAt.milliseconds < previousCompleted.milliseconds
+    ) {
+      return rejectToolTiming(merged);
+    }
+    if (merged.startedAt === null) merged.startedAt = currentObservedAt.value;
+  }
+  if (
+    (current.status === "completed" || current.status === "failed") &&
+    currentObservedAt !== undefined
+  ) {
+    if (
+      previousStarted !== undefined &&
+      currentObservedAt.milliseconds < previousStarted.milliseconds
+    ) {
+      return rejectToolTiming(merged);
+    }
+    merged.completedAt = currentObservedAt.value;
+  }
+  return merged;
 }
 
 function normalizeLogicalToolObservations(
@@ -649,7 +781,11 @@ function normalizeLogicalToolObservations(
       indexesByIdentity.set(identity, observations.length);
       observations.push(observation);
     } else {
-      observations[previousIndex] = observation;
+      observations[previousIndex] = mergeCodexToolObservation(
+        observations[previousIndex] as NormalizedToolObservation,
+        observation,
+        parseObservedTimestamp(call.observedAt),
+      );
     }
   }
   return observations;
@@ -660,11 +796,15 @@ function buildAgentEvalRecord(input: AgentEvalRecordInput): AgentEvalRecord {
   const identity = normalizeAgentEvalIdentity(input);
   const observations: NormalizedToolObservation[] =
     normalizeLogicalToolObservations(input.agent, input.toolCalls);
-  const sequence = observations.map(({ tool, surface, status }) => ({
-    tool,
-    surface,
-    status,
-  }));
+  const sequence = observations.map(
+    ({ tool, surface, status, startedAt, completedAt }) => ({
+      tool,
+      surface,
+      status,
+      startedAt,
+      completedAt,
+    }),
+  );
   const warnings = [...usage.warnings];
   if (input.agent !== "codex") {
     warnings.push("tool_logical_count_not_implemented");
@@ -765,7 +905,7 @@ export function buildAgentEvalMetrics(
     ),
   };
   return agentEvalMetricsSchema.parse({
-    schemaVersion: 2,
+    schemaVersion: 3,
     runId: input.runId,
     startedAt: input.startedAt,
     completedAt: input.completedAt,
@@ -784,10 +924,29 @@ export function parseAgentEvalMetrics(value: unknown): AgentEvalMetrics {
   const current = agentEvalMetricsSchema.safeParse(value);
   if (current.success) return current.data;
 
+  const prior = priorAgentEvalMetricsSchema.safeParse(value);
+  if (prior.success) {
+    return agentEvalMetricsSchema.parse({
+      ...prior.data,
+      schemaVersion: 3,
+      records: prior.data.records.map((record) => ({
+        ...record,
+        tools: {
+          ...record.tools,
+          sequence: record.tools.sequence.map((call) => ({
+            ...call,
+            startedAt: null,
+            completedAt: null,
+          })),
+        },
+      })),
+    });
+  }
+
   const legacy = legacyAgentEvalMetricsSchema.parse(value);
   return agentEvalMetricsSchema.parse({
     ...legacy,
-    schemaVersion: 2,
+    schemaVersion: 3,
     records: legacy.records.map((record) => ({
       ...record,
       guidanceProfile:
@@ -801,6 +960,14 @@ export function parseAgentEvalMetrics(value: unknown): AgentEvalMetrics {
           : null,
       intentProfile: "neutral",
       intentFragmentHash: null,
+      tools: {
+        ...record.tools,
+        sequence: record.tools.sequence.map((call) => ({
+          ...call,
+          startedAt: null,
+          completedAt: null,
+        })),
+      },
     })),
   });
 }

--- a/scripts/agent-eval-report.ts
+++ b/scripts/agent-eval-report.ts
@@ -131,6 +131,7 @@ export interface DiscoverySummary {
 export interface FinalReportSummary {
   status: string;
   confidence: string;
+  answer?: string;
   usefulness?: string;
   usefulnessReason?: string;
   expectedToolUse?: string[];
@@ -522,6 +523,7 @@ export function summarizeFinalReport(
     confidence:
       typeof record.confidence === "string" ? record.confidence : "unknown",
   };
+  if (typeof record.answer === "string") summary.answer = record.answer;
   if (typeof record.githitsUsefulness === "string")
     summary.usefulness = record.githitsUsefulness;
   if (typeof record.githitsUsefulnessReason === "string")
@@ -633,6 +635,7 @@ function buildWorkloadReport(
   const paths = {
     toolCalls: join(workloadDir, "tool-calls.json"),
     final: join(workloadDir, "final.json"),
+    prompt: join(workloadDir, "prompt.md"),
     invalidFinal: join(workloadDir, "invalid-final.json"),
     stderr: join(workloadDir, "stderr.txt"),
     skillInstallation: join(workloadDir, "skill-installation.json"),

--- a/scripts/agent-eval-suite.test.ts
+++ b/scripts/agent-eval-suite.test.ts
@@ -897,8 +897,8 @@ describe("agent eval suites", () => {
         parsed.cells.every((cell) => cell.intentProfile === "neutral"),
       ).toBe(true);
       const imported = loadImportedSuite(suitePath);
-      expect(imported.shards.discovery.metrics?.schemaVersion).toBe(2);
-      expect(imported.shards.full.metrics?.schemaVersion).toBe(2);
+      expect(imported.shards.discovery.metrics?.schemaVersion).toBe(3);
+      expect(imported.shards.full.metrics?.schemaVersion).toBe(3);
 
       const nullProfile = {
         ...v1,

--- a/scripts/agent-eval.test.ts
+++ b/scripts/agent-eval.test.ts
@@ -46,6 +46,7 @@ import {
   parseArgs,
   prepareFullGuidanceWorkspace,
   prepareSkillsWorkspace,
+  readObservedStdout,
   redactText,
   runAgentEval,
   runWithTimeout,
@@ -653,7 +654,7 @@ describe("agent eval harness", () => {
         intentFragmentHash: GITHITS_INTENT_FRAGMENT_HASH,
       });
       expect(metrics).toMatchObject({
-        schemaVersion: 2,
+        schemaVersion: 3,
         records: [
           {
             scenario: "intent",
@@ -730,6 +731,35 @@ describe("agent eval harness", () => {
     expect(result.stdout).toBe("complete");
     expect(process.listenerCount("SIGINT")).toBe(before.sigint);
     expect(process.listenerCount("SIGTERM")).toBe(before.sigterm);
+  });
+
+  it("observes complete JSONL lines across chunks and a final unterminated line", async () => {
+    const timestamps = [
+      "2026-08-28T10:00:00.000Z",
+      "2026-08-28T10:00:01.000Z",
+      "2026-08-28T10:00:02.000Z",
+    ];
+    let timestampIndex = 0;
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(
+          new TextEncoder().encode('{"event":"first"}\n{"event":"sec'),
+        );
+        controller.enqueue(new TextEncoder().encode('ond"}\n{"event":"last"}'));
+        controller.close();
+      },
+    });
+
+    await expect(
+      readObservedStdout(stream, () => timestamps[timestampIndex++] ?? ""),
+    ).resolves.toEqual({
+      stdout: '{"event":"first"}\n{"event":"second"}\n{"event":"last"}',
+      lines: [
+        { line: '{"event":"first"}', observedAt: timestamps[0]! },
+        { line: '{"event":"second"}', observedAt: timestamps[1]! },
+        { line: '{"event":"last"}', observedAt: timestamps[2]! },
+      ],
+    });
   });
 
   it("kills a timed-out POSIX subprocess process group", async () => {
@@ -2250,6 +2280,98 @@ describe("agent eval harness", () => {
     }
   });
 
+  it("persists streamed observation timestamps in raw and normalized artifacts", async () => {
+    const codexHome = mkdtempSync(join(tmpdir(), "agent-eval-codex-home-"));
+    const outDir = mkdtempSync(join(tmpdir(), "agent-eval-observed-tools-"));
+    const workload = resolve("eval/agentic/workloads/express-router.md");
+    const startedAt = "2026-08-28T10:00:00.100Z";
+    const completedAt = "2026-08-28T10:00:00.300Z";
+    const events = [
+      {
+        type: "item.started",
+        item: {
+          type: "mcp_tool_call",
+          id: "mcp-1",
+          server: "githits",
+          tool: "search",
+          status: "in_progress",
+        },
+      },
+      {
+        type: "item.completed",
+        item: {
+          type: "mcp_tool_call",
+          id: "mcp-1",
+          server: "githits",
+          tool: "search",
+          status: "completed",
+        },
+      },
+      { status: "success", answer: "done", confidence: "high" },
+    ];
+    const stdout = events.map((event) => JSON.stringify(event)).join("\n");
+    try {
+      await runAgentEval(
+        parseArgs(
+          ["--agent", "codex", "--out", outDir, "--workload", workload],
+          process.cwd(),
+        ),
+        {
+          baseEnv: { PATH: "/bin", CODEX_HOME: codexHome },
+          assertAgentAvailable: async () => {},
+          collectAgentVersions: async () => [
+            undefined,
+            "codex-test",
+            undefined,
+          ],
+          runCommand: async () => ({
+            stdout,
+            stderr: "",
+            exitCode: 0,
+            timedOut: false,
+            observedStdoutLines: events.map((event, index) => ({
+              line: JSON.stringify(event),
+              observedAt:
+                index === 0
+                  ? startedAt
+                  : index === 1
+                    ? completedAt
+                    : "2026-08-28T10:00:00.400Z",
+            })),
+          }),
+        },
+      );
+
+      const workloadDir = join(outDir, "workloads", "express-router");
+      const rawToolCalls = JSON.parse(
+        readFileSync(join(workloadDir, "tool-calls.json"), "utf8"),
+      ) as Array<{ observedAt?: string }>;
+      expect(rawToolCalls.map((call) => call.observedAt)).toEqual([
+        startedAt,
+        completedAt,
+      ]);
+      const metrics = JSON.parse(
+        readFileSync(join(outDir, "metrics.json"), "utf8"),
+      ) as {
+        records: Array<{
+          tools: { sequence: Array<Record<string, unknown>> };
+        }>;
+      };
+      expect(metrics.records[0]?.tools.sequence).toEqual([
+        {
+          tool: "search",
+          surface: "mcp",
+          status: "completed",
+          startedAt,
+          completedAt,
+        },
+      ]);
+    } finally {
+      rmSync(codexHome, { recursive: true, force: true });
+      rmSync(outDir, { recursive: true, force: true });
+    }
+  });
+
   it("creates disposable per-workload homes and preserves caller CODEX_HOME", () => {
     const isolation = createWorkloadIsolation({
       PATH: "/bin",
@@ -2819,8 +2941,20 @@ describe("agent eval harness", () => {
       },
     });
     expect(metrics.records[0]?.tools.sequence).toEqual([
-      { tool: "search", surface: "cli", status: "started" },
-      { tool: "pkg_info", surface: "mcp", status: "completed" },
+      {
+        tool: "search",
+        surface: "cli",
+        status: "started",
+        startedAt: null,
+        completedAt: null,
+      },
+      {
+        tool: "pkg_info",
+        surface: "mcp",
+        status: "completed",
+        startedAt: null,
+        completedAt: null,
+      },
     ]);
     expect(metrics.aggregates).toMatchObject({
       durationMs: 3000,
@@ -3507,6 +3641,30 @@ describe("agent eval harness", () => {
     ]);
   });
 
+  it("propagates harness observation timestamps into extracted tool calls", () => {
+    const observedAt = "2026-08-28T10:00:00.000Z";
+    expect(
+      extractToolCalls(
+        [
+          {
+            line: JSON.stringify({
+              type: "item.started",
+              item: {
+                type: "mcp_tool_call",
+                id: "mcp-1",
+                server: "githits",
+                tool: "search",
+                status: "in_progress",
+              },
+            }),
+            observedAt,
+          },
+        ],
+        "codex",
+      ),
+    ).toMatchObject([{ providerCallId: "mcp-1", observedAt }]);
+  });
+
   it("preserves Codex provider IDs and statuses for paired MCP and CLI events", () => {
     const events = [
       {
@@ -3923,15 +4081,41 @@ describe("agent eval harness", () => {
 
   it("reports calls by tool with status totals and surface separation", () => {
     const sequence: Parameters<typeof summarizeCallsByTool>[0] = [
-      { tool: "mcp__githits__pkg_info", surface: "mcp", status: "started" },
+      {
+        tool: "mcp__githits__pkg_info",
+        surface: "mcp",
+        status: "started",
+        startedAt: null,
+        completedAt: null,
+      },
       {
         tool: "mcp__githits__.pkg_info",
         surface: "mcp",
         status: "completed",
+        startedAt: null,
+        completedAt: null,
       },
-      { tool: "pkg_info", surface: "mcp", status: "unknown" },
-      { tool: "githits.pkg_info", surface: "cli", status: "failed" },
-      { tool: "search", surface: "cli", status: "completed" },
+      {
+        tool: "pkg_info",
+        surface: "mcp",
+        status: "unknown",
+        startedAt: null,
+        completedAt: null,
+      },
+      {
+        tool: "githits.pkg_info",
+        surface: "cli",
+        status: "failed",
+        startedAt: null,
+        completedAt: null,
+      },
+      {
+        tool: "search",
+        surface: "cli",
+        status: "completed",
+        startedAt: null,
+        completedAt: null,
+      },
     ];
 
     expect(summarizeCallsByTool(sequence, 5)).toEqual([
@@ -3967,7 +4151,13 @@ describe("agent eval harness", () => {
 
   it("keeps calls by tool unknown when logical telemetry is unavailable", () => {
     const sequence: Parameters<typeof summarizeCallsByTool>[0] = [
-      { tool: "pkg_info", surface: "mcp", status: "completed" },
+      {
+        tool: "pkg_info",
+        surface: "mcp",
+        status: "completed",
+        startedAt: null,
+        completedAt: null,
+      },
     ];
     expect(summarizeCallsByTool(sequence, null)).toBeNull();
     expect(summarizeCallsByTool(sequence, 0)).toBeNull();

--- a/scripts/agent-eval.test.ts
+++ b/scripts/agent-eval.test.ts
@@ -3977,6 +3977,7 @@ describe("agent eval harness", () => {
   it("summarizes final reports without treating expected tools as actual calls", () => {
     const summary = summarizeFinalReport({
       status: "success",
+      answer: "The package has no active vulnerabilities.",
       githitsUsefulness: "helped",
       githitsUsefulnessReason: "useful",
       confidence: "high",
@@ -3989,10 +3990,22 @@ describe("agent eval harness", () => {
     expect(summary?.expectedToolUse).toEqual(["pkg_vulns"]);
     expect(summary?.unexpectedToolUse).toEqual(["pkg_info"]);
     expect(summary?.toolIssues).toEqual(["issue", "pkg_vulns: unclear range"]);
+    expect(summary?.answer).toBe("The package has no active vulnerabilities.");
+    expect(
+      summarizeFinalReport({ status: "success", confidence: "low", answer: 42 })
+        ?.answer,
+    ).toBeUndefined();
+    expect(
+      summarizeFinalReport({ status: "success", confidence: "low" })?.answer,
+    ).toBeUndefined();
   });
 
   it("builds a portable run report from persisted artifacts", () => {
     const runDir = createRunFixture();
+    writeFileSync(
+      join(runDir, "workloads", "pkg-vulns", "prompt.md"),
+      "Check this package for active vulnerabilities.\n",
+    );
     const run = JSON.parse(readFileSync(join(runDir, "run.json"), "utf8"));
     const report = buildRunReportFromMetadata(runDir, run);
 
@@ -4000,10 +4013,16 @@ describe("agent eval harness", () => {
     expect(report.workloads[0]?.artifacts.toolCalls).toBe(
       "workloads/pkg-vulns/tool-calls.json",
     );
+    expect(report.workloads[0]?.artifacts.prompt).toBe(
+      "workloads/pkg-vulns/prompt.md",
+    );
     expect(report.workloads[0]?.toolCalls.rawCount).toBe(2);
     expect(report.workloads[0]?.finalReport?.instructionIssues).toEqual([
       "Package aliases were unclear",
     ]);
+    expect(report.workloads[0]?.finalReport?.answer).toBe(
+      "No active vulnerabilities.",
+    );
     const formatted = formatRunReport(report);
     expect(formatted).toContain(
       "pkg-vulns success 1.2s uniqueTools=1 rawEvents=2",
@@ -4014,6 +4033,14 @@ describe("agent eval harness", () => {
     expect(formatted).toContain(
       "Inspect raw calls: workloads/pkg-vulns/tool-calls.json",
     );
+  });
+
+  it("omits the optional prompt artifact when it is absent", () => {
+    const runDir = createRunFixture();
+    const run = JSON.parse(readFileSync(join(runDir, "run.json"), "utf8"));
+    const report = buildRunReportFromMetadata(runDir, run);
+
+    expect(report.workloads[0]?.artifacts.prompt).toBeUndefined();
   });
 
   it("reports only the selected agent CLI version", () => {
@@ -4810,6 +4837,31 @@ describe("agent eval harness", () => {
     expect(report.workloads[0]?.toolCalls.rawCount).toBe(0);
     expect(report.workloads[0]?.warnings[0]).toContain(
       "artifact path outside run directory ignored",
+    );
+  });
+
+  it("does not expose a prompt symlink outside the run directory", () => {
+    const runDir = mkdtempSync(join(tmpdir(), "agent-eval-prompt-symlink-"));
+    const workloadDir = join(runDir, "workloads", "unsafe-prompt");
+    const outsideDir = mkdtempSync(
+      join(tmpdir(), "agent-eval-prompt-outside-"),
+    );
+    mkdirSync(workloadDir, { recursive: true });
+    writeJson(join(workloadDir, "tool-calls.json"), []);
+    writeFileSync(join(workloadDir, "stderr.txt"), "");
+    writeFileSync(join(outsideDir, "prompt.md"), "outside prompt\n");
+    symlinkSync(join(outsideDir, "prompt.md"), join(workloadDir, "prompt.md"));
+
+    const report = buildRunReportFromMetadata(runDir, {
+      workloads: [{ id: "unsafe-prompt", status: "success", workloadDir }],
+    });
+
+    expect(report.workloads[0]?.artifacts.prompt).toBeUndefined();
+    expect(report.workloads[0]?.warnings).toContain(
+      `artifact path outside run directory ignored: prompt: ${join(
+        workloadDir,
+        "prompt.md",
+      )}`,
     );
   });
 

--- a/scripts/agent-eval.ts
+++ b/scripts/agent-eval.ts
@@ -176,6 +176,11 @@ interface WorkloadRunExecution {
   artifacts: Record<string, string>;
 }
 
+export interface ObservedStdoutLine {
+  line: string;
+  observedAt: string;
+}
+
 export interface AgentEvalMetricsExecutionInput
   extends Omit<AgentEvalRecordInput, "usage"> {
   stdout?: string;
@@ -209,6 +214,7 @@ interface ExtractedToolCall {
   status?: string;
   arguments?: unknown;
   error?: unknown;
+  observedAt?: string;
 }
 
 export type DiscoveryObservation = "observed" | "not_observed" | "not_exposed";
@@ -1502,6 +1508,7 @@ function extractTextFromContent(content: unknown): string | undefined {
 
 function extractClaudeToolCalls(
   event: Record<string, unknown>,
+  observedAt?: string,
 ): ExtractedToolCall[] {
   const message = event.message;
   if (message === null || typeof message !== "object") return [];
@@ -1524,6 +1531,7 @@ function extractClaudeToolCalls(
         tool,
         status: "started",
         arguments: record.input,
+        ...(observedAt ? { observedAt } : {}),
       },
     ];
   });
@@ -1531,6 +1539,7 @@ function extractClaudeToolCalls(
 
 function extractCodexToolCall(
   event: Record<string, unknown>,
+  observedAt?: string,
 ): ExtractedToolCall | undefined {
   const item = event.item;
   if (item === null || typeof item !== "object") return undefined;
@@ -1550,11 +1559,13 @@ function extractCodexToolCall(
     status: typeof record.status === "string" ? record.status : undefined,
     arguments: record.arguments,
     error: record.error,
+    ...(observedAt ? { observedAt } : {}),
   };
 }
 
 function extractOpenCodeToolCall(
   event: Record<string, unknown>,
+  observedAt?: string,
 ): ExtractedToolCall | undefined {
   if (event.type !== "tool_use") return undefined;
   const part = event.part;
@@ -1577,6 +1588,7 @@ function extractOpenCodeToolCall(
     status: typeof state?.status === "string" ? state.status : undefined,
     arguments: state?.input,
     error: state?.error ?? outputError,
+    ...(observedAt ? { observedAt } : {}),
   };
 }
 
@@ -1658,6 +1670,7 @@ function cliToolNameFromCommand(command: string): string | undefined {
 function extractCliToolCalls(
   event: Record<string, unknown>,
   agent: AgentName,
+  observedAt?: string,
 ): ExtractedToolCall[] {
   const commands = collectCommandStrings(event);
   const item = event.item;
@@ -1691,30 +1704,35 @@ function extractCliToolCalls(
         ...(providerCallId ? { providerCallId } : {}),
         status: itemStatus ?? "started",
         arguments: { command },
+        ...(observedAt ? { observedAt } : {}),
       },
     ];
   });
 }
 
 export function extractToolCalls(
-  stdout: string,
+  stdout: string | readonly ObservedStdoutLine[],
   agent: AgentName,
 ): ExtractedToolCall[] {
   const calls: ExtractedToolCall[] = [];
-  for (const line of stdout.split("\n")) {
+  const lines: Array<{ line: string; observedAt?: string }> =
+    typeof stdout === "string"
+      ? stdout.split("\n").map((line) => ({ line }))
+      : stdout.map(({ line, observedAt }) => ({ line, observedAt }));
+  for (const { line, observedAt } of lines) {
     if (line.trim().length === 0) continue;
     try {
       const event = JSON.parse(line) as Record<string, unknown>;
       if (agent === "claude") {
-        calls.push(...extractCliToolCalls(event, agent));
-        calls.push(...extractClaudeToolCalls(event));
+        calls.push(...extractCliToolCalls(event, agent, observedAt));
+        calls.push(...extractClaudeToolCalls(event, observedAt));
       } else if (agent === "codex") {
-        calls.push(...extractCliToolCalls(event, agent));
-        const call = extractCodexToolCall(event);
+        calls.push(...extractCliToolCalls(event, agent, observedAt));
+        const call = extractCodexToolCall(event, observedAt);
         if (call) calls.push(call);
       } else {
-        calls.push(...extractCliToolCalls(event, agent));
-        const call = extractOpenCodeToolCall(event);
+        calls.push(...extractCliToolCalls(event, agent, observedAt));
+        const call = extractOpenCodeToolCall(event, observedAt);
         if (call) calls.push(call);
       }
     } catch {
@@ -2020,6 +2038,46 @@ async function killProcessTree(
   }
 }
 
+export async function readObservedStdout(
+  stream: ReadableStream<Uint8Array>,
+  observe: () => string = () => new Date().toISOString(),
+): Promise<{ stdout: string; lines: ObservedStdoutLine[] }> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  const lines: ObservedStdoutLine[] = [];
+  let stdout = "";
+  let pending = "";
+
+  const consume = (text: string): void => {
+    stdout += text;
+    pending += text;
+    while (true) {
+      const newline = pending.indexOf("\n");
+      if (newline < 0) return;
+      lines.push({
+        line: pending.slice(0, newline),
+        observedAt: observe(),
+      });
+      pending = pending.slice(newline + 1);
+    }
+  };
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      consume(decoder.decode(value, { stream: true }));
+    }
+    consume(decoder.decode());
+    if (pending.length > 0) {
+      lines.push({ line: pending, observedAt: observe() });
+    }
+    return { stdout, lines };
+  } finally {
+    reader.releaseLock();
+  }
+}
+
 export async function runWithTimeout(
   command: string[],
   cwd: string,
@@ -2030,6 +2088,7 @@ export async function runWithTimeout(
   stderr: string;
   exitCode?: number;
   timedOut: boolean;
+  observedStdoutLines?: ObservedStdoutLine[];
 }> {
   const proc = Bun.spawn(command, {
     cwd,
@@ -2074,14 +2133,20 @@ export async function runWithTimeout(
   }, timeoutSeconds * 1_000);
 
   try {
-    const [stdout, stderr, exitCode] = await Promise.all([
-      new Response(proc.stdout).text(),
+    const [observed, stderr, exitCode] = await Promise.all([
+      readObservedStdout(proc.stdout),
       new Response(proc.stderr).text(),
       proc.exited.catch(() => undefined),
     ]);
     clearTimeout(timer);
     if (cleanupPromise !== undefined) await cleanupPromise;
-    return { stdout, stderr, exitCode, timedOut };
+    return {
+      stdout: observed.stdout,
+      stderr,
+      exitCode,
+      timedOut,
+      observedStdoutLines: observed.lines,
+    };
   } finally {
     clearTimeout(timer);
     if (cleanupPromise !== undefined) await cleanupPromise;
@@ -2477,7 +2542,10 @@ async function runWorkload(
       redactText(result.stderr, secretValues),
     );
 
-    const toolCalls = extractToolCalls(result.stdout, options.agent);
+    const toolCalls = extractToolCalls(
+      result.observedStdoutLines ?? result.stdout,
+      options.agent,
+    );
     writeJson(
       join(workloadDir, "tool-calls.json"),
       redactValue(toolCalls, secretValues),
@@ -2562,12 +2630,13 @@ async function runWorkload(
       },
       stdout: result.stdout,
       toolCalls: toolCalls.map(
-        ({ tool, server, providerCallId, status, error }) => ({
+        ({ tool, server, providerCallId, status, error, observedAt }) => ({
           tool,
           server,
           ...(providerCallId ? { providerCallId } : {}),
           status,
           error,
+          ...(observedAt ? { observedAt } : {}),
         }),
       ),
       artifacts: existingWorkloadArtifacts(runDir, workloadDir),


### PR DESCRIPTION
## Summary

- map accepted discovery and intent suite artifacts to one normalized Braintrust row per workload
- persist prompts, neutral answers, status, token/cost/duration metrics, and detailed tool telemetry without adding agent tracing or fabricated quality scores
- export after the concise CI report with narrowly scoped credentials and explicit failure aggregation
- document local validation/query workflows and add an internal Braintrust operations skill

## Validation

- `bun test` — 3,745 passed, 0 failed
- `bun run typecheck`
- `bun run format:check`
- `bun run lint`
- `bun run build`
- `actionlint .github/workflows/agent-evals.yml`
- `bun run plugins:check`
- internal skill validator
- validate-only mapping of accepted artifacts — 23 rows
- two local Braintrust exports/readbacks — 23 rows each
- Luna preflight review — READY
- Claude Opus review round 3 — clean

## Pending operational validation

`BRAINTRUST_API_KEY` is not currently visible in the repository or selected organization Actions-secret inventory. The `agent-eval` label is intentionally not applied yet: a labeled run would spend the eval budget and then fail persistence. After the secret is available, apply the label and verify one 23-row CI experiment/readback.