### PR TITLE
fix: wait for npm availability before completing releases

### DIFF
--- a/.github/workflows/mcp-release.yml
+++ b/.github/workflows/mcp-release.yml
@@ -15,6 +15,7 @@ on:
       - "packages/core-internal/**"
       - "packages/mcp/**"
       - "scripts/validate-public-packages.ts"
+      - "scripts/publish-npm*"
       - "src/package-release-boundaries.test.ts"
       - "tsconfig.json"
   workflow_dispatch:
@@ -178,7 +179,9 @@ jobs:
       - name: Publish @githits/mcp to npm
         if: steps.mcp_version.outputs.npm_published == 'false'
         working-directory: packages/mcp
-        run: npm publish --access public
+        # Includes up to 20 minutes for npm's asynchronous scanning.
+        timeout-minutes: 25
+        run: bun run ../../scripts/publish-npm.ts
 
       - name: Create MCP GitHub Release
         if: steps.mcp_version.outputs.release_exists == 'false'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,7 +93,9 @@ jobs:
             # See: https://docs.npmjs.com/trusted-publishers
             - name: Publish to npm
               if: steps.version.outputs.should_release == 'true' && steps.version.outputs.npm_published == 'false'
-              run: npm publish --access public
+              # Includes up to 20 minutes for npm's asynchronous scanning.
+              timeout-minutes: 25
+              run: bun run scripts/publish-npm.ts
 
             - name: Install MCP publisher
               if: steps.version.outputs.should_release == 'true'
@@ -210,6 +212,7 @@ jobs:
                       --generate-notes
                   else
                     gh release create "$TAG" \
+                      --target "$(git rev-parse HEAD)" \
                       --title "$TAG" \
                       --generate-notes
                   fi

--- a/changes/npm-release-availability.fixed.md
+++ b/changes/npm-release-availability.fixed.md
@@ -1,0 +1,8 @@
+---
+"githits": none
+"@githits/mcp": none
+---
+
+- **Release availability checks** - Both npm release pipelines wait for the exact
+  package version to become public before downstream publication, and recover
+  accepted uploads still undergoing npm scanning when a release job is rerun.

--- a/docs/implementation/release-process.md
+++ b/docs/implementation/release-process.md
@@ -141,3 +141,52 @@ The release-boundary tests validate fragment names, front matter, and body
 shape during development, and require release sections for the versions
 currently declared in both public package manifests. A version bump without a
 matching changelog section must fail before release.
+
+## npm Publication Completion and Recovery
+
+Both release workflows use `scripts/publish-npm.ts` from the package's working
+directory. It runs `npm publish --access public` with the existing trusted
+publishing configuration, then verifies that the exact package name and version
+are publicly readable from `registry.npmjs.org`. Successful upload alone does
+not complete the step. The root workflow waits before MCP registry registration;
+both workflows wait before creating their GitHub release.
+When creating a new root release tag, the workflow targets its checked-out
+commit explicitly so commits arriving on `main` during scanning do not change
+which source revision the tag identifies. MCP tags are already created from
+the checked-out commit before uploading.
+
+npm scans new uploads before making them available. Its
+[publish-time scanning announcement](https://github.blog/changelog/2026-07-28-npm-publish-time-malware-scanning-and-dual-use-metadata/)
+describes typical delays around five minutes and sometimes 15 minutes or more,
+without a timing guarantee. This caused the `githits` 0.12.1 and 0.14.0 release
+failures: npm accepted the uploads, but MCP registry validation still received
+404 for those versions.
+
+The shared script checks availability every 15 seconds after a 404, for at most
+20 minutes after upload. Each HTTP request has a timeout of at most 15 seconds,
+bounded by the remaining deadline. The check uses public metadata without npm
+credentials. Unexpected HTTP statuses, transport errors, malformed metadata,
+and mismatched identities fail immediately. Each workflow allows 25 minutes for
+the combined upload and availability step.
+
+Existing public versions continue to skip the upload. An immediate rerun while
+scanning is pending can instead receive npm E409 with `Cannot publish over
+previously staged version` for the exact version. The script recognizes that
+specific response and checks availability without retrying the upload. It does
+not suppress unrelated publishing errors or count a staged upload as completion.
+Recognition uses the modern npm error output shipped with the pinned Node
+runtime; incompatible output changes fail the release rather than silently
+accepting the upload.
+
+If the availability deadline expires, downstream publication stays stopped.
+Inspect npm's package status and any maintainer notifications: a public 404
+cannot distinguish pending scanning, manual review, or a blocked package. Do not
+bump the version or republish repeatedly to bypass this state. Once npm makes
+the version public, rerun the failed release job to finish the remaining
+artifacts. A rerun that publishes registry entries or creates tags/releases
+still requires the normal explicit human authorization.
+
+The availability deadline is an operational bound, not a promise that npm will
+finish scanning within 20 minutes. Unit tests simulate pending uploads and error
+states with injected HTTP, process, and clock dependencies; workflow contract
+tests verify both downstream release paths depend on publication completion.

--- a/scripts/publish-npm.test.ts
+++ b/scripts/publish-npm.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, it, mock } from "bun:test";
+import {
+  type AvailabilityDependencies,
+  publishNpm,
+  waitForNpmAvailability,
+} from "./publish-npm.js";
+
+const pkg = { name: "githits", version: "0.14.0" };
+
+function createDependencies(responses: Response[] = [Response.json(pkg)]) {
+  let elapsed = 0;
+  const fetch = mock(async (): Promise<Response> => {
+    const response = responses.shift();
+    if (!response) throw new Error("Unexpected request");
+    return response;
+  });
+  const sleep = mock(async (ms: number): Promise<void> => {
+    elapsed += ms;
+  });
+  const dependencies: AvailabilityDependencies = {
+    fetch,
+    sleep,
+    now: (): number => elapsed,
+    log: mock((): void => {}),
+  };
+  return { dependencies, fetch, sleep };
+}
+
+describe("npm publication completion", () => {
+  it("accepts an immediately available exact version without sleeping", async () => {
+    const { dependencies, fetch, sleep } = createDependencies();
+    await waitForNpmAvailability(pkg, dependencies);
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledWith(
+      "https://registry.npmjs.org/githits/0.14.0",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it("waits through scanning 404s until the version becomes available", async () => {
+    const { dependencies, fetch, sleep } = createDependencies([
+      new Response(null, { status: 404 }),
+      new Response(null, { status: 404 }),
+      Response.json(pkg),
+    ]);
+    await waitForNpmAvailability(pkg, dependencies);
+    expect(fetch).toHaveBeenCalledTimes(3);
+    expect(sleep.mock.calls).toEqual([[15_000], [15_000]]);
+  });
+
+  it("addresses the exact scoped package version without sending credentials", async () => {
+    const scoped = { ...pkg, name: "@githits/mcp" };
+    const { dependencies, fetch } = createDependencies([Response.json(scoped)]);
+    await waitForNpmAvailability(scoped, dependencies);
+    expect(fetch).toHaveBeenCalledWith(
+      "https://registry.npmjs.org/%40githits%2Fmcp/0.14.0",
+      { signal: expect.any(AbortSignal) },
+    );
+  });
+
+  it("fails after 20 minutes when the version stays unavailable", async () => {
+    const { dependencies, fetch, sleep } = createDependencies(
+      Array.from({ length: 80 }, () => new Response(null, { status: 404 })),
+    );
+    await expect(waitForNpmAvailability(pkg, dependencies)).rejects.toThrow(
+      "githits@0.14.0 is still unavailable after 20 minutes",
+    );
+    expect(fetch).toHaveBeenCalledTimes(80);
+    expect(sleep).toHaveBeenCalledTimes(80);
+    expect(dependencies.now()).toBe(20 * 60_000);
+  });
+
+  it("counts HTTP time against the deadline and shortens the last wait", async () => {
+    let elapsed = 0;
+    const { dependencies, fetch, sleep } = createDependencies();
+    dependencies.now = (): number => elapsed;
+    fetch.mockImplementation(async (): Promise<Response> => {
+      elapsed = 20 * 60_000 - 5_000;
+      return new Response(null, { status: 404 });
+    });
+    sleep.mockImplementation(async (ms: number): Promise<void> => {
+      elapsed += ms;
+    });
+    await expect(waitForNpmAvailability(pkg, dependencies)).rejects.toThrow(
+      "after 20 minutes",
+    );
+    expect(sleep.mock.calls).toEqual([[5_000]]);
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps a verified available response when the clock reaches the deadline", async () => {
+    let elapsed = 0;
+    const { dependencies, fetch } = createDependencies();
+    dependencies.now = (): number => elapsed;
+    fetch.mockImplementation(async (): Promise<Response> => {
+      elapsed = 20 * 60_000;
+      return Response.json(pkg);
+    });
+    await waitForNpmAvailability(pkg, dependencies);
+    expect(dependencies.log).toHaveBeenCalledWith(
+      "githits@0.14.0 is publicly available on npm.",
+    );
+  });
+
+  it.each(["headers", "body"])(
+    "reports the overall deadline when it aborts the last request's %s",
+    async (phase) => {
+      let clockReads = 0;
+      const { dependencies } = createDependencies();
+      // Begin the first request with just one millisecond left in the overall budget.
+      dependencies.now = (): number =>
+        clockReads++ === 0 ? 0 : 20 * 60_000 - 1;
+      dependencies.fetch = async (
+        _url: string,
+        options: RequestInit,
+      ): Promise<Response> => {
+        const signal = options.signal!;
+        const abort = new Promise<never>((_resolve, reject) => {
+          signal.addEventListener(
+            "abort",
+            () => {
+              dependencies.now = (): number => 20 * 60_000;
+              reject(signal.reason);
+            },
+            { once: true },
+          );
+        });
+        if (phase === "headers") return abort;
+        return new Response(
+          new ReadableStream({
+            start(controller): void {
+              void abort.catch((error: unknown) => controller.error(error));
+            },
+          }),
+        );
+      };
+      await expect(waitForNpmAvailability(pkg, dependencies)).rejects.toThrow(
+        "Check npm's package status before rerunning the release",
+      );
+    },
+  );
+
+  it.each([401, 403, 429, 500, 503])(
+    "fails immediately on HTTP %s",
+    async (status) => {
+      const { dependencies, fetch, sleep } = createDependencies([
+        new Response("Response bodies must not reach errors", { status }),
+      ]);
+      await expect(waitForNpmAvailability(pkg, dependencies)).rejects.toThrow(
+        `npm availability check failed with HTTP ${status}`,
+      );
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(sleep).not.toHaveBeenCalled();
+    },
+  );
+
+  it("fails on a transport error without retrying", async () => {
+    const { dependencies, fetch, sleep } = createDependencies();
+    fetch.mockRejectedValue(new Error("connection failed"));
+    await expect(waitForNpmAvailability(pkg, dependencies)).rejects.toThrow();
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { ...pkg, name: "other-package" },
+    { ...pkg, version: "0.13.0" },
+    { error: "not found" },
+  ])(
+    "rejects metadata that does not identify the requested release: %j",
+    async (body) => {
+      const { dependencies } = createDependencies([Response.json(body)]);
+      await expect(waitForNpmAvailability(pkg, dependencies)).rejects.toThrow(
+        "npm returned unexpected package metadata",
+      );
+    },
+  );
+
+  it("rejects malformed JSON without exposing the response", async () => {
+    const { dependencies } = createDependencies([new Response("private body")]);
+    await expect(waitForNpmAvailability(pkg, dependencies)).rejects.toThrow(
+      "npm returned invalid package metadata",
+    );
+  });
+
+  it("does not finish publication while npm is still scanning", async () => {
+    const { dependencies } = createDependencies([
+      new Response(null, { status: 404 }),
+      Response.json(pkg),
+    ]);
+    const publish = mock(async () => ({ exitCode: 0, stderr: "" }));
+    await publishNpm(pkg, publish, dependencies);
+    expect(publish).toHaveBeenCalledTimes(1);
+    expect(dependencies.now()).toBe(15_000);
+  });
+
+  it("recovers the observed staged-version conflict by checking availability", async () => {
+    const { dependencies, fetch } = createDependencies([
+      new Response(null, { status: 404 }),
+      Response.json(pkg),
+    ]);
+    const publish = mock(async () => ({
+      exitCode: 1,
+      stderr:
+        'npm error code E409\nnpm error 409 Conflict - PUT https://registry.npmjs.org/githits - Cannot publish over previously staged version "0.14.0".\n',
+    }));
+    await publishNpm(pkg, publish, dependencies);
+    expect(publish).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not count a staged conflict as completed publication if npm stays unavailable", async () => {
+    const { dependencies } = createDependencies(
+      Array.from({ length: 80 }, () => new Response(null, { status: 404 })),
+    );
+    await expect(
+      publishNpm(
+        pkg,
+        async () => ({
+          exitCode: 1,
+          stderr:
+            'npm error code E409\nCannot publish over previously staged version "0.14.0".\n',
+        }),
+        dependencies,
+      ),
+    ).rejects.toThrow("after 20 minutes");
+  });
+
+  it.each([
+    "npm error code E401\nUnauthorized",
+    "npm error code E409\nUnrelated conflict",
+    'npm error code E409\nCannot publish over previously staged version "0.13.0".',
+    'npm error code E403\nCannot publish over previously staged version "0.14.0".',
+  ])(
+    "does not treat an unrelated publish failure as acceptance: %s",
+    async (stderr) => {
+      const { dependencies, fetch } = createDependencies();
+      await expect(
+        publishNpm(pkg, async () => ({ exitCode: 1, stderr }), dependencies),
+      ).rejects.toThrow("npm publish failed with exit code 1");
+      expect(fetch).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/scripts/publish-npm.ts
+++ b/scripts/publish-npm.ts
@@ -1,0 +1,135 @@
+import { readFile } from "node:fs/promises";
+import { z } from "zod";
+
+const packageIdentity = z.object({
+  name: z.string().min(1),
+  version: z.string().min(1),
+});
+
+interface PackageIdentity {
+  name: string;
+  version: string;
+}
+
+export interface AvailabilityDependencies {
+  fetch: (url: string, options: RequestInit) => Promise<Response>;
+  now: () => number;
+  sleep: (milliseconds: number) => Promise<void>;
+  log: (message: string) => void;
+}
+
+interface PublishResult {
+  exitCode: number;
+  stderr: string;
+}
+
+const availabilityDependencies: AvailabilityDependencies = {
+  fetch: (url, options): Promise<Response> => fetch(url, options),
+  now: (): number => performance.now(),
+  sleep: async (milliseconds): Promise<void> => {
+    await Bun.sleep(milliseconds);
+  },
+  log: (message): void => console.log(message),
+};
+
+/** npm accepts uploads before scanning finishes; downstream releases need visibility. */
+export async function waitForNpmAvailability(
+  pkg: PackageIdentity,
+  dependencies: AvailabilityDependencies = availabilityDependencies,
+): Promise<void> {
+  const deadline = dependencies.now() + 20 * 60_000;
+  const label = `${pkg.name}@${pkg.version}`;
+  const url = `https://registry.npmjs.org/${encodeURIComponent(pkg.name)}/${encodeURIComponent(pkg.version)}`;
+
+  while (dependencies.now() < deadline) {
+    const signal = AbortSignal.timeout(
+      Math.max(1, Math.ceil(Math.min(15_000, deadline - dependencies.now()))),
+    );
+    try {
+      const response = await dependencies.fetch(url, { signal });
+
+      if (response.status === 200) {
+        const metadata = await response.json().catch(() => {
+          throw new Error("npm returned invalid package metadata");
+        });
+        const parsed = packageIdentity.safeParse(metadata);
+        if (
+          !parsed.success ||
+          parsed.data.name !== pkg.name ||
+          parsed.data.version !== pkg.version
+        ) {
+          throw new Error("npm returned unexpected package metadata");
+        }
+        dependencies.log(`${label} is publicly available on npm.`);
+        return;
+      }
+
+      await response.body?.cancel();
+      if (response.status !== 404) {
+        throw new Error(
+          `npm availability check failed with HTTP ${response.status}`,
+        );
+      }
+    } catch (error) {
+      // A request stopped by the overall deadline needs the recovery message below.
+      if (signal.aborted && dependencies.now() >= deadline) break;
+      throw error;
+    }
+
+    dependencies.log(`${label} is not public yet; waiting for npm processing.`);
+    await dependencies.sleep(
+      Math.max(0, Math.min(15_000, deadline - dependencies.now())),
+    );
+  }
+
+  throw new Error(
+    `${label} is still unavailable after 20 minutes. npm may still be scanning or holding the upload. Check npm's package status before rerunning the release; downstream publication has not continued.`,
+  );
+}
+
+/** Upload once, then verify availability, including recovery of an accepted pending upload. */
+export async function publishNpm(
+  pkg: PackageIdentity,
+  publish: () => Promise<PublishResult>,
+  dependencies: AvailabilityDependencies = availabilityDependencies,
+): Promise<void> {
+  const result = await publish();
+  if (result.exitCode !== 0) {
+    // Matches the modern npm output used by the pinned Node release runtime.
+    const alreadyStaged =
+      /(?:^|\n)npm error code E409\r?(?:\n|$)/.test(result.stderr) &&
+      result.stderr.includes(
+        `Cannot publish over previously staged version "${pkg.version}".`,
+      );
+    if (!alreadyStaged) {
+      throw new Error(`npm publish failed with exit code ${result.exitCode}`);
+    }
+    dependencies.log(`${pkg.name}@${pkg.version} was already accepted by npm.`);
+  }
+  await waitForNpmAvailability(pkg, dependencies);
+}
+
+if (import.meta.main) {
+  try {
+    const pkg = packageIdentity.parse(
+      JSON.parse(await readFile("package.json", "utf8")),
+    );
+    await publishNpm(pkg, async (): Promise<PublishResult> => {
+      const child = Bun.spawn(["npm", "publish", "--access", "public"], {
+        stdout: "inherit",
+        stderr: "pipe",
+      });
+      const [exitCode, stderr] = await Promise.all([
+        child.exited,
+        new Response(child.stderr).text(),
+      ]);
+      process.stderr.write(stderr);
+      return { exitCode, stderr };
+    });
+  } catch (error) {
+    console.error(
+      error instanceof Error ? error.message : "npm publication failed",
+    );
+    process.exitCode = 1;
+  }
+}

--- a/src/package-release-boundaries.test.ts
+++ b/src/package-release-boundaries.test.ts
@@ -212,4 +212,71 @@ describe("package release boundaries", () => {
       expect(instructions).toContain("does not authorize merging");
     }
   });
+
+  it("gates downstream releases on npm publication availability in both workflows", async () => {
+    interface WorkflowStep {
+      name: string;
+      run?: string;
+      if?: string;
+      "working-directory"?: string;
+      "continue-on-error"?: boolean;
+      "timeout-minutes"?: number;
+    }
+    interface ReleaseWorkflow {
+      on: { pull_request?: { paths: string[] } };
+      jobs: Record<string, { steps: WorkflowStep[] }>;
+    }
+
+    const cases = [
+      {
+        file: "release.yml",
+        job: "release",
+        publish: "Publish to npm",
+        command: "bun run scripts/publish-npm.ts",
+        downstream: ["Publish to MCP registry", "Create GitHub Release"],
+      },
+      {
+        file: "mcp-release.yml",
+        job: "publish",
+        publish: "Publish @githits/mcp to npm",
+        command: "bun run ../../scripts/publish-npm.ts",
+        downstream: ["Create MCP GitHub Release"],
+      },
+    ];
+    for (const entry of cases) {
+      const workflow = parseYaml(
+        await readFile(
+          join(import.meta.dir, "..", ".github", "workflows", entry.file),
+          "utf8",
+        ),
+      ) as ReleaseWorkflow;
+      const steps = workflow.jobs[entry.job]!.steps;
+      const publishIndex = steps.findIndex(
+        (step) => step.name === entry.publish,
+      );
+      expect(publishIndex).toBeGreaterThan(-1);
+      const publish = steps[publishIndex]!;
+      expect(publish.run).toBe(entry.command);
+      expect(publish["continue-on-error"]).not.toBe(true);
+      expect(publish["timeout-minutes"]).toBeGreaterThan(20);
+      expect(publish.if).toContain("npm_published == 'false'");
+      for (const name of entry.downstream) {
+        const index = steps.findIndex((step) => step.name === name);
+        expect(index).toBeGreaterThan(publishIndex);
+        expect(steps[index]!.if).not.toMatch(/always\(|failure\(/);
+      }
+      if (entry.file === "mcp-release.yml") {
+        expect(publish["working-directory"]).toBe("packages/mcp");
+        expect(workflow.on.pull_request?.paths).toContain(
+          "scripts/publish-npm*",
+        );
+      } else {
+        expect(publish["working-directory"]).toBeUndefined();
+        const release = steps.find(
+          (step) => step.name === "Create GitHub Release",
+        )!;
+        expect(release.run).toContain('--target "$(git rev-parse HEAD)"');
+      }
+    }
+  });
 });


### PR DESCRIPTION
npm accepts uploads before publish-time scanning makes the version public. This caused MCP registry registration to fail for `githits` 0.12.1 and 0.14.0; an immediate rerun could also fail because npm had already staged the upload.

Both release workflows now use one shared script that checks the exact public npm version every 15 seconds for up to 20 minutes before continuing. It recognizes only the observed staged-version E409 as an accepted pending upload; other publish, HTTP, transport, and metadata errors still fail. Existing public versions continue to skip uploading. New root tags also target the built commit explicitly, so main advancing during scanning cannot change the tagged revision. The change includes recovery documentation and an operations-only changelog fragment, with no package version bump.

Validation: all 4,227 Bun tests pass after review fixes, including delayed availability, timeout, staged-upload recovery, error handling, and both workflow gates. Typecheck, format, lint, build, and plugin checks pass. The availability function was checked against both public 0.14.0 packages without publishing anything. The recovered 0.14.0 release is already public; this PR prevents the same premature downstream publication on future releases.

One Claude Opus review pass completed with no blocking findings. Its deadline-edge finding and two minor test/documentation notes were resolved and verified inline, keeping the approved 20-minute bound.

CI passes: Linux and Windows tests, build/static checks, built CLI/MCP smoke tests, MCP package validation, and Node 20/22/24/26 plus Bun compatibility.
