### PR TITLE
chore: release githits and MCP 0.16.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,12 +6,12 @@
   },
   "metadata": {
     "description": "The code context layer for AI coding agents",
-    "version": "0.15.1"
+    "version": "0.16.0"
   },
   "plugins": [
     {
       "name": "githits",
-      "version": "0.15.1",
+      "version": "0.16.0",
       "description": "The code context layer for AI coding agents",
       "author": {
         "name": "GitHits"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,60 @@ changes use independent files under [`changes/`](changes/README.md) and are
 consolidated here only during release preparation. Dated, versioned sections
 are historical records and change only to correct blatant factual errors.
 
+## [githits 0.16.0] - 2026-09-10
+
+Minor release: removes feedback (breaking change) and marks all remaining MCP
+information tools read-only. Packaged skills match the smaller tool catalog.
+
+### Changed
+
+- **Read-only information tools** - All remaining MCP tools advertise
+  `readOnlyHint: true`, including local experimental Ask. Internal result
+  storage, preparation, and research-thread behavior remain unchanged.
+
+### Removed
+
+- **Feedback submission** - Remove the MCP `feedback` tool and `githits feedback`
+  command. Remove feedback instructions; existing
+  `experimental.report_tool_issues` config keys are ignored. Remove feedback
+  calls from integrations and refresh MCP tool discovery after updating.
+
+### Fixed
+
+- **Actionable Ask target errors** - CLI and local MCP Ask preserve validated
+  server diagnostics and recovery guidance, including unfamiliar diagnostic
+  codes and reasons. Diagnostic codes and reasons can evolve without a client
+  update. Legacy or malformed responses receive actionable fallback text.
+- **Public skill guidance** - Remove CLI feedback recommendations and the
+  onboarding feedback disclosure. Onboarding and recovery preserve the requested
+  CLI version, project scope, guidance preference, and separate Cursor
+  authentication. This release packages the skill cleanup already merged to main.
+
+Hosted MCP users, including plugins and direct Cursor setup, receive the tool
+annotation and feedback changes after the remote server adopts the new MCP
+package and deploys.
+
+## [@githits/mcp 0.16.0] - 2026-09-10
+
+Minor release: removes the feedback tool and service API (breaking change).
+
+### Changed
+
+- **Read-only information tools** - All remaining tools advertise
+  `readOnlyHint: true`. The public `runMcpSmoke()` helper requires this annotation
+  on every advertised tool and rejects catalogs that retain feedback. Internal
+  result storage and preparation retain their existing behavior.
+
+### Removed
+
+- **Feedback submission** - Remove the MCP `feedback` tool and `submitFeedback`
+  from the public service interface and concrete clients. Remove feedback
+  instructions. Consumers must remove calls to the retired API/tool and refresh
+  MCP tool discovery after updating.
+
+Hosted clients receive these changes after the remote server adopts
+`@githits/mcp@0.16.0` and deploys.
+
 ## [githits 0.15.1] - 2026-09-08
 
 Patch release: aligns Ask target clarification across CLI and local MCP and

--- a/bun.lock
+++ b/bun.lock
@@ -45,7 +45,7 @@
     },
     "packages/mcp": {
       "name": "@githits/mcp",
-      "version": "0.15.1",
+      "version": "0.16.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "^4.4.3",

--- a/changes/ask-target-diagnostics.fixed.md
+++ b/changes/ask-target-diagnostics.fixed.md
@@ -1,6 +1,0 @@
----
-"githits": patch
-"@githits/mcp": patch
----
-
-- **Actionable Ask target errors** - CLI and MCP preserve validated server diagnostics and recovery guidance, including unfamiliar diagnostic codes and reasons. Guidance and diagnostic categories can evolve without client updates. Legacy or malformed responses receive actionable fallback text.

--- a/changes/information-tools-read-only.changed.md
+++ b/changes/information-tools-read-only.changed.md
@@ -1,6 +1,0 @@
----
-"githits": patch
-"@githits/mcp": patch
----
-
-- **Classify information tools as read-only** - All remaining MCP tools advertise `readOnlyHint: true`, including local experimental Ask. The public `runMcpSmoke()` helper checks every advertised tool's annotation and rejects catalogs that retain feedback. Internal result storage and preparation retain their existing behavior. Hosted clients receive the annotations after the MCP package is adopted and deployed.

--- a/changes/public-skill-feedback-cleanup.fixed.md
+++ b/changes/public-skill-feedback-cleanup.fixed.md
@@ -1,6 +1,0 @@
----
-"githits": patch
-"@githits/mcp": none
----
-
-- **Align public skills with feedback retirement** - Remove CLI feedback recommendations and the onboarding feedback disclosure after the backing removal merged. Preserve the requested CLI version, project scope, guidance preference, and separate Cursor authentication during onboarding recovery. Public skills update from main; the next CLI release packages the same guidance.

--- a/changes/retire-feedback.removed.md
+++ b/changes/retire-feedback.removed.md
@@ -1,6 +1,0 @@
----
-"githits": minor
-"@githits/mcp": minor
----
-
-- **Retire feedback submission** - Remove the MCP feedback tool, `githits feedback`, and `submitFeedback` from the public service interface and concrete MCP clients. Remove feedback instructions; existing `experimental.report_tool_issues` config keys are ignored. CLI and onboarding public skill cleanup follows release preparation; refresh MCP tool discovery after updating.

--- a/docs/plans/read-only-tools-and-feedback-removal.md
+++ b/docs/plans/read-only-tools-and-feedback-removal.md
@@ -1,7 +1,7 @@
 # Read-only tools and feedback removal
 
 Status: phase 1 merged; phase 2 skill cleanup complete and reviewed;
-phase 3 release and hosted adoption pending.
+phase 3 release candidate prepared and reviewed; publication and hosted adoption pending.
 Date: 2026-09-10.
 Baseline: `dfbdf6b94be2afa552c4b0f62784c7ff0c0373d5`, branch
 `skvark/fix-ask-readonly-hint`; both public packages are `0.15.1`.
@@ -141,7 +141,8 @@ Retained reviewer: `term_92a86fae-9864-489a-ba62-eae810b859a3`.
 
 ## Phase 3: release alignment and hosted adoption
 
-Status: pending the normal release process. Expected outcome:
+Status: release candidate prepared and reviewed; publication and hosted adoption pending.
+Expected outcome:
 released CLI, skills, and hosted catalog reflect the same product policy.
 Dependencies: phase 1 validated; release preparation includes its changes;
 hosted adoption requires the new published MCP package.
@@ -151,6 +152,40 @@ during release preparation/adoption. No further product decisions are needed.
 
 Include phase 2's skill cleanup in the next CLI release. Preserve stable MCP
 builder/skill exact parity and verify generated assets at release preparation.
+
+Release preparation on 2026-09-10 starts from merged main `53463de5` and covers
+the complete `v0.15.1` and `mcp-v0.15.1` ranges: PR #376 (Ask diagnostics),
+PR #378 (read-only annotations and feedback removal), and PR #379 (skills).
+All four pending fragments cover those changes. Public export/build inspection
+corrected the Ask diagnostic fragment's MCP impact: its Ask client, adapter,
+mapper, and diagnostic detail type are not exported in the MCP package. That
+fix ships in `githits` CLI/local MCP only, so its effective impacts are patch
+for `githits` and none for `@githits/mcp`. Feedback retirement is minor for both;
+annotations are patch for both; skill cleanup is patch/none. Aggregate impact
+remains minor for both public artifacts, so both release versions are `0.16.0`.
+Prepared separate changelog sections, consumed all four fragments, updated
+package/registry/lockfile versions, and regenerated plugin manifests. The
+superseded skill-deferral wording is omitted from the assembled release notes;
+skill cleanup is included. Historical changelog sections remain unchanged.
+Validation: 51 release/packaging tests pass, along with plugin generation/check,
+build, packed public-consumer validation using Bun 1.4.2, and all four source
+and built CLI/MCP smoke modes (25 CLI steps and nine MCP steps per mode).
+Historical changelog content is unchanged. Pinned `mcp-publisher` v1.7.9 validates
+`server.json`; public resource metadata returns 200 and the unauthenticated
+hosted endpoint returns 401 with its resource-metadata challenge. These checks
+do not establish deployment of the new tool catalog.
+The unchanged runtime baseline `53463de5` has successful Main CI run
+`34452636638`: Linux/Windows unit tests and Node 20/22/24/26/Bun compatibility.
+Prior feature validation and skill-eval dry-run limitations remain recorded
+above; no live agent behavior is newly claimed by release metadata changes.
+Internal review and Claude Opus round 3 are clean. The fresh-context check ran
+in round 1. Final notes preserve diagnostic compatibility and explicitly cover
+hosted adoption for plugins and direct Cursor setup. The rejected suggestion
+to document a removed public `createFeedbackTool` export was checked against
+the historical `@githits/mcp/tools` entrypoint, which never exported it.
+Retained release reviewer: `term_094ea670-44bb-4201-b0b0-2523e5fda328`.
+Package publication, MCP registry publication, and hosted dependency adoption
+remain pending after release PR preparation and require the normal merge gate.
 
 Prepare coordinated artifact release notes, including removal of service APIs,
 the ignored old config key, and client restart/tool-discovery refresh. Follow

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "description": "The code context layer for AI coding agents",
   "mcpServers": {
     "githits": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "githits",
   "description": "The code context layer for AI coding agents",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "mcpName": "com.githits/githits",
   "type": "module",
   "workspaces": [

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@githits/mcp",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "description": "Reusable MCP server APIs and tools for GitHits",
   "type": "module",
   "files": [

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "githits",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/server.json
+++ b/server.json
@@ -16,7 +16,7 @@
     "source": "github",
     "id": "1165453165"
   },
-  "version": "0.15.1",
+  "version": "0.16.0",
   "remotes": [
     {
       "type": "streamable-http",
@@ -28,7 +28,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "githits",
-      "version": "0.15.1",
+      "version": "0.16.0",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
Prepare `githits@0.16.0` and `@githits/mcp@0.16.0` from merged main `53463de5`. Feedback tool/command/service removal requires a coordinated pre-1.0 minor release. This includes the read-only annotations, CLI/local MCP Ask diagnostics, and completed public skill cleanup from #376, #378, and #379.

Update package, lockfile, registry and generated plugin versions; consume all four fragments into separate package changelog sections. Preserve historical notes and omit the superseded skill-deferral wording. Ask diagnostics belong only to the CLI/local MCP artifact, despite the original fragment's MCP patch marker; the package export/build audit corrected the notes, with both release versions still determined by feedback removal.

Validation passed: 51 release/packaging tests, nine release-boundary tests after note correction, plugin generation/check, build, packed public-consumer validation with Bun 1.4.2, and source/built CLI/MCP smoke suites. MCP publisher v1.7.9 validates server.json. Public OAuth metadata and unauthenticated challenge checks passed. The unchanged runtime baseline has [green Main CI](https://github.com/githits-com/githits-cli/actions/runs/34452636638), including Linux/Windows tests and Node 20/22/24/26/Bun compatibility. Live agent evaluations remain unverified; earlier skill/feature eval runs were dry-run only.

Release preparation only. Merge requires separate approval; publication follows the approved merge and successful Main workflow. Hosted clients need remote-mcp to adopt the published MCP package and deploy it. Consumers should remove feedback calls and refresh MCP tool discovery.

Internal and Claude Opus release reviews are clean. The release plan records validation, corrected artifact scope, and the remaining publication/deployment handoff.
