### PR TITLE
chore: release githits and MCP 0.14.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,12 +6,12 @@
   },
   "metadata": {
     "description": "The code context layer for AI coding agents",
-    "version": "0.13.0"
+    "version": "0.14.0"
   },
   "plugins": [
     {
       "name": "githits",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "description": "The code context layer for AI coding agents",
       "author": {
         "name": "GitHits"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,73 @@ changes use independent files under [`changes/`](changes/README.md) and are
 consolidated here only during release preparation. Dated, versioned sections
 are historical records and change only to correct blatant factual errors.
 
+## [githits 0.14.0] - 2026-09-07
+
+Minor release: changes default search text to authoritative match evidence and
+adds opt-in resolved-dependency vulnerability audits and dependency registries.
+
+### Added
+
+- **Expand dependency registry support** - CLI `pkg deps` and MCP `pkg_deps` now accept
+  NuGet, Maven, and Packagist alongside the other deployed dependency registries.
+- **Discovery match evidence** - Search JSON adds indexed-field provenance,
+  authoritative matched source, and crawled-documentation previews. Default search text
+  renders path-only matches as compact file headers instead of arbitrary source chunks,
+  shows proven source snippets, and uses structural documentation previews. Requires the
+  deployed additive v31 producer schema.
+- **Audit resolved dependency vulnerabilities** - Add opt-in transitive vulnerability
+  evidence to `pkg vulns` and `pkg_vulns` while preserving direct-only defaults and
+  applying advisory scope consistently to root and dependency rows.
+
+### Changed
+
+- **Complete CLI vulnerability rows** - CLI compact text now shows every selected direct
+  and transitive advisory row; verbose mode adds clearer transitive evidence and JSON
+  preserves advisory-wide affected-range and fixed-version fields.
+
+### Fixed
+
+- **Agent eval isolation validation** - Stop treating `rg --files` guidance filename
+  globs as guidance content reads, while retaining checks for actual reads in the same
+  command.
+
+### Security
+
+- **Sanitize vulnerability terminal text** - Strip hostile terminal control sequences
+  from vulnerability display values while preserving lossless JSON evidence.
+
+## [@githits/mcp 0.14.0] - 2026-09-07
+
+Minor release: changes default search text to authoritative match evidence and
+adds opt-in resolved-dependency vulnerability audits and dependency registries.
+
+### Added
+
+- **Expand dependency registry support** - `pkg_deps` now accepts NuGet, Maven, and
+  Packagist alongside the other deployed dependency registries.
+- **Discovery match evidence** - Search JSON adds indexed-field provenance,
+  authoritative matched source, and crawled-documentation previews. Default search text
+  renders path-only matches as compact file headers instead of arbitrary source chunks,
+  shows proven source snippets, and uses structural documentation previews. Requires the
+  deployed additive v31 producer schema.
+- **Audit resolved dependency vulnerabilities** - Add opt-in transitive vulnerability
+  evidence to `pkg vulns` and `pkg_vulns` while preserving direct-only defaults and
+  applying advisory scope consistently to root and dependency rows.
+
+### Changed
+
+- **Detailed vulnerability evidence** - Verbose text adds clearer transitive evidence
+  and JSON preserves advisory-wide affected-range and fixed-version fields. Compact MCP
+  text remains capped; use verbose mode for all selected advisory rows.
+
+### Security
+
+- **Sanitize vulnerability terminal text** - Strip hostile terminal control sequences
+  from vulnerability display values while preserving lossless JSON evidence.
+
+Hosted MCP clients receive these changes after remote-mcp updates this package
+and deploys the hosted server.
+
 ## [githits 0.13.0] - 2026-09-07
 
 Minor release: adds semantic search context and documentation read targets,

--- a/bun.lock
+++ b/bun.lock
@@ -45,7 +45,7 @@
     },
     "packages/mcp": {
       "name": "@githits/mcp",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "^4.4.3",

--- a/changes/agent-eval-filename-globs.fixed.md
+++ b/changes/agent-eval-filename-globs.fixed.md
@@ -1,6 +1,0 @@
----
-"githits": none
-"@githits/mcp": none
----
-
-- **Agent eval isolation validation** - Stop treating `rg --files` guidance filename globs as guidance content reads, while retaining checks for actual reads in the same command.

--- a/changes/cli-vulnerability-row-completeness.changed.md
+++ b/changes/cli-vulnerability-row-completeness.changed.md
@@ -1,6 +1,0 @@
----
-"githits": patch
-"@githits/mcp": patch
----
-
-- **Complete CLI vulnerability rows** - CLI compact text now shows every selected direct and transitive advisory row; verbose mode adds clearer transitive evidence and JSON preserves advisory-wide affected-range and fixed-version fields.

--- a/changes/dependency-registry-parity.added.md
+++ b/changes/dependency-registry-parity.added.md
@@ -1,7 +1,0 @@
----
-"githits": minor
-"@githits/mcp": minor
----
-
-- **Expand dependency registry support** - `pkg_deps` now accepts NuGet, Maven, and Packagist alongside the other deployed dependency registries.
-  <!-- Not a changelog entry: release preparation must update `skills/githits-package/SKILL.md` only after the backing behavior is in the release branch. -->

--- a/changes/search-v31-discovery-evidence.added.md
+++ b/changes/search-v31-discovery-evidence.added.md
@@ -1,6 +1,0 @@
----
-"githits": minor
-"@githits/mcp": minor
----
-
-- **Discovery match evidence** - Add named indexed-field provenance, authoritative matched source, and crawled-documentation previews to search JSON. Shared text keeps path-only hits compact and shows proven snippets without repetitive captions; these new clients require the deployed additive v31 producer schema.

--- a/changes/transitive-vulnerability-audit.added.md
+++ b/changes/transitive-vulnerability-audit.added.md
@@ -1,7 +1,0 @@
----
-"githits": minor
-"@githits/mcp": minor
----
-
-- **Audit resolved dependency vulnerabilities** - Add opt-in transitive vulnerability evidence to `pkg vulns` and `pkg_vulns` while preserving direct-only defaults and applying advisory scope consistently to root and dependency rows.
-  <!-- Not a changelog entry: release preparation must update `skills/githits-package/SKILL.md` and `skills/githits-package/references/package.md` only after the backing behavior is in the release branch. -->

--- a/changes/vulnerability-terminal-text-safety.security.md
+++ b/changes/vulnerability-terminal-text-safety.security.md
@@ -1,6 +1,0 @@
----
-"githits": patch
-"@githits/mcp": patch
----
-
-- **Sanitize vulnerability terminal text** - Strip hostile terminal control sequences from vulnerability display values while preserving lossless JSON evidence.

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "The code context layer for AI coding agents",
   "mcpServers": {
     "githits": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "githits",
   "description": "The code context layer for AI coding agents",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "mcpName": "com.githits/githits",
   "type": "module",
   "workspaces": [

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@githits/mcp",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Reusable MCP server APIs and tools for GitHits",
   "type": "module",
   "files": [

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "githits",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/server.json
+++ b/server.json
@@ -16,7 +16,7 @@
     "source": "github",
     "id": "1165453165"
   },
-  "version": "0.13.0",
+  "version": "0.14.0",
   "remotes": [
     {
       "type": "streamable-http",
@@ -28,7 +28,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "githits",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/skills/githits-code/references/code-and-docs.md
+++ b/skills/githits-code/references/code-and-docs.md
@@ -6,6 +6,8 @@ Package target syntax requires an explicit registry: `registry:name[@version]`, 
 
 `githits search "<query>" --in <target>` searches indexed dependency code, docs, symbols, and exact standalone documentation sites. Repeat `--in` for multiple targets. Use `--source code`, `--source docs`, or `--source symbol` to force a source; omit it for auto-routing. For a standalone site, pass `--source docs --in site:<host[/path]>`.
 
+Search text shows producer-proven matched source and structural documentation previews. Path-only matches render as compact file headers; they do not prove a source-content match. Follow the emitted read locator when source context is needed. JSON preserves compatibility evidence and adds indexed-field provenance, matched source, and documentation previews.
+
 Useful filters: `--kind`, `--category`, `--path-prefix`, `--intent`, `--public`, `--name`, `--lang`, `--limit`, `--offset`, `--wait`, `--allow-partial`, `--json`.
 
 If search returns a `searchRef`, continue with `githits search-status <searchRef> [--wait <seconds>]` only when the output explicitly supplies that follow-up, including for active `PENDING`, `INDEXING`, or `SEARCHING` progress or a completed result with an evidence notice. The bounded wait defaults to 20 seconds, and the explicit value must be an integer from 0 to 60. Terminal `DEFERRED`, `TIMEOUT`, or `FAILED` progress, and unrecognized statuses, do not advance: keep any disclosed evidence, do not poll the same reference, and follow the rendered new-search action.

--- a/skills/githits-package/SKILL.md
+++ b/skills/githits-package/SKILL.md
@@ -32,6 +32,7 @@ githits pkg info npm:express --verbose --json
 githits pkg vulns npm:lodash@4.17.20 --severity high
 githits pkg vulns npm:lodash --scope all --include-withdrawn --json
 githits pkg vulns npm:lodash@4.17.21 --scope non_affecting
+githits pkg vulns npm:express@4.17.1 --transitive --scope all --json
 
 githits pkg deps npm:express
 githits pkg deps npm:express --lifecycle all
@@ -49,6 +50,7 @@ githits pkg upgrade-review --package npm:zod@4.3.6..4.4.3 --package npm:lint-sta
 
 - Need current package health: start with `githits pkg info <registry:name>`.
 - Need security status for a specific installed version: use `githits pkg vulns <registry:name@version>`.
+- Need vulnerabilities in resolved dependency versions: add `pkg vulns --transitive`; this opt-in adds graph-analysis cost and audits the resolved graph, not a local application lockfile.
 - Need historical advisories that do not affect the inspected version: use `pkg vulns --scope non_affecting`; use `--scope all` for affected plus historical rows.
 - Need dependency footprint: start with `pkg deps`; add `--lifecycle all` for non-runtime groups and `--depth <n>` for aggregate transitive graph data.
 - Need upgrade evidence for dependency updates, outdated package bumps, or lockfile changes: prefer `pkg upgrade-review` because it compares current vs target vulnerabilities, changelog range evidence, deprecation metadata, peer changes, dependency changes, and transitive security evidence by default. It reports facts only; you still own the final assessment.
@@ -57,7 +59,7 @@ githits pkg upgrade-review --package npm:zod@4.3.6..4.4.3 --package npm:lint-sta
 ## Gotchas
 
 - Vulnerability data is not available for `vcpkg` or `zig`.
-- Dependency graphs support npm, PyPI, Hex, Crates, Zig, vcpkg, RubyGems, Go, and Swift; NuGet/Maven/Packagist are not dependency-graph targets.
+- Dependency graphs support npm, PyPI, Hex, Crates, NuGet, Maven, Packagist, Zig, vcpkg, RubyGems, Go, and Swift.
 - Go exact-version inputs accept either `v1.2.3` or `1.2.3` (including pseudo versions) and are sent in canonical `v`-prefixed form. Other changelog range inputs omit a leading `v`, except Swift release tags.
 - For repeatable `pkg upgrade-review --package` entries, use `<registry>:<name>@<current>..<target>`.
 - Prefer structured JSON for final comparisons; terminal text is optimized for human scanning.

--- a/skills/githits-package/references/package.md
+++ b/skills/githits-package/references/package.md
@@ -11,7 +11,11 @@ Swift package targets use `swift:github.com/<owner>/<repo>`; Zig package targets
 
 `githits pkg vulns <registry:name[@version]>` lists known OSV/CVE advisories. Omit the version for latest.
 
-Flags: `--severity low|medium|high|critical`, `--scope affected|non_affecting|all`, `--include-withdrawn`, `--verbose`, `--json`.
+Flags: `--severity low|medium|high|critical`, `--scope affected|non_affecting|all`, `--include-withdrawn`, `--transitive`, `--verbose`, `--json`.
+
+Direct-only is the default. `--transitive` adds vulnerability evidence for versions in the resolved dependency graph, at additional graph-analysis cost; it does not inspect a local application lockfile. `--severity` and `--scope` apply to root and dependency rows. `--include-withdrawn` affects direct rows only; transitive withdrawn advisories remain excluded. Use `--scope all` for affected plus historical dependency advisories, or `--scope non_affecting` for historical rows.
+
+CLI text shows every selected direct and transitive advisory row. `--verbose` adds aliases, dates, malicious-advisory markers, and complete range/fix evidence; `--json` retains structured advisory-wide affected ranges and fixed versions. Compact MCP text remains capped; use `verbose:true` for all selected rows.
 
 Supported registries: npm, PyPI, Hex, Crates, NuGet, Maven, Packagist, RubyGems, Go, Swift. vcpkg and Zig are unsupported for vulnerability data.
 
@@ -20,6 +24,8 @@ Supported registries: npm, PyPI, Hex, Crates, NuGet, Maven, Packagist, RubyGems,
 `githits pkg deps <registry:name[@version]>` lists direct runtime dependencies by default.
 
 Flags: `--lifecycle runtime|development|build|peer|optional|all`, `--depth 1-10`, `--verbose`, `--json`.
+
+Supported dependency registries: npm, PyPI, Hex, Crates, NuGet, Maven, Packagist, RubyGems, Go, Swift, vcpkg, and Zig.
 
 Use `--depth` to request transitive output capped to that traversal depth. Omit it for direct dependencies only.
 
@@ -46,7 +52,7 @@ Use `pkg upgrade-review` for dependency update assessment instead of inferring s
 ## Command Name Mapping
 
 - `githits pkg info` maps to MCP `pkg_info`.
-- `githits pkg vulns` maps to MCP `pkg_vulns`.
+- `githits pkg vulns` maps to MCP `pkg_vulns`; CLI `--transitive` maps to `include_transitive:true`.
 - `githits pkg deps` maps to MCP `pkg_deps`.
 - `githits pkg changelog` maps to MCP `pkg_changelog`.
 - `githits pkg upgrade-review` maps to MCP `pkg_upgrade_review`.


### PR DESCRIPTION
Prepare coordinated minor releases of `githits@0.14.0` and `@githits/mcp@0.14.0` from main.

Default search text now renders path-only matches as compact file headers instead of arbitrary source chunks. This release also adds authoritative search evidence, opt-in transitive vulnerability audits, and NuGet/Maven/Packagist dependency support.

- Consolidate all six pending fragments into separate package changelog sections; preserve historical entries.
- Align package, lockfile, MCP registry, and generated plugin versions.
- Update public CLI skills for the released search and vulnerability behavior and supported registries.
- Search requires the deployed additive v31 producer schema. Hosted MCP adoption requires a separate remote-mcp dependency update and deployment.

Validation: 4,201 tests pass; typecheck, formatting, lint, both builds, generated-plugin checks, and public-package validation with MCP publish dry run pass. Live CLI/MCP smoke suites and both built Node smoke suites pass. Release delta reviewed inline.

Targeted skill evals: Claude could not authenticate and made no tool calls. Codex completed both workloads, but all five GitHits CLI calls failed because the isolated skills environment lacked GitHits authentication. The agent fell back to external sources and returned high-confidence answers; this is not successful validation of the GitHits behavior. Traces confirm selection of transitive/all-scope/historical vulnerability flags and search. No isolation-violation artifacts were emitted. The generic skill validator rejects the pre-existing `compatibility` frontmatter; the repository's public-skill YAML and packaging checks pass.

This PR prepares the release only. Merge requires separate human approval; no tags or publication have been initiated.
