### PR TITLE
docs: link public API documentation from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ health, compare dependency upgrades, and find source-cited examples from real
 open-source projects when model knowledge and local repository context are not
 enough.
 
+Want to use GitHits as part of your agent harness or software factory? Check out
+our [public API documentation](https://docs.githits.com/api/overview).
+
 ## Quick Start
 
 ```sh


### PR DESCRIPTION
Adds a link to the public API overview before Quick Start for users integrating GitHits into an agent harness or software factory.

Validation: verified the documentation URL loads, reviewed the README diff, and passed `git diff --check` and `bun run build`.
