### PR TITLE
fix: preserve sampled changelog context

### DIFF
--- a/changes/package-upgrade-review-sampled-releases.fixed.md
+++ b/changes/package-upgrade-review-sampled-releases.fixed.md
@@ -1,0 +1,6 @@
+---
+"githits": patch
+"@githits/mcp": patch
+---
+
+- **Improve upgrade-review release context** - Compact output keeps identity-only sampled releases visible and avoids repeating releases across heuristic, sampled, and verbose entries.

--- a/docs/implementation/pkg-upgrade-review.md
+++ b/docs/implementation/pkg-upgrade-review.md
@@ -340,10 +340,15 @@ summary retains `Target: deprecation unknown`.
 Default samples remain bounded: direct advisories and transitive vulnerable
 package details and dependency-issue locators show up to five rows per category,
 peer changes up to ten, and dependency change details use the existing
-compact/verbose limits. Changelog keyword hits remain visible; ordinary entries
-are sampled. `--verbose` expands the bounded row groups in place without
-changing the JSON response. Backend truncation and unknown evidence remain
-explicit rather than being presented as complete.
+compact/verbose limits. Changelog keyword evidence renders first, followed by
+each distinct sampled release not already represented by keyword evidence, in
+sample source order. Identity-only samples retain their available version,
+publication date, URL, and headline without inventing a body. The existing
+`changelogEntryKey` identity prevents repeats across keyword, sampled, and
+verbose other tiers; verbose other entries remain body-preview-backed.
+`--verbose` expands the bounded row groups in place without changing the JSON
+response. Backend truncation and unknown evidence remain explicit rather than
+being presented as complete.
 
 ## Fact Reporting Rules
 

--- a/docs/implementation/pkg-upgrade-review.md
+++ b/docs/implementation/pkg-upgrade-review.md
@@ -80,7 +80,7 @@ Validation rules:
 - Reject tag-style `v` versions for package-addressed registry versions, matching `pkg_vulns`, `pkg_deps`, and `pkg_changelog`.
 - Keep transitive security evidence enabled by default because direct-only security hides important dependency-tree evidence. Allow callers to pass `skip_transitive_security: true` when latency is more important than transitive vulnerability context.
 - Keep `include_dependency_issues` default `false` initially for the same reason. Turn it on automatically only when the caller explicitly asks for lockfile/dependency-tree evidence, or document that agents should pass it for lockfile reviews.
-- Changelog keyword detection scans the full backend range response and keyword-hit entries are surfaced separately so relevant signals are not hidden by the ordinary sample limit. The ordinary sampled-entry cap is internal; agents should not need to tune it.
+- Changelog keyword detection scans the full backend range response and keyword-hit entries are surfaced separately so relevant signals are not hidden by the ordinary sample limit. The sampled-entry cap is internal; agents should not need to tune it.
 - `min_severity` maps to the same CVSS thresholds as `pkg_vulns` (`low=0`, `medium=4`, `high=7`, `critical=9`). It filters direct current/target vulnerability queries and transitive `vulnerabilitySummary(minSeverity:)` aggregates.
 
 CLI shape:

--- a/docs/implementation/pkg-upgrade-review.md
+++ b/docs/implementation/pkg-upgrade-review.md
@@ -80,7 +80,7 @@ Validation rules:
 - Reject tag-style `v` versions for package-addressed registry versions, matching `pkg_vulns`, `pkg_deps`, and `pkg_changelog`.
 - Keep transitive security evidence enabled by default because direct-only security hides important dependency-tree evidence. Allow callers to pass `skip_transitive_security: true` when latency is more important than transitive vulnerability context.
 - Keep `include_dependency_issues` default `false` initially for the same reason. Turn it on automatically only when the caller explicitly asks for lockfile/dependency-tree evidence, or document that agents should pass it for lockfile reviews.
-- Changelog keyword detection scans the full backend range response and keyword-hit entries are surfaced separately so relevant signals are not hidden by the ordinary sample limit. The ordinary non-keyword sample cap is internal; agents should not need to tune it.
+- Changelog keyword detection scans the full backend range response and keyword-hit entries are surfaced separately so relevant signals are not hidden by the ordinary sample limit. The ordinary sampled-entry cap is internal; agents should not need to tune it.
 - `min_severity` maps to the same CVSS thresholds as `pkg_vulns` (`low=0`, `medium=4`, `high=7`, `critical=9`). It filters direct current/target vulnerability queries and transitive `vulnerabilitySummary(minSeverity:)` aggregates.
 
 CLI shape:

--- a/packages/mcp/src/shared/package-upgrade-review-response.test.ts
+++ b/packages/mcp/src/shared/package-upgrade-review-response.test.ts
@@ -873,6 +873,141 @@ describe("package upgrade review response", () => {
     expect(text).not.toContain("Sampled release entries");
   });
 
+  it("renders keyword and distinct sampled entries in source order", () => {
+    const base = formatterReview();
+    const keywordEntry = {
+      ...base.changelog.keywordEntries[0]!,
+      version: "4.4.3",
+      htmlUrl: "https://example.com/releases/4.4.3",
+      headline: "Keyword release",
+    };
+    const firstSample = {
+      ...keywordEntry,
+      version: "4.4.2",
+      htmlUrl: "https://example.com/releases/4.4.2",
+      headline: "First sampled release",
+      signals: [],
+    };
+    const secondSample = {
+      ...keywordEntry,
+      version: "4.4.1",
+      htmlUrl: "https://example.com/releases/4.4.1",
+      headline: "Second sampled release",
+      signals: [],
+    };
+    const text = formatPackageUpgradeReviewTerminal(
+      formatterResponse([
+        formatterReview({
+          changelog: {
+            ...base.changelog,
+            entries: [keywordEntry, firstSample, secondSample],
+            sampledEntries: [firstSample, secondSample],
+            keywordEntries: [keywordEntry],
+            totalKeywordEntries: 1,
+            totalEntries: 3,
+            totalEntriesWithBodies: 3,
+          },
+        }),
+      ]),
+    );
+
+    expect(text).toContain("Heuristic release entries");
+    expect(text).toContain("Sampled release entries");
+    expect(text.indexOf("Heuristic release entries")).toBeLessThan(
+      text.indexOf("Sampled release entries"),
+    );
+    expect(text.indexOf("4.4.2")).toBeLessThan(text.indexOf("4.4.1"));
+    expect(text).toContain("First sampled release");
+    expect(text).toContain("Second sampled release");
+  });
+
+  it("renders an overlapping keyword and sampled entry only once", () => {
+    const base = formatterReview();
+    const keywordEntry = {
+      ...base.changelog.keywordEntries[0]!,
+      version: "4.4.3",
+      htmlUrl: "https://example.com/releases/overlap",
+      headline: "Overlapping release",
+    };
+    const distinctSample = {
+      ...keywordEntry,
+      version: "4.4.2",
+      htmlUrl: "https://example.com/releases/distinct",
+      headline: "Distinct sampled release",
+      signals: [],
+    };
+    const text = formatPackageUpgradeReviewTerminal(
+      formatterResponse([
+        formatterReview({
+          changelog: {
+            ...base.changelog,
+            entries: [keywordEntry, distinctSample],
+            sampledEntries: [keywordEntry, distinctSample],
+            keywordEntries: [keywordEntry],
+            totalKeywordEntries: 1,
+            totalEntries: 2,
+            totalEntriesWithBodies: 2,
+          },
+        }),
+      ]),
+    );
+
+    expect(text.split(keywordEntry.htmlUrl).length - 1).toBe(1);
+    expect(text).toContain("Sampled release entries");
+    expect(text).toContain(distinctSample.htmlUrl);
+  });
+
+  it("excludes keyword and sampled entries from verbose extras", () => {
+    const base = formatterReview();
+    const keywordEntry = {
+      ...base.changelog.keywordEntries[0]!,
+      version: "4.4.3",
+      htmlUrl: "https://example.com/releases/keyword",
+      headline: "Keyword release",
+    };
+    const sampledEntry = {
+      ...keywordEntry,
+      version: "4.4.2",
+      htmlUrl: "https://example.com/releases/sampled",
+      headline: "Sampled release",
+      signals: [],
+    };
+    const otherEntry = {
+      ...keywordEntry,
+      version: "4.4.1",
+      htmlUrl: "https://example.com/releases/other",
+      headline: "Other release",
+      body: "Other release body",
+      bodyPreview: "Other release body",
+      signals: [],
+    };
+    const text = formatPackageUpgradeReviewTerminal(
+      formatterResponse([
+        formatterReview({
+          changelog: {
+            ...base.changelog,
+            entries: [keywordEntry, sampledEntry, otherEntry],
+            sampledEntries: [sampledEntry],
+            keywordEntries: [keywordEntry],
+            totalKeywordEntries: 1,
+            totalEntries: 3,
+            totalEntriesWithBodies: 3,
+          },
+        }),
+      ]),
+      { verbose: true },
+    );
+    const otherSection = text.slice(text.indexOf("Other release entries"));
+
+    expect(text).toContain("Sampled release entries");
+    expect(text.split(keywordEntry.htmlUrl).length - 1).toBe(1);
+    expect(text.split(sampledEntry.htmlUrl).length - 1).toBe(1);
+    expect(text.split(otherEntry.htmlUrl).length - 1).toBe(1);
+    expect(otherSection).toContain(otherEntry.htmlUrl);
+    expect(otherSection).not.toContain(keywordEntry.htmlUrl);
+    expect(otherSection).not.toContain(sampledEntry.htmlUrl);
+  });
+
   it("keeps no-color text ASCII-authored and colors attention without changing words", () => {
     const plain = formatPackageUpgradeReviewTerminal(formatterResponse(), {
       useColors: false,

--- a/packages/mcp/src/shared/package-upgrade-review-response.test.ts
+++ b/packages/mcp/src/shared/package-upgrade-review-response.test.ts
@@ -1008,6 +1008,106 @@ describe("package upgrade review response", () => {
     expect(otherSection).not.toContain(sampledEntry.htmlUrl);
   });
 
+  it("renders verbose extras when no keyword entries are available", () => {
+    const base = formatterReview();
+    const sampledEntry = {
+      ...base.changelog.entries[0]!,
+      version: "4.4.2",
+      htmlUrl: "https://example.com/releases/sampled-without-keywords",
+      headline: "Sampled release",
+      signals: [],
+    };
+    const otherEntry = {
+      ...sampledEntry,
+      version: "4.4.1",
+      htmlUrl: "https://example.com/releases/other-without-keywords",
+      headline: "Other release",
+      body: "Other release body",
+      bodyPreview: "Other release body",
+    };
+    const text = formatPackageUpgradeReviewTerminal(
+      formatterResponse([
+        formatterReview({
+          changelog: {
+            ...base.changelog,
+            entries: [sampledEntry, otherEntry],
+            sampledEntries: [sampledEntry],
+            keywordEntries: [],
+            totalKeywordEntries: 0,
+            totalEntries: 2,
+            totalEntriesWithBodies: 2,
+            breakingSignals: [],
+            migrationSignals: [],
+          },
+        }),
+      ]),
+      { verbose: true },
+    );
+
+    expect(text).toContain("Sampled release entries");
+    expect(text).toContain("Other release entries");
+    expect(text).toContain(otherEntry.htmlUrl);
+    expect(text.split(sampledEntry.htmlUrl).length - 1).toBe(1);
+    expect(text.split(otherEntry.htmlUrl).length - 1).toBe(1);
+  });
+
+  it("deduplicates entries within each rendered changelog tier", () => {
+    const base = formatterReview();
+    const keywordEntry = {
+      ...base.changelog.keywordEntries[0]!,
+      version: "4.4.3",
+      htmlUrl: "https://example.com/releases/duplicate-keyword",
+      headline: "Keyword release",
+    };
+    const duplicateKeyword = {
+      ...keywordEntry,
+      headline: "Duplicate keyword release",
+    };
+    const sampledEntry = {
+      ...keywordEntry,
+      version: "4.4.2",
+      htmlUrl: "https://example.com/releases/duplicate-sampled",
+      headline: "Sampled release",
+      signals: [],
+    };
+    const duplicateSampled = {
+      ...sampledEntry,
+      headline: "Duplicate sampled release",
+    };
+    const otherEntry = {
+      ...sampledEntry,
+      version: "4.4.1",
+      htmlUrl: "https://example.com/releases/duplicate-other",
+      headline: "Other release",
+      body: "Other release body",
+      bodyPreview: "Other release body",
+    };
+    const duplicateOther = {
+      ...otherEntry,
+      headline: "Duplicate other release",
+    };
+    const text = formatPackageUpgradeReviewTerminal(
+      formatterResponse([
+        formatterReview({
+          changelog: {
+            ...base.changelog,
+            entries: [keywordEntry, sampledEntry, otherEntry, duplicateOther],
+            sampledEntries: [sampledEntry, duplicateSampled],
+            keywordEntries: [keywordEntry, duplicateKeyword],
+            totalKeywordEntries: 2,
+            totalEntries: 4,
+            totalEntriesWithBodies: 4,
+          },
+        }),
+      ]),
+      { verbose: true },
+    );
+
+    expect(text.split(keywordEntry.htmlUrl).length - 1).toBe(1);
+    expect(text.split(sampledEntry.htmlUrl).length - 1).toBe(1);
+    expect(text.split(otherEntry.htmlUrl).length - 1).toBe(1);
+  });
+
   it("keeps no-color text ASCII-authored and colors attention without changing words", () => {
     const plain = formatPackageUpgradeReviewTerminal(formatterResponse(), {
       useColors: false,

--- a/packages/mcp/src/shared/package-upgrade-review-response.test.ts
+++ b/packages/mcp/src/shared/package-upgrade-review-response.test.ts
@@ -906,11 +906,16 @@ describe("package upgrade review response", () => {
             totalKeywordEntries: 1,
             totalEntries: 3,
             totalEntriesWithBodies: 3,
+            truncated: true,
           },
         }),
       ]),
     );
 
+    expect(text.replace(/\s+/g, " ")).toContain(
+      "3 entries | 3 with release notes | 2 release entries sampled",
+    );
+    expect(text).not.toContain("ordinary entries sampled");
     expect(text).toContain("Heuristic release entries");
     expect(text).toContain("Sampled release entries");
     expect(text.indexOf("Heuristic release entries")).toBeLessThan(

--- a/packages/mcp/src/shared/package-upgrade-review-response.test.ts
+++ b/packages/mcp/src/shared/package-upgrade-review-response.test.ts
@@ -816,6 +816,63 @@ describe("package upgrade review response", () => {
     ).toBe(true);
   });
 
+  it("renders identity-only sampled changelog entries without a preview", () => {
+    const base = formatterReview();
+    const sampledEntry = {
+      ...base.changelog.entries[0]!,
+      version: "4.4.3",
+      publishedAt: "2025-12-01T20:49:43.268Z",
+      htmlUrl: "https://example.com/releases/4.4.3",
+      body: undefined,
+      bodyPreview: undefined,
+      headline: "Identity-only release",
+    };
+    const text = formatPackageUpgradeReviewTerminal(
+      formatterResponse([
+        formatterReview({
+          changelog: {
+            ...base.changelog,
+            entries: [sampledEntry],
+            sampledEntries: [sampledEntry],
+            keywordEntries: [],
+            totalKeywordEntries: 0,
+            breakingSignals: [],
+            migrationSignals: [],
+          },
+        }),
+      ]),
+    );
+
+    expect(text).toContain(
+      "Sampled release entries\n    - 4.4.3 (2025-12-01T20:49:43.268Z) https://example.com/releases/4.4.3",
+    );
+    expect(text).toContain("      Identity-only release");
+    expect(text).not.toContain("Breaking: removed an API.");
+  });
+
+  it("omits the sampled release heading when no entries are available", () => {
+    const base = formatterReview();
+    const text = formatPackageUpgradeReviewTerminal(
+      formatterResponse([
+        formatterReview({
+          changelog: {
+            ...base.changelog,
+            entries: [],
+            sampledEntries: [],
+            keywordEntries: [],
+            totalKeywordEntries: 0,
+            totalEntries: 0,
+            totalEntriesWithBodies: 0,
+            breakingSignals: [],
+            migrationSignals: [],
+          },
+        }),
+      ]),
+    );
+
+    expect(text).not.toContain("Sampled release entries");
+  });
+
   it("keeps no-color text ASCII-authored and colors attention without changing words", () => {
     const plain = formatPackageUpgradeReviewTerminal(formatterResponse(), {
       useColors: false,

--- a/packages/mcp/src/shared/package-upgrade-review-response.ts
+++ b/packages/mcp/src/shared/package-upgrade-review-response.ts
@@ -852,7 +852,7 @@ function formatChangesSection(
   const lines = [sectionTitle("Changes", useColors)];
   let coverage = `${source} | ${changelog.totalEntries} ${entryWord} | ${changelog.totalEntriesWithBodies} with release notes`;
   if (changelog.truncated)
-    coverage += ` | ${changelog.sampledEntries.length} ordinary entries sampled`;
+    coverage += ` | ${changelog.sampledEntries.length} release entries sampled`;
   appendWrappedText(lines, "  ", coverage, width, "  ");
   const keywords = changelogKeywordSummary(changelog);
   if (keywords.length > 0 || changelog.totalKeywordEntries > 0) {

--- a/packages/mcp/src/shared/package-upgrade-review-response.ts
+++ b/packages/mcp/src/shared/package-upgrade-review-response.ts
@@ -869,49 +869,48 @@ function formatChangesSection(
       (line) => colorizeSignalKeywords(line, keywords, useColors),
     );
   }
-  if (changelog.keywordEntries.length > 0) {
+  const renderedKeys = new Set<string>();
+  const keywordEntries = changelog.keywordEntries.filter((entry) => {
+    const key = changelogEntryKey(entry);
+    if (renderedKeys.has(key)) return false;
+    renderedKeys.add(key);
+    return true;
+  });
+  if (keywordEntries.length > 0) {
     lines.push("  Heuristic release entries");
-    for (const entry of changelog.keywordEntries) {
+    for (const entry of keywordEntries) {
       lines.push(
         ...formatKeywordChangelogEntry(entry, options, width, useColors),
       );
     }
-    const keywordKeys = new Set(
-      changelog.keywordEntries.map((entry) => changelogEntryKey(entry)),
-    );
-    const sampledKeys = new Set(keywordKeys);
-    const sampledEntries = changelog.sampledEntries.filter((entry) => {
+  }
+  const sampledEntries = changelog.sampledEntries.filter((entry) => {
+    const key = changelogEntryKey(entry);
+    if (renderedKeys.has(key)) return false;
+    renderedKeys.add(key);
+    return true;
+  });
+  appendPlainChangelogEntries(
+    lines,
+    "Sampled release entries",
+    sampledEntries,
+    width,
+  );
+  if (options.verbose === true) {
+    const otherEntries = changelog.entries.filter((entry) => {
+      if (!entry.bodyPreview) return false;
       const key = changelogEntryKey(entry);
-      if (sampledKeys.has(key)) return false;
-      sampledKeys.add(key);
+      if (renderedKeys.has(key)) return false;
+      renderedKeys.add(key);
       return true;
     });
     appendPlainChangelogEntries(
       lines,
-      "Sampled release entries",
-      sampledEntries,
+      "Other release entries",
+      otherEntries,
       width,
     );
-    if (options.verbose === true) {
-      const otherEntries = changelog.entries.filter(
-        (entry) =>
-          entry.bodyPreview && !sampledKeys.has(changelogEntryKey(entry)),
-      );
-      appendPlainChangelogEntries(
-        lines,
-        "Other release entries",
-        otherEntries,
-        width,
-      );
-    }
   }
-  if (changelog.keywordEntries.length === 0)
-    appendPlainChangelogEntries(
-      lines,
-      "Sampled release entries",
-      changelog.sampledEntries,
-      width,
-    );
   return lines;
 }
 

--- a/packages/mcp/src/shared/package-upgrade-review-response.ts
+++ b/packages/mcp/src/shared/package-upgrade-review-response.ts
@@ -917,10 +917,9 @@ function appendPlainChangelogEntries(
   entries: UpgradeChangelogEntry[],
   width: number,
 ): void {
-  const visibleEntries = entries.filter((entry) => entry.bodyPreview);
-  if (visibleEntries.length === 0) return;
+  if (entries.length === 0) return;
   lines.push(`  ${label}`);
-  for (const entry of visibleEntries) {
+  for (const entry of entries) {
     lines.push(...formatPlainChangelogEntry(entry, width));
   }
 }

--- a/packages/mcp/src/shared/package-upgrade-review-response.ts
+++ b/packages/mcp/src/shared/package-upgrade-review-response.ts
@@ -876,13 +876,26 @@ function formatChangesSection(
         ...formatKeywordChangelogEntry(entry, options, width, useColors),
       );
     }
+    const keywordKeys = new Set(
+      changelog.keywordEntries.map((entry) => changelogEntryKey(entry)),
+    );
+    const sampledKeys = new Set(keywordKeys);
+    const sampledEntries = changelog.sampledEntries.filter((entry) => {
+      const key = changelogEntryKey(entry);
+      if (sampledKeys.has(key)) return false;
+      sampledKeys.add(key);
+      return true;
+    });
+    appendPlainChangelogEntries(
+      lines,
+      "Sampled release entries",
+      sampledEntries,
+      width,
+    );
     if (options.verbose === true) {
-      const keywordKeys = new Set(
-        changelog.keywordEntries.map((entry) => changelogEntryKey(entry)),
-      );
       const otherEntries = changelog.entries.filter(
         (entry) =>
-          entry.bodyPreview && !keywordKeys.has(changelogEntryKey(entry)),
+          entry.bodyPreview && !sampledKeys.has(changelogEntryKey(entry)),
       );
       appendPlainChangelogEntries(
         lines,
@@ -891,14 +904,14 @@ function formatChangesSection(
         width,
       );
     }
-    return lines;
   }
-  appendPlainChangelogEntries(
-    lines,
-    "Sampled release entries",
-    changelog.sampledEntries,
-    width,
-  );
+  if (changelog.keywordEntries.length === 0)
+    appendPlainChangelogEntries(
+      lines,
+      "Sampled release entries",
+      changelog.sampledEntries,
+      width,
+    );
   return lines;
 }
 


### PR DESCRIPTION
## Outcome

Compact package-upgrade reviews now keep release context visible even when heuristic keyword evidence exists or a sampled release has no body.

- Render heuristic entries first, then every distinct sampled release in source order.
- Preserve version, publication date, URL, and headline for identity-only samples.
- Deduplicate release identities across heuristic, sampled, and verbose tiers.
- Describe truncated sample counts without incorrectly classifying heuristic matches as ordinary entries.
- Keep verbose-only entries body-backed and leave JSON and GraphQL contracts unchanged.
- Record patch impact for both githits and @githits/mcp.

## Why

Backend changelog samples and keyword hits can overlap, and bodyless package-version samples are a real response shape. The prior formatter returned after keyword evidence and filtered bodyless samples, which could hide the target release context.

## Verification

- `bun test` — 3,805 passed, 0 failed
- `bun run typecheck` — passed
- `bun run format:check` — passed
- `bun run lint` — passed
- `bun run build` — passed
- `bun run smoke:cli` — 93 live smoke steps passed
- `bun run smoke:mcp` — 50 live smoke steps passed
- Package-upgrade-safety Codex MCP eval — 28 of 28 calls completed, no validation violations
- Local Zod 4.3.6 to 4.4.3 text smoke — target sample identity and both backend unknowns rendered
- Local three-package text smoke — distinct sample hierarchies and dependency evidence remained readable

Published-package verification remains a post-release check.
