### PR TITLE
Fix feedback and onboarding guidance in public skills

### DIFF
--- a/changes/public-skill-feedback-cleanup.fixed.md
+++ b/changes/public-skill-feedback-cleanup.fixed.md
@@ -1,0 +1,6 @@
+---
+"githits": patch
+"@githits/mcp": none
+---
+
+- **Align public skills with feedback retirement** - Remove CLI feedback recommendations and the onboarding feedback disclosure after the backing removal merged. Preserve the requested CLI version, project scope, guidance preference, and separate Cursor authentication during onboarding recovery. Public skills update from main; the next CLI release packages the same guidance.

--- a/docs/plans/read-only-tools-and-feedback-removal.md
+++ b/docs/plans/read-only-tools-and-feedback-removal.md
@@ -1,6 +1,7 @@
 # Read-only tools and feedback removal
 
-Status: phase 1 complete; phase 2 release and hosted adoption pending.
+Status: phase 1 merged; phase 2 skill cleanup complete and reviewed;
+phase 3 release and hosted adoption pending.
 Date: 2026-09-10.
 Baseline: `dfbdf6b94be2afa552c4b0f62784c7ff0c0373d5`, branch
 `skvark/fix-ask-readonly-hint`; both public packages are `0.15.1`.
@@ -92,14 +93,55 @@ result identifiers, and quick-start parity pass the checks recorded below.
 The independent change fragments record patch impacts for annotations and minor
 pre-1.0 breaking impacts for removal across both public packages. Versions and
 historical changelogs remain unchanged. Plugin generation/check produced no
-content changes. Release-dependent CLI/onboarding skill edits remain in phase 2.
+content changes. CLI/onboarding skill follow-through is recorded in phase 2.
 
 Actual verification results and limitations are recorded under implementation
 evidence below; full-suite and live-eval coverage are not claimed.
 
-## Phase 2: release alignment and hosted adoption
+## Phase 2: public skill follow-through
 
-Status: pending phase 1 and the normal release process. Expected outcome:
+Status: complete and reviewed.
+
+After PR #378 merged at `d9b8f965`, the user explicitly requested a new PR
+fixing the audited skill issues. This request moves the previously deferred
+CLI/onboarding skill cleanup into this feature PR, overriding the usual
+release-branch timing for this specific change. It does not change the general
+release policy or authorize release/version changes. Skills read from main will
+stop recommending feedback before the next CLI package release.
+
+Removed feedback recommendations from the code skill and the onboarding
+disclosure; changed the packaging assertion to reject retired feedback advice.
+Onboarding troubleshooting follows the main skill's command policy. Both the
+main verification step and troubleshooting now use CLI-emitted verification,
+preserving project scope and guidance preference and keeping local CLI
+authentication separate from Cursor OAuth/tool discovery.
+The public MCP skill and package skill required no changes. A CLI-only patch
+fragment records the packaged guidance impact.
+
+Validation: 232 skill/setup tests passed; all 17 skill tests passed again after
+the internal review's main-verification consistency fix. Plugin generation/check
+(10 assets, no generated content changes), build, changed-file Biome checks,
+and secret-free CLI/MCP smoke passed. Four Claude/Codex skill-eval dry runs
+covered global-example and onboarding; they do not establish live agent behavior.
+Live onboarding would change host configuration/authentication and is outside
+this verification scope. The generic skill-creator validator rejects the
+repository's existing `compatibility` frontmatter field; preserved that metadata
+and used the repository's passing YAML/skill contracts instead.
+
+Review follow-through: preserved the original removal fragment under the
+independent-fragment rule. This PR's new fragment records completed skill
+cleanup; when assembling release notes, omit the superseded "CLI and onboarding
+public skill cleanup follows release preparation" clause from the older note.
+Expanded the new feedback regression to every public skill Markdown file,
+including references, so new files cannot escape the same inventory check.
+Internal review and Claude Opus round 3 are clean; the one-time fresh-context
+check ran in round 2. The release-note reconciliation above remains part of
+phase 3, with the new fragment also recording that skill cleanup is complete.
+Retained reviewer: `term_92a86fae-9864-489a-ba62-eae810b859a3`.
+
+## Phase 3: release alignment and hosted adoption
+
+Status: pending the normal release process. Expected outcome:
 released CLI, skills, and hosted catalog reflect the same product policy.
 Dependencies: phase 1 validated; release preparation includes its changes;
 hosted adoption requires the new published MCP package.
@@ -107,16 +149,8 @@ Assumptions: existing independent CLI/MCP releases and hosted ownership remain.
 Unknowns: actual release versions and remote deployment revision/date, resolved
 during release preparation/adoption. No further product decisions are needed.
 
-On the release branch containing the backing changes, remove the CLI feedback
-workflow from `skills/githits-code/SKILL.md` and the setup disclosure from
-`skills/githits-onboarding/SKILL.md`; inspect all four skills and their references.
-Update `src/skills-packaging.test.ts` expectations at the same boundary as the
-public onboarding skill. Preserve stable MCP builder/skill exact parity. Run
-plugin generation/check and the relevant skill/setup tests and agent evaluations.
-The current tests permit this split: `src/commands/init/init.test.ts` checks
-the runtime disclosure independently, while `src/skills-packaging.test.ts`
-checks the public onboarding skill text. Change each assertion with its owned
-surface; do not disable either test during the release window.
+Include phase 2's skill cleanup in the next CLI release. Preserve stable MCP
+builder/skill exact parity and verify generated assets at release preparation.
 
 Prepare coordinated artifact release notes, including removal of service APIs,
 the ignored old config key, and client restart/tool-discovery refresh. Follow
@@ -222,8 +256,7 @@ Validation:
   Internal review and external Claude round 3 confirmed closure with no
   outstanding findings. Claude completed one fresh-context check in round 2;
   round 3 directly checked the final documentation changes. Retained reviewer:
-  `term_198c7156-7b0e-47c0-8405-c31f7eed4e42` (Opus).
+  `term_198c7156-7b0e-47c0-8405-c31f7eed4e42` (Opus), released after PR #378 merged.
 
-Phase 2 remains pending release preparation: the CLI and onboarding public skill
-edits (and the onboarding packaging assertion) must land on the release branch.
+The phase 2 skill edits moved into the user-requested follow-up PR after merge.
 Hosted adoption still requires package publication and a remote server deployment.

--- a/skills/githits-code/SKILL.md
+++ b/skills/githits-code/SKILL.md
@@ -68,7 +68,6 @@ githits docs read <docsReadTarget> --lines 20-120
 - If grep returns no matches, do not repeat it unchanged. Follow the returned guidance by changing the pattern, broadening the file scope, or switching to `githits search` for conceptual discovery.
 - For a missing or ambiguous standalone site, use the returned `suggestedSiteTargets` in order. Do not rewrite the original target or retry automatically; when `suggestedSiteTargetsTruncated` is true, state that additional candidates were omitted.
 - If a code-navigation command returns `INDEXING`, use the elapsed/expected duration in the message to decide whether to retry with `--wait`; prefer any displayed indexed refs/versions when you need an immediate follow-up.
-- After using GitHits results, send feedback when practical. Use `githits feedback <solution_id> --accept|--reject` for `githits example` results, or omit `<solution_id>` for generic session feedback such as `githits feedback --reject --tool search -m "missing kotlin support"`.
 
 ## External Content Posture
 

--- a/skills/githits-onboarding/SKILL.md
+++ b/skills/githits-onboarding/SKILL.md
@@ -84,7 +84,6 @@ Follow the CLI JSON `instructions` remediation for these states rather than repl
 Tell the user:
 
 - GitHits queries and public package, repository, and documentation targets are sent to GitHits services for processing.
-- Feedback submission is an outbound write that sends feedback data to GitHits services.
 - Installing GitHits does not itself upload the local workspace.
 - After installation, open a new coding-agent session so it loads MCP configuration and any supporting instructions. The terminal and machine do not need to be restarted.
 
@@ -166,21 +165,9 @@ With `--no-browser`, surface the printed sign-in URL clearly so the user can ope
 
 7. Verify setup after login and installation.
 
-Project-level verification:
+Follow the CLI-emitted verification instruction for the selected setup scope, preserving `--project` and `--no-guidance` when applicable. Confirm selected tools are `already_configured` for that scope. For local CLI/stdio integrations, confirm local authentication is active using the auth-status command above. Skip local CLI authentication checks for Cursor-only setup; use the Cursor verification below. For mixed setups, verify each authentication path separately.
 
-```bash
-npx -y githits@latest auth status
-npx -y githits@latest init --project --detect-agents --json
-```
-
-User-level verification:
-
-```bash
-npx -y githits@latest auth status
-npx -y githits@latest init --detect-agents --json
-```
-
-Confirm auth is active and selected tools are `already_configured` for the selected scope. If MCP configuration or supporting guidance changed, tell the user to open a new coding-agent session in the project or user environment so the tool reloads its MCP configuration and any supporting instructions. The terminal and machine do not need to be restarted.
+If MCP configuration or supporting guidance changed, tell the user to open a new coding-agent session in the project or user environment so the tool reloads its MCP configuration and any supporting instructions. The terminal and machine do not need to be restarted.
 
 For Cursor, `already_configured` verifies only that the remote URL is present. It does not verify Cursor-managed OAuth or tool discovery. Do not report Cursor as ready based on `githits auth status` or init detection alone.
 

--- a/skills/githits-onboarding/references/troubleshooting.md
+++ b/skills/githits-onboarding/references/troubleshooting.md
@@ -8,7 +8,7 @@ If you cannot run shell commands, explain that you cannot complete setup directl
 
 ## npx Unavailable
 
-`npx -y githits@latest` requires Node/npm tooling. If `npx` is unavailable, try an already installed `githits` binary. Otherwise explain that Node/npm or the GitHits CLI is required before agent-driven setup can continue.
+`npx -y githits@latest` requires Node/npm tooling. If `npx` is unavailable, explain that Node/npm is required before normal onboarding can continue. Do not fall back to a globally installed CLI. Use a local or pinned command only when the user explicitly requested that testing mode, preserving their command and environment.
 
 ## No Supported Tools Detected
 
@@ -48,11 +48,8 @@ For `init --install-agents <ids> --json`, inspect `outcomes`. Report each failed
 
 ## Verification Fails
 
-After setup, run:
+Follow the CLI-emitted verification instruction for the selected setup scope. Preserve `--project` for project setup and `--no-guidance` when guidance was declined; do not substitute a user-level detection command. Report the specific mismatch if selected tools are not `already_configured`.
 
-```bash
-npx -y githits@latest auth status
-npx -y githits@latest init --detect-agents --json
-```
+For local CLI/stdio integrations, check `npx -y githits@latest auth status` (or the user-requested local/pinned command). For Cursor, follow the main skill's Cursor verification flow: local CLI authentication and `already_configured` do not establish Cursor readiness. Skip local CLI authentication for Cursor-only setup; verify Cursor-managed OAuth and tool discovery in a new Cursor Agent chat, using `cursor-agent` when available. For mixed setups, verify each authentication path separately.
 
-If auth is active but selected tools are not `already_configured`, report the specific mismatch and failed tool state. If tools are configured, tell the user to open a new agent session so MCP config changes are loaded.
+After MCP configuration or supporting guidance changes, tell the user to open a new coding-agent session. The terminal and machine do not need to be restarted.

--- a/src/skills-packaging.test.ts
+++ b/src/skills-packaging.test.ts
@@ -225,7 +225,24 @@ describe("agent skills packaging", () => {
       "GITHITS_API_TOKEN",
       "GITHITS_AUTH_STORAGE=file",
       "plaintext",
+      "Do not fall back to a globally installed CLI",
+      "user explicitly requested that testing mode",
+      "CLI-emitted verification instruction",
+      "Preserve `--project`",
+      "`--no-guidance`",
+      "Skip local CLI authentication for Cursor-only setup",
+      "Cursor-managed OAuth and tool discovery",
     ]);
+  });
+
+  it("keeps retired feedback workflows out of public skills", async () => {
+    const skillsRoot = join(root, "skills");
+    const paths = await readdir(skillsRoot, { recursive: true });
+    for (const path of paths.filter((path) => path.endsWith(".md"))) {
+      expect(await read(join(skillsRoot, path)), path).not.toMatch(
+        /\bfeedback\b/i,
+      );
+    }
   });
 
   it("keeps install review and guidance repair behavior in the canonical onboarding skill", async () => {
@@ -237,7 +254,6 @@ describe("agent skills packaging", () => {
       "do not infer guidance-only repair",
       "guidance repair",
       "GitHits queries and public package, repository, and documentation targets are sent to GitHits services",
-      "Feedback submission is an outbound write",
       "does not itself upload the local workspace",
       "new coding-agent session",
       "terminal and machine do not need to be restarted",


### PR DESCRIPTION
Complete the public skill follow-through from #378: remove the retired feedback command recommendation and onboarding disclosure, and replace the packaging test that required that disclosure with a regression check for its absence.

Align onboarding and troubleshooting: normal setup keeps the latest-CLI policy; verification follows the CLI-emitted instructions, preserving project scope and declined guidance. Cursor-only setup skips local CLI authentication checks and verifies Cursor OAuth/tool discovery separately. The plan records the requested skill cleanup now and leaves package release/hosted adoption pending.

Validation: 232 skill/setup tests passed; all 17 skill tests passed again after the final verification-guidance edit. Build, plugin generation/check, changed-file Biome checks, and unauthenticated CLI/MCP smoke passed. Four Claude/Codex skill-eval dry runs completed; live onboarding was not exercised. The generic skill validator rejects the existing compatibility frontmatter field; repository YAML/skill contracts pass.

Review: internal and Claude Opus reviews are clean. Release preparation should reconcile the older feedback-removal fragment's deferred-skill clause with this PR's completed-cleanup fragment, as recorded in the plan.
