### PR TITLE
chore: release githits and MCP 0.15.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,12 +6,12 @@
   },
   "metadata": {
     "description": "The code context layer for AI coding agents",
-    "version": "0.14.0"
+    "version": "0.15.0"
   },
   "plugins": [
     {
       "name": "githits",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "description": "The code context layer for AI coding agents",
       "author": {
         "name": "GitHits"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,65 @@ changes use independent files under [`changes/`](changes/README.md) and are
 consolidated here only during release preparation. Dated, versioned sections
 are historical records and change only to correct blatant factual errors.
 
+## [githits 0.15.0] - 2026-09-08
+
+Minor release: adds Codeberg and nested GitLab repository targets and lets
+experimental CLI Ask infer a target from a question.
+
+### Added
+
+- **Multi-provider repository targets** - Add explicit `codeberg:owner/repo` and
+  nested `gitlab:group/subgroup/project` targets alongside GitHub across search
+  and code navigation. Preserve provider identity and exact refs in follow-ups,
+  GitHub shorthand/HTTP compatibility, and registry-native Swift/Zig coordinates.
+  Bare repository names and unsupported hosts are rejected. Public code, MCP,
+  and package guidance now describe the supported target forms.
+- **Question-only Ask** - Experimental CLI `githits ask "question"` lets GitHits
+  identify a public package or repository from the question. Explicit targets
+  and thread follow-ups remain supported.
+
+### Fixed
+
+- **Code navigation authentication** - Recognize backend
+  `AUTHENTICATION_REQUIRED` errors and attempt the existing single credential
+  refresh, matching package-intelligence behavior while preserving access-denied
+  errors.
+- **Rejected refresh credentials** - Recognize OAuth and Supabase refresh-token
+  and session rejection codes without relying on description wording, clearing
+  unchanged rejected tokens while preserving client registration and credentials
+  replaced during refresh.
+- **On-demand site documentation** - Resolution describes site documentation
+  needing preparation as crawled on demand while preserving ordinary on-demand
+  search continuation, identity, ordering, and security checks.
+- **Release availability checks** - Both npm release pipelines wait for the exact
+  package version to become public before downstream publication, and recover
+  accepted uploads still undergoing npm scanning when a release job is rerun.
+
+## [@githits/mcp 0.15.0] - 2026-09-08
+
+Minor release: adds Codeberg and nested GitLab repository targets.
+
+### Added
+
+- **Multi-provider repository targets** - Add explicit `codeberg:owner/repo` and
+  nested `gitlab:group/subgroup/project` targets alongside GitHub across search
+  and code navigation. Preserve provider identity and exact refs in follow-ups,
+  GitHub shorthand/HTTP compatibility, and registry-native Swift/Zig coordinates.
+  Bare repository names and unsupported hosts are rejected. MCP guidance and
+  contextual tool help describe the supported target forms.
+
+### Fixed
+
+- **Code navigation authentication** - Recognize backend
+  `AUTHENTICATION_REQUIRED` errors and use the existing authentication handling
+  path while preserving access-denied errors.
+- **On-demand site documentation** - Resolution describes site documentation
+  needing preparation as crawled on demand while preserving ordinary on-demand
+  search continuation, identity, ordering, and security checks.
+
+Hosted MCP clients receive these changes after remote-mcp updates this package
+and deploys the hosted server.
+
 ## [githits 0.14.0] - 2026-09-07
 
 Minor release: changes default search text to authoritative match evidence and

--- a/bun.lock
+++ b/bun.lock
@@ -45,7 +45,7 @@
     },
     "packages/mcp": {
       "name": "@githits/mcp",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "^4.4.3",

--- a/changes/ask-optional-target.added.md
+++ b/changes/ask-optional-target.added.md
@@ -1,6 +1,0 @@
----
-"githits": minor
-"@githits/mcp": none
----
-
-- **Question-only Ask** - Experimental CLI `githits ask "question"` lets GitHits identify a public package or repository from the question. Explicit targets and thread follow-ups remain supported.

--- a/changes/code-navigation-authentication-required.fixed.md
+++ b/changes/code-navigation-authentication-required.fixed.md
@@ -1,6 +1,0 @@
----
-"githits": patch
-"@githits/mcp": patch
----
-
-- **Code navigation authentication** - Recognize backend `AUTHENTICATION_REQUIRED` errors and attempt the existing single credential refresh, matching package-intelligence behavior while preserving access-denied errors.

--- a/changes/npm-release-availability.fixed.md
+++ b/changes/npm-release-availability.fixed.md
@@ -1,8 +1,0 @@
----
-"githits": none
-"@githits/mcp": none
----
-
-- **Release availability checks** - Both npm release pipelines wait for the exact
-  package version to become public before downstream publication, and recover
-  accepted uploads still undergoing npm scanning when a release job is rerun.

--- a/changes/r3b-repository-targets.added.md
+++ b/changes/r3b-repository-targets.added.md
@@ -1,6 +1,0 @@
----
-githits: minor
-"@githits/mcp": minor
----
-
-- **Multi-provider repository targets** - Add explicit `codeberg:owner/repo` and nested `gitlab:group/subgroup/project` repository targets alongside GitHub across CLI/MCP search and code navigation, with canonical HTTPS backend URLs and provider-preserving ref/follow-up formatting. Preserve GitHub shorthand/HTTP and registry-native Swift/Zig package coordinates; reject bare repository names and unsupported hosts. Public code/MCP guidance is updated in this increment; hosted clients require the subsequent MCP package adoption and deployment.

--- a/changes/refresh-grant-classification.fixed.md
+++ b/changes/refresh-grant-classification.fixed.md
@@ -1,6 +1,0 @@
----
-"githits": patch
-"@githits/mcp": none
----
-
-- **Rejected refresh credentials** - Recognize OAuth and Supabase refresh-token/session rejection codes without relying on description wording, clearing unchanged rejected tokens while preserving client registration and credentials replaced during refresh.

--- a/changes/resolve-site-documentation-readiness.fixed.md
+++ b/changes/resolve-site-documentation-readiness.fixed.md
@@ -1,6 +1,0 @@
----
-"githits": patch
-"@githits/mcp": patch
----
-
-- **On-demand site documentation** - CLI and MCP resolution now describe site documentation needing preparation as crawled on demand while preserving ordinary on-demand search continuation, identity, ordering, and security checks.

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "The code context layer for AI coding agents",
   "mcpServers": {
     "githits": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "githits",
   "description": "The code context layer for AI coding agents",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "mcpName": "com.githits/githits",
   "type": "module",
   "workspaces": [

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@githits/mcp",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Reusable MCP server APIs and tools for GitHits",
   "type": "module",
   "files": [

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "githits",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/server.json
+++ b/server.json
@@ -16,7 +16,7 @@
     "source": "github",
     "id": "1165453165"
   },
-  "version": "0.14.0",
+  "version": "0.15.0",
   "remotes": [
     {
       "type": "streamable-http",
@@ -28,7 +28,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "githits",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/skills/githits-package/references/package.md
+++ b/skills/githits-package/references/package.md
@@ -5,7 +5,7 @@
 `githits pkg info <registry:name>` returns latest-version triage: license, description, repository popularity, downloads, publish age, and separate latest-affected and package-wide advisory-history scopes. Use `--verbose` for GitHub language/topics/last-pushed, package-wide advisory history (all versions), published-version count, download freshness, and recent changes. Use `--json` for structured fields.
 
 Supported registries include npm, PyPI, Hex, Crates, NuGet, Maven, Packagist, RubyGems, Go, Swift, vcpkg, and Zig.
-Swift package targets use `swift:github.com/<owner>/<repo>`; Zig package targets use `zig:gh/<owner>/<repo>`.
+Swift package targets use `swift:github.com/<owner>/<repo>` or `swift:gitlab.com/<group>/<project>`; Zig package targets use `zig:gh/<owner>/<repo>` or `zig:cb/<owner>/<repo>`. Keep these registry-native coordinates for package evidence; direct repository targets inspect the full repository.
 
 ## Vulnerabilities
 
@@ -36,6 +36,8 @@ Use `--depth` to request transitive output capped to that traversal depth. Omit 
 Flags: `--repo-url <url>`, `--from <version>`, `--to <version>`, `--limit 1-50`, `--git-ref <ref>`, `--verbose`, `--no-body`, `--json`.
 
 Do not use `registry:name@version` for changelog. Use `--to <version>`.
+
+For repository changelogs, pass a full HTTPS URL on github.com, codeberg.org, or gitlab.com to `--repo-url`; use `--git-ref` for a branch or tag. Codeberg requires owner/repo; GitLab permits nested namespaces. Do not pass compact `github:`, `codeberg:`, or `gitlab:` targets to this URL field.
 
 ## Upgrade Review
 


### PR DESCRIPTION
Prepare coordinated minor releases of `githits` and `@githits/mcp` at **0.15.0**.

The release adds Codeberg and nested GitLab repository targets, question-only experimental CLI Ask, code-navigation authentication handling, refresh-credential rejection fixes, on-demand documentation wording, and npm publication availability checks.

Both previous release tags point to `8ef0fac0`. Audited their complete delta through `89246f79` against all six pending fragments; both packages require a minor bump. Consolidate the fragments into separate artifact sections dated 2026-09-08, preserve historical entries, align package/lockfile/registry/generated plugin versions, and complete the package skill reference for provider-specific package coordinates and repository changelog URLs.

Validation:
- 4,103 product tests pass. The complete repository run passed 4,481 tests with one environment failure: the Codex dry-run harness rejects this session's global `AGENTS.md`.
- Typecheck, lint, both builds, plugin generation/check, and packed public-package consumer validation including MCP npm publish dry-run pass. Used cached Bun 1.4.2 after Bun 1.3.9 hit its Windows path assertion.
- Formatting passes for all 466 files on an LF-normalized snapshot; the working checkout uses CRLF.
- Authenticated MCP smoke and both secret-free built CLI/MCP smoke suites pass.
- Authenticated CLI smoke passed its stable tool and JSON-parity checks, then failed an experimental live fixture: `resolve expressjs` now returns `site:expressjs.com` with backend `medium` confidence, but the fixture requires `exact|high`. Direct text/JSON inspection confirms correct related targets and the explicit-choice guard.
- Attempted the targeted package-changelog skills eval with Codex and Claude. Codex preflight rejected global instructions; isolated Claude lacked login and cleanup reported Windows EBUSY. No new agent-quality evidence is claimed. Prior provider navigation eval and live dev/production evidence remain documented in `docs/implementation/repository-targets.md`.

Hosted MCP clients receive the package changes after remote-mcp adopts 0.15.0 and deploys. Merge, auto-merge, tagging, and publication remain pending separate human approval of this PR.

