### PR TITLE
fix: allow question-only Ask in local MCP

### DIFF
--- a/changes/local-mcp-ask-parity.fixed.md
+++ b/changes/local-mcp-ask-parity.fixed.md
@@ -1,0 +1,6 @@
+---
+"githits": patch
+"@githits/mcp": none
+---
+
+- **Question-only local MCP Ask** - Allow Ask to identify the target from the question, matching the CLI. Return candidates for user selection when the target is ambiguous; explicit targets and thread follow-ups remain supported.

--- a/docs/experimental-tools.md
+++ b/docs/experimental-tools.md
@@ -97,13 +97,18 @@ terminal control sequences.
 Use `--source-format url` to return the original upstream HTTP URLs instead of
 CLI source commands. This changes only source presentation.
 
-The local MCP `ask` tool accepts exactly one of `target` for a new thread or
-`thread_id` for a needed follow-up. It defaults to MCP-native `code_read` and
-`docs_read` source calls. Set `source_format` to `url` for original upstream HTTP
-URLs. Text output includes source pointers, the Ask run ID, thread ID, and
-conditional follow-up guidance. JSON returns the response for the selected source
-format. The tool description directs agents to call `resolve_target` first when
-the intended target is ambiguous or not yet canonical.
+The local MCP `ask` tool also accepts a question alone. Omit both `target` and
+`thread_id` to identify the target from the question, supply `target` to choose
+one explicitly, or use `thread_id` for a needed follow-up. Do not combine them.
+It defaults to MCP-native `code_read` and `docs_read` source calls. Set
+`source_format` to `url` for original upstream HTTP URLs. Answer text includes
+source pointers, the Ask run ID, thread ID, and conditional follow-up guidance.
+JSON returns the response for the selected source format.
+
+When Ask cannot confidently select a target, both CLI and local MCP return a
+clarification with resolver candidates instead of an answer or thread. JSON
+identifies this as `outcome: "needs_target"`. Repeat the question with a selected
+target; do not infer identity from popularity or silently pick an ambiguous hit.
 
 Resolve a noncanonical name before calling another GitHits command:
 

--- a/docs/implementation/ask-target-clarification.md
+++ b/docs/implementation/ask-target-clarification.md
@@ -2,7 +2,7 @@
 
 A targetless Ask lookup that cannot choose confidently returns HTTP 200 with
 `outcome: "needs_target"`, `message`, and the compact resolver result in `resolution`.
-It is a completed lookup requiring caller input. It has no `answer_markdown`, source
+The response describes a completed lookup requiring caller input. It has no `answer_markdown`, source
 pointers, run ID, or thread ID. Empty results use the same shape with no candidates.
 
 The service validates resolver output with the existing compact resolver schema and
@@ -20,8 +20,10 @@ completes successfully. Retry the question with a selected canonical target:
 githits ask github:openai/codex 'How does codex handle chat compaction?'
 ```
 
-Local MCP admission still requires an explicit target or thread, so its current request
-path cannot receive targetless clarification. This change does not broaden admission.
+Local MCP Ask accepts the same question-only lookup: omit both `target` and
+`thread_id`. Text and JSON return the same clarification and candidates as the CLI.
+Repeat the original question with a selected `target` to continue. Explicit targets
+and thread follow-ups remain supported, but cannot be supplied together.
 
 Deploy clients supporting this response before enabling the backend change: older
 clients expect every HTTP 200 response to contain an answer and identifiers. The new

--- a/eval/agentic/README.md
+++ b/eval/agentic/README.md
@@ -262,9 +262,9 @@ Canary has `express-router` and
 `package-upgrade-safety`; stable-full contains all 22 stable workloads.
 `stateful-manual` contains only `githits-onboarding` and is dry-run-only in
 this phase. `experimental` contains only
-`experimental-code-diff`, `experimental-resolution-follow-up`, and
+`experimental-code-diff`, `experimental-question-only-ask`, `experimental-resolution-follow-up`, and
 `experimental-site-resolution-follow-up`. The manifest therefore classifies
-26 workloads: 22 stable, one stateful, and three experimental. Canary is a
+27 workloads: 22 stable, one stateful, and four experimental. Canary is a
 subset of smoke, smoke is a subset of stable-full, and stateful or experimental
 workloads never enter those stable suites.
 
@@ -836,7 +836,12 @@ add the workload from the table. Compare
 `tool-calls.json`, `metrics.json`, and the final JSON's answer/confidence across
 branches or against a published run.
 
-For local experimental tool changes, run both new workloads and the
+For question-only Ask parity, use `experimental-question-only-ask.md` with
+`--experimental-tools` and descriptor-only guidance. Inspect whether calls omit
+both selectors and whether returned candidates remain choices for the user;
+do not count authentication failures as behavioral evidence.
+
+For local experimental tool changes, run the relevant workloads and the
 `express-router.md` regression cohort with Claude and Codex:
 
 ```bash

--- a/eval/agentic/suites.json
+++ b/eval/agentic/suites.json
@@ -56,6 +56,12 @@
       "suites": ["experimental"]
     },
     {
+      "id": "experimental-question-only-ask",
+      "path": "eval/agentic/workloads/experimental-question-only-ask.md",
+      "safety": "experimental",
+      "suites": ["experimental"]
+    },
+    {
       "id": "experimental-resolution-follow-up",
       "path": "eval/agentic/workloads/experimental-resolution-follow-up.md",
       "safety": "experimental",

--- a/eval/agentic/workloads/experimental-question-only-ask.md
+++ b/eval/agentic/workloads/experimental-question-only-ask.md
@@ -1,0 +1,1 @@
+How does Codex handle chat compaction?

--- a/packages/mcp/src/mcp/instructions.test.ts
+++ b/packages/mcp/src/mcp/instructions.test.ts
@@ -65,7 +65,10 @@ describe("buildLocalMcpQuickStart", () => {
     expect(instructions).toContain(
       "public repository or package question and receive a source-cited answer",
     );
-    expect(instructions).toContain("Call `resolve_target` first");
+    expect(instructions).toContain("Omit `target` and `thread_id`");
+    expect(instructions).toContain(
+      "ask the user to select a `target`, then retry",
+    );
     expect(instructions).toContain("Reuse a returned `thread_id` only");
     expect(instructions).toContain('`source_format:"url"`');
     expect(instructions).toContain("Do not invent or rewrite sources");

--- a/packages/mcp/src/mcp/instructions.ts
+++ b/packages/mcp/src/mcp/instructions.ts
@@ -148,10 +148,7 @@ const LOCAL_EXPERIMENTAL_PRIVACY =
   "Inputs are sent to GitHits. Never send credentials, personal data, private or proprietary content, local paths, or private targets.";
 
 const LOCAL_AGENTIC_ASK_GUIDANCE_START =
-  "- `ask` — ask a public repository or package question and receive a source-cited answer.";
-
-const LOCAL_AGENTIC_ASK_RESOLVE_GUIDANCE =
-  " Call `resolve_target` first when the intended target is ambiguous or noncanonical.";
+  "- `ask` — ask a public repository or package question and receive a source-cited answer. Omit `target` and `thread_id` for question-only lookup. For candidates, ask the user to select a `target`, then retry.";
 
 const LOCAL_AGENTIC_ASK_GUIDANCE_END =
   ' Reuse a returned `thread_id` only when the previous answer is insufficient or more information is needed. Sources default to directly callable MCP tools; use `source_format:"url"` for original upstream URLs. Do not invent or rewrite sources. Use the returned Ask run ID when reporting a defect. Keep text; use JSON only for required fields absent from text.';
@@ -179,7 +176,7 @@ export function buildLocalMcpQuickStart(
   const toolGuidance: string[] = [];
   if (enabled.has("ask")) {
     toolGuidance.push(
-      `${LOCAL_AGENTIC_ASK_GUIDANCE_START}${enabled.has("resolve_target") ? LOCAL_AGENTIC_ASK_RESOLVE_GUIDANCE : ""}${LOCAL_AGENTIC_ASK_GUIDANCE_END}`,
+      `${LOCAL_AGENTIC_ASK_GUIDANCE_START}${LOCAL_AGENTIC_ASK_GUIDANCE_END}`,
     );
   }
   if (enabled.has("resolve_target")) {

--- a/packages/mcp/src/mcp/local-agentic-ask.test.ts
+++ b/packages/mcp/src/mcp/local-agentic-ask.test.ts
@@ -2,12 +2,15 @@ import { describe, expect, it, mock } from "bun:test";
 import {
   AgenticAskHttpError,
   type AgenticAskMcpResponse,
+  type AgenticAskNeedsTargetResponse,
   type AgenticAskService,
   type AgenticAskUrlResponse,
   AuthenticationError,
+  parseCompactResolveTargetResult,
 } from "@githits/core-internal";
 import { TermsAcceptanceRequiredError } from "@githits/core-internal/browser";
 import { z } from "zod";
+import { ASK_NEEDS_TARGET_WIRE } from "../../../core-internal/src/services/ask-needs-target.fixture.js";
 import {
   type AgenticAskMcpArgs,
   createLocalAgenticAskTool,
@@ -62,12 +65,14 @@ function urlResponse(): AgenticAskUrlResponse {
 }
 
 type McpAsk = (
-  request: ({ target: string } | { threadId: string }) & {
+  request: ({ target?: string } | { threadId: string }) & {
     question: string;
     sourceFormat: "mcp" | "url";
   },
   options?: { signal?: AbortSignal },
-) => Promise<AgenticAskMcpResponse | AgenticAskUrlResponse>;
+) => Promise<
+  AgenticAskMcpResponse | AgenticAskUrlResponse | AgenticAskNeedsTargetResponse
+>;
 
 function createService(
   ask: McpAsk = mock(() => Promise.resolve(response())),
@@ -94,9 +99,20 @@ describe("local ask MCP adapter", () => {
       "Ask a public repository or package question and receive a source-cited answer.",
     );
     expect(firstSentence.length).toBeLessThanOrEqual(79);
+    expect(DESCRIPTION.slice(0, 80)).toStartWith(firstSentence);
     expect(DESCRIPTION).toContain(
-      "Call resolve_target first when the intended target is ambiguous",
+      "Omit target and thread_id to identify the target from the question",
     );
+    expect(DESCRIPTION).toContain(
+      "ask the user to select a target before retrying",
+    );
+    expect(
+      z.object(tool.schema).parse({ question: "How does codex work?" }),
+    ).toEqual({
+      question: "How does codex work?",
+      source_format: "mcp",
+      format: "text",
+    });
     expect(tool.annotations).toEqual({
       readOnlyHint: false,
       openWorldHint: false,
@@ -118,6 +134,8 @@ describe("local ask MCP adapter", () => {
       enum: ["text", "json"],
     });
     expect(tool.schema.format?.parse(undefined)).toBe("text");
+    expect(tool.schema.target?.safeParse("").success).toBe(false);
+    expect(tool.schema.thread_id?.safeParse("").success).toBe(false);
     expect(tool.schema.format?.safeParse("text-v1").success).toBe(false);
     expect(tool.schema.format?.description).toContain("token-efficient");
     expect(tool.schema.format?.description).toContain(
@@ -165,12 +183,11 @@ describe("local ask MCP adapter", () => {
     );
   });
 
-  it("rejects ambiguous, missing, and malformed selectors before the service call", async () => {
+  it("rejects conflicting and malformed selectors before the service call", async () => {
     const ask = mock(() => Promise.resolve(response()));
     const tool = createLocalAgenticAskTool(createService(ask));
     const invalidArgs: AgenticAskMcpArgs[] = [
       { target: "npm:example", thread_id: THREAD_ID, question: "How?" },
-      { question: "How?" },
       { thread_id: "not-a-uuid", question: "How?" },
     ];
 
@@ -184,6 +201,74 @@ describe("local ask MCP adapter", () => {
     }
     expect(ask).not.toHaveBeenCalled();
   });
+
+  it.each(["mcp", "url"] as const)(
+    "answers a question-only request with %s sources",
+    async (sourceFormat) => {
+      const answer = sourceFormat === "mcp" ? response() : urlResponse();
+      const ask = mock(() => Promise.resolve(answer));
+      const signal = new AbortController().signal;
+      const result = await invoke(
+        createLocalAgenticAskTool(createService(ask)),
+        {
+          question: "How does express routing work?",
+          source_format: sourceFormat,
+        },
+        signal,
+      );
+      expect(ask).toHaveBeenCalledWith(
+        {
+          question: "How does express routing work?",
+          sourceFormat,
+        },
+        { signal },
+      );
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0]?.text).toBe(formatAgenticAskMcpText(answer));
+    },
+  );
+
+  it.each(["text", "json"] as const)(
+    "returns question-only clarification as successful %s without retrying",
+    async (format) => {
+      const resolution = parseCompactResolveTargetResult(
+        ASK_NEEDS_TARGET_WIRE.resolution,
+      );
+      if (!resolution) throw new Error("Invalid clarification fixture");
+      const clarification: AgenticAskNeedsTargetResponse = {
+        outcome: "needs_target",
+        message: ASK_NEEDS_TARGET_WIRE.message,
+        resolution,
+      };
+      const ask = mock(() => Promise.resolve(clarification));
+      const result = await invoke(
+        createLocalAgenticAskTool(createService(ask)),
+        {
+          question: "How does codex handle chat compaction?",
+          format,
+        },
+      );
+      expect(ask).toHaveBeenCalledTimes(1);
+      expect(ask).toHaveBeenCalledWith(
+        {
+          question: "How does codex handle chat compaction?",
+          sourceFormat: "mcp",
+        },
+        undefined,
+      );
+      expect(result.isError).toBeUndefined();
+      const text = result.content[0]?.text ?? "";
+      if (format === "json") {
+        expect(JSON.parse(text)).toEqual(clarification);
+        expect(JSON.parse(text)).not.toHaveProperty("thread_id");
+      } else {
+        expect(text).toContain("github:openai/codex [medium]");
+        expect(text).toContain("Related targets:");
+        expect(text).toContain("protected exact-name match");
+        expect(text).not.toContain("Thread ID:");
+      }
+    },
+  );
 
   it("returns only the validated MCP envelope for JSON", async () => {
     const result = await invoke(createLocalAgenticAskTool(createService()), {
@@ -294,19 +379,30 @@ describe("local ask MCP adapter", () => {
     },
   );
 
-  it("omits a missing failure run ID", async () => {
+  it("preserves question-only service failures without inventing identifiers", async () => {
     const ask = mock(() =>
       Promise.reject(
-        new AgenticAskHttpError("EXECUTION_FAILED", "Agentic Ask failed.", 500),
+        new AgenticAskHttpError(
+          "SERVICE_UNAVAILABLE",
+          "Agentic Ask is temporarily unavailable.",
+          503,
+        ),
       ),
     );
     const result = await invoke(createLocalAgenticAskTool(createService(ask)), {
-      target: "npm:example",
-      question: "How?",
+      question: "How does Express routing work?",
     });
 
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0]?.text ?? "{}")).toMatchObject({
+      code: "BACKEND_ERROR",
+      details: { status: 503 },
+    });
     expect(JSON.parse(result.content[0]?.text ?? "{}")).not.toHaveProperty(
       "tool_call_id",
+    );
+    expect(JSON.parse(result.content[0]?.text ?? "{}")).not.toHaveProperty(
+      "thread_id",
     );
   });
 

--- a/packages/mcp/src/mcp/local-agentic-ask.ts
+++ b/packages/mcp/src/mcp/local-agentic-ask.ts
@@ -35,14 +35,14 @@ const schema: ZodRawShape = {
     .min(1)
     .optional()
     .describe(
-      "One canonical public OSS package or repository target, such as npm:express or github:expressjs/express. Call resolve_target first when the intended target is ambiguous or not canonical.",
+      "Optional canonical public OSS package or repository target, such as npm:express or github:expressjs/express. Omit target and thread_id to identify the target from the question.",
     ),
   thread_id: z
     .string()
     .min(1)
     .optional()
     .describe(
-      "Thread UUID returned by an earlier ask call. Provide exactly one of target or thread_id, and reuse a thread only when the prior answer is insufficient or additional information is needed.",
+      "Thread UUID returned by an earlier ask call. Cannot be combined with target. Reuse a thread only when the prior answer is insufficient or additional information is needed.",
     ),
   question: z
     .string()
@@ -65,7 +65,7 @@ const schema: ZodRawShape = {
 };
 
 export const DESCRIPTION =
-  "Ask a public repository or package question and receive a source-cited answer. Call resolve_target first when the intended target is ambiguous or not canonical. Continue a prior thread by its returned thread_id only when the earlier answer is insufficient or additional information is needed. Sources default to actionable MCP calls; request source_format=url for original upstream URLs.";
+  "Ask a public repository or package question and receive a source-cited answer. Omit target and thread_id to identify the target from the question. If Ask returns candidates, ask the user to select a target before retrying. Supply at most one of target or thread_id. Continue a prior thread by its returned thread_id only when the earlier answer is insufficient or additional information is needed. Sources default to actionable MCP calls; request source_format=url for original upstream URLs.";
 
 export function createLocalAgenticAskTool(
   service: AgenticAskService,
@@ -166,11 +166,12 @@ function isTextFormat(format: AgenticAskMcpArgs["format"]): boolean {
 
 function resolveMcpAskSubject(
   args: AgenticAskMcpArgs,
-): { target: string } | { threadId: string } | { error: string } {
-  if ((args.target === undefined) === (args.thread_id === undefined)) {
-    return { error: "Provide exactly one of target or thread_id." };
+): { target?: string } | { threadId: string } | { error: string } {
+  if (args.target !== undefined && args.thread_id !== undefined) {
+    return { error: "Provide at most one of target or thread_id." };
   }
   if (args.target !== undefined) return { target: args.target };
+  if (args.thread_id === undefined) return {};
 
   const threadId = normalizeAgenticAskThreadId(args.thread_id);
   return threadId

--- a/packages/mcp/src/mcp/local-server.test.ts
+++ b/packages/mcp/src/mcp/local-server.test.ts
@@ -263,7 +263,7 @@ describe("createLocalMcpServer", () => {
     )._registeredTools.resolve_target!;
 
     const askResult = await registeredTools(server).ask!.handler(
-      { target: "npm:express", question: "How?", format: "json" },
+      { question: "How does Express routing work?", format: "json" },
       undefined as unknown as RequestHandlerExtra<
         ServerRequest,
         ServerNotification
@@ -272,8 +272,7 @@ describe("createLocalMcpServer", () => {
     expect(askResult.isError).toBeUndefined();
     expect(ask).toHaveBeenCalledWith(
       {
-        target: "npm:express",
-        question: "How?",
+        question: "How does Express routing work?",
         sourceFormat: "mcp",
       },
       undefined,

--- a/scripts/agent-eval-suite.test.ts
+++ b/scripts/agent-eval-suite.test.ts
@@ -389,10 +389,10 @@ function expectFixtureError(
 }
 
 describe("agent eval suites", () => {
-  it("loads the checked-in manifest with the exact initial inventory", () => {
+  it("loads the checked-in manifest with the exact workload inventory", () => {
     const manifest = loadSuiteManifest();
     expect(manifest.schemaVersion).toBe(1);
-    expect(manifest.workloads).toHaveLength(26);
+    expect(manifest.workloads).toHaveLength(27);
     expect(
       manifest.workloads.filter((workload) => workload.safety === "stable"),
     ).toHaveLength(22);
@@ -403,7 +403,7 @@ describe("agent eval suites", () => {
       manifest.workloads.filter(
         (workload) => workload.safety === "experimental",
       ),
-    ).toHaveLength(3);
+    ).toHaveLength(4);
 
     expect(
       selectSuiteWorkloads(manifest, "canary").map((item) => item.id),
@@ -451,6 +451,7 @@ describe("agent eval suites", () => {
       selectSuiteWorkloads(manifest, "experimental").map((item) => item.id),
     ).toEqual([
       "experimental-code-diff",
+      "experimental-question-only-ask",
       "experimental-resolution-follow-up",
       "experimental-site-resolution-follow-up",
     ]);

--- a/scripts/mcp-smoke.ts
+++ b/scripts/mcp-smoke.ts
@@ -254,22 +254,24 @@ async function runExperimentalRegistrationSmoke(
       ["--experimental-tools"],
       async (client) => {
         await assertExperimentalMcpSession(client, "experimental registration");
-        const askResult = (await trackSmokeStep(
-          'mcp ask {"target":"npm:express"} registration',
-          () =>
-            client.callTool({
-              name: "ask",
-              arguments: {
-                target: "npm:express",
-                question: "Where is router dispatch implemented?",
-              },
-            }),
-        )) as McpSmokeToolResult;
-        assert(
-          assertCleanErrorEnvelope(askResult, "ask registration").code ===
-            "AUTH_REQUIRED",
-          "ask registration should require auth",
-        );
+        for (const subject of [{ target: "npm:express" }, {}]) {
+          const askResult = (await trackSmokeStep(
+            `mcp ask ${JSON.stringify(subject)} registration`,
+            () =>
+              client.callTool({
+                name: "ask",
+                arguments: {
+                  ...subject,
+                  question: "Where is Express router dispatch implemented?",
+                },
+              }),
+          )) as McpSmokeToolResult;
+          assert(
+            assertCleanErrorEnvelope(askResult, "ask registration").code ===
+              "AUTH_REQUIRED",
+            "ask registration should require auth",
+          );
+        }
 
         const resolveResult = (await trackSmokeStep(
           'mcp resolve_target {"name":"express"} registration',


### PR DESCRIPTION
Local MCP Ask currently requires a target or thread even though CLI Ask accepts a question alone. This change lets local MCP infer the target from the question and return candidates for user selection when it is ambiguous. Explicit targets and thread follow-ups retain their behavior.

Includes matching tool guidance, regression tests, smoke coverage, and an experimental evaluation workload containing only:

> How does Codex handle chat compaction?

Split from release PR #374 so the behavior change can be followed separately. This PR targets `main`; the release PR will be stacked on it.

Validation: the implementation previously passed 4,502 tests, source and built CLI/MCP smoke checks, package validation, and CI. The split preserves that implementation; only the evaluation prompt was shortened. The live evaluation remains unverified. No additional review rounds were run for the split.