### PR TITLE
fix: hide internal agent skills

### DIFF
--- a/.agents/skills/braintrust-agent-evals/SKILL.md
+++ b/.agents/skills/braintrust-agent-evals/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: braintrust-agent-evals
 description: Inspect, query, compare, or explicitly export GitHits agent-eval history in Braintrust using the repository's verified workflow.
+metadata:
+  internal: true
 ---
 
 # Braintrust agent evals

--- a/changes/hide-braintrust-agent-evals-skill.fixed.md
+++ b/changes/hide-braintrust-agent-evals-skill.fixed.md
@@ -1,0 +1,6 @@
+---
+"githits": patch
+"@githits/mcp": none
+---
+
+- **Hide the Braintrust eval skill from public installers** - Mark the repository-only operations skill as internal so skill registries do not offer it to end users.

--- a/docs/implementation/plugin-packaging.md
+++ b/docs/implementation/plugin-packaging.md
@@ -59,6 +59,11 @@ directories:
 - `githits-onboarding`
 - `githits-package`
 
+`CANONICAL_SKILL_NAMES` is the public allow-list. Skills under
+`.agents/skills/` are repository-only and must set `metadata.internal: true`;
+plugin generation validates both sides so generic skill installers cannot
+surface maintenance or operations skills.
+
 Generated plugin assets package these root skills directly. Direct `githits
 init` setup places the same files at each selected host's verified active root;
 shared hosts use `.agents/skills`, while Claude Code, Kiro, Factory Droid,

--- a/scripts/generate-plugin-assets.test.ts
+++ b/scripts/generate-plugin-assets.test.ts
@@ -177,8 +177,23 @@ describe("plugin asset generation", () => {
       for (const skillName of CANONICAL_SKILL_NAMES) {
         const skillRoot = join(root, "skills", skillName);
         await mkdir(skillRoot, { recursive: true });
-        await writeFile(join(skillRoot, "SKILL.md"), `# ${skillName}\n`);
+        await writeFile(
+          join(skillRoot, "SKILL.md"),
+          `---\nname: ${skillName}\ndescription: Public skill.\n---\n`,
+        );
       }
+      const internalSkillRoot = join(
+        root,
+        ".agents",
+        "skills",
+        "internal-evals",
+      );
+      const internalSkillPath = join(internalSkillRoot, "SKILL.md");
+      await mkdir(internalSkillRoot, { recursive: true });
+      await writeFile(
+        internalSkillPath,
+        "---\nname: internal-evals\ndescription: Internal skill.\nmetadata:\n  internal: true\n---\n",
+      );
 
       await generatePluginAssets({ root });
       await expect(
@@ -193,6 +208,26 @@ describe("plugin asset generation", () => {
       await generatePluginAssets({ root });
       expect(await readFile(join(root, ".mcp.json"), "utf8")).toContain(
         "https://mcp.githits.com",
+      );
+
+      await writeFile(
+        internalSkillPath,
+        "---\nname: internal-evals\ndescription: Internal skill.\n---\n",
+      );
+      await expect(generatePluginAssets({ root })).rejects.toThrow(
+        "must set metadata.internal: true",
+      );
+
+      await writeFile(
+        internalSkillPath,
+        "---\nname: internal-evals\ndescription: Internal skill.\nmetadata:\n  internal: true\n---\n",
+      );
+      await writeFile(
+        join(root, "skills", "githits-code", "SKILL.md"),
+        "---\nname: githits-code\ndescription: Public skill.\nmetadata:\n  internal: true\n---\n",
+      );
+      await expect(generatePluginAssets({ root })).rejects.toThrow(
+        "is in the public skill allow-list",
       );
     } finally {
       await rm(root, { recursive: true, force: true });

--- a/scripts/generate-plugin-assets.ts
+++ b/scripts/generate-plugin-assets.ts
@@ -1,6 +1,7 @@
 import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { parse as parseYaml } from "yaml";
 
 export const CANONICAL_SKILL_NAMES = [
   "githits-code",
@@ -64,6 +65,12 @@ interface RegistryMeta {
   "io.modelcontextprotocol.registry/publisher-provided"?: RegistryPublisherMetadata;
 }
 
+interface SkillFrontmatter {
+  metadata?: {
+    internal?: unknown;
+  };
+}
+
 export interface PluginServerJson {
   version?: string;
   remotes?: RegistryRemote[];
@@ -125,6 +132,23 @@ function assertCanonicalSkills(skillNames: string[]): void {
       `Canonical skill set mismatch. Expected ${expected.join(", ")}; received ${actual.join(", ") || "none"}`,
     );
   }
+}
+
+function parseSkillFrontmatter(
+  content: string,
+  path: string,
+): SkillFrontmatter {
+  const match = content.match(/^---\r?\n(.*?)\r?\n---/s);
+  if (!match) {
+    throw new Error(`${path} must start with YAML frontmatter`);
+  }
+
+  const parsed = parseYaml(match[1] ?? "") as unknown;
+  if (!parsed || typeof parsed !== "object") {
+    throw new Error(`${path} frontmatter must parse to an object`);
+  }
+
+  return parsed as SkillFrontmatter;
 }
 
 export function createPluginAssetInputs(
@@ -373,14 +397,54 @@ async function discoverSkillNames(root: string): Promise<string[]> {
       continue;
     }
     try {
-      await readFile(join(skillsRoot, entry.name, "SKILL.md"), "utf8");
+      const path = join(skillsRoot, entry.name, "SKILL.md");
+      const frontmatter = parseSkillFrontmatter(
+        await readFile(path, "utf8"),
+        path,
+      );
+      if (
+        (CANONICAL_SKILL_NAMES as readonly string[]).includes(entry.name) &&
+        frontmatter.metadata?.internal === true
+      ) {
+        throw new Error(
+          `${path} is in the public skill allow-list and must not set metadata.internal: true`,
+        );
+      }
       skillNames.push(entry.name);
-    } catch {
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw error;
+      }
       // Non-skill directories do not belong to the public skill surface.
     }
   }
 
   return skillNames.sort();
+}
+
+async function assertInternalSkills(root: string): Promise<void> {
+  const skillsRoot = join(root, ".agents", "skills");
+  const entries = await readdir(skillsRoot, { withFileTypes: true });
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    const path = join(skillsRoot, entry.name, "SKILL.md");
+    let content: string;
+    try {
+      content = await readFile(path, "utf8");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        continue;
+      }
+      throw error;
+    }
+    const frontmatter = parseSkillFrontmatter(content, path);
+    if (frontmatter.metadata?.internal !== true) {
+      throw new Error(`${path} must set metadata.internal: true`);
+    }
+  }
 }
 
 export async function generatePluginAssets(
@@ -396,6 +460,7 @@ export async function generatePluginAssets(
     join(root, "server.json"),
   );
   const skillNames = await discoverSkillNames(root);
+  await assertInternalSkills(root);
   const assets = renderPluginAssets(
     createPluginAssetInputs(packageJson, serverJson, skillNames),
   );

--- a/src/skills-packaging.test.ts
+++ b/src/skills-packaging.test.ts
@@ -41,6 +41,13 @@ const pluginMaintenanceSkillPath = join(
   "githits-plugin-maintenance",
   "SKILL.md",
 );
+const braintrustAgentEvalsSkillPath = join(
+  root,
+  ".agents",
+  "skills",
+  "braintrust-agent-evals",
+  "SKILL.md",
+);
 async function read(path: string): Promise<string> {
   return readFile(path, "utf8");
 }
@@ -366,6 +373,19 @@ describe("agent skills packaging", () => {
     ]);
   });
 
+  it("keeps the Braintrust eval skill repository-internal", async () => {
+    const content = await read(braintrustAgentEvalsSkillPath);
+    const match = content.match(/^---\r?\n(.*?)\r?\n---/s);
+
+    expect(match).not.toBe(null);
+
+    const parsed = parseYaml(match?.[1] ?? "") as {
+      metadata?: { internal?: boolean };
+    };
+
+    expect(parsed.metadata?.internal).toBe(true);
+  });
+
   it("has valid YAML frontmatter in every public skill SKILL.md", async () => {
     const skillsDir = join(root, "skills");
     const entries = await readdir(skillsDir, { withFileTypes: true });
@@ -403,6 +423,11 @@ describe("agent skills packaging", () => {
         record.description,
         `${dir}/SKILL.md must have a description`,
       ).toBeDefined();
+      const metadata = record.metadata as Record<string, unknown> | undefined;
+      expect(
+        metadata?.internal,
+        `${dir}/SKILL.md must remain publicly discoverable`,
+      ).not.toBe(true);
     }
   });
 });


### PR DESCRIPTION
## Summary

- mark the Braintrust agent-eval operations skill as internal
- enforce the four canonical public skills as an allow-list during plugin validation
- require repository-only skills to declare `metadata.internal: true`

## Verification

- `npx --yes skills add . --list` shows only the four public GitHits skills
- `bun test` (3,801 tests)
- `bun run build`
- `bun run plugins:check`
- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `bun run smoke:cli`
- `bun run smoke:mcp`