### PR TITLE
fix: quote YAML description in githits-mcp SKILL.md

### DIFF
--- a/skills/githits-mcp/SKILL.md
+++ b/skills/githits-mcp/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: githits-mcp
-description: Use whenever invoking GitHits MCP tools for public OSS/package evidence: package, dependency, release, security, documentation, repository source/code search, or canonical examples. Load before any GitHits MCP tool call.
+description: "Use whenever invoking GitHits MCP tools for public OSS/package evidence: package, dependency, release, security, documentation, repository source/code search, or canonical examples. Load before any GitHits MCP tool call."
 ---
 
 # GitHits MCP

--- a/src/skills-packaging.test.ts
+++ b/src/skills-packaging.test.ts
@@ -377,7 +377,7 @@ describe("agent skills packaging", () => {
       const skillPath = join(skillsDir, dir, "SKILL.md");
       const content = await read(skillPath);
 
-      const match = content.match(/^---\n(.*?)\n---/s);
+      const match = content.match(/^---\r?\n(.*?)\r?\n---/s);
       expect(
         match,
         `${dir}/SKILL.md must start with YAML frontmatter`,

--- a/src/skills-packaging.test.ts
+++ b/src/skills-packaging.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "bun:test";
-import { readFile } from "node:fs/promises";
+import { readdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { buildMcpQuickStart } from "@githits/mcp";
+import { parse as parseYaml } from "yaml";
 
 const root = join(import.meta.dir, "..");
 const onboardingSkillPath = join(
@@ -363,5 +364,45 @@ describe("agent skills packaging", () => {
       "internal, repository-only skill",
       "Do not publish or package it",
     ]);
+  });
+
+  it("has valid YAML frontmatter in every public skill SKILL.md", async () => {
+    const skillsDir = join(root, "skills");
+    const entries = await readdir(skillsDir, { withFileTypes: true });
+    const skillDirs = entries.filter((e) => e.isDirectory()).map((e) => e.name);
+
+    expect(skillDirs.length).toBeGreaterThanOrEqual(4);
+
+    for (const dir of skillDirs) {
+      const skillPath = join(skillsDir, dir, "SKILL.md");
+      const content = await read(skillPath);
+
+      const match = content.match(/^---\n(.*?)\n---/s);
+      expect(
+        match,
+        `${dir}/SKILL.md must start with YAML frontmatter`,
+      ).not.toBe(null);
+
+      const frontmatter = match?.[1] ?? "";
+      let parsed: unknown;
+      try {
+        parsed = parseYaml(frontmatter);
+      } catch (e) {
+        throw new Error(
+          `${dir}/SKILL.md has invalid YAML frontmatter: ${(e as Error).message}`,
+        );
+      }
+
+      expect(
+        typeof parsed,
+        `${dir}/SKILL.md frontmatter must parse to an object`,
+      ).toBe("object");
+      const record = parsed as Record<string, unknown>;
+      expect(record.name, `${dir}/SKILL.md must have a name`).toBeDefined();
+      expect(
+        record.description,
+        `${dir}/SKILL.md must have a description`,
+      ).toBeDefined();
+    }
   });
 });


### PR DESCRIPTION
## Problem

The `description` field in `skills/githits-mcp/SKILL.md` is an unquoted string containing colons:

```yaml
description: Use whenever invoking GitHits MCP tools for public OSS/package evidence: package, dependency, release, ...
```

YAML interprets the colons inside the value as nested mappings, causing a parse error:

```
mapping values are not allowed here
  in line 2, column 85
```

This causes [dotagents](https://github.com/getsentry/dotagents) (Sentry's agent dependency manager) to fail when resolving the skill:

```
Failed to resolve skill "githits-mcp": Invalid YAML frontmatter
```

## Fix

Quote the description value:

```yaml
description: "Use whenever invoking GitHits MCP tools for public OSS/package evidence: ..."
```

The other three githits skills (`githits-code`, `githits-onboarding`, `githits-package`) already use folded scalar syntax (`>-`) and parse correctly. This fix uses a quoted string for minimal diff.

## Test

Added a test in `src/skills-packaging.test.ts` that parses YAML frontmatter from every `SKILL.md` in the `skills/` directory, verifying each has valid YAML with `name` and `description` fields.

## Validation

- `bun test src/skills-packaging.test.ts` — 15 pass, 0 fail
- `bun run typecheck` — passed
- `bun run lint` — passed (447 files, no fixes applied)