### PR TITLE
fix: avoid agent eval isolation failures for filename globs

### DIFF
--- a/changes/agent-eval-filename-globs.fixed.md
+++ b/changes/agent-eval-filename-globs.fixed.md
@@ -1,0 +1,6 @@
+---
+"githits": none
+"@githits/mcp": none
+---
+
+- **Agent eval isolation validation** - Stop treating `rg --files` guidance filename globs as guidance content reads, while retaining checks for actual reads in the same command.

--- a/scripts/agent-eval.test.ts
+++ b/scripts/agent-eval.test.ts
@@ -2519,6 +2519,46 @@ describe("agent eval harness", () => {
     }
   });
 
+  it("distinguishes rg filename globs from guidance content reads", () => {
+    const workspaceDir = mkdtempSync(join(tmpdir(), "agent-eval-globs-"));
+    const violations = (command: string) =>
+      extractEvalValidationViolations(
+        JSON.stringify({ item: { type: "command_execution", command } }),
+        { surface: "mcp", guidanceProfile: "descriptors" },
+        workspaceDir,
+        "codex",
+      );
+    try {
+      for (const command of [
+        `/bin/bash -lc "pwd && rg --files -g 'SKILL.md' -g '*git*' | head -50 && rg -n 'GitHits|githits' . -S --hidden -g '!node_modules' | head -50"`,
+        "rg --files -g SKILL.md",
+        'rg --files --glob="SKILL.md"',
+        "rg --files --glob SKILL.md",
+      ]) {
+        expect(violations(command)).toEqual([]);
+      }
+      for (const command of [
+        "rg --files -g 'SKILL.md' && cat SKILL.md",
+        "rg --files -g 'SKILL.md'; cat SKILL.md",
+        "rg --files -g 'SKILL.md' | xargs cat SKILL.md",
+        'rg --files -g "$(cat SKILL.md)"',
+        "rg --files -g `cat SKILL.md`",
+        "rg -n instructions SKILL.md",
+        "rg instructions -g SKILL.md",
+        "rg --files-with-matches instructions -g SKILL.md",
+      ]) {
+        expect(violations(command)).toEqual([
+          {
+            category: "descriptor-guidance-read",
+            path: "<workspace>/SKILL.md",
+          },
+        ]);
+      }
+    } finally {
+      rmSync(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
   it("normalizes delimiters from bare guidance references", () => {
     const workspaceDir = mkdtempSync(
       join(tmpdir(), "agent-eval-bare-guidance-"),

--- a/scripts/agent-eval.ts
+++ b/scripts/agent-eval.ts
@@ -1800,6 +1800,15 @@ function externalGuidancePaths(value: string): string[] {
     /(?:[A-Za-z]:[\\/]|\\\\|\/|~\/|\$[A-Za-z_][A-Za-z0-9_]*\/|\.\.?[\\/]|(?:[A-Za-z0-9_.-]+[\\/])+)[^"'`\s),;]*?(?:AGENTS|CLAUDE|GEMINI|SKILL)\.md|(?:^|[\s"'`(=])(?:AGENTS|CLAUDE|GEMINI|SKILL)\.md/gi;
   for (const match of value.matchAll(pattern)) {
     const path = match[0]?.replace(/^[\s"'`(=]+/, "");
+    // rg --files globs select filenames without reading guidance contents.
+    // Stop at shell operators/substitutions so subsequent reads remain checked.
+    const prefix = value.slice(0, match.index + match[0].length - path.length);
+    if (
+      /(?:^|[\s"'])rg\s+--files(?=\s)[^;&|()`\n$<>]*\s(?:-g\s+|--glob(?:\s+|=))["']?$/.test(
+        prefix,
+      )
+    )
+      continue;
     if (path) paths.push(path);
   }
   return paths;


### PR DESCRIPTION
The main-branch Agent Evals run falsely failed `intent/code-read-window`: `rg --files -g 'SKILL.md'` lists filenames, but isolation validation classified the glob as a guidance content read. The actual MCP calls succeeded.

Exclude `rg --files` glob selectors from guidance-read detection. Keep checking actual reads in compound commands, pipelines, substitutions, and content-search modes such as `--files-with-matches`.

Validation:
- Regression reproduced the failure before the fix; `bun test scripts/agent-eval.test.ts`: 130 passed, 708 assertions.
- Replayed the captured failing CI stdout through the corrected validator: zero violations. Original artifacts retained locally.
- `bun run typecheck`, `bun run lint`, `bun run format:check`, and `bun run build` passed.
- Inline review of the nine-line harness change and regression coverage; no product behavior or release workflow changes.

Incident: https://github.com/githits-com/githits-cli/actions/runs/34096830763

The release failure is separate: Main succeeded and triggered publishing; MCP registry registration could not yet resolve the newly published npm version. This PR does not rerun publishing or change release gates.
