### PR TITLE
Align upgrade-review batches with the 30-package backend limit

### DIFF
--- a/changes/package-upgrade-review-batch-limit.changed.md
+++ b/changes/package-upgrade-review-batch-limit.changed.md
@@ -1,0 +1,6 @@
+---
+"githits": patch
+"@githits/mcp": patch
+---
+
+- **Align upgrade-review batch validation** - CLI and MCP now advertise and enforce the deployed limit of 30 nonblank package upgrades before sending a request.

--- a/docs/implementation/pkg-upgrade-review.md
+++ b/docs/implementation/pkg-upgrade-review.md
@@ -77,6 +77,7 @@ Validation rules:
 
 - Require either `packages` or the single-package fields.
 - Reject `packages` combined with `registry`, `package_name`, `current_version`, or `target_version`.
+- Accept at most 30 nonblank `packages[]` rows. Blank rows are removed before applying the limit, and a larger batch is rejected by the shared CLI/MCP request builder before any package-intelligence service call.
 - Reject tag-style `v` versions for package-addressed registry versions, matching `pkg_vulns`, `pkg_deps`, and `pkg_changelog`.
 - Keep transitive security evidence enabled by default because direct-only security hides important dependency-tree evidence. Allow callers to pass `skip_transitive_security: true` when latency is more important than transitive vulnerability context.
 - Keep `include_dependency_issues` default `false` initially for the same reason. Turn it on automatically only when the caller explicitly asks for lockfile/dependency-tree evidence, or document that agents should pass it for lockfile reviews.

--- a/packages/mcp/src/shared/package-upgrade-review-request.test.ts
+++ b/packages/mcp/src/shared/package-upgrade-review-request.test.ts
@@ -1,6 +1,19 @@
 import { describe, expect, it } from "bun:test";
 import { InvalidPackageSpecError } from "./package-spec.js";
-import { buildPackageUpgradeReviewRequest } from "./package-upgrade-review-request.js";
+import {
+  buildPackageUpgradeReviewRequest,
+  PACKAGE_UPGRADE_REVIEW_MAX_PACKAGES,
+  type UpgradeReviewPackageInput,
+} from "./package-upgrade-review-request.js";
+
+function batchPackage(index: number): UpgradeReviewPackageInput {
+  return {
+    registry: "npm",
+    packageName: `package-${index}`,
+    currentVersion: "1.0.0",
+    targetVersion: "1.0.1",
+  };
+}
 
 describe("buildPackageUpgradeReviewRequest", () => {
   it("treats an empty packages array as absent for single-package mode", () => {
@@ -96,6 +109,44 @@ describe("buildPackageUpgradeReviewRequest", () => {
       currentVersion: "4.18.0",
       targetVersion: "5.0.0",
     });
+  });
+
+  it("accepts the maximum batch size after dropping blank rows", () => {
+    const { packages } = buildPackageUpgradeReviewRequest({
+      packages: [
+        {
+          registry: " ",
+          packageName: "",
+          currentVersion: "\t",
+          targetVersion: "",
+        },
+        ...Array.from(
+          { length: PACKAGE_UPGRADE_REVIEW_MAX_PACKAGES },
+          (_, index) => batchPackage(index),
+        ),
+      ],
+    });
+
+    expect(packages).toHaveLength(PACKAGE_UPGRADE_REVIEW_MAX_PACKAGES);
+  });
+
+  it("rejects batches above the maximum", () => {
+    expect(() =>
+      buildPackageUpgradeReviewRequest({
+        packages: Array.from(
+          { length: PACKAGE_UPGRADE_REVIEW_MAX_PACKAGES + 1 },
+          (_, index) => batchPackage(index),
+        ),
+      }),
+    ).toThrow(InvalidPackageSpecError);
+    expect(() =>
+      buildPackageUpgradeReviewRequest({
+        packages: Array.from(
+          { length: PACKAGE_UPGRADE_REVIEW_MAX_PACKAGES + 1 },
+          (_, index) => batchPackage(index),
+        ),
+      }),
+    ).toThrow("packages[] must contain at most 30 upgrades.");
   });
 
   it("still rejects calls without a package target", () => {

--- a/packages/mcp/src/shared/package-upgrade-review-request.ts
+++ b/packages/mcp/src/shared/package-upgrade-review-request.ts
@@ -56,6 +56,7 @@ export interface PackageUpgradeReviewRequestBuildResult {
 }
 
 const DEFAULT_CHANGELOG_LIMIT = 20;
+export const PACKAGE_UPGRADE_REVIEW_MAX_PACKAGES = 30;
 
 export function buildPackageUpgradeReviewRequest(
   input: PackageUpgradeReviewRequestInput,
@@ -144,6 +145,11 @@ function parseBatch(
   if (!Array.isArray(packages) || packages.length === 0) {
     throw new InvalidPackageSpecError(
       "packages[] must contain at least one upgrade.",
+    );
+  }
+  if (packages.length > PACKAGE_UPGRADE_REVIEW_MAX_PACKAGES) {
+    throw new InvalidPackageSpecError(
+      `packages[] must contain at most ${PACKAGE_UPGRADE_REVIEW_MAX_PACKAGES} upgrades.`,
     );
   }
   return packages.map(parsePackageInput);

--- a/packages/mcp/src/tools/package-upgrade-review.test.ts
+++ b/packages/mcp/src/tools/package-upgrade-review.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, mock } from "bun:test";
+import { z } from "zod";
 import { createMockPackageIntelligenceService } from "../services/test-helpers.js";
+import { PACKAGE_UPGRADE_REVIEW_MAX_PACKAGES } from "../shared/package-upgrade-review-request.js";
 import { createPackageUpgradeReviewTool } from "./package-upgrade-review.js";
 
 function parseText(result: { content: Array<{ text: string }> }): unknown {
@@ -27,6 +29,13 @@ describe("createPackageUpgradeReviewTool", () => {
       "target_version",
       "verbose",
     ]);
+
+    const inputSchema = z.toJSONSchema(z.object(tool.schema));
+    expect(inputSchema.properties?.packages).toMatchObject({
+      description: expect.stringContaining("at most 30 upgrades"),
+    });
+    expect(inputSchema.properties?.packages).not.toHaveProperty("maxItems");
+    expect(tool.description).toContain("at most 30 upgrades");
   });
 
   it("calls the aggregate service method with normalized single-package params", async () => {
@@ -186,5 +195,39 @@ describe("createPackageUpgradeReviewTool", () => {
 
     expect(result.isError).toBe(true);
     expect(parseText(result)).toMatchObject({ code: "INVALID_ARGUMENT" });
+  });
+
+  it("rejects over-cap batches before calling the service", async () => {
+    const packageUpgradeReview = mock(() =>
+      Promise.reject(new Error("service must not be called")),
+    );
+    const tool = createPackageUpgradeReviewTool(
+      createMockPackageIntelligenceService({
+        packageUpgradeReview: packageUpgradeReview as never,
+      }),
+    );
+
+    const result = await tool.handler(
+      {
+        packages: Array.from(
+          { length: PACKAGE_UPGRADE_REVIEW_MAX_PACKAGES + 1 },
+          (_, index) => ({
+            registry: "npm",
+            package_name: `package-${index}`,
+            current_version: "1.0.0",
+            target_version: "1.0.1",
+          }),
+        ),
+      },
+      {},
+    );
+
+    expect(packageUpgradeReview).not.toHaveBeenCalled();
+    expect(result.isError).toBe(true);
+    expect(parseText(result)).toMatchObject({
+      code: "INVALID_ARGUMENT",
+      retryable: false,
+      error: "packages[] must contain at most 30 upgrades.",
+    });
   });
 });

--- a/packages/mcp/src/tools/package-upgrade-review.ts
+++ b/packages/mcp/src/tools/package-upgrade-review.ts
@@ -2,7 +2,10 @@ import type { PackageIntelligenceService } from "@githits/core-internal";
 import { PKGSEER_REGISTRY_LIST } from "@githits/core-internal";
 import { z } from "zod";
 import { mapPackageIntelligenceError } from "../shared/package-intelligence-error-map.js";
-import { buildPackageUpgradeReviewRequest } from "../shared/package-upgrade-review-request.js";
+import {
+  buildPackageUpgradeReviewRequest,
+  PACKAGE_UPGRADE_REVIEW_MAX_PACKAGES,
+} from "../shared/package-upgrade-review-request.js";
 import {
   buildPackageUpgradeReview,
   formatPackageUpgradeReviewTerminal,
@@ -77,7 +80,9 @@ const schema: ZodRawShape = {
   packages: z
     .array(packageSchema)
     .optional()
-    .describe("Batch mode. Mutually exclusive with single-package fields."),
+    .describe(
+      `Batch mode with at most ${PACKAGE_UPGRADE_REVIEW_MAX_PACKAGES} upgrades after blank rows are removed. Mutually exclusive with single-package fields.`,
+    ),
   skip_transitive_security: z
     .boolean()
     .optional()
@@ -116,8 +121,8 @@ const DESCRIPTION =
   "The tool reports facts only and does not assign risk or decide whether to accept an upgrade. " +
   "Use this instead of inferring acceptability from semver, including patch bumps. " +
   "Accepts either one package via registry/package_name/current_version/" +
-  "target_version or batch `packages[]`. Batch execution is capped internally " +
-  "to avoid flooding the package-intelligence backend. Use `pkg_info` for latest health, `pkg_changelog` for release notes, `pkg_vulns` for advisory detail, or `pkg_deps` for dependency graphs." +
+  `target_version or batch \`packages[]\` with at most ${PACKAGE_UPGRADE_REVIEW_MAX_PACKAGES} upgrades. ` +
+  "Use `pkg_info` for latest health, `pkg_changelog` for release notes, `pkg_vulns` for advisory detail, or `pkg_deps` for dependency graphs." +
   `\n\n${PKG_UPGRADE_REVIEW_GUARDRAIL}`;
 
 export function createPackageUpgradeReviewTool(

--- a/src/commands/pkg/upgrade-review.test.ts
+++ b/src/commands/pkg/upgrade-review.test.ts
@@ -1,9 +1,14 @@
-import { afterEach, describe, expect, it, mock } from "bun:test";
-import { InvalidPackageSpecError } from "@githits/mcp/internal";
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test";
+import {
+  InvalidPackageSpecError,
+  PACKAGE_UPGRADE_REVIEW_MAX_PACKAGES,
+} from "@githits/mcp/internal";
+import { Command } from "commander";
 import { createMockPackageIntelligenceService } from "../../services/test-helpers.js";
 import {
   parseUpgradeReviewPackageOption,
   pkgUpgradeReviewAction,
+  registerPkgUpgradeReviewCommand,
 } from "./upgrade-review.js";
 
 const originalStdoutWrite = process.stdout.write;
@@ -57,6 +62,60 @@ describe("parseUpgradeReviewPackageOption", () => {
     expect(() => parseUpgradeReviewPackageOption("npm:zod@4.3.6-")).toThrow(
       "The shell likely treated '>' as output redirection",
     );
+  });
+});
+
+describe("pkg upgrade-review help", () => {
+  it("advertises the maximum batch size", () => {
+    const command = registerPkgUpgradeReviewCommand(
+      new Command().command("pkg"),
+    );
+    const help = command.helpInformation().replace(/\s+/g, " ");
+
+    expect(help).toContain("at most 30 upgrades");
+    expect(help).toContain("maximum 30");
+  });
+});
+
+describe("pkgUpgradeReviewAction", () => {
+  it("rejects over-cap batches before calling the service", async () => {
+    const packageUpgradeReview = mock(() =>
+      Promise.reject(new Error("service must not be called")),
+    );
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+
+    try {
+      await expect(
+        pkgUpgradeReviewAction(
+          undefined,
+          {
+            package: Array.from(
+              { length: PACKAGE_UPGRADE_REVIEW_MAX_PACKAGES + 1 },
+              (_, index) => `npm:package-${index}@1.0.0..1.0.1`,
+            ),
+          },
+          {
+            packageIntelligenceService: createMockPackageIntelligenceService({
+              packageUpgradeReview: packageUpgradeReview as never,
+            }),
+            codeNavigationUrl: "https://pkgseer.dev",
+            hasValidToken: true,
+            mcpUrl: "https://mcp.githits.com",
+          },
+        ),
+      ).rejects.toThrow("process.exit");
+
+      expect(packageUpgradeReview).not.toHaveBeenCalled();
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("packages[] must contain at most 30 upgrades."),
+      );
+    } finally {
+      errorSpy.mockRestore();
+      exitSpy.mockRestore();
+    }
   });
 
   it("writes JSON through stdout.write instead of console.log", async () => {

--- a/src/commands/pkg/upgrade-review.ts
+++ b/src/commands/pkg/upgrade-review.ts
@@ -4,6 +4,7 @@ import {
   buildPackageUpgradeReviewRequest,
   formatPackageUpgradeReviewTerminal,
   InvalidPackageSpecError,
+  PACKAGE_UPGRADE_REVIEW_MAX_PACKAGES,
   parsePackageSpec,
   requireAuth,
   shouldUseColors,
@@ -191,6 +192,7 @@ const DESCRIPTION = `Report evidence for a package upgrade without assigning ris
 
 Single package: githits pkg upgrade-review npm:zod@4.3.6 --to 4.4.3
 Batch: githits pkg upgrade-review --package npm:zod@4.3.6..4.4.3 --package npm:lint-staged@16.2.7..16.4.0
+Batch accepts at most ${PACKAGE_UPGRADE_REVIEW_MAX_PACKAGES} upgrades.
 
 The older -> delimiter is still accepted when quoted, but unquoted > is shell
 redirection in zsh/bash. Prefer .. for repeatable --package entries.
@@ -209,7 +211,7 @@ export function registerPkgUpgradeReviewCommand(pkgCommand: Command): Command {
     .option("--to <version>", "Target version for single-package mode")
     .option(
       "--package <spec>",
-      "Repeatable batch entry: <registry>:<name>@<current>..<target>",
+      `Repeatable batch entry (maximum ${PACKAGE_UPGRADE_REVIEW_MAX_PACKAGES}): <registry>:<name>@<current>..<target>`,
       collectPackage,
       [] as string[],
     )


### PR DESCRIPTION
## Summary

- enforce the deployed maximum of 30 nonblank package upgrades at the shared CLI/MCP request boundary
- advertise the limit in MCP metadata/tool guidance and CLI help
- document the downstream contract and add patch release metadata for both public packages

Blank rows are filtered before capacity is applied. Single-package behavior and the GraphQL query/response path are unchanged.

## Validation

- `bun test packages/mcp/src/shared/package-upgrade-review-request.test.ts packages/mcp/src/tools/package-upgrade-review.test.ts src/commands/pkg/upgrade-review.test.ts src/tools/package-upgrade-review-parity.test.ts` — 27 pass
- `bun test` — 3,821 pass
- `bun run typecheck`
- `bun run build`
- `bun run format:check`
- `bun run lint`
- `bun run validate:packages`
- `bun run plugins:generate` and `bun run plugins:check`
- `bun run smoke:cli` — 93 live steps passed
- `bun run smoke:mcp` — 50 live steps passed
- targeted descriptor-only package-upgrade agent eval — success/high confidence, 4 MCP calls, no failures or validation violations
- authenticated rich 30-row request against the normal package endpoint — 30 reviews returned
- authenticated rich 30-row request against the development MCP/API/PkgSeer environment — 30 reviews returned
- internal Codex review and Claude Opus review — clean

The GraphQL service file matches the base byte-for-byte. No credential data was inspected or exposed.