### PR TITLE
chore: prepare 0.12.0 minor releases

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,12 +6,12 @@
   },
   "metadata": {
     "description": "The code context layer for AI coding agents",
-    "version": "0.11.5"
+    "version": "0.12.0"
   },
   "plugins": [
     {
       "name": "githits",
-      "version": "0.11.5",
+      "version": "0.12.0",
       "description": "The code context layer for AI coding agents",
       "author": {
         "name": "GitHits"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.11.5",
+  "version": "0.12.0",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.11.5",
+  "version": "0.12.0",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.11.5",
+  "version": "0.12.0",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.11.5",
+  "version": "0.12.0",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,53 @@ changes use independent files under [`changes/`](changes/README.md) and are
 consolidated here only during release preparation. Dated, versioned sections
 are historical records and change only to correct blatant factual errors.
 
+## [githits 0.12.0] - 2026-09-03
+
+Minor release: adds opt-in Agentic Ask and improves repository grep,
+upgrade-review validation and release context, and Windows token-refresh
+handoff.
+
+### Added
+
+- **Experimental Agentic Ask** - Add opt-in `githits ask` CLI and local MCP
+  surfaces with source-cited answers, follow-up threads, directly executable
+  source calls, and original upstream URL sources.
+
+### Changed
+
+- **Align upgrade-review batch validation** - CLI and MCP now advertise and
+  enforce the deployed limit of 30 nonblank package upgrades before sending a
+  request.
+
+### Fixed
+
+- **Align grep symbol fields** - CLI and MCP validation now expose only symbol
+  metadata that repository grep can hydrate.
+- **Improve upgrade-review release context** - Compact output keeps
+  identity-only sampled releases visible and avoids repeating releases across
+  heuristic, sampled, and verbose entries.
+- **Serialize Windows token refresh handoff** - Release file-backed auth locks
+  without racing successor agents against removal of the shared lock path.
+
+## [@githits/mcp 0.12.0] - 2026-09-03
+
+Coordinated minor release: aligns `@githits/mcp` with the CLI 0.12 line and
+improves repository grep and upgrade-review validation and release context.
+
+### Changed
+
+- **Align upgrade-review batch validation** - CLI and MCP now advertise and
+  enforce the deployed limit of 30 nonblank package upgrades before sending a
+  request.
+
+### Fixed
+
+- **Align grep symbol fields** - CLI and MCP validation now expose only symbol
+  metadata that repository grep can hydrate.
+- **Improve upgrade-review release context** - Compact output keeps
+  identity-only sampled releases visible and avoids repeating releases across
+  heuristic, sampled, and verbose entries.
+
 ## [githits 0.11.5] - 2026-09-02
 
 Coordinated patch release: improves quick-start discovery and public OSS

--- a/bun.lock
+++ b/bun.lock
@@ -45,7 +45,7 @@
     },
     "packages/mcp": {
       "name": "@githits/mcp",
-      "version": "0.11.5",
+      "version": "0.12.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "^4.4.3",

--- a/changes/experimental-agentic-ask.added.md
+++ b/changes/experimental-agentic-ask.added.md
@@ -1,6 +1,0 @@
----
-"githits": minor
-"@githits/mcp": none
----
-
-- **Experimental Agentic Ask** - Add opt-in `githits ask` CLI and local MCP surfaces with source-cited answers, follow-up threads, directly executable source calls, and original upstream URL sources.

--- a/changes/grep-symbol-fields.fixed.md
+++ b/changes/grep-symbol-fields.fixed.md
@@ -1,6 +1,0 @@
----
-"githits": patch
-"@githits/mcp": patch
----
-
-- **Align grep symbol fields** - CLI and MCP validation now expose only symbol metadata that repository grep can hydrate.

--- a/changes/package-upgrade-review-batch-limit.changed.md
+++ b/changes/package-upgrade-review-batch-limit.changed.md
@@ -1,6 +1,0 @@
----
-"githits": patch
-"@githits/mcp": patch
----
-
-- **Align upgrade-review batch validation** - CLI and MCP now advertise and enforce the deployed limit of 30 nonblank package upgrades before sending a request.

--- a/changes/package-upgrade-review-sampled-releases.fixed.md
+++ b/changes/package-upgrade-review-sampled-releases.fixed.md
@@ -1,6 +1,0 @@
----
-"githits": patch
-"@githits/mcp": patch
----
-
-- **Improve upgrade-review release context** - Compact output keeps identity-only sampled releases visible and avoids repeating releases across heuristic, sampled, and verbose entries.

--- a/changes/windows-token-refresh-handoff.fixed.md
+++ b/changes/windows-token-refresh-handoff.fixed.md
@@ -1,6 +1,0 @@
----
-"githits": patch
-"@githits/mcp": none
----
-
-- **Serialize Windows token refresh handoff** - Release file-backed auth locks without racing successor agents against removal of the shared lock path.

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.11.5",
+  "version": "0.12.0",
   "description": "The code context layer for AI coding agents",
   "mcpServers": {
     "githits": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "githits",
   "description": "The code context layer for AI coding agents",
-  "version": "0.11.5",
+  "version": "0.12.0",
   "mcpName": "com.githits/githits",
   "type": "module",
   "workspaces": [

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@githits/mcp",
-  "version": "0.11.5",
+  "version": "0.12.0",
   "description": "Reusable MCP server APIs and tools for GitHits",
   "type": "module",
   "files": [

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "githits",
-  "version": "0.11.5",
+  "version": "0.12.0",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/server.json
+++ b/server.json
@@ -16,7 +16,7 @@
     "source": "github",
     "id": "1165453165"
   },
-  "version": "0.11.5",
+  "version": "0.12.0",
   "remotes": [
     {
       "type": "streamable-http",
@@ -28,7 +28,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "githits",
-      "version": "0.11.5",
+      "version": "0.12.0",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Summary

- bump `githits` and `@githits/mcp` from 0.11.5 to 0.12.0
- regenerate versioned plugin, assistant, and MCP registry manifests from canonical release metadata
- consolidate all five pending fragments into artifact-specific 2026-09-03 changelog sections
- include the newly merged 30-package upgrade-review batch limit in both artifacts

## Validation

- `bun install --frozen-lockfile`
- `bun run plugins:check`
- `bun run lint`
- `bun run typecheck`
- focused release and newly merged upgrade-review tests (50 pass, 0 fail)
- `bun run build`
- `bun run smoke:cli` (stable and experimental live cohorts passed, including Ask)
- `bun run smoke:mcp` (stable and experimental live cohorts passed, including Ask)
- `bun run smoke:cli:built`
- `bun run smoke:mcp:built`
- `git diff --check`
- npm, Git tag, and GitHub Release collision checks for 0.12.0

## Local environment notes

- Full `bun test`: 3,905 pass and 2 environment-specific failures. One is a repeatable Windows `EBUSY` temporary-directory cleanup failure; the other correctly rejects this host's non-isolated `CODEX_HOME` because it contains global instructions. The release-focused and PR #348 tests pass independently.
- `bun run format:check` reports CRLF-only diagnostics across 414 pre-existing files in this Windows worktree. The staged-file commit hooks formatted all release changes, and `git diff --check` passes.
- `bun run validate:packages` and `bun run validate:packages:mcp-publish` reach the MCP build and then hit the known Bun 1.3.9 Windows `bunup` path panic. Root build and built-artifact smokes pass; Linux CI remains the package-validation gate.
- `mcp-publisher` is not installed locally, so registry validation is deferred to CI.

## Merge gate

Do not merge or enable auto-merge without separate explicit human approval for this release PR.