### PR TITLE
Refresh init intro: CONTEXT/TOOLS table and support links

### DIFF
--- a/changes/brand-green-mint.changed.md
+++ b/changes/brand-green-mint.changed.md
@@ -1,0 +1,6 @@
+---
+"githits": patch
+"@githits/mcp": patch
+---
+
+- **Use brand mint for green output** - Recolors the shared green used across CLI and MCP text output (success checkmarks, setup rows, and diff `+`/added markers) to the GitHits brand mint `#57FEC9` via truecolor; terminals without truecolor fall back to their default foreground.

--- a/changes/init-intro-refresh.changed.md
+++ b/changes/init-intro-refresh.changed.md
@@ -1,0 +1,6 @@
+---
+"githits": patch
+"@githits/mcp": none
+---
+
+- **Refresh `githits init` intro** - Reworks the onboarding banner copy, shows the CLI version beside the logo, lists capabilities in a bordered two-column table that degrades to a stacked list on narrow terminals, and leads the "no cloning required" note with a green checkmark.

--- a/changes/init-intro-refresh.changed.md
+++ b/changes/init-intro-refresh.changed.md
@@ -3,4 +3,4 @@
 "@githits/mcp": none
 ---
 
-- **Refresh `githits init` intro** - Reworks the onboarding banner copy, shows the CLI version beside the logo, lists capabilities in a bordered two-column table that degrades to a stacked list on narrow terminals, and leads the "no cloning required" note with a green checkmark.
+- **Refresh `githits init` intro** - Reworks the onboarding banner copy, shows the CLI version beside the logo, lists capabilities in a bordered two-column table that degrades to a stacked list on narrow terminals, leads the "no cloning required" note with a green checkmark, and adds FAQ and support contact lines below the docs link.

--- a/packages/mcp/src/shared/colors.ts
+++ b/packages/mcp/src/shared/colors.ts
@@ -8,12 +8,13 @@ export const colors = {
   bold: "\x1b[1m",
   dim: "\x1b[2m",
   italic: "\x1b[3m",
-  green: "\x1b[32m",
+  green: "\x1b[38;2;87;254;201m", // GitHits brand mint #57FEC9
   yellow: "\x1b[33m",
   blue: "\x1b[34m",
   magenta: "\x1b[35m",
   cyan: "\x1b[36m",
   red: "\x1b[31m",
+  white: "\x1b[37m",
 };
 
 export interface TerminalColor {

--- a/src/commands/init/init.test.ts
+++ b/src/commands/init/init.test.ts
@@ -3431,13 +3431,14 @@ describe("initAction", () => {
     const logCalls = getLogOutput();
     expect(
       logCalls.some((msg) =>
-        msg.includes("Your agent can only read your local codebase"),
+        msg.includes("Let your agents see beyond your codebase"),
       ),
     ).toBe(true);
+    expect(logCalls.some((msg) => msg.includes("GitHits connects them"))).toBe(
+      true,
+    );
     expect(
-      logCalls.some((msg) =>
-        msg.includes("navigate the open-source code your app depends on"),
-      ),
+      logCalls.some((msg) => msg.includes("open-source dependency index")),
     ).toBe(true);
     expect(logCalls.some((msg) => msg.includes("With GitHits"))).toBe(true);
     expect(
@@ -3492,9 +3493,11 @@ describe("initAction", () => {
 
       await initAction({ guidance: false }, { ...deps, isInteractive: false });
       const introLines = getLogOutput();
-      expect(introLines).toContain("  Your agent can only read your local");
-      expect(introLines).toContain("  codebase.");
-      expect(introLines).not.toContain("  codebas e.");
+      expect(introLines).toContain("  Let your agents see beyond your");
+      expect(introLines).toContain("  version-aware open-source dependency");
+      expect(introLines).not.toContain(
+        "  version-aware open-sourc e dependency",
+      );
 
       logSpy.mockClear();
       await initAction(

--- a/src/commands/init/init.test.ts
+++ b/src/commands/init/init.test.ts
@@ -3430,17 +3430,26 @@ describe("initAction", () => {
     expect(fs.atomicWriteFile).toHaveBeenCalled();
     const logCalls = getLogOutput();
     expect(
+      logCalls.some((msg) => msg.includes("The code discovery infrastructure")),
+    ).toBe(true);
+    expect(
+      logCalls.some((msg) => msg.includes("software factories and agents")),
+    ).toBe(true);
+    expect(
       logCalls.some((msg) =>
-        msg.includes("Let your agents see beyond your codebase"),
+        msg.includes("A version-pinned index of open-source packages"),
       ),
     ).toBe(true);
-    expect(logCalls.some((msg) => msg.includes("GitHits connects them"))).toBe(
-      true,
-    );
     expect(
-      logCalls.some((msg) => msg.includes("open-source dependency index")),
+      logCalls.some((msg) => msg.includes("CONTEXT") && msg.includes("TOOLS")),
     ).toBe(true);
-    expect(logCalls.some((msg) => msg.includes("With GitHits"))).toBe(true);
+    expect(
+      logCalls.some(
+        (msg) =>
+          msg.includes("CODE") &&
+          msg.includes("files, grep, read, example, languages"),
+      ),
+    ).toBe(true);
     expect(
       logCalls.some((msg) => msg.includes("https://docs.githits.com")),
     ).toBe(true);
@@ -3493,10 +3502,10 @@ describe("initAction", () => {
 
       await initAction({ guidance: false }, { ...deps, isInteractive: false });
       const introLines = getLogOutput();
-      expect(introLines).toContain("  Let your agents see beyond your");
-      expect(introLines).toContain("  version-aware open-source dependency");
-      expect(introLines).not.toContain(
-        "  version-aware open-sourc e dependency",
+      expect(introLines).toContain("  GitHits – The code discovery");
+      expect(introLines).toContain("  A version-pinned index of open-source");
+      expect(introLines.every((line) => !line.includes("open-sourc e"))).toBe(
+        true,
       );
 
       logSpy.mockClear();

--- a/src/commands/init/init.ts
+++ b/src/commands/init/init.ts
@@ -11,6 +11,7 @@ import {
 } from "@githits/mcp/internal";
 import { ExitPromptError } from "@inquirer/core";
 import type { Command } from "commander";
+import { version } from "../../../package.json";
 import {
   type CreateContainerOptions,
   createContainer,
@@ -727,6 +728,26 @@ function colorizeLogo(logo: string, useColors: boolean): string {
     .join("\n");
 }
 
+/**
+ * Render the ASCII logo with the current CLI version tag aligned to the right
+ * of its last row. The tag tracks `package.json`, so releases update it
+ * automatically.
+ */
+function renderLogoWithVersion(useColors: boolean): string {
+  const rawLines = GITHITS_ASCII_LOGO.split("\n");
+  const coloredLines = colorizeLogo(GITHITS_ASCII_LOGO, useColors).split("\n");
+  const logoWidth = Math.max(...rawLines.map((line) => line.length));
+  const targetIndex = rawLines.reduce(
+    (last, line, index) => (line.trim().length > 0 ? index : last),
+    0,
+  );
+  const rawLine = rawLines[targetIndex] ?? "";
+  const gap = " ".repeat(Math.max(1, logoWidth - rawLine.length + 1));
+  const tag = colorize(`v${version}`, "dim", useColors);
+  coloredLines[targetIndex] = `${coloredLines[targetIndex]}${gap}${tag}`;
+  return coloredLines.join("\n");
+}
+
 const INIT_INTENT_CHOICES: SelectChoice<InitIntent>[] = [
   {
     name: "Install GitHits MCP + supporting instructions (Recommended)",
@@ -742,7 +763,8 @@ const INIT_INTENT_CHOICES: SelectChoice<InitIntent>[] = [
   {
     name: "Use Agent Skills instead",
     value: "skills",
-    description: "Use GitHits Agent Skills instead of MCP.",
+    description:
+      "Use GitHits Agent Skills instead of MCP (Exits current setup).",
   },
   {
     name: "Exit",
@@ -858,36 +880,146 @@ function printTask(
   }
 }
 
+/** Capabilities GitHits exposes, rendered as a two-column intro table. */
+const GITHITS_CAPABILITIES: ReadonlyArray<{
+  name: string;
+  description: string;
+}> = [
+  {
+    name: "Code Navigation",
+    description:
+      "Search, grep, list files, and read exact line ranges across packages and repos.",
+  },
+  {
+    name: "Documentation Access",
+    description:
+      "Read hosted and repository documentation for a specific version.",
+  },
+  {
+    name: "Package Intelligence",
+    description:
+      "Inspect dependencies, versions, vulnerabilities, changelogs, and upgrade changes.",
+  },
+  {
+    name: "Dependency Graph",
+    description:
+      "Relationships and transitive dependencies across packages and versions.",
+  },
+  {
+    name: "Examples",
+    description:
+      "Prior art and implementation patterns from public repositories, issues, discussions, and pull requests.",
+  },
+];
+
+/** Wrap plain text to a fixed column width, breaking on whitespace. */
+function wrapToWidth(text: string, width: number): string[] {
+  const lines: string[] = [];
+  let current = "";
+  for (const word of text.trim().split(/\s+/)) {
+    if (current.length === 0) {
+      current = word;
+    } else if (current.length + 1 + word.length <= width) {
+      current += ` ${word}`;
+    } else {
+      lines.push(current);
+      current = word;
+    }
+  }
+  if (current.length > 0) {
+    lines.push(current);
+  }
+  return lines.length > 0 ? lines : [""];
+}
+
+/** Largest width the capability table is allowed to occupy. */
+const MAX_CAPABILITY_TABLE_WIDTH = 84;
+/** Minimum description column before the table degrades to a stacked list. */
+const MIN_CAPABILITY_DESC_WIDTH = 24;
+
+/**
+ * Print the capabilities in two columns. On terminals wide enough it renders a
+ * bordered ASCII table (rules use `-` and `|`, no corner characters), capped at
+ * a maximum width so it never spans the whole screen. On narrow terminals,
+ * where borders would wrap and break, it falls back to a stacked, borderless
+ * list that stays legible.
+ */
+function printCapabilityTable(useColors: boolean): void {
+  const indent = "  ";
+  const nameWidth = Math.max(
+    ...GITHITS_CAPABILITIES.map((capability) => capability.name.length),
+  );
+  const columns = process.stdout.columns ?? DEFAULT_INIT_PROSE_WIDTH;
+  const width = Math.min(columns, MAX_CAPABILITY_TABLE_WIDTH);
+  // Each row renders as "| <name> | <desc> |": two padding spaces per cell
+  // plus the three separators account for seven fixed columns.
+  const overhead = indent.length + 7;
+  const descWidth = width - overhead - nameWidth;
+
+  if (descWidth < MIN_CAPABILITY_DESC_WIDTH) {
+    printCapabilityList(useColors, width);
+    return;
+  }
+
+  const rule = `${indent}${"-".repeat(nameWidth + descWidth + 7)}`;
+  console.log(rule);
+  for (const capability of GITHITS_CAPABILITIES) {
+    const descLines = wrapToWidth(capability.description, descWidth);
+    descLines.forEach((descLine, rowIndex) => {
+      const namePlain = (rowIndex === 0 ? capability.name : "").padEnd(
+        nameWidth,
+      );
+      const nameCell =
+        rowIndex === 0
+          ? colorizeBrand(namePlain, "primary", useColors, { bold: true })
+          : namePlain;
+      console.log(`${indent}| ${nameCell} | ${descLine.padEnd(descWidth)} |`);
+    });
+    console.log(rule);
+  }
+}
+
+/** Stacked, borderless capability layout for narrow terminals. */
+function printCapabilityList(useColors: boolean, width: number): void {
+  const nameIndent = "  ";
+  const descIndent = "    ";
+  const descWidth = Math.max(20, width - descIndent.length);
+  for (const capability of GITHITS_CAPABILITIES) {
+    console.log(
+      `${nameIndent}${colorizeBrand(capability.name, "primary", useColors, { bold: true })}`,
+    );
+    for (const line of wrapToWidth(capability.description, descWidth)) {
+      console.log(`${descIndent}${line}`);
+    }
+  }
+}
+
 function printInitIntro(useColors: boolean): void {
-  console.log(colorizeLogo(GITHITS_ASCII_LOGO, useColors));
-  printInitProse("  Your agent can only read your local codebase.");
-  console.log();
+  console.log(renderLogoWithVersion(useColors));
+  printInitProse("  Let your agents see beyond your codebase.");
   printInitProse(
-    "  GitHits lets it navigate the open-source code your app depends on.",
+    "  GitHits connects them to a version-aware open-source dependency index.",
   );
   console.log();
   console.log(
-    `  ${colorizeBrand("With GitHits, your agent can:", "primary", useColors)}`,
+    `  ${colorize("With GitHits, your agents get access to:", "white", useColors)}`,
   );
-  printInitProse(
-    "  • Find implementation examples from open-source code, issues, discussions, and pull requests",
-  );
-  printInitProse(
-    "  • Search, grep, list files, and read exact lines in any repo or package",
-  );
-  printInitProse(
-    "  • Inspect dependency internals, versions, changelogs, and upgrade changes",
-  );
-  printInitProse("  • Access package documentation");
+  printCapabilityTable(useColors);
   console.log();
   printInitProse(
-    "  No cloning or local indexing required. GitHits handles everything automatically.",
+    "  Works with Cursor, Claude Code, Codex, OpenCode, Pi, VS Code, Windsurf, and many more.",
   );
   console.log();
-  printInitProse(
-    "  Works with Cursor, Claude Code, Codex, OpenCode, Pi, VS Code, Windsurf, and more.",
+  const okColumns = process.stdout.columns ?? DEFAULT_INIT_PROSE_WIDTH;
+  const okLines = wrapInitProse(
+    "  ✓ No cloning or local indexing required. GitHits handles everything automatically.",
+    okColumns,
   );
-  console.log();
+  const firstOkLine = okLines[0] ?? "";
+  okLines[0] = firstOkLine.replace("✓", colorize("✓", "green", useColors));
+  for (const line of okLines) {
+    console.log(line);
+  }
   printInitProse("  More info: https://docs.githits.com");
   console.log();
 }

--- a/src/commands/init/init.ts
+++ b/src/commands/init/init.ts
@@ -882,33 +882,14 @@ function printTask(
 
 /** Capabilities GitHits exposes, rendered as a two-column intro table. */
 const GITHITS_CAPABILITIES: ReadonlyArray<{
-  name: string;
-  description: string;
+  family: string;
+  tools: ReadonlyArray<string>;
 }> = [
+  { family: "CODE", tools: ["files", "grep", "read", "example", "languages"] },
+  { family: "DOCS", tools: ["list", "read"] },
   {
-    name: "Code Navigation",
-    description:
-      "Search, grep, list files, and read exact line ranges across packages and repos.",
-  },
-  {
-    name: "Documentation Access",
-    description:
-      "Read hosted and repository documentation for a specific version.",
-  },
-  {
-    name: "Package Intelligence",
-    description:
-      "Inspect dependencies, versions, vulnerabilities, changelogs, and upgrade changes.",
-  },
-  {
-    name: "Dependency Graph",
-    description:
-      "Relationships and transitive dependencies across packages and versions.",
-  },
-  {
-    name: "Examples",
-    description:
-      "Prior art and implementation patterns from public repositories, issues, discussions, and pull requests.",
+    family: "PACKAGE",
+    tools: ["info", "deps", "vulns", "changelog", "upgrade"],
   },
 ];
 
@@ -934,11 +915,22 @@ function wrapToWidth(text: string, width: number): string[] {
 
 /** Largest width the capability table is allowed to occupy. */
 const MAX_CAPABILITY_TABLE_WIDTH = 84;
-/** Minimum description column before the table degrades to a stacked list. */
-const MIN_CAPABILITY_DESC_WIDTH = 24;
+/** Minimum tools column before the table degrades to a stacked list. */
+const MIN_CAPABILITY_TOOLS_WIDTH = 24;
+
+/** Column headers for the capability table. */
+const CAPABILITY_HEADERS = { context: "CONTEXT", tools: "TOOLS" } as const;
+
+/** Comma-separated tool list shown in the family's second column. */
+function familyTools(
+  capability: (typeof GITHITS_CAPABILITIES)[number],
+): string {
+  return capability.tools.join(", ");
+}
 
 /**
- * Print the capabilities in two columns. On terminals wide enough it renders a
+ * Print the capabilities as a two-column table: the family in the left column
+ * and its tools listed in the right. On terminals wide enough it renders a
  * bordered ASCII table (rules use `-` and `|`, no corner characters), capped at
  * a maximum width so it never spans the whole screen. On narrow terminals,
  * where borders would wrap and break, it falls back to a stacked, borderless
@@ -947,63 +939,78 @@ const MIN_CAPABILITY_DESC_WIDTH = 24;
 function printCapabilityTable(useColors: boolean): void {
   const indent = "  ";
   const nameWidth = Math.max(
-    ...GITHITS_CAPABILITIES.map((capability) => capability.name.length),
+    CAPABILITY_HEADERS.context.length,
+    ...GITHITS_CAPABILITIES.map((capability) => capability.family.length),
   );
   const columns = process.stdout.columns ?? DEFAULT_INIT_PROSE_WIDTH;
   const width = Math.min(columns, MAX_CAPABILITY_TABLE_WIDTH);
-  // Each row renders as "| <name> | <desc> |": two padding spaces per cell
+  // Each row renders as "| <context> | <tools> |": two padding spaces per cell
   // plus the three separators account for seven fixed columns.
   const overhead = indent.length + 7;
-  const descWidth = width - overhead - nameWidth;
+  const toolsWidth = width - overhead - nameWidth;
 
-  if (descWidth < MIN_CAPABILITY_DESC_WIDTH) {
+  if (toolsWidth < MIN_CAPABILITY_TOOLS_WIDTH) {
     printCapabilityList(useColors, width);
     return;
   }
 
-  const rule = `${indent}${"-".repeat(nameWidth + descWidth + 7)}`;
+  const rule = `${indent}${"-".repeat(nameWidth + toolsWidth + 7)}`;
+  const row = (name: string, tools: string): string =>
+    `${indent}| ${name} | ${tools} |`;
+  const header = (text: string, columnWidth: number): string =>
+    colorizeBrand(text.padEnd(columnWidth), "primary", useColors, {
+      bold: true,
+    });
+
+  console.log(rule);
+  console.log(
+    row(
+      header(CAPABILITY_HEADERS.context, nameWidth),
+      header(CAPABILITY_HEADERS.tools, toolsWidth),
+    ),
+  );
   console.log(rule);
   for (const capability of GITHITS_CAPABILITIES) {
-    const descLines = wrapToWidth(capability.description, descWidth);
-    descLines.forEach((descLine, rowIndex) => {
-      const namePlain = (rowIndex === 0 ? capability.name : "").padEnd(
+    const toolLines = wrapToWidth(familyTools(capability), toolsWidth);
+    toolLines.forEach((toolLine, rowIndex) => {
+      const namePlain = (rowIndex === 0 ? capability.family : "").padEnd(
         nameWidth,
       );
       const nameCell =
         rowIndex === 0
           ? colorizeBrand(namePlain, "primary", useColors, { bold: true })
           : namePlain;
-      console.log(`${indent}| ${nameCell} | ${descLine.padEnd(descWidth)} |`);
+      console.log(row(nameCell, toolLine.padEnd(toolsWidth)));
     });
-    console.log(rule);
   }
+  console.log(rule);
 }
 
 /** Stacked, borderless capability layout for narrow terminals. */
 function printCapabilityList(useColors: boolean, width: number): void {
   const nameIndent = "  ";
-  const descIndent = "    ";
-  const descWidth = Math.max(20, width - descIndent.length);
+  const toolsIndent = "    ";
+  const toolsWidth = Math.max(20, width - toolsIndent.length);
   for (const capability of GITHITS_CAPABILITIES) {
     console.log(
-      `${nameIndent}${colorizeBrand(capability.name, "primary", useColors, { bold: true })}`,
+      `${nameIndent}${colorizeBrand(capability.family, "primary", useColors, { bold: true })}`,
     );
-    for (const line of wrapToWidth(capability.description, descWidth)) {
-      console.log(`${descIndent}${line}`);
+    for (const line of wrapToWidth(familyTools(capability), toolsWidth)) {
+      console.log(`${toolsIndent}${line}`);
     }
   }
 }
 
 function printInitIntro(useColors: boolean): void {
   console.log(renderLogoWithVersion(useColors));
-  printInitProse("  Let your agents see beyond your codebase.");
   printInitProse(
-    "  GitHits connects them to a version-aware open-source dependency index.",
+    "  GitHits – The code discovery infrastructure for software factories and agents",
   );
   console.log();
-  console.log(
-    `  ${colorize("With GitHits, your agents get access to:", "white", useColors)}`,
+  printInitProse(
+    "  A version-pinned index of open-source packages and their dependency graphs, giving agents access to the source, documentation, package metadata, vulnerabilities, licenses, changelogs, upgrade evidence, and real-world implementation patterns for the exact versions your software depends on, with every result traceable and auditable. API, MCP, CLI.",
   );
+  console.log();
   printCapabilityTable(useColors);
   console.log();
   printInitProse(
@@ -1021,6 +1028,8 @@ function printInitIntro(useColors: boolean): void {
     console.log(line);
   }
   printInitProse("  More info: https://docs.githits.com");
+  printInitProse("  Questions? Visit https://githits.com/faq/");
+  printInitProse("  Support: support@githits.com");
   console.log();
 }
 


### PR DESCRIPTION
## What

Continues the `githits init` onboarding intro refresh:

- **Capability table** — replaces the prose capability descriptions with a compact `CONTEXT`/`TOOLS` table grouping tools by family:

  | CONTEXT | TOOLS |
  |---|---|
  | CODE | files, grep, read, example, languages |
  | DOCS | list, read |
  | PACKAGE | info, deps, vulns, changelog, upgrade |

- **Support links** — adds FAQ and support contact lines below the docs link:
  ```
  More info: https://docs.githits.com
  Questions? Visit https://githits.com/faq/
  Support: support@githits.com
  ```

The table keeps the existing ASCII `-`/`|` bordered rendering and its stacked fallback on narrow terminals.

## Screenshot

<img width="1185" height="692" alt="Screenshot" src="https://github.com/user-attachments/assets/aeae9fa9-4a05-4fde-ad65-f76e6e1c88ec" />


## Testing

- `bun test src/commands/init/init.test.ts` — 215/215
- `bun run build` — clean
- `bun run smoke:cli` — pass
