### PR TITLE
chore: prepare 0.11.5 patch releases

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,12 +6,12 @@
   },
   "metadata": {
     "description": "The code context layer for AI coding agents",
-    "version": "0.11.4"
+    "version": "0.11.5"
   },
   "plugins": [
     {
       "name": "githits",
-      "version": "0.11.4",
+      "version": "0.11.5",
       "description": "The code context layer for AI coding agents",
       "author": {
         "name": "GitHits"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,53 @@ changes use independent files under [`changes/`](changes/README.md) and are
 consolidated here only during release preparation. Dated, versioned sections
 are historical records and change only to correct blatant factual errors.
 
+## [githits 0.11.5] - 2026-09-02
+
+Coordinated patch release: improves quick-start discovery and public OSS
+content safety, fixes Agent Skill discovery and packaging, and expands
+maintainer eval coverage.
+
+### Changed
+
+- **Temporarily evaluate every main update** - Run the advisory Luna agent-eval
+  workflow on every push to `main` while maintainers collect Braintrust
+  variance and workload-optimization evidence; daily, manual, and explicitly
+  labeled pull-request runs remain available.
+
+### Fixed
+
+- **Hide the Braintrust eval skill from public installers** - Mark the
+  repository-only operations skill as internal so skill registries do not
+  offer it to end users.
+- **Improve quick-start discovery** - The `quick_start` catalog sentence now
+  identifies the required first call and the untrusted-content safety rules it
+  loads before plain MCP sessions use evidence tools.
+- **Keep the MCP skill installable** - Quote its YAML frontmatter description
+  so standards-compliant Agent Skill installers parse it successfully.
+
+### Security
+
+- **Clarify remote OSS content boundaries** - Frame retrieved public OSS
+  content as untrusted evidence that cannot override user authorization or
+  host safeguards while preserving prompt-injection protections.
+
+## [@githits/mcp 0.11.5] - 2026-09-02
+
+Coordinated patch release: improves quick-start discovery and clarifies the
+security boundaries for retrieved public OSS content.
+
+### Fixed
+
+- **Improve quick-start discovery** - The `quick_start` catalog sentence now
+  identifies the required first call and the untrusted-content safety rules it
+  loads before plain MCP sessions use evidence tools.
+
+### Security
+
+- **Clarify remote OSS content boundaries** - Frame retrieved public OSS
+  content as untrusted evidence that cannot override user authorization or
+  host safeguards while preserving prompt-injection protections.
+
 ## [githits 0.11.4] - 2026-09-01
 
 Patch release: adds definition-aware search evidence, improves MCP session

--- a/bun.lock
+++ b/bun.lock
@@ -45,7 +45,7 @@
     },
     "packages/mcp": {
       "name": "@githits/mcp",
-      "version": "0.11.4",
+      "version": "0.11.5",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "^4.4.3",

--- a/changes/agent-eval-main-push.changed.md
+++ b/changes/agent-eval-main-push.changed.md
@@ -1,6 +1,0 @@
----
-"githits": none
-"@githits/mcp": none
----
-
-- **Temporarily evaluate every main update** - Run the advisory Luna agent-eval workflow on every push to `main` while maintainers collect Braintrust variance and workload-optimization evidence; daily, manual, and explicitly labeled pull-request runs remain available.

--- a/changes/hide-braintrust-agent-evals-skill.fixed.md
+++ b/changes/hide-braintrust-agent-evals-skill.fixed.md
@@ -1,6 +1,0 @@
----
-"githits": patch
-"@githits/mcp": none
----
-
-- **Hide the Braintrust eval skill from public installers** - Mark the repository-only operations skill as internal so skill registries do not offer it to end users.

--- a/changes/neutral-remote-oss-content-posture.security.md
+++ b/changes/neutral-remote-oss-content-posture.security.md
@@ -1,6 +1,0 @@
----
-"githits": patch
-"@githits/mcp": patch
----
-
-- **Clarify remote OSS content boundaries** - Frame retrieved public OSS content as untrusted evidence that cannot override user authorization or host safeguards while preserving prompt-injection protections.

--- a/changes/quick-start-retrieval.fixed.md
+++ b/changes/quick-start-retrieval.fixed.md
@@ -1,8 +1,0 @@
----
-"githits": patch
-"@githits/mcp": patch
----
-
-- **Improve quick-start discovery** - The `quick_start` catalog sentence now
-  identifies the required first call and the untrusted-content safety rules it
-  loads before plain MCP sessions use evidence tools.

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "description": "The code context layer for AI coding agents",
   "mcpServers": {
     "githits": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "githits",
   "description": "The code context layer for AI coding agents",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "mcpName": "com.githits/githits",
   "type": "module",
   "workspaces": [

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@githits/mcp",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "description": "Reusable MCP server APIs and tools for GitHits",
   "type": "module",
   "files": [

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "githits",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/server.json
+++ b/server.json
@@ -16,7 +16,7 @@
     "source": "github",
     "id": "1165453165"
   },
-  "version": "0.11.4",
+  "version": "0.11.5",
   "remotes": [
     {
       "type": "streamable-http",
@@ -28,7 +28,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "githits",
-      "version": "0.11.4",
+      "version": "0.11.5",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Summary

- bump `githits` and `@githits/mcp` from 0.11.4 to 0.11.5
- regenerate versioned plugin and assistant manifests from canonical release metadata
- consolidate all pending fragments into artifact-specific 2026-09-02 changelog sections
- add the missing release note for standards-compliant parsing of the public MCP skill frontmatter

## Validation

- `bun install --frozen-lockfile`
- `bun run plugins:check`
- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `bun test` (3,801 pass, 0 fail)
- `bun run build`
- `bun run validate:packages`
- `bun run validate:packages:mcp-publish`
- `bun run smoke:cli`
- `bun run smoke:mcp`
- `bun run smoke:cli:built`
- `bun run smoke:mcp:built`
- pinned `mcp-publisher v1.7.9 validate server.json`
- npm, Git tag, and GitHub Release collision checks for 0.11.5
- targeted Codex Luna-low agent evals: descriptor+intent called `quick_start` first and exactly once; full skill guidance skipped it; both succeeded with high confidence, zero CLI fallback, and no isolation violations

## Qualitative eval note

The Claude catalog-salience probe could not run because the required isolated noninteractive Claude authentication input is unavailable. No credential state was inspected or changed.

## Merge gate

Do not merge or enable auto-merge without separate explicit human approval for this release PR.