### PR TITLE
feat: allow experimental ask without an explicit target

### DIFF
--- a/changes/ask-optional-target.added.md
+++ b/changes/ask-optional-target.added.md
@@ -3,4 +3,4 @@
 "@githits/mcp": none
 ---
 
-- **Question-only Ask** - Experimental CLI `githits ask "question"` lets the backend resolve one public package or repository. Explicit targets and thread follow-ups remain supported; question-only calls require the optional-target backend pipeline.
+- **Question-only Ask** - Experimental CLI `githits ask "question"` lets GitHits identify a public package or repository from the question. Explicit targets and thread follow-ups remain supported.

--- a/changes/ask-optional-target.added.md
+++ b/changes/ask-optional-target.added.md
@@ -1,0 +1,6 @@
+---
+"githits": minor
+"@githits/mcp": none
+---
+
+- **Question-only Ask** - Experimental CLI `githits ask "question"` lets the backend resolve one public package or repository. Explicit targets and thread follow-ups remain supported; question-only calls require the optional-target backend pipeline.

--- a/docs/experimental-tools.md
+++ b/docs/experimental-tools.md
@@ -82,12 +82,9 @@ githits ask npm:express "Where is router dispatch implemented?" --source-format 
 githits ask --thread 019c4f26-79b2-7bcb-b729-f9e39043a94b "How does that interact with route parameters?"
 ```
 
-With one positional argument, the CLI sends the question without a target.
-The backend pre-evaluator validates the question and resolves one canonical
-public package or repository. The CLI does not guess a target or choose a docs
-site. With two positional arguments, the first remains an explicit target and
-the second is the question. Quote multi-word questions. Question-only calls
-require the optional-target backend pipeline; older backends may reject them.
+With one positional argument, GitHits uses the question to identify a public
+package or repository. With two positional arguments, the first is an explicit
+target and the second is the question. Quote multi-word questions.
 
 By default, human output contains the grounded answer, an Ask run ID, the
 thread ID, and source commands in the form `npx githits@latest ...` that can be

--- a/docs/experimental-tools.md
+++ b/docs/experimental-tools.md
@@ -71,14 +71,23 @@ and deliberately disables experimental issue-reporting guidance. Use
 
 ## Use the CLI commands
 
-Ask one question about a canonical package or repository target:
+Ask a question about a public package or repository, optionally supplying a
+canonical target:
 
 ```sh
+githits ask "How does FastAPI dependency injection resolve nested dependencies?"
 githits ask pypi:fastapi "How does dependency injection resolve nested dependencies?"
 githits ask github:expressjs/express "Where is router dispatch implemented?" --json
 githits ask npm:express "Where is router dispatch implemented?" --source-format url
 githits ask --thread 019c4f26-79b2-7bcb-b729-f9e39043a94b "How does that interact with route parameters?"
 ```
+
+With one positional argument, the CLI sends the question without a target.
+The backend pre-evaluator validates the question and resolves one canonical
+public package or repository. The CLI does not guess a target or choose a docs
+site. With two positional arguments, the first remains an explicit target and
+the second is the question. Quote multi-word questions. Question-only calls
+require the optional-target backend pipeline; older backends may reject them.
 
 By default, human output contains the grounded answer, an Ask run ID, the
 thread ID, and source commands in the form `npx githits@latest ...` that can be

--- a/docs/implementation/cli-commands.md
+++ b/docs/implementation/cli-commands.md
@@ -288,6 +288,30 @@ same projection and documentation-source formatter for both commands; contributo
 duplicated onto generic progress targets. JSON remains the stable, lossless
 follow-up contract even when text collapses healthy sources or groups recovery inline.
 
+### `githits ask` (experimental)
+
+```sh
+githits ask "How does Express routing work?"
+githits ask npm:express "How is routing implemented?"
+githits ask --thread <UUID> "Where is that checked?"
+githits ask "How does Express routing work?" --source-format url --json
+```
+
+Requires experimental tools to be enabled in local configuration. One positional
+argument is the question; two are target and question. Quote multi-word questions.
+With neither a target nor `--thread`, the CLI sends only `question` and
+`source_format` to `POST /ask`. The backend pre-evaluator validates the question
+and resolves one canonical public package or repository; the CLI does not infer a
+target or substitute a documentation site.
+
+Explicit targets remain supported, including documentation-site targets supported
+by the backend. `--thread` continues the existing bound scope and cannot be
+combined with an explicit target. Use it only when the previous answer needs a
+follow-up. Source formatting, run/thread IDs, authentication, and the existing
+210-second client timeout are unchanged. Question-only calls require the backend
+pipeline that accepts an omitted target (backend PR #390); older backends may
+reject them. This CLI change does not change the local MCP Ask schema.
+
 ### `githits languages`
 
 ```

--- a/docs/implementation/cli-commands.md
+++ b/docs/implementation/cli-commands.md
@@ -299,18 +299,15 @@ githits ask "How does Express routing work?" --source-format url --json
 
 Requires experimental tools to be enabled in local configuration. One positional
 argument is the question; two are target and question. Quote multi-word questions.
-With neither a target nor `--thread`, the CLI sends only `question` and
-`source_format` to `POST /ask`. The backend pre-evaluator validates the question
-and resolves one canonical public package or repository; the CLI does not infer a
-target or substitute a documentation site.
+With neither a target nor `--thread`, GitHits uses the question to identify a
+public package or repository.
 
 Explicit targets remain supported, including documentation-site targets supported
 by the backend. `--thread` continues the existing bound scope and cannot be
 combined with an explicit target. Use it only when the previous answer needs a
 follow-up. Source formatting, run/thread IDs, authentication, and the existing
-210-second client timeout are unchanged. Question-only calls require the backend
-pipeline that accepts an omitted target (backend PR #390); older backends may
-reject them. This CLI change does not change the local MCP Ask schema.
+210-second client timeout are unchanged. This CLI change does not change the
+local MCP Ask schema.
 
 ### `githits languages`
 

--- a/packages/core-internal/src/services/agentic-ask-service.test.ts
+++ b/packages/core-internal/src/services/agentic-ask-service.test.ts
@@ -137,6 +137,68 @@ function createService(
 
 describe("AgenticAskServiceImpl", () => {
   it.each([
+    "https://docs.example/page?lang=en&view=full#section",
+    "repo-doc:sha:pinned",
+    "docs:example:guide",
+  ])("preserves emitted CLI documentation read targets: %s", async (target) => {
+    const body: AgenticAskCliResponse = {
+      ...responseBody(),
+      source_format: "cli",
+      sources: [
+        {
+          command: "npx",
+          arguments: [
+            "githits@latest",
+            "docs",
+            "read",
+            "--lines",
+            "3-8",
+            "--",
+            target,
+          ],
+        },
+      ],
+    };
+    const fetchFn = mock(() =>
+      Promise.resolve(jsonResponse(body)),
+    ) as unknown as typeof fetch;
+
+    const result = await createService(fetchFn).ask({
+      question: "How does Express routing work?",
+    });
+
+    expect(result).toEqual(body);
+  });
+
+  it.each([
+    "https://docs.example/page?lang=en&view=full#section",
+    "repo-doc:sha:pinned",
+    "docs:example:guide",
+  ])("preserves emitted MCP documentation read targets: %s", async (target) => {
+    const body: AgenticAskMcpResponse = {
+      ...mcpResponseBody(),
+      source_format: "mcp",
+      sources: [
+        {
+          name: "docs_read",
+          arguments: { page_id: target, start_line: 3, end_line: 8 },
+        },
+      ],
+    };
+    const fetchFn = mock(() =>
+      Promise.resolve(jsonResponse(body)),
+    ) as unknown as typeof fetch;
+
+    const result = await createService(fetchFn).ask({
+      target: "npm:express",
+      question: "How does routing work?",
+      sourceFormat: "mcp",
+    });
+
+    expect(result).toEqual(body);
+  });
+
+  it.each([
     {
       subject: {},
       message:

--- a/packages/core-internal/src/services/agentic-ask-service.test.ts
+++ b/packages/core-internal/src/services/agentic-ask-service.test.ts
@@ -136,6 +136,69 @@ function createService(
 }
 
 describe("AgenticAskServiceImpl", () => {
+  it.each([
+    {
+      subject: {},
+      message:
+        "GitHits could not answer this question for a supported target. Clarify the question or specify a public package or repository.",
+    },
+    {
+      subject: { target: "npm:example" },
+      message: "GitHits rejected the Agentic Ask target.",
+    },
+    {
+      subject: { threadId: THREAD_ID },
+      message: "GitHits rejected the Agentic Ask target.",
+    },
+  ])(
+    "keeps 400 guidance accurate for the supplied subject: %j",
+    async ({ subject, message }) => {
+      const fetchFn = mock(() =>
+        Promise.resolve(
+          jsonResponse({ detail: "private provider detail" }, { status: 400 }),
+        ),
+      ) as unknown as typeof fetch;
+      await expect(
+        createService(fetchFn).ask({ ...subject, question: "How?" }),
+      ).rejects.toMatchObject({
+        code: "INVALID_TARGET",
+        status: 400,
+        message,
+        retryable: false,
+      });
+      expect(fetchFn).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it.each(["cli", "url"] as const)(
+    "omits target and thread_id for a question-only %s request",
+    async (sourceFormat) => {
+      let capturedInit: RequestInit | undefined;
+      const fetchFn = mock(
+        (_url: string | URL | Request, init?: RequestInit) => {
+          capturedInit = init;
+          return Promise.resolve(
+            jsonResponse(
+              sourceFormat === "url" ? urlResponseBody() : responseBody(),
+            ),
+          );
+        },
+      ) as unknown as typeof fetch;
+
+      const service = createService(fetchFn);
+      const question = "How does Express routing work?";
+      if (sourceFormat === "url") {
+        await service.ask({ question, sourceFormat });
+      } else {
+        await service.ask({ question });
+      }
+      expect(JSON.parse(String(capturedInit?.body))).toEqual({
+        question,
+        source_format: sourceFormat,
+      });
+    },
+  );
+
   it("sends the CLI source format with standard identity headers", async () => {
     let capturedUrl: string | undefined;
     let capturedInit: RequestInit | undefined;

--- a/packages/core-internal/src/services/agentic-ask-service.ts
+++ b/packages/core-internal/src/services/agentic-ask-service.ts
@@ -111,7 +111,7 @@ interface AgenticAskQuestion {
 }
 
 type AgenticAskSubject =
-  | { target: string; threadId?: never }
+  | { target?: string; threadId?: never }
   | { target?: never; threadId: string };
 
 export type AgenticAskCliRequest = AgenticAskQuestion &
@@ -396,7 +396,7 @@ export class AgenticAskServiceImpl implements AgenticAskService {
       } else {
         await response.body?.cancel().catch(() => undefined);
       }
-      throw createHttpError(response, toolCallId, threadId);
+      throw createHttpError(response, toolCallId, threadId, request);
     }
 
     let body: string;
@@ -491,13 +491,16 @@ function createHttpError(
   response: Response,
   toolCallId: string | undefined,
   threadId: string | undefined,
+  request: AgenticAskRequest,
 ): AgenticAskHttpError {
   const status = response.status;
   switch (status) {
     case 400:
       return new AgenticAskHttpError(
         "INVALID_TARGET",
-        "GitHits rejected the Agentic Ask target.",
+        request.target === undefined && request.threadId === undefined
+          ? "GitHits could not answer this question for a supported target. Clarify the question or specify a public package or repository."
+          : "GitHits rejected the Agentic Ask target.",
         status,
         toolCallId,
         undefined,

--- a/scripts/cli-smoke.ts
+++ b/scripts/cli-smoke.ts
@@ -1013,7 +1013,8 @@ async function assertExperimentalUnauthenticatedBehavior(): Promise<void> {
     const askHelp = await runCliWithEnv(["ask", "--help"], env);
     assert(
       askHelp.exitCode === 0 &&
-        askHelp.stdout.includes("<target> <question>") &&
+        askHelp.stdout.includes("[target] <question>") &&
+        askHelp.stdout.includes("Omit the target") &&
         askHelp.stdout.includes("--thread <UUID>") &&
         askHelp.stdout.includes("--source-format <format>") &&
         askHelp.stdout.includes('choices: "cli", "url"') &&
@@ -1071,6 +1072,15 @@ async function assertExperimentalUnauthenticatedBehavior(): Promise<void> {
     assertJsonErrorCode(
       askJson,
       "experimental unauthenticated ask",
+      "AUTH_REQUIRED",
+    );
+    const targetlessAskJson = await runCliWithEnv(
+      ["ask", "How does Express routing work?", "--json"],
+      env,
+    );
+    assertJsonErrorCode(
+      targetlessAskJson,
+      "experimental unauthenticated targetless ask",
       "AUTH_REQUIRED",
     );
     const codeDiffJson = await runCliWithEnv(

--- a/src/cli/experimental-tools.test.ts
+++ b/src/cli/experimental-tools.test.ts
@@ -133,7 +133,7 @@ describe("experimental CLI process policy", () => {
 
         const ask = await runCli(xdgConfigHome, ["ask", "--help"]);
         expect(ask.exitCode).toBe(0);
-        expect(ask.stdout).toContain("<target> <question>");
+        expect(ask.stdout).toContain("[target] <question>");
         expect(ask.stdout).toContain("--source-format <format>");
         expect(ask.stdout).toContain('choices: "cli", "url"');
         expect(ask.stdout).toContain("--json");

--- a/src/commands/ask.test.ts
+++ b/src/commands/ask.test.ts
@@ -536,6 +536,31 @@ describe("Agentic Ask positional parsing", () => {
 
 describe("Agentic Ask registration", () => {
   it.each(
+    ["", " ", "\t\n"].flatMap((question) => [
+      { args: ["ask", question] },
+      { args: ["ask", "npm:example", question] },
+      { args: ["ask", "--thread", THREAD_ID, question] },
+    ]),
+  )(
+    "rejects blank questions before root command work: %j",
+    async ({ args }) => {
+      const program = new Command().name("githits").exitOverride();
+      let rootWorkStarted = false;
+      const action = mock(() => undefined);
+      program.hook("preAction", (_thisCommand, actionCommand) => {
+        validateAskCommandBeforeAction(actionCommand);
+        rootWorkStarted = true;
+      });
+      registerAskCommand(program).action(action);
+      await expect(
+        program.parseAsync(["node", "githits", ...args]),
+      ).rejects.toThrow("non-empty question");
+      expect(rootWorkStarted).toBe(false);
+      expect(action).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(
     [
       ["ask", "How does Express routing work?"],
       [

--- a/src/commands/ask.test.ts
+++ b/src/commands/ask.test.ts
@@ -460,6 +460,41 @@ describe("askAction", () => {
 });
 
 describe("Agentic Ask human formatting", () => {
+  it.each([
+    {
+      target: "https://docs.example/page?lang=en&view=full#section",
+      argument: "'https://docs.example/page?lang=en&view=full#section'",
+    },
+    { target: "repo-doc:sha:pinned", argument: "repo-doc:sha:pinned" },
+    { target: "docs:example:guide", argument: "docs:example:guide" },
+  ])(
+    "renders documentation read targets unchanged: $target",
+    ({ target, argument }) => {
+      const formatted = formatAgenticAskHumanResponse(
+        result({
+          sources: [
+            {
+              command: "npx",
+              arguments: [
+                "githits@latest",
+                "docs",
+                "read",
+                "--lines",
+                "3-8",
+                "--",
+                target,
+              ],
+            },
+          ],
+        }),
+      );
+
+      expect(formatted).toContain(
+        `Sources:\n  1. npx githits@latest docs read --lines 3-8 -- ${argument}\n`,
+      );
+    },
+  );
+
   it("preserves markdown newlines while stripping terminal controls", () => {
     const formatted = formatAgenticAskHumanResponse(
       result({

--- a/src/commands/ask.test.ts
+++ b/src/commands/ask.test.ts
@@ -77,7 +77,7 @@ function urlResult(): AgenticAskUrlResponse {
 }
 
 type CliAsk = (
-  request: ({ target: string } | { threadId: string }) & {
+  request: ({ target?: string; threadId?: never } | { threadId: string }) & {
     question: string;
     sourceFormat?: "cli" | "url";
   },
@@ -152,15 +152,35 @@ describe("askAction", () => {
     );
   });
 
-  it("rejects ambiguous, missing, and malformed thread selectors", async () => {
+  it.each([undefined, "url"] as const)(
+    "forwards a question without target or thread with source format %s",
+    async (sourceFormat) => {
+      const ask = mock(() =>
+        Promise.resolve(sourceFormat === "url" ? urlResult() : result()),
+      );
+      spyOn(console, "log").mockImplementation(() => undefined);
+      await askAction(
+        undefined,
+        "How does Express routing work?",
+        { json: true, sourceFormat },
+        createDeps(ask),
+      );
+      expect(ask).toHaveBeenCalledWith(
+        {
+          question: "How does Express routing work?",
+          ...(sourceFormat ? { sourceFormat } : {}),
+        },
+        undefined,
+      );
+    },
+  );
+
+  it("rejects ambiguous and malformed thread selectors", async () => {
     const ask = mock(() => Promise.resolve(result()));
 
     await expect(
       askAction("npm:example", "How?", { thread: THREAD_ID }, createDeps(ask)),
-    ).rejects.toThrow("exactly one");
-    await expect(
-      askAction(undefined, "How?", {}, createDeps(ask)),
-    ).rejects.toThrow("exactly one");
+    ).rejects.toThrow("Do not provide a target");
     await expect(
       askAction(undefined, "How?", { thread: "not-a-uuid" }, createDeps(ask)),
     ).rejects.toThrow("thread UUID");
@@ -473,6 +493,18 @@ describe("Agentic Ask human formatting", () => {
 });
 
 describe("Agentic Ask positional parsing", () => {
+  it.each(["How does Express routing work?", "express", "npm:example"])(
+    "treats one positional as the question without guessing target syntax: %s",
+    (question) => {
+      expect(
+        resolveAskCommandPositionals(question, undefined, undefined),
+      ).toEqual({
+        target: undefined,
+        question,
+      });
+    },
+  );
+
   it("keeps the initial target and question form", () => {
     expect(
       resolveAskCommandPositionals("npm:example", "How?", undefined),
@@ -494,8 +526,8 @@ describe("Agentic Ask positional parsing", () => {
       resolveAskCommandPositionals("npm:example", "How?", THREAD_ID),
     ).toThrow("Do not provide a target");
     expect(() =>
-      resolveAskCommandPositionals("npm:example", undefined, undefined),
-    ).toThrow("Provide a target and question");
+      resolveAskCommandPositionals(undefined, undefined, undefined),
+    ).toThrow("Provide a question");
     expect(() =>
       resolveAskCommandPositionals(undefined, undefined, THREAD_ID),
     ).toThrow("Provide a question");
@@ -503,9 +535,33 @@ describe("Agentic Ask positional parsing", () => {
 });
 
 describe("Agentic Ask registration", () => {
+  it.each(
+    [
+      ["ask", "How does Express routing work?"],
+      [
+        "ask",
+        "--json",
+        "How does Express routing work?",
+        "--source-format",
+        "url",
+      ],
+      ["ask", "npm:express", "How is routing implemented?"],
+      ["ask", "--thread", THREAD_ID, "Where is that checked?"],
+    ].map((args) => ({ args })),
+  )("accepts valid positionals through Commander: %j", async ({ args }) => {
+    const program = new Command().name("githits").exitOverride();
+    const action = mock(() => undefined);
+    program.hook("preAction", (_thisCommand, actionCommand) => {
+      validateAskCommandBeforeAction(actionCommand);
+    });
+    registerAskCommand(program).action(action);
+    await program.parseAsync(["node", "githits", ...args]);
+    expect(action).toHaveBeenCalledTimes(1);
+  });
+
   it.each([
     ["missing follow-up question", ["ask", "--thread", THREAD_ID]],
-    ["missing initial question", ["ask", "npm:example"]],
+    ["missing initial question", ["ask"]],
     [
       "target combined with thread",
       ["ask", "npm:example", "How?", "--thread", THREAD_ID],

--- a/src/commands/ask.ts
+++ b/src/commands/ask.ts
@@ -163,13 +163,14 @@ function isCallerCancellation(
 function resolveAskSubject(
   target: string | undefined,
   thread: string | undefined,
-): { target: string } | { threadId: string } {
-  if ((target === undefined) === (thread === undefined)) {
+): { target?: string; threadId?: never } | { threadId: string } {
+  if (target !== undefined && thread !== undefined) {
     throw new InvalidArgumentError(
-      "Provide exactly one of a target or --thread <UUID>.",
+      "Do not provide a target together with --thread.",
     );
   }
   if (target !== undefined) return { target };
+  if (thread === undefined) return {};
 
   const threadId = normalizeAgenticAskThreadId(thread);
   if (!threadId) {
@@ -178,6 +179,7 @@ function resolveAskSubject(
   return { threadId };
 }
 
+/** One positional is the question; two preserve the explicit-target form. */
 export function resolveAskCommandPositionals(
   targetOrQuestion: string | undefined,
   question: string | undefined,
@@ -197,10 +199,13 @@ export function resolveAskCommandPositionals(
     return { target: undefined, question: targetOrQuestion };
   }
 
-  if (targetOrQuestion === undefined || question === undefined) {
+  if (targetOrQuestion === undefined) {
     throw new InvalidArgumentError(
-      "Provide a target and question, or --thread <UUID> and question.",
+      "Provide a question, optionally preceded by a target.",
     );
+  }
+  if (question === undefined) {
+    return { target: undefined, question: targetOrQuestion };
   }
   return { target: targetOrQuestion, question };
 }
@@ -224,6 +229,9 @@ export function validateAskCommandBeforeAction(command: Command): void {
 
 const DESCRIPTION = `Ask a public repository or package question and receive a source-cited answer.
 
+Omit the target to let GitHits infer one public repository or package from your
+question. Quote multi-word questions. An explicit target keeps the search scoped.
+
 Use a returned thread ID with --thread only when the previous answer is
 insufficient or more information is needed.`;
 
@@ -233,9 +241,12 @@ export function registerAskCommand(program: Command): Command {
     .summary("Ask a public repository or package question")
     .description(DESCRIPTION)
     .usage(
-      "[options] <target> <question>\n       githits ask --thread <UUID> <question>",
+      "[options] [target] <question>\n       githits ask --thread <UUID> <question>",
     )
-    .argument("[target-or-question]", "Target, or question with --thread")
+    .argument(
+      "[target-or-question]",
+      "Question, or target when followed by a question",
+    )
     .argument("[question]", "Question to answer from indexed public sources")
     .option(
       "--thread <UUID>",

--- a/src/commands/ask.ts
+++ b/src/commands/ask.ts
@@ -185,6 +185,14 @@ export function resolveAskCommandPositionals(
   question: string | undefined,
   thread: string | undefined,
 ): { target: string | undefined; question: string } {
+  const effectiveQuestion = question ?? targetOrQuestion;
+  if (
+    effectiveQuestion !== undefined &&
+    effectiveQuestion.trim().length === 0
+  ) {
+    throw new InvalidArgumentError("Provide a non-empty question.");
+  }
+
   if (thread !== undefined) {
     if (question !== undefined) {
       throw new InvalidArgumentError(


### PR DESCRIPTION
## Summary

- Allow `githits ask "question"` without an explicit target.
- Preserve explicit-target commands and thread follow-ups.
- Reject blank questions before authentication and provide clearer error guidance.
- Update CLI help, documentation, and regression coverage. MCP tool inputs are unchanged.

## Validation

- 102 focused tests passed.
- Typecheck, lint, build, and changed-file formatting passed.
- Source and built CLI/MCP smoke checks passed.
- A local full-suite run encountered a Windows temporary-file cleanup failure; see CI for platform test results.