### PR TITLE
ci: collect agent evals on main pushes

### DIFF
--- a/.agents/skills/braintrust-agent-evals/SKILL.md
+++ b/.agents/skills/braintrust-agent-evals/SKILL.md
@@ -72,7 +72,15 @@ duration, 2,686,094 prompt tokens, 20,172 completion tokens, 2,706,266 total
 tokens, and estimated cost `$0.22819038`. Compare averages were duration
 `22.343956532685652`, estimated cost `$0.009921320869565216`, tool calls
 `5.043478260869565`, tool errors `0`, and total tokens `117663.73913043478`.
-The default-branch scheduled/manual activation remains pending merge.
+The first stable default-branch bootstrap is [run
+33477846273](https://github.com/githits-com/githits-cli/actions/runs/33477846273)
+at SHA `40796bd0eabaf87afec5ea0e4460ff47e7448603`. Experiment
+`main-r33477846273-a1` (ID `6f3847fc-3816-4b32-b1f6-65019c2757b7`) read back
+23 eval roots and 112 tool children, zero CLI calls, 3,024,404 tokens,
+445.728 seconds cumulative agent duration, and estimated cost `$0.24188221`.
+Its null base is the expected one-time bootstrap result. Main pushes now
+temporarily run the same matrix, in addition to the daily/manual/label paths,
+to collect variance and workload-optimization evidence.
 
 For current comparisons, inspect experiment-level `metadata.channel` and
 `baseExperiment` in the safe exporter result or CI summary. A current main
@@ -83,7 +91,8 @@ Validate-only reports the base as unresolved/not queried and performs no
 discovery. The first main run is a one-time bootstrap; PR and default-local
 exports fail before initialization when no main baseline exists. Explicit
 local `--base-experiment` takes precedence and skips discovery. No live
-readback has yet proven later-main, PR, and local linkage under the new names.
+readback has proven the first main bootstrap, but not later-main, PR, or local
+linkage under the new names.
 For exports, use the returned experiment name from the SDK readback; it can
 differ from a reused explicit local name if Braintrust de-duplicates it.
 Validate-only reports the requested or generated name.
@@ -93,6 +102,11 @@ The exercised comparison syntax is:
 ```bash
 bt experiments --json --project githits-cli-agent-evals compare <experiment-a> <experiment-b>
 ```
+
+For custom cross-experiment SQL analysis, join eval rows by
+`metadata.cellId`, not `metadata.workloadId`: the same workload can appear in
+multiple scenarios. Braintrust's built-in experiment comparison already
+matches the stable row inputs and avoids this ambiguity.
 
 The prior custom-only experiments succeeded but reported only generic
 Braintrust trace metrics, which were zero and did not expose their custom eval

--- a/.github/workflows/agent-evals.yml
+++ b/.github/workflows/agent-evals.yml
@@ -4,6 +4,8 @@ on:
   schedule:
     - cron: "0 3 * * *"
   workflow_dispatch:
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
     types: [labeled]

--- a/changes/agent-eval-main-push.changed.md
+++ b/changes/agent-eval-main-push.changed.md
@@ -1,0 +1,6 @@
+---
+"githits": none
+"@githits/mcp": none
+---
+
+- **Temporarily evaluate every main update** - Run the advisory Luna agent-eval workflow on every push to `main` while maintainers collect Braintrust variance and workload-optimization evidence; daily, manual, and explicitly labeled pull-request runs remain available.

--- a/docs/implementation/agentic-eval-metrics.md
+++ b/docs/implementation/agentic-eval-metrics.md
@@ -10,9 +10,9 @@ replace the raw terminal output or `tool-calls.json`.
 This is local maintainer tooling plus the repository's dedicated Luna CI
 workflow and its Braintrust persistence boundary. It is not a deterministic CI
 gate or quality judge. Named Luna suites, local paired/offline comparisons,
-daily or explicitly authorized pull-request execution, and normalized
-per-workload history are implemented here; answer-quality scoring remains a
-later phase.
+daily, temporary per-main-push, or explicitly authorized pull-request
+execution, and normalized per-workload history are implemented here;
+answer-quality scoring remains a later phase.
 
 ## Braintrust persistence contract
 
@@ -58,7 +58,7 @@ detached suite requires `--branch`.
 The experiment metadata and allowlisted tags retain source (`local` or
 `github`), channel (`local`, `main`, or `pr`), branch, optional PR number, full
 SHA, run identity, and evaluated-target `repoInfo` including dirty state. The
-workflow passes `channel=main` for schedule/manual runs on `main` and
+workflow passes `channel=main` for push/schedule/manual runs on `main` and
 `channel=pr` with the head branch and numeric PR number for the trusted
 same-repository label event. Manual dispatch on a non-main ref is rejected
 before either paid scenario job can start.
@@ -241,9 +241,8 @@ completion tokens, 2,706,266 total tokens, and estimated cost `$0.22819038`.
 Standard Braintrust compare averages were duration
 `22.343956532685652`, estimated cost `$0.009921320869565216`, tool calls
 `5.043478260869565`, tool errors `0`, and total tokens
-`117663.73913043478`. This validates the labeled pull-request path; default-
-branch scheduled/manual activation remains pending merge. No paid rerun
-was made for this documentation-only closeout.
+`117663.73913043478`. This validates the labeled pull-request path; the stable
+main bootstrap is recorded in the live CI evidence section below.
 
 ## Scenario and intent identity
 
@@ -582,8 +581,11 @@ reporter into two independent matrix entries on GitHub-hosted Ubuntu:
 | discovery | `canary`      | `discovery` |                    2 | 40 min  |
 | intent    | `stable-full` | `intent`    |                    4 | 40 min  |
 
-It triggers at `03:00` UTC from the default branch, on `workflow_dispatch`, and
-on `pull_request` events of type `labeled` targeting `main`. The paid jobs run
+It triggers on every push to `main`, at `03:00` UTC from the default branch, on
+`workflow_dispatch`, and on `pull_request` events of type `labeled` targeting
+`main`. The push trigger is temporary data-collection policy for measuring
+run-to-run variance and selecting workloads to optimize; daily/manual/label
+coverage remains available and the workflow remains advisory. The paid jobs run
 for a pull request only when the event label is exactly `agent-eval` and the
 head repository is the current repository. They check out the immutable
 labeled head SHA; scheduled and manual runs use `github.sha`. A later
@@ -641,9 +643,17 @@ input, 701,553 cache-write input, 22,048 output, and 4,739 reasoning tokens.
 
 All 23 Codex configs contained only the name-only `GITHITS_API_TOKEN`
 `env_vars` entry and no literal token assignment; secret values were not read
-during inspection. The same-repository label path is live-validated. Default
-branch scheduled/manual execution remains pending merge, so this does not yet
-establish scheduled/manual behavior or complete all deployment acceptance.
+during inspection. The same-repository label path is live-validated.
+
+The first stable main bootstrap
+([workflow run 33477846273](https://github.com/githits-com/githits-cli/actions/runs/33477846273))
+at merge SHA `40796bd` succeeded on 2026-09-01 as experiment
+`main-r33477846273-a1`. It persisted 23 eval roots and 112 MCP tool children,
+with zero CLI calls, 3,024,404 total tokens, 445.728 seconds cumulative agent
+duration, and a $0.24188221 rate-based estimated cost. The required Braintrust
+readback returned no base, which is the expected one-time bootstrap result.
+This proves default-branch manual execution and stable main identity, but not
+yet later-main-to-main, pull-request-to-main, or local-to-main linkage.
 
 ## Previous paid comparison: contaminated; capacity evidence only
 

--- a/docs/plans/systematic-agent-evals.md
+++ b/docs/plans/systematic-agent-evals.md
@@ -4,25 +4,23 @@
 
 - Overall: IN PROGRESS
 - Current phase: Phase 4 — Braintrust Persistence Proof Of Concept
-  (IDENTITY/LINKAGE IMPLEMENTED LOCALLY; LIVE MAIN PROOF PENDING)
+  (MAIN BOOTSTRAP PROVEN; LIVE LINKAGE PROOF PENDING)
 - Previous work: Phase 2 correction is COMPLETE. Phase 3 is merged and its
   same-repository label path is live-validated; Phase 4's exporter, CI wiring,
   local Braintrust readback, and first qualifying labeled CI export/readback
   are complete. The exact-head run proved persistence again, but exposed null
   branch and base-experiment identity. Stable naming and native main-baseline
-  linkage are implemented locally and are now awaiting live main-baseline proof
-  before Phase 4 is complete.
+  linkage are implemented. The first stable main bootstrap is live-proven and
+  later-main, pull-request, and local linkage remain before Phase 4 is complete.
 - Owner: repository maintainers
-- Last verified: 2026-08-31
+- Last verified: 2026-09-01
 - Deployment: Phases 1 through 3 are merged to `main`. The Phase 3
-  same-repository label path is live-validated; the scheduled path is waiting
-  for its first default-branch execution. Phase 4's exact-pinned exporter and
-  post-report CI step are implemented, with local and labeled CI
-  persistence/readback proven. A push to `main` deliberately does not trigger
-  the workflow. Stable channel-aware identity and explicit main-baseline
-  linkage are implemented locally, but no live export has yet proven
-  later-main, pull-request, and local readback linkage. Default-branch
-  scheduled/manual activation remains pending merge.
+  same-repository label path and first default-branch manual bootstrap are
+  live-validated. Phase 4's exact-pinned exporter and post-report CI step are
+  implemented, with local, labeled CI, and main-bootstrap persistence/readback
+  proven. Pushes to `main` now temporarily trigger the workflow to collect
+  variance and workload-optimization evidence. No live export has yet proven
+  later-main, pull-request, and local readback linkage.
 
 ## Problem And Expected Outcome
 
@@ -489,11 +487,11 @@ changes are not confused with harness changes.
 
 ## Unknowns And Product Decisions
 
-None block Phase 3 implementation. The same-repository label path is
-live-validated; scheduled/manual activation and final acceptance remain pending
-external workflow execution after merge using the verified `OPENAI_API_KEY` and
-`GITHITS_API_TOKEN` secret names. This is an operational validation dependency,
-not a product decision.
+None block Phase 3 implementation. The same-repository label and first
+default-branch manual paths are live-validated using the verified
+`OPENAI_API_KEY` and `GITHITS_API_TOKEN` secret names. Phase 4 linkage
+acceptance remains an operational validation dependency, not a product
+decision.
 
 The following must be resolved before Phase 4 is detailed:
 
@@ -620,17 +618,17 @@ The following must be resolved before Phase 6:
    isolation, and Codex interactive isolation parity are implemented and
    validated; corrected discovery/intent evidence supersedes the two-profile
    behavior policy.
-3. **Phase 3 — parallel CI execution and concise reporting (MERGED;
-   SAME-REPOSITORY LABEL PATH LIVE-VALIDATED; FIRST SCHEDULED RUN PENDING):**
-   clean GitHub-hosted jobs run the Luna discovery and intent suites daily or
-   after an authorized PR label, retain raw evidence, and render a concise
-   no-baseline summary. A push to `main` does not start a paid run.
-4. **Phase 4 — Braintrust persistence proof of concept (IDENTITY/LINKAGE
-   IMPLEMENTED LOCALLY; LIVE MAIN PROOF PENDING):** normalized Phase 3 records
+3. **Phase 3 — parallel CI execution and concise reporting (MERGED; LABEL AND
+   MAIN-MANUAL PATHS LIVE-VALIDATED; TEMPORARY MAIN-PUSH COLLECTION ENABLED):**
+   clean GitHub-hosted jobs run the Luna discovery and intent suites on main
+   pushes, daily, or after an authorized PR label, retain raw evidence, and
+   render a concise no-baseline summary.
+4. **Phase 4 — Braintrust persistence proof of concept (MAIN BOOTSTRAP PROVEN;
+   LIVE LINKAGE PROOF PENDING):** normalized Phase 3 records
    become durable per-workload/per-agent history without making agent execution
    dependent on Braintrust. Local and labeled CI export/readback are proven;
-   stable channel-aware names and native main-baseline linkage are implemented
-   locally, but still require live proof for main, pull-request, and local runs.
+   stable channel-aware names and native main-baseline linkage are implemented;
+   later-main, pull-request, and local linkage still require live proof.
 5. **Phase 5 — broader discovery matrix (PLANNED):** the proven metrics, suite,
    CI, and persistence contracts add approved Codex/Claude agent-model cells to
    the neutral canary without changing Luna history.
@@ -1464,11 +1462,12 @@ captured below; Braintrust persistence is intentionally a later phase.
 
 ### Status
 
-MERGED; SAME-REPOSITORY LABEL PATH LIVE-VALIDATED. The runner, schema-v3 suite
-artifacts, CI reporter, workflow, and operational documentation are merged.
-The corrected label run passed its clean runner and summary checks; the first
-default-branch scheduled/manual execution has not happened yet. A push to
-`main` does not trigger this paid workflow.
+MERGED; SAME-REPOSITORY LABEL AND MAIN-MANUAL PATHS LIVE-VALIDATED. The runner,
+schema-v3 suite artifacts, CI reporter, workflow, and operational documentation
+are merged. The corrected label run and first default-branch manual bootstrap
+passed their runner, summary, and persistence checks. This increment
+temporarily enables paid execution on every push to `main` to collect variance
+and workload-optimization evidence.
 
 ### Live label-run evidence
 
@@ -1637,25 +1636,24 @@ None.
    status classification, including zero-call discovery, per-tool frequencies,
    unknown telemetry, partial/missing suites, CLI fallback, and isolation
    violations. Implement the pure formatter and thin CLI entrypoint.
-3. **Merged; same-repository label path live-validated:** Add the dedicated
-   workflow with the three triggers, an explicit
-   `github.event.label.name == 'agent-eval'` job gate, same-repository label/SHA
-   authorization, clean Codex home and API-key setup, the two scenario jobs,
-   unconditional artifact upload/reporting, 14-day retention, and minimal
+3. **Merged; same-repository label and main-manual paths live-validated; main
+   pushes enabled in this increment:** Add the dedicated workflow triggers, an
+   explicit `github.event.label.name == 'agent-eval'` job gate, same-repository
+   label/SHA authorization, clean Codex home and API-key setup, the two scenario
+   jobs, unconditional artifact upload/reporting, 14-day retention, and minimal
    permissions. Keep secret scope to the paid execution steps. The corrected
-   label run passed; the first default-branch scheduled/manual execution is
-   pending.
+   label and first default-branch manual runs passed. Temporarily add the
+   `push: main` trigger for variance collection without making results a gate.
 4. **Completed locally:** Update local/CI operational documentation, the durable implementation
    contract, and the required no-public-impact change fragment. Document label
    authorization, re-label behavior, exact suites/concurrency, expected
    duration/cost, secret names, and artifact/report locations.
-5. **Local and label evidence complete; first scheduled/manual evidence
-   pending:** Run focused tests, all suite dry-runs at concurrency 1 and the CI-selected
+5. **Local, label, and first main-manual evidence complete:** Run focused tests,
+   all suite dry-runs at concurrency 1 and the CI-selected
    values, `bun test`, typecheck, format, lint, build, and workflow syntax/action
    validation. The same-repository label path is live-validated with no global
-   skill/guidance reads or CLI fallbacks. Verify the scheduled/default-branch
-   path on its first run before treating Phase 3 deployment acceptance as
-   complete.
+   skill/guidance reads or CLI fallbacks. Main bootstrap run `33477846273`
+   verifies default-branch execution, summary, and persistence.
 
 ### Acceptance Criteria
 
@@ -1688,7 +1686,7 @@ None.
 
 ### Status
 
-IDENTITY/LINKAGE IMPLEMENTED LOCALLY; LIVE MAIN PROOF PENDING.
+MAIN BOOTSTRAP PROVEN; LIVE LINKAGE PROOF PENDING.
 Phase 3 is merged and its same-repository label path has clean runner evidence.
 The exact-pinned Braintrust exporter, post-report CI wiring, local
 persistence/readback proof, internal operations skill, and qualifying labeled
@@ -1697,10 +1695,11 @@ verify tool counts, exact observed boundaries, child duration, tokens, and
 cost. Exact-head labeled run `33429755678` persisted the final PR head but
 confirmed that experiment `base_exp_id` and branch identity are null and that
 the opaque `github-<run>-<attempt>` name is insufficient for routine operation.
-Stable naming and native comparison linkage are implemented locally. No live
+Stable naming and native comparison linkage are implemented. Main bootstrap
+run `33477846273` persisted `main-r33477846273-a1` with the expected null base,
+proving default-branch manual execution and stable main identity. No live
 export/readback has yet proved later-main-to-main, PR-to-main, and
-local-to-main linkage, so Phase 4 remains incomplete. Default-branch
-scheduled/manual activation remains pending merge.
+local-to-main linkage, so Phase 4 remains incomplete.
 SDK tracing was deliberately not added.
 
 ### Expected Outcome
@@ -1824,9 +1823,11 @@ No product choice blocks the implementation. The selected policy is:
   workflow status so missing persistence cannot be silent;
 - retention: Braintrust is the durable normalized history. GitHub raw artifacts
   remain at 14 days until observed operations justify a change; and
-- cadence: unchanged in this phase. The existing schedule/manual/label triggers
-  remain; push-to-main behavior is reconsidered only after Braintrust evidence
-  is available.
+- cadence: every push to `main` temporarily runs the existing Luna matrix while
+  enough Braintrust history is collected to measure variance and select
+  workloads to optimize. The schedule/manual/label triggers remain, and the
+  workflow stays advisory rather than becoming a merge gate. Reconsider the
+  push trigger after that evidence exists.
 
 The built-in experiment comparison behavior observed on prior custom-only rows
 is a historical limitation, not a native-first result: its exercised output
@@ -1835,9 +1836,9 @@ telemetry. The current exporter records one structural `tool` child per known
 logical call, using exact harness-observed boundaries and computed duration for
 completed/failed calls. Native comparison now reports those child-derived
 `tool_calls` and `tool_errors`; bounded SQL remains the path for the exact
-GitHits-specific sequence and status counts. The labeled CI export/readback is
-verified below; default-branch scheduled/manual activation remains pending
-merge.
+GitHits-specific sequence and status counts. The labeled CI export/readback and
+first stable main bootstrap are verified below; later-main, pull-request, and
+local linkage remain pending.
 
 ### Dependencies
 
@@ -1848,8 +1849,8 @@ merge.
   inspect `.bt/`, Keychain contents, or any credential value.
 - `BRAINTRUST_API_KEY` is effective in the repository Actions context, as
   verified by the labeled CI export/readback in run `33424857668`. Secret
-  values were never read. Default-branch scheduled/manual activation remains
-  pending merge.
+  values were never read. Default-branch manual bootstrap is proven by run
+  `33477846273`; its expected null base is not later-main linkage proof.
 
 ### Verified Braintrust Constraints
 
@@ -1960,9 +1961,9 @@ completion tokens, 2,706,266 total tokens, and estimated cost `$0.22819038`.
 Standard Braintrust compare averages were duration
 `22.343956532685652`, estimated cost `$0.009921320869565216`, tool calls
 `5.043478260869565`, tool errors `0`, and total tokens
-`117663.73913043478`. This proves the labeled PR path; default-branch
-scheduled/manual activation remains pending merge. No paid rerun was
-made for this documentation-only closeout.
+`117663.73913043478`. This proves the labeled PR path. Main bootstrap run
+`33477846273` subsequently proved default-branch manual execution and the
+stable `main-r33477846273-a1` identity with the expected null base.
 
 The user then requested an exact-head PR run. GitHub run
 [33429755678](https://github.com/githits-com/githits-cli/actions/runs/33429755678)
@@ -2226,13 +2227,13 @@ case; it does not satisfy native baseline linkage.
    permalink against source artifacts. The current proof is recorded below for
    `.agent-eval/suites/native-tool-smoke-2`; the earlier native-root experiment
    remains superseded historical evidence.
-4. **Implemented and labeled-path validated; default-branch activation
-   pending:** The CI export/final-status steps and repository Actions
+4. **Implemented; labeled and first main-manual paths validated:** The CI
+   export/final-status steps and repository Actions
    `BRAINTRUST_API_KEY` configuration are implemented. Workflow contract tests,
    YAML/action-reference validation, and direct SDK execution in CI were
    included in the implementation evidence. Run `33424857668` exported/read back
-   the expected 23 eval roots and 116 structural children; default-branch
-   scheduled/manual activation remains pending merge.
+   the expected 23 eval roots and 116 structural children; run `33477846273`
+   proved the stable main bootstrap and required null-base readback.
 5. **Implemented locally:** Update durable eval operations documentation and
    create the internal `braintrust-agent-evals` skill from the commands and
    field semantics proven in step 3. Validate it with the skill validator. Run
@@ -2265,8 +2266,8 @@ case; it does not satisfy native baseline linkage.
   for its two-cell canary, and labeled CI run `33424857668` read back 23 eval
   spans and 116 structural tool children. Native comparison showed
   `tool_calls` average `5.0` locally and `5.043478260869565` in CI, with
-  `tool_errors` `0` in both. Default-branch scheduled/manual activation remains
-  pending merge.
+  `tool_errors` `0` in both. Main bootstrap run `33477846273` added 23 eval
+  roots and 112 structural tool children with the expected null base.
 - Every row is filterable by workload, scenario, agent, exact CLI/model,
   reasoning, guidance, intent, target SHA, and used-tool tags. Structured
   metadata exposes ordered tools and per-tool/per-status counts.
@@ -2301,8 +2302,8 @@ case; it does not satisfy native baseline linkage.
   Braintrust derives them from exact-timed structural tool children. The local
   v2 readback verifies those native metrics and bounded SQL verifies the
   GitHits-specific/custom sequence and status metadata. Labeled CI run
-  `33424857668` verifies the native structural counts and metrics; default-
-  branch scheduled/manual activation remains pending merge.
+  `33424857668` verifies the native structural counts and metrics; main run
+  `33477846273` verifies default-branch manual bootstrap behavior.
 - The existing GitHub concise report and 14-day raw artifact upload complete
   even when export fails; the final workflow is red and names export as the
   failed stage. Local suite/report generation works without Braintrust or its

--- a/eval/agentic/README.md
+++ b/eval/agentic/README.md
@@ -8,9 +8,12 @@ It is not a smoke test. Smoke tests exercise CLI and MCP contracts directly.
 Agentic evals exercise agent behavior end-to-end.
 
 Use this harness locally to understand how MCP tool-description, quick-start,
-or skill changes affect real agent behavior. The dedicated CI workflow runs a
-small Luna matrix daily and on explicitly authorized same-repository pull
-requests. Do not treat a live agent pass/fail result as a deterministic
+or skill changes affect real agent behavior. The dedicated CI workflow
+temporarily runs a small Luna matrix on every push to `main`, as well as daily
+and on explicitly authorized same-repository pull requests. This elevated
+cadence collects enough comparable history to measure variance and identify
+workloads worth optimizing; it should be reconsidered after that data exists.
+Do not treat a live agent pass/fail result as a deterministic
 regression test: model behavior, backend indexing state, auth state, network
 conditions, and package data can all change. The useful output is the artifact
 set, especially `tool-calls.json`, `final.json`, `metrics.json`, `report.json`,
@@ -18,9 +21,10 @@ and `isolation-violations.json`.
 
 The repository-local named-suite commands below are the local measurement
 workflow. They run the fixed Luna matrix and produce validated suite and
-comparison artifacts. The CI workflow composes the same commands for daily and
-explicitly authorized pull-request runs; it retains raw artifacts for diagnosis
-and exports normalized rows to Braintrust, but does not judge answer quality.
+comparison artifacts. The CI workflow composes the same commands for main
+pushes, daily runs, and explicitly authorized pull-request runs; it retains raw
+artifacts for diagnosis and exports normalized rows to Braintrust, but does not
+judge answer quality.
 
 ## What Is Under Test
 
@@ -406,8 +410,8 @@ tool views are populated by the current exporter: completed/failed child spans
 carry exact harness-observed start/end times and computed duration, while
 started-only children remain open without a fabricated duration. Root rows do
 not set `tool_calls` or `tool_errors`; Braintrust derives those native metrics
-from the structural children. The labeled CI proof is recorded below;
-default-branch scheduled/manual activation remains pending merge.
+from the structural children. The labeled CI proof and first stable main
+bootstrap are recorded below.
 
 The current local native structural proof used suite
 `.agent-eval/suites/native-tool-smoke-2` at target and measurement commit
@@ -443,9 +447,15 @@ completion tokens, 2,706,266 total tokens, and estimated cost `$0.22819038`.
 Standard Braintrust compare averages were duration
 `22.343956532685652`, estimated cost `$0.009921320869565216`, tool calls
 `5.043478260869565`, tool errors `0`, and total tokens
-`117663.73913043478`. This validates the labeled pull-request path; default-
-branch scheduled/manual activation remains pending merge. No paid rerun
-was made for this documentation-only closeout.
+`117663.73913043478`. This validates the labeled pull-request path.
+
+The first stable main bootstrap is GitHub run
+[33477846273](https://github.com/githits-com/githits-cli/actions/runs/33477846273)
+at merge SHA `40796bd`. Its experiment `main-r33477846273-a1` persisted 23 eval
+roots and 112 MCP tool children, with zero CLI calls, 3,024,404 total tokens,
+445.728 seconds cumulative agent duration, and a `$0.24188221` rate-based
+estimated cost. Its required base readback was null, which is expected for the
+one-time bootstrap and is not later-main linkage proof.
 
 Validate downloaded or local suites without credentials or network access:
 
@@ -534,9 +544,12 @@ parallel on GitHub-hosted Ubuntu:
 | discovery | `canary`                | `discovery` |                    2 |
 | intent    | `stable-full`           | `intent`    |                    4 |
 
-The workflow runs at 03:00 UTC from the default branch, on manual
-`workflow_dispatch`, and for a `pull_request` `labeled` event targeting
-`main`. A pull request run is authorized only when the event label is exactly
+The workflow runs on every push to `main`, at 03:00 UTC from the default
+branch, on manual `workflow_dispatch`, and for a `pull_request` `labeled` event
+targeting `main`. The push trigger is intentionally temporary while
+maintainers collect run-to-run variance and workload-optimization evidence; it
+does not change the advisory, non-gating policy. A pull request run is
+authorized only when the event label is exactly
 `agent-eval` and `github.event.pull_request.head.repo.full_name` equals the
 repository; forks cannot consume the provider secrets. The workflow checks out
 the immutable labeled head SHA for that event and `github.sha` for scheduled or

--- a/scripts/agent-eval-braintrust.test.ts
+++ b/scripts/agent-eval-braintrust.test.ts
@@ -2196,6 +2196,11 @@ interface WorkflowStepContract {
 }
 
 interface WorkflowContract {
+  on?: {
+    push?: {
+      branches?: string[];
+    };
+  };
   jobs: Record<string, { if?: string; steps: WorkflowStepContract[] }>;
 }
 
@@ -2222,7 +2227,7 @@ function githubExpression(name: string): string {
 }
 
 describe("Agent eval workflow Braintrust integration", () => {
-  it("routes stable Braintrust identity and guards non-main manual dispatch", () => {
+  it("routes stable identity for main pushes and guards non-main manual dispatch", () => {
     const workflow = readAgentEvalWorkflow();
     const scenario = workflow.jobs.scenario;
     const summarySteps = readSummarySteps(workflow);
@@ -2238,6 +2243,7 @@ describe("Agent eval workflow Braintrust integration", () => {
     const braintrust = summarySteps[braintrustIndex];
     const finalize = summarySteps[finalIndex];
 
+    expect(workflow.on?.push?.branches).toEqual(["main"]);
     expect(scenario?.if).toContain(
       "github.event_name != 'workflow_dispatch' || github.ref_name == 'main'",
     );


### PR DESCRIPTION
## Summary

- temporarily run the advisory Luna agent-eval matrix on every push to main
- retain the daily, manual, and explicitly labeled PR triggers
- record the first stable main bootstrap and update the internal Braintrust analysis guidance
- add a workflow contract assertion for the main push trigger

## Cost and behavior

The measured bootstrap cost about $0.24 and completed in roughly 2–3 minutes. Results remain observational and do not gate merges. The push trigger should be reconsidered after enough history exists to measure variance and select workloads to optimize.

## Validation

- bun test scripts/agent-eval-braintrust.test.ts (44 pass, 253 expectations)
- bun test (3,798 pass, 12,839 expectations)
- bun run typecheck
- bun run lint
- bun run format:check
- bun run build
- bun run plugins:generate (no generated diff)
- bun run plugins:check
- internal skill validator
- git diff --check