### PR TITLE
fix: preserve actionable Ask target diagnostics

### DIFF
--- a/changes/ask-target-diagnostics.fixed.md
+++ b/changes/ask-target-diagnostics.fixed.md
@@ -3,4 +3,4 @@
 "@githits/mcp": patch
 ---
 
-- **Actionable Ask target errors** - CLI and MCP preserve validated backend target diagnostics and recovery guidance. Older servers receive useful fallback guidance without exposing raw provider errors. Detailed reasons require the matching backend update.
+- **Actionable Ask target errors** - CLI and MCP preserve validated server diagnostics and recovery guidance, including unfamiliar diagnostic codes and reasons. Guidance and diagnostic categories can evolve without client updates. Legacy or malformed responses receive actionable fallback text.

--- a/changes/ask-target-diagnostics.fixed.md
+++ b/changes/ask-target-diagnostics.fixed.md
@@ -1,0 +1,6 @@
+---
+"githits": patch
+"@githits/mcp": patch
+---
+
+- **Actionable Ask target errors** - CLI and MCP preserve validated backend target diagnostics and recovery guidance. Older servers receive useful fallback guidance without exposing raw provider errors. Detailed reasons require the matching backend update.

--- a/docs/implementation/ask-target-clarification.md
+++ b/docs/implementation/ask-target-clarification.md
@@ -8,7 +8,17 @@ pointers, run ID, or thread ID. Empty results use the same shape with no candida
 The service validates resolver output with the existing compact resolver schema and
 normalizes nullable metadata the same way as `resolve`. It rejects clarification for
 an explicit target or existing thread. Response size and cancellation limits are shared
-with answered responses. Other HTTP errors retain their existing safe mappings.
+with answered responses.
+
+HTTP 400 target errors may provide structured `detail` with `code`, `message`,
+`hint`, and optional `reason`. Recognized codes are `INVALID_TARGET_SYNTAX` and
+`TARGET_RESOLUTION_FAILED`. The shared service validates this shape, bounds its
+body to 16 KiB, and preserves its message and hint. CLI/MCP error envelopes keep
+`INVALID_ARGUMENT` and add the bounded reason and hint to `details`; tool-call and
+thread IDs remain available. Unrecognized/legacy bodies use safe correction
+guidance and never expose raw provider details. Other HTTP errors retain their
+existing safe mappings. Detailed guidance requires the matching backend update;
+older clients continue working but discard those diagnostics.
 
 CLI text and the local MCP text formatter reuse the candidate section of the resolve
 formatter, preserving provider order, confidence, related groups, protected matches,

--- a/docs/implementation/ask-target-clarification.md
+++ b/docs/implementation/ask-target-clarification.md
@@ -11,13 +11,16 @@ an explicit target or existing thread. Response size and cancellation limits are
 with answered responses.
 
 HTTP 400 target errors may provide structured `detail` with `code`, `message`,
-`hint`, and optional `reason`. Recognized codes are `INVALID_TARGET_SYNTAX` and
-`TARGET_RESOLUTION_FAILED`. The shared service validates this shape, bounds its
-body to 16 KiB, and preserves its message and hint. CLI/MCP error envelopes keep
+`hint`, and optional `reason`. Codes and reasons are open-ended identifiers, so
+new server diagnostics do not require a client release. Each identifier is 1–128
+ASCII letters, digits, underscores, periods, colons, or hyphens, starting with a
+letter or digit. The shared service validates this shape, bounds its body to
+16 KiB, and preserves its message and hint (each 1–1024 characters without control
+characters). Unknown extra fields are ignored. CLI/MCP error envelopes keep
 `INVALID_ARGUMENT` and add `targetErrorCode`, `hint`, and optional bounded `reason`
 to `details`. A missing resolver reason stays absent; tool-call and
-thread IDs remain available. Unrecognized/legacy bodies use safe correction
-guidance and never expose raw provider details. Other HTTP errors retain their
+thread IDs remain available. Malformed/legacy bodies use safe correction
+guidance rather than displaying unstructured response content. Other HTTP errors retain their
 existing safe mappings. Detailed guidance requires the matching backend update;
 older clients continue working but discard those diagnostics.
 

--- a/docs/implementation/ask-target-clarification.md
+++ b/docs/implementation/ask-target-clarification.md
@@ -14,7 +14,8 @@ HTTP 400 target errors may provide structured `detail` with `code`, `message`,
 `hint`, and optional `reason`. Recognized codes are `INVALID_TARGET_SYNTAX` and
 `TARGET_RESOLUTION_FAILED`. The shared service validates this shape, bounds its
 body to 16 KiB, and preserves its message and hint. CLI/MCP error envelopes keep
-`INVALID_ARGUMENT` and add the bounded reason and hint to `details`; tool-call and
+`INVALID_ARGUMENT` and add `targetErrorCode`, `hint`, and optional bounded `reason`
+to `details`. A missing resolver reason stays absent; tool-call and
 thread IDs remain available. Unrecognized/legacy bodies use safe correction
 guidance and never expose raw provider details. Other HTTP errors retain their
 existing safe mappings. Detailed guidance requires the matching backend update;

--- a/packages/core-internal/src/services/agentic-ask-service.test.ts
+++ b/packages/core-internal/src/services/agentic-ask-service.test.ts
@@ -984,10 +984,60 @@ describe("Ask target diagnostics", () => {
     },
   );
 
+  it.each(
+    ["cli", "mcp", "url"].flatMap((sourceFormat) =>
+      [
+        { ...detail, code: "TARGET_VERSION_UNAVAILABLE" },
+        { ...detail, reason: "version_not_indexed" },
+        {
+          ...detail,
+          code: "TARGET_VERSION_UNAVAILABLE",
+          reason: "version_not_indexed",
+        },
+      ].map((diagnostic) => ({ sourceFormat, diagnostic })),
+    ),
+  )(
+    "preserves future diagnostic identifiers: %j",
+    async ({ sourceFormat, diagnostic }) => {
+      const fetchFn = mock(() =>
+        Promise.resolve(
+          jsonResponse(
+            { detail: { ...diagnostic, future_metadata: { ignored: true } } },
+            { status: 400 },
+          ),
+        ),
+      ) as unknown as typeof fetch;
+      const service = createService(fetchFn);
+      const request = { target: "npm:prisma", question: "How?" };
+      const result =
+        sourceFormat === "cli"
+          ? service.ask({ ...request, sourceFormat })
+          : sourceFormat === "mcp"
+            ? service.ask({ ...request, sourceFormat })
+            : service.ask({ ...request, sourceFormat: "url" });
+      await expect(result).rejects.toMatchObject({
+        code: "INVALID_TARGET",
+        message: `${diagnostic.message} ${diagnostic.hint}`,
+        targetError: diagnostic,
+        status: 400,
+        retryable: false,
+      });
+      expect(fetchFn).toHaveBeenCalledTimes(1);
+    },
+  );
+
   it.each([
     { detail: "private provider detail" },
-    { detail: { ...detail, code: "INTERNAL_ERROR" } },
+    { detail: { ...detail, code: "private provider detail" } },
+    { detail: { ...detail, code: "" } },
+    { detail: { ...detail, code: 400 } },
+    { detail: { ...detail, code: "A".repeat(129) } },
+    { detail: { ...detail, code: "ERROR\u001b[31m" } },
     { detail: { ...detail, reason: "private provider detail" } },
+    { detail: { ...detail, reason: "" } },
+    { detail: { ...detail, reason: {} } },
+    { detail: { ...detail, reason: "a".repeat(129) } },
+    { detail: { ...detail, reason: "reason\u001b[31m" } },
     { detail: { ...detail, message: "private provider detail\u001b[31m" } },
     { detail: { ...detail, hint: "private provider detail".repeat(100) } },
   ])("does not expose an unrecognized error body: %j", async (body) => {

--- a/packages/core-internal/src/services/agentic-ask-service.test.ts
+++ b/packages/core-internal/src/services/agentic-ask-service.test.ts
@@ -277,11 +277,13 @@ describe("AgenticAskServiceImpl", () => {
     },
     {
       subject: { target: "npm:example" },
-      message: "GitHits rejected the Agentic Ask target.",
+      message:
+        "GitHits could not validate this Ask request or its target. Check the question and use a repository such as github:owner/repo#ref or a package such as npm:prisma@version. To correct a thread's target, start a new request without thread_id.",
     },
     {
       subject: { threadId: THREAD_ID },
-      message: "GitHits rejected the Agentic Ask target.",
+      message:
+        "GitHits could not validate this Ask request or its target. Check the question and use a repository such as github:owner/repo#ref or a package such as npm:prisma@version. To correct a thread's target, start a new request without thread_id.",
     },
   ])(
     "keeps 400 guidance accurate for the supplied subject: %j",
@@ -912,5 +914,124 @@ describe("normalizeAgenticAskThreadId", () => {
     ` ${THREAD_ID}`,
   ])("rejects unsafe or ambiguous value %s", (value) => {
     expect(normalizeAgenticAskThreadId(value)).toBeUndefined();
+  });
+});
+
+describe("Ask target diagnostics", () => {
+  const detail = {
+    code: "TARGET_RESOLUTION_FAILED",
+    message: "The target lookup found no supported match.",
+    hint: "Check the exact repository or registry/package identity.",
+    reason: "missing_best",
+  };
+
+  it("preserves syntax guidance when no resolver reason is present", async () => {
+    const syntax = {
+      code: "INVALID_TARGET_SYNTAX",
+      message: "Invalid target syntax.",
+      hint: "Use github:owner/repo[#ref] or registry:package[@version].",
+    };
+    const fetchFn = mock(() =>
+      Promise.resolve(jsonResponse({ detail: syntax }, { status: 400 })),
+    ) as unknown as typeof fetch;
+    await expect(
+      createService(fetchFn).ask({
+        target: "prisma",
+        question: "How?",
+      }),
+    ).rejects.toMatchObject({
+      code: "INVALID_TARGET",
+      targetError: syntax,
+      message: `${syntax.message} ${syntax.hint}`,
+    });
+  });
+
+  it.each(["cli", "mcp", "url"] as const)(
+    "preserves validated target guidance for %s",
+    async (sourceFormat) => {
+      const fetchFn = mock(() =>
+        Promise.resolve(
+          jsonResponse(
+            { detail },
+            {
+              status: 400,
+              headers: {
+                "X-GitHits-Tool-Call-Id": TOOL_CALL_ID,
+                "X-GitHits-Thread-Id": THREAD_ID,
+              },
+            },
+          ),
+        ),
+      ) as unknown as typeof fetch;
+      const service = createService(fetchFn);
+      const request = { target: "github:prisma/prisma", question: "How?" };
+      const result =
+        sourceFormat === "cli"
+          ? service.ask({ ...request, sourceFormat })
+          : sourceFormat === "mcp"
+            ? service.ask({ ...request, sourceFormat })
+            : service.ask({ ...request, sourceFormat });
+      await expect(result).rejects.toMatchObject({
+        code: "INVALID_TARGET",
+        message: `${detail.message} ${detail.hint}`,
+        targetError: detail,
+        status: 400,
+        retryable: false,
+        toolCallId: TOOL_CALL_ID,
+        threadId: THREAD_ID,
+      });
+      expect(fetchFn).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it.each([
+    { detail: "private provider detail" },
+    { detail: { ...detail, code: "INTERNAL_ERROR" } },
+    { detail: { ...detail, reason: "private provider detail" } },
+    { detail: { ...detail, message: "private provider detail\u001b[31m" } },
+    { detail: { ...detail, hint: "private provider detail".repeat(100) } },
+  ])("does not expose an unrecognized error body: %j", async (body) => {
+    const fetchFn = mock(() =>
+      Promise.resolve(jsonResponse(body, { status: 400 })),
+    ) as unknown as typeof fetch;
+    try {
+      await createService(fetchFn).ask({
+        target: "npm:prisma",
+        question: "How?",
+      });
+      throw new Error("Expected rejection");
+    } catch (error) {
+      expect(error).toBeInstanceOf(AgenticAskHttpError);
+      expect((error as Error).message).not.toContain("private provider detail");
+      expect((error as AgenticAskHttpError).targetError).toBeUndefined();
+      expect((error as Error).message).toContain("github:owner/repo#ref");
+    }
+  });
+
+  it("bounds streamed error bodies and retains 400 recovery guidance", async () => {
+    let cancelled = false;
+    const fetchFn = mock(() =>
+      Promise.resolve(
+        new Response(
+          new ReadableStream({
+            start(controller) {
+              controller.enqueue(new Uint8Array(16_385));
+            },
+            cancel() {
+              cancelled = true;
+            },
+          }),
+          { status: 400 },
+        ),
+      ),
+    ) as unknown as typeof fetch;
+    await expect(
+      createService(fetchFn).ask({ target: "npm:prisma", question: "How?" }),
+    ).rejects.toMatchObject({
+      status: 400,
+      code: "INVALID_TARGET",
+      targetError: undefined,
+    });
+    expect(cancelled).toBe(true);
   });
 });

--- a/packages/core-internal/src/services/agentic-ask-service.ts
+++ b/packages/core-internal/src/services/agentic-ask-service.ts
@@ -66,6 +66,34 @@ const needsTargetResponseSchema = z.object({
   resolution: z.unknown(),
 });
 
+const targetErrorTextSchema = z
+  .string()
+  .min(1)
+  .max(1024)
+  .refine((value) => !hasControlCharacters(value));
+const targetErrorSchema = z.object({
+  detail: z.object({
+    code: z.enum(["INVALID_TARGET_SYNTAX", "TARGET_RESOLUTION_FAILED"]),
+    message: targetErrorTextSchema,
+    hint: targetErrorTextSchema,
+    reason: z
+      .enum([
+        "ambiguous",
+        "missing_best",
+        "unsupported_kind",
+        "low_confidence",
+        "missing_full_target",
+        "unsafe_latest_version",
+        "invalid_canonical_target",
+        "kind_mismatch",
+        "explicit_target_mismatch",
+      ])
+      .optional(),
+  }),
+});
+
+type TargetErrorDetail = z.infer<typeof targetErrorSchema>["detail"];
+
 const mcpCodeReadSourceCallSchema = z.object({
   name: z.literal("code_read"),
   arguments: z.object({
@@ -261,6 +289,7 @@ export class AgenticAskHttpError extends Error {
     readonly retryAfterSeconds?: number,
     retryable = false,
     readonly threadId?: string,
+    readonly targetError?: TargetErrorDetail,
   ) {
     super(message);
     this.name = "AgenticAskHttpError";
@@ -403,18 +432,29 @@ export class AgenticAskServiceImpl implements AgenticAskService {
       response.headers.get("X-GitHits-Thread-Id"),
     );
     if (!response.ok) {
-      if (response.status === 403) {
+      let targetError: TargetErrorDetail | undefined;
+      if (response.status === 403 || response.status === 400) {
         let body = "";
         try {
-          body = await readBoundedResponseBody(response);
+          body = await readBoundedResponseBody(
+            response,
+            response.status === 400 ? 16_384 : AGENTIC_ASK_MAX_RESPONSE_BYTES,
+          );
         } catch (cause) {
           if (signal.aborted) throw signal.reason ?? cause;
         }
-        throwIfTermsAcceptanceRequired(body);
+        if (response.status === 403) throwIfTermsAcceptanceRequired(body);
+        else targetError = parseTargetError(body);
       } else {
         await response.body?.cancel().catch(() => undefined);
       }
-      throw createHttpError(response, toolCallId, threadId, request);
+      throw createHttpError(
+        response,
+        toolCallId,
+        threadId,
+        request,
+        targetError,
+      );
     }
 
     let body: string;
@@ -486,9 +526,12 @@ function normalizeUuidV7(value: string | null | undefined): string | undefined {
   return UUID_V7_PATTERN.test(value) ? value.toLowerCase() : undefined;
 }
 
-async function readBoundedResponseBody(response: Response): Promise<string> {
+async function readBoundedResponseBody(
+  response: Response,
+  maxBytes: number = AGENTIC_ASK_MAX_RESPONSE_BYTES,
+): Promise<string> {
   const declaredLength = response.headers.get("Content-Length");
-  if (isDeclaredBodyTooLarge(declaredLength)) {
+  if (isDeclaredBodyTooLarge(declaredLength, maxBytes)) {
     await response.body?.cancel().catch(() => undefined);
     throw new AgenticAskResponseTooLargeError();
   }
@@ -503,7 +546,7 @@ async function readBoundedResponseBody(response: Response): Promise<string> {
       const { done, value } = await reader.read();
       if (done) break;
       totalBytes += value.byteLength;
-      if (totalBytes > AGENTIC_ASK_MAX_RESPONSE_BYTES) {
+      if (totalBytes > maxBytes) {
         await reader.cancel().catch(() => undefined);
         throw new AgenticAskResponseTooLargeError();
       }
@@ -515,12 +558,24 @@ async function readBoundedResponseBody(response: Response): Promise<string> {
   }
 }
 
-function isDeclaredBodyTooLarge(value: string | null): boolean {
+function isDeclaredBodyTooLarge(
+  value: string | null,
+  maxBytes: number,
+): boolean {
   if (!value || !/^\d+$/.test(value)) return false;
   try {
-    return BigInt(value) > BigInt(AGENTIC_ASK_MAX_RESPONSE_BYTES);
+    return BigInt(value) > BigInt(maxBytes);
   } catch {
     return false;
+  }
+}
+
+function parseTargetError(body: string): TargetErrorDetail | undefined {
+  try {
+    const parsed = targetErrorSchema.safeParse(JSON.parse(body));
+    return parsed.success ? parsed.data.detail : undefined;
+  } catch {
+    return undefined;
   }
 }
 
@@ -529,20 +584,24 @@ function createHttpError(
   toolCallId: string | undefined,
   threadId: string | undefined,
   request: AgenticAskRequest,
+  targetError?: TargetErrorDetail,
 ): AgenticAskHttpError {
   const status = response.status;
   switch (status) {
     case 400:
       return new AgenticAskHttpError(
         "INVALID_TARGET",
-        request.target === undefined && request.threadId === undefined
-          ? "GitHits could not answer this question for a supported target. Clarify the question or specify a public package or repository."
-          : "GitHits rejected the Agentic Ask target.",
+        targetError
+          ? `${targetError.message} ${targetError.hint}`
+          : request.target === undefined && request.threadId === undefined
+            ? "GitHits could not answer this question for a supported target. Clarify the question or specify a public package or repository."
+            : "GitHits could not validate this Ask request or its target. Check the question and use a repository such as github:owner/repo#ref or a package such as npm:prisma@version. To correct a thread's target, start a new request without thread_id.",
         status,
         toolCallId,
         undefined,
         false,
         threadId,
+        targetError,
       );
     case 401:
       return new AgenticAskHttpError(

--- a/packages/core-internal/src/services/agentic-ask-service.ts
+++ b/packages/core-internal/src/services/agentic-ask-service.ts
@@ -71,41 +71,26 @@ const targetErrorTextSchema = z
   .min(1)
   .max(1024)
   .refine((value) => !hasControlCharacters(value));
+// Diagnostic identifiers may grow independently of client releases.
+const targetErrorIdentifierSchema = z
+  .string()
+  .min(1)
+  .max(128)
+  .regex(/^[A-Za-z0-9][A-Za-z0-9_.:-]*$/);
 const targetErrorSchema = z.object({
   detail: z.object({
-    code: z.enum(["INVALID_TARGET_SYNTAX", "TARGET_RESOLUTION_FAILED"]),
+    code: targetErrorIdentifierSchema,
     message: targetErrorTextSchema,
     hint: targetErrorTextSchema,
-    reason: z
-      .enum([
-        "ambiguous",
-        "missing_best",
-        "unsupported_kind",
-        "low_confidence",
-        "missing_full_target",
-        "unsafe_latest_version",
-        "invalid_canonical_target",
-        "kind_mismatch",
-        "explicit_target_mismatch",
-      ])
-      .optional(),
+    reason: targetErrorIdentifierSchema.optional(),
   }),
 });
 
 interface TargetErrorDetail {
-  code: "INVALID_TARGET_SYNTAX" | "TARGET_RESOLUTION_FAILED";
+  code: string;
   message: string;
   hint: string;
-  reason?:
-    | "ambiguous"
-    | "missing_best"
-    | "unsupported_kind"
-    | "low_confidence"
-    | "missing_full_target"
-    | "unsafe_latest_version"
-    | "invalid_canonical_target"
-    | "kind_mismatch"
-    | "explicit_target_mismatch";
+  reason?: string;
 }
 
 const mcpCodeReadSourceCallSchema = z.object({

--- a/packages/core-internal/src/services/agentic-ask-service.ts
+++ b/packages/core-internal/src/services/agentic-ask-service.ts
@@ -92,7 +92,21 @@ const targetErrorSchema = z.object({
   }),
 });
 
-type TargetErrorDetail = z.infer<typeof targetErrorSchema>["detail"];
+interface TargetErrorDetail {
+  code: "INVALID_TARGET_SYNTAX" | "TARGET_RESOLUTION_FAILED";
+  message: string;
+  hint: string;
+  reason?:
+    | "ambiguous"
+    | "missing_best"
+    | "unsupported_kind"
+    | "low_confidence"
+    | "missing_full_target"
+    | "unsafe_latest_version"
+    | "invalid_canonical_target"
+    | "kind_mismatch"
+    | "explicit_target_mismatch";
+}
 
 const mcpCodeReadSourceCallSchema = z.object({
   name: z.literal("code_read"),
@@ -289,7 +303,7 @@ export class AgenticAskHttpError extends Error {
     readonly retryAfterSeconds?: number,
     retryable = false,
     readonly threadId?: string,
-    readonly targetError?: TargetErrorDetail,
+    readonly targetError: TargetErrorDetail | undefined = undefined,
   ) {
     super(message);
     this.name = "AgenticAskHttpError";

--- a/packages/mcp/src/shared/agentic-ask-error-map.test.ts
+++ b/packages/mcp/src/shared/agentic-ask-error-map.test.ts
@@ -2,67 +2,74 @@ import { expect, it } from "bun:test";
 import { AgenticAskHttpError } from "@githits/core-internal";
 import { mapAgenticAskError } from "./agentic-ask-error-map.js";
 
-it("retains actionable Ask diagnostics in the shared CLI/MCP error envelope", () => {
-  const targetError = {
-    code: "TARGET_RESOLUTION_FAILED" as const,
-    message: "The target lookup found no supported match.",
-    hint: "Check the exact repository or registry/package identity.",
-    reason: "missing_best" as const,
-  };
-  const message = `${targetError.message} ${targetError.hint}`;
-  const result = mapAgenticAskError(
-    new AgenticAskHttpError(
-      "INVALID_TARGET",
-      message,
-      400,
-      "call-id",
-      undefined,
-      false,
-      "thread-id",
-      targetError,
-    ),
-  );
-  expect(result).toEqual({
-    mapped: {
-      code: "INVALID_ARGUMENT",
-      message,
-      retryable: false,
-      details: {
-        status: 400,
-        targetErrorCode: "TARGET_RESOLUTION_FAILED",
-        reason: "missing_best",
-        hint: targetError.hint,
-      },
-    },
-    toolCallId: "call-id",
-    threadId: "thread-id",
-  });
-});
-
-it.each(["INVALID_TARGET_SYNTAX", "TARGET_RESOLUTION_FAILED"] as const)(
-  "keeps %s separate from an absent resolver reason",
-  (code) => {
+it.each([
+  { code: "TARGET_RESOLUTION_FAILED", reason: "missing_best" },
+  { code: "TARGET_VERSION_UNAVAILABLE", reason: "version_not_indexed" },
+])(
+  "retains Ask diagnostics in the shared CLI/MCP envelope: %j",
+  ({ code, reason }) => {
     const targetError = {
       code,
-      message: "Target error.",
-      hint: "Check the target.",
+      message: "The target lookup found no supported match.",
+      hint: "Check the exact repository or registry/package identity.",
+      reason,
     };
+    const message = `${targetError.message} ${targetError.hint}`;
     const result = mapAgenticAskError(
       new AgenticAskHttpError(
         "INVALID_TARGET",
-        "Target error. Check the target.",
+        message,
         400,
-        undefined,
+        "call-id",
         undefined,
         false,
-        undefined,
+        "thread-id",
         targetError,
       ),
     );
-    expect(result.mapped.details).toEqual({
-      status: 400,
-      targetErrorCode: code,
-      hint: targetError.hint,
+    expect(result).toEqual({
+      mapped: {
+        code: "INVALID_ARGUMENT",
+        message,
+        retryable: false,
+        details: {
+          status: 400,
+          targetErrorCode: code,
+          reason,
+          hint: targetError.hint,
+        },
+      },
+      toolCallId: "call-id",
+      threadId: "thread-id",
     });
   },
 );
+
+it.each([
+  "INVALID_TARGET_SYNTAX",
+  "TARGET_RESOLUTION_FAILED",
+  "TARGET_VERSION_UNAVAILABLE",
+])("keeps %s separate from an absent resolver reason", (code) => {
+  const targetError = {
+    code,
+    message: "Target error.",
+    hint: "Check the target.",
+  };
+  const result = mapAgenticAskError(
+    new AgenticAskHttpError(
+      "INVALID_TARGET",
+      "Target error. Check the target.",
+      400,
+      undefined,
+      undefined,
+      false,
+      undefined,
+      targetError,
+    ),
+  );
+  expect(result.mapped.details).toEqual({
+    status: 400,
+    targetErrorCode: code,
+    hint: targetError.hint,
+  });
+});

--- a/packages/mcp/src/shared/agentic-ask-error-map.test.ts
+++ b/packages/mcp/src/shared/agentic-ask-error-map.test.ts
@@ -1,0 +1,35 @@
+import { expect, it } from "bun:test";
+import { AgenticAskHttpError } from "@githits/core-internal";
+import { mapAgenticAskError } from "./agentic-ask-error-map.js";
+
+it("retains actionable Ask diagnostics in the shared CLI/MCP error envelope", () => {
+  const targetError = {
+    code: "TARGET_RESOLUTION_FAILED" as const,
+    message: "The target lookup found no supported match.",
+    hint: "Check the exact repository or registry/package identity.",
+    reason: "missing_best" as const,
+  };
+  const message = `${targetError.message} ${targetError.hint}`;
+  const result = mapAgenticAskError(
+    new AgenticAskHttpError(
+      "INVALID_TARGET",
+      message,
+      400,
+      "call-id",
+      undefined,
+      false,
+      "thread-id",
+      targetError,
+    ),
+  );
+  expect(result).toEqual({
+    mapped: {
+      code: "INVALID_ARGUMENT",
+      message,
+      retryable: false,
+      details: { status: 400, reason: "missing_best", hint: targetError.hint },
+    },
+    toolCallId: "call-id",
+    threadId: "thread-id",
+  });
+});

--- a/packages/mcp/src/shared/agentic-ask-error-map.test.ts
+++ b/packages/mcp/src/shared/agentic-ask-error-map.test.ts
@@ -27,9 +27,42 @@ it("retains actionable Ask diagnostics in the shared CLI/MCP error envelope", ()
       code: "INVALID_ARGUMENT",
       message,
       retryable: false,
-      details: { status: 400, reason: "missing_best", hint: targetError.hint },
+      details: {
+        status: 400,
+        targetErrorCode: "TARGET_RESOLUTION_FAILED",
+        reason: "missing_best",
+        hint: targetError.hint,
+      },
     },
     toolCallId: "call-id",
     threadId: "thread-id",
   });
 });
+
+it.each(["INVALID_TARGET_SYNTAX", "TARGET_RESOLUTION_FAILED"] as const)(
+  "keeps %s separate from an absent resolver reason",
+  (code) => {
+    const targetError = {
+      code,
+      message: "Target error.",
+      hint: "Check the target.",
+    };
+    const result = mapAgenticAskError(
+      new AgenticAskHttpError(
+        "INVALID_TARGET",
+        "Target error. Check the target.",
+        400,
+        undefined,
+        undefined,
+        false,
+        undefined,
+        targetError,
+      ),
+    );
+    expect(result.mapped.details).toEqual({
+      status: 400,
+      targetErrorCode: code,
+      hint: targetError.hint,
+    });
+  },
+);

--- a/packages/mcp/src/shared/agentic-ask-error-map.ts
+++ b/packages/mcp/src/shared/agentic-ask-error-map.ts
@@ -28,6 +28,12 @@ export function mapAgenticAskError(error: unknown): AgenticAskMappedError {
         retryable: error.retryable,
         details: {
           status: error.status,
+          ...(error.targetError
+            ? {
+                reason: error.targetError.reason ?? error.targetError.code,
+                hint: error.targetError.hint,
+              }
+            : {}),
           ...(error.retryAfterSeconds !== undefined
             ? { retryAfterSeconds: error.retryAfterSeconds }
             : {}),

--- a/packages/mcp/src/shared/agentic-ask-error-map.ts
+++ b/packages/mcp/src/shared/agentic-ask-error-map.ts
@@ -30,8 +30,11 @@ export function mapAgenticAskError(error: unknown): AgenticAskMappedError {
           status: error.status,
           ...(error.targetError
             ? {
-                reason: error.targetError.reason ?? error.targetError.code,
+                targetErrorCode: error.targetError.code,
                 hint: error.targetError.hint,
+                ...(error.targetError.reason !== undefined
+                  ? { reason: error.targetError.reason }
+                  : {}),
               }
             : {}),
           ...(error.retryAfterSeconds !== undefined

--- a/packages/mcp/src/shared/mapped-error.ts
+++ b/packages/mcp/src/shared/mapped-error.ts
@@ -65,8 +65,10 @@ export interface MappedErrorDetails {
   currentVersion?: string;
   /** Suggested package-manager command when an update is required. */
   updateCommand?: string;
-  /** Human-readable update reason. */
+  /** Failure/update explanation; Ask uses a bounded resolver reason when supplied. */
   reason?: string;
+  /** Ask target diagnostic category, separate from its optional resolver reason. */
+  targetErrorCode?: "INVALID_TARGET_SYNTAX" | "TARGET_RESOLUTION_FAILED";
   /** Whether auth failed before making a request or after backend rejection. */
   authSource?: AuthenticationErrorSource;
   /** Canonical legal document URL for terms-acceptance remediation. */

--- a/packages/mcp/src/shared/mapped-error.ts
+++ b/packages/mcp/src/shared/mapped-error.ts
@@ -67,8 +67,8 @@ export interface MappedErrorDetails {
   updateCommand?: string;
   /** Failure/update explanation; Ask uses a bounded resolver reason when supplied. */
   reason?: string;
-  /** Ask target diagnostic category, separate from its optional resolver reason. */
-  targetErrorCode?: "INVALID_TARGET_SYNTAX" | "TARGET_RESOLUTION_FAILED";
+  /** Open-ended Ask diagnostic identifier, separate from its optional reason. */
+  targetErrorCode?: string;
   /** Whether auth failed before making a request or after backend rejection. */
   authSource?: AuthenticationErrorSource;
   /** Canonical legal document URL for terms-acceptance remediation. */


### PR DESCRIPTION
Ask HTTP 400 errors currently discard server guidance and report only that the target was rejected. Preserve validated messages, correction hints, diagnostic codes, and optional reasons in CLI/MCP errors. Malformed or legacy responses retain actionable fallback text.

Accept unfamiliar diagnostic identifiers so guidance and diagnostic categories can evolve without client releases. Keep response-size, text, and identifier validation, and preserve the existing error category, request identifiers, and retry behavior.

Validation: 4,534 tests passed, including unfamiliar code/reason combinations across response formats and malformed-value cases. TypeScript, Biome, both package builds, public package validation, and CLI/MCP smoke checks passed.
