### PR TITLE
chore: prepare 0.12.1 patch releases

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,12 +6,12 @@
   },
   "metadata": {
     "description": "The code context layer for AI coding agents",
-    "version": "0.12.0"
+    "version": "0.12.1"
   },
   "plugins": [
     {
       "name": "githits",
-      "version": "0.12.0",
+      "version": "0.12.1",
       "description": "The code context layer for AI coding agents",
       "author": {
         "name": "GitHits"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,45 @@ changes use independent files under [`changes/`](changes/README.md) and are
 consolidated here only during release preparation. Dated, versioned sections
 are historical records and change only to correct blatant factual errors.
 
+## [githits 0.12.1] - 2026-09-04
+
+Patch release: adds opt-in dependency issue analysis and expanded package
+overview evidence, and improves GitHits skill discovery.
+
+### Added
+
+- **Dependency issue analysis** - Opt into deprecated, outdated, duplicate, and
+  conflict analysis with `pkg deps --issues` or MCP `include_issues: true`,
+  including actionable conflict constraints and importer provenance in text and
+  JSON.
+- **Clarify package overview evidence** - `pkg_info` separates latest-version
+  affected vulnerabilities from package-wide advisory history, keeps that
+  summary evidence-only, improves URL contrast, and exposes published-version
+  count plus download freshness in verbose text and JSON. Full-history routing
+  remains available in CLI help and the MCP descriptor.
+
+### Fixed
+
+- **Improve GitHits skill discovery** - Make the MCP skill describe the OSS and
+  package tasks that should trigger it instead of assuming GitHits was already
+  selected.
+
+## [@githits/mcp 0.12.1] - 2026-09-04
+
+Coordinated patch release: adds opt-in dependency issue analysis and expanded
+package overview evidence.
+
+### Added
+
+- **Dependency issue analysis** - Opt into deprecated, outdated, duplicate, and
+  conflict analysis with MCP `include_issues: true`, including actionable
+  conflict constraints and importer provenance in text and JSON.
+- **Clarify package overview evidence** - `pkg_info` separates latest-version
+  affected vulnerabilities from package-wide advisory history, keeps that
+  summary evidence-only, improves URL contrast, and exposes published-version
+  count plus download freshness in verbose text and JSON. Full-history routing
+  remains available in the MCP descriptor.
+
 ## [githits 0.12.0] - 2026-09-03
 
 Minor release: adds opt-in Agentic Ask and improves repository grep,

--- a/bun.lock
+++ b/bun.lock
@@ -45,7 +45,7 @@
     },
     "packages/mcp": {
       "name": "@githits/mcp",
-      "version": "0.12.0",
+      "version": "0.12.1",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "^4.4.3",

--- a/changes/improve-githits-skill-trigger.fixed.md
+++ b/changes/improve-githits-skill-trigger.fixed.md
@@ -1,8 +1,0 @@
----
-"githits": patch
-"@githits/mcp": none
----
-
-- **Improve GitHits skill discovery** - Make the MCP skill describe the OSS and
-  package tasks that should trigger it instead of assuming GitHits was already
-  selected.

--- a/changes/pkg-deps-issue-analysis.added.md
+++ b/changes/pkg-deps-issue-analysis.added.md
@@ -1,6 +1,0 @@
----
-"githits": minor
-"@githits/mcp": minor
----
-
-- **Dependency issue analysis** - Opt into deprecated, outdated, duplicate, and conflict analysis with `pkg deps --issues` or MCP `include_issues: true`, including actionable conflict constraints and importer provenance in text and JSON.

--- a/changes/pkg-info-package-evidence.added.md
+++ b/changes/pkg-info-package-evidence.added.md
@@ -1,6 +1,0 @@
----
-"githits": minor
-"@githits/mcp": minor
----
-
-- **Clarify package overview evidence** - `pkg_info` separates latest-version affected vulnerabilities from package-wide advisory history, keeps that summary evidence-only, improves URL contrast, and exposes published-version count plus download freshness in verbose text and JSON. Full-history routing remains available in CLI help and the MCP descriptor. The next `githits` artifact must carry the matching CLI behavior so main-published skill guidance and installed behavior stay aligned.

--- a/docs/plans/package-intelligence-client-improvements.md
+++ b/docs/plans/package-intelligence-client-improvements.md
@@ -6,9 +6,9 @@
 - Phase 1 — package overview distinguishes current-version and package-history
   evidence: **COMPLETE — merged in PR #350 at `9d267a2`**
 - Phase 2 — dependency analysis exposes actionable issue and conflict evidence:
-  **IMPLEMENTED — draft PR #351, awaiting merge**
+  **COMPLETE — merged in PR #351 at `16ecf75`**
 - Phase 3 — vulnerability inspection optionally audits resolved transitive
-  dependencies: **PENDING REORIENTATION — blocked on Phase 2 merge and `$next-steps`**
+  dependencies: **PENDING REORIENTATION — awaiting `$next-steps` after Phase 2 merge**
 - Last verified: 2026-09-04
 
 ## Problem and expected outcome
@@ -312,7 +312,7 @@ client view consumes. Callers never have to discover and combine coupled flags.
 
 - None for Phases 1 and 2. This plan fixes non-bold cyan and removal of the inline
   action as the Phase 1 product contract.
-- Phase 3 tactical detail will be refreshed after Phase 2 merges, but its product
+- Phase 3 tactical detail will be refreshed now that Phase 2 has merged, but its product
   outcome, opt-in behavior, scope semantics, and error behavior are decided here.
 
 ## Cross-cutting considerations
@@ -402,7 +402,7 @@ client view consumes. Callers never have to discover and combine coupled flags.
 
 ### Phase 2 — dependency issues and conflicts become actionable
 
-- **Status:** IMPLEMENTED — draft PR #351, awaiting merge
+- **Status:** COMPLETE — merged in PR #351 at `16ecf75`
 - **Expected outcome:** callers can explicitly request deprecated, outdated,
   duplicate, and conflict analysis, and every visible conflict can identify the
   target package, incompatible constraints, and contributing importers without
@@ -422,7 +422,7 @@ client view consumes. Callers never have to discover and combine coupled flags.
 
 ### Phase 3 — vulnerability inspection optionally audits transitive risk
 
-- **Status:** PENDING REORIENTATION — blocked on Phase 2 merge and `$next-steps`
+- **Status:** PENDING REORIENTATION — awaiting `$next-steps` after Phase 2 merge
 - **Expected outcome:** an explicit `pkg_vulns` transitive mode reports direct
   package affectedness plus vulnerabilities affecting resolved dependency versions,
   with severity, package/version, matched-range, and nearest-fix evidence and without
@@ -678,8 +678,8 @@ as they do now.
 
 ## Phase 2 implemented result
 
-Phase 2 is implemented in the client repository and is awaiting merge as draft PR
-#351. It delivered CLI `--issues` and MCP `include_issues`, conditional issue and
+Phase 2 is complete and merged in PR #351 at `16ecf75`. It delivered CLI `--issues`
+and MCP `include_issues`, conditional issue and
 companion-graph selection with full-graph versus depth-bounded cost, exact lossless
 issue/conflict JSON requirements, bounded compact and complete wrapped verbose text,
 and fail-closed validation for missing issue/graph data and edge-backed ordinary
@@ -704,8 +704,8 @@ graph validation.
 Phase 2 commits, grouped compactly: feature work `56eed9f`, `ddde860`, `df37442`,
 `942278d`, `e5d9e9e`, `003141f`; tests/smoke/docs `4e1900a`, `aa1a3af`, `258c352`;
 corrections `07e11f5`, `e4fe879`, `01df950`, `2b4ef01`, `4bd9110`, `16dc4ca`,
-`d38b8c3`. The implementation is carried by draft PR #351 and is not yet merged,
-released, or deployed.
+`d38b8c3`. The implementation was merged by PR #351 and is not yet released or
+deployed.
 
 ## Phase 2 detailed implementation plan
 
@@ -719,7 +719,7 @@ A live `npm:express` dependency probe still reports one conflict without importe
 detail, while a live upgrade-review probe with dependency issues successfully returned
 current and target issue totals from the deployed backend. Phase 2 therefore remained
 relevant and implementation-ready at that recheck, with no product decision or
-missing contract detail; it is now implemented and awaiting the merge recorded above.
+missing contract detail; it is now merged as recorded above.
 
 ### Behavioral contract
 

--- a/docs/plans/package-intelligence-client-improvements.md
+++ b/docs/plans/package-intelligence-client-improvements.md
@@ -678,11 +678,11 @@ as they do now.
 
 ## Phase 2 implemented result
 
-Phase 2 is complete and merged in PR #351 at `16ecf75`. It delivered CLI `--issues`
-and MCP `include_issues`, conditional issue and
-companion-graph selection with full-graph versus depth-bounded cost, exact lossless
-issue/conflict JSON requirements, bounded compact and complete wrapped verbose text,
-and fail-closed validation for missing issue/graph data and edge-backed ordinary
+Phase 2 is complete and merged in PR #351 at `16ecf75`. It delivered CLI
+`--issues` and MCP `include_issues`, conditional issue and companion-graph
+selection with full-graph versus depth-bounded cost, exact lossless issue/conflict
+JSON requirements, bounded compact and complete wrapped verbose text, and
+fail-closed validation for missing issue/graph data and edge-backed ordinary
 transitive conflicts. Edge-free conflict summaries remain valid without a graph.
 There was no backend change and no new infrastructure.
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "The code context layer for AI coding agents",
   "mcpServers": {
     "githits": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "githits",
   "description": "The code context layer for AI coding agents",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "mcpName": "com.githits/githits",
   "type": "module",
   "workspaces": [

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@githits/mcp",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Reusable MCP server APIs and tools for GitHits",
   "type": "module",
   "files": [

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "githits",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/server.json
+++ b/server.json
@@ -16,7 +16,7 @@
     "source": "github",
     "id": "1165453165"
   },
-  "version": "0.12.0",
+  "version": "0.12.1",
   "remotes": [
     {
       "type": "streamable-http",
@@ -28,7 +28,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "githits",
-      "version": "0.12.0",
+      "version": "0.12.1",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Summary

- bump `githits` and `@githits/mcp` from 0.12.0 to 0.12.1
- consolidate all three pending fragments into artifact-specific 2026-09-04 changelog sections
- regenerate versioned plugin, assistant, and MCP registry manifests from canonical release metadata
- correct the Phase 2 plan status now that PR #351 is merged
- record the maintainer-approved patch classification for the additive package-intelligence capabilities, overriding the fragments' original minor impact

## Validation

- `bun test` (3,976 pass, 0 fail)
- `bun run plugins:check`
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run build`
- `bun run validate:packages`
- `bun run validate:packages:mcp-publish`
- `bun run smoke:cli` (103 live steps)
- `bun run smoke:mcp` (54 live steps)
- `bun run smoke:cli:built` (23 unauthenticated Node steps)
- `bun run smoke:mcp:built` (8 registration steps)
- pinned `mcp-publisher` v1.7.9 validation of `server.json`
- npm and Git tag collision checks for both 0.12.1 artifacts
- `git diff --check`

The package validation publish dry-run passed on its first run. A concurrently launched standard validation initially received non-JSON output from `npm pack`; its isolated rerun completed successfully. Targeted Codex descriptor evaluations for the behavior changes passed in their feature PRs and are recorded in the active implementation plan; no release-metadata behavior changed here.

## Merge gate

Do not merge or enable auto-merge without separate explicit human approval for this release PR.
