### PR TITLE
docs: replace broken Smithery badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
   <a href="https://www.npmjs.com/package/githits"><img alt="Node" src="https://img.shields.io/node/v/githits.svg"></a>
   <a href="https://modelcontextprotocol.io/"><img alt="MCP" src="https://img.shields.io/badge/MCP-enabled-5C4EE5"></a>
   <a href="https://skills.sh/githits-com/githits-cli"><img alt="skills.sh" src="https://skills.sh/b/githits-com/githits-cli"></a>
-  <a href="https://smithery.ai/servers/githits/GitHits"><img alt="smithery badge" src="https://smithery.ai/badge/githits/GitHits"></a>
+  <a href="https://lightnow.ai/servers/com.githits/githits"><img alt="LightNow capabilities" src="https://lightnow.ai/badge/com.githits/githits"></a>
   <a href="https://glama.ai/mcp/servers/githits-com/githits-cli"><img alt="githits-cli MCP server" src="https://glama.ai/mcp/servers/githits-com/githits-cli/badges/score.svg"></a>
   <a href="https://lobehub.com/mcp/githits-com-githits-cli"><img alt="MCP Badge" src="https://lobehub.com/badge/mcp/githits-com-githits-cli?style=plastic"></a>
 </p>

--- a/changes/replace-smithery-badge.fixed.md
+++ b/changes/replace-smithery-badge.fixed.md
@@ -1,0 +1,6 @@
+---
+"githits": patch
+"@githits/mcp": none
+---
+
+- **Capability badge** - Replace the unavailable Smithery badge with the verified LightNow capability badge.


### PR DESCRIPTION
## Summary

Replaces the broken Smithery badge with the matching LightNow capability badge and records the user-visible change in a release fragment.

- Server: https://lightnow.ai/servers/com.githits/githits
- Badge docs and variants: https://docs.lightnow.ai/how-to/add-capability-badge/

## Validation

- `bun run build`
- `bun test` — 4,008 tests passed

Validation ran in an isolated container with networking disabled.