### PR TITLE
chore: release githits and MCP 0.16.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,12 +6,12 @@
   },
   "metadata": {
     "description": "The code context layer for AI coding agents",
-    "version": "0.16.0"
+    "version": "0.16.1"
   },
   "plugins": [
     {
       "name": "githits",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "description": "The code context layer for AI coding agents",
       "author": {
         "name": "GitHits"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,60 @@ changes use independent files under [`changes/`](changes/README.md) and are
 consolidated here only during release preparation. Dated, versioned sections
 are historical records and change only to correct blatant factual errors.
 
+## [githits 0.16.1] - 2026-09-10
+
+Patch release: routes agents through a smaller self-contained MCP guide and
+accepts oversized grep context requests by clamping them to the supported range.
+
+### Added
+
+- **Reproducible agent context measurements** - Add offline content
+  inventory/replay, request-usage extraction, a production-schema fixture
+  server, and documented Codex/Claude discovery and routing-format experiments
+  without changing published guidance or runtime behavior.
+- **Skill-bearing PR eval coverage** - Include the existing full-guidance
+  scenario in agent-eval CI and Braintrust exports so canonical MCP skill
+  changes are measured alongside descriptor-only scenarios.
+
+### Changed
+
+- **Routing guidance before tool discovery** - Make the self-contained MCP
+  skill and quick-start guide lead with question-to-tool routing, defer argument
+  details to the selected tool, and preserve public-source scope, citations, and
+  untrusted-content rules.
+
+### Fixed
+
+- **Grep oversized context without a retry** - Clamp nonnegative integer context
+  requests to 10 lines per side, preserve asymmetric overrides, and return
+  requested/effective values in JSON with an actionable text notice. Direct
+  larger source windows to `code_read` instead of repeating grep.
+
+Hosted MCP users receive the routing and grep changes after the remote server
+adopts `@githits/mcp@0.16.1` and deploys.
+
+## [@githits/mcp 0.16.1] - 2026-09-10
+
+Patch release: improves evidence-tool routing and handles oversized grep context
+requests without requiring a retry.
+
+### Changed
+
+- **Routing guidance before tool discovery** - Make the self-contained MCP
+  skill and quick-start guide lead with question-to-tool routing, defer argument
+  details to the selected tool, and preserve public-source scope, citations, and
+  untrusted-content rules.
+
+### Fixed
+
+- **Grep oversized context without a retry** - Clamp nonnegative integer context
+  requests to 10 lines per side, preserve asymmetric overrides, and return
+  requested/effective values in JSON with an actionable text notice. Direct
+  larger source windows to `code_read` instead of repeating grep.
+
+Hosted clients receive these changes after the remote server adopts
+`@githits/mcp@0.16.1` and deploys.
+
 ## [githits 0.16.0] - 2026-09-10
 
 Minor release: removes feedback (breaking change) and marks all remaining MCP

--- a/bun.lock
+++ b/bun.lock
@@ -45,7 +45,7 @@
     },
     "packages/mcp": {
       "name": "@githits/mcp",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "^4.4.3",

--- a/changes/agent-context-loading.added.md
+++ b/changes/agent-context-loading.added.md
@@ -1,6 +1,0 @@
----
-"githits": none
-"@githits/mcp": none
----
-
-- **Reproducible agent context measurements** - Add offline content inventory/replay, request-usage extraction, a production-schema fixture server, and documented Codex/Claude discovery and routing-format experiments without changing published guidance or runtime behavior.

--- a/changes/agent-eval-full-guidance.added.md
+++ b/changes/agent-eval-full-guidance.added.md
@@ -1,6 +1,0 @@
----
-"githits": none
-"@githits/mcp": none
----
-
-- **Skill-bearing PR eval coverage** - Include the existing full-guidance scenario in agent-eval CI and Braintrust exports so canonical MCP skill changes are measured alongside descriptor-only scenarios.

--- a/changes/grep-context-clamping.fixed.md
+++ b/changes/grep-context-clamping.fixed.md
@@ -1,6 +1,0 @@
----
-"githits": patch
-"@githits/mcp": patch
----
-
-- **Grep oversized context without a retry** - Clamp nonnegative integer context requests to 10 lines per side, preserve asymmetric overrides, and return requested/effective values in JSON with an actionable text notice. Direct larger source windows to code_read instead of repeating grep.

--- a/changes/mcp-routing-guidance.changed.md
+++ b/changes/mcp-routing-guidance.changed.md
@@ -1,6 +1,0 @@
----
-"githits": patch
-"@githits/mcp": patch
----
-
-- **Routing guidance before tool discovery** - Make the self-contained MCP skill and quick-start guide lead with question-to-tool routing, defer argument details to the selected tool, and preserve public-source scope, citations, and untrusted-content rules.

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "The code context layer for AI coding agents",
   "mcpServers": {
     "githits": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "githits",
   "description": "The code context layer for AI coding agents",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "mcpName": "com.githits/githits",
   "type": "module",
   "workspaces": [

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@githits/mcp",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Reusable MCP server APIs and tools for GitHits",
   "type": "module",
   "files": [

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "githits",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/server.json
+++ b/server.json
@@ -16,7 +16,7 @@
     "source": "github",
     "id": "1165453165"
   },
-  "version": "0.16.0",
+  "version": "0.16.1",
   "remotes": [
     {
       "type": "streamable-http",
@@ -28,7 +28,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "githits",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
Prepare `githits@0.16.1` and `@githits/mcp@0.16.1` from merged main `8481c90`. Both packages receive the smaller self-contained routing guide and oversized grep context clamping from #377.

Update package, lockfile, registry, and generated plugin versions. Consume all four pending fragments into separate artifact changelog sections; the two `none/none` eval-infrastructure fragments belong only to the root release notes.

Validation passed:

- plugin generation and committed-output check
- 4,529 unit tests
- production build
- packed public-package validation and MCP publish dry run
- source MCP live smoke and built MCP registration smoke
- built CLI unauthenticated stable and experimental smoke
- MCP publisher v1.7.9 validation of `server.json`
- merged #377 CI across Ubuntu, Windows, Node 20/22/24/26, Bun, and public MCP package validation
- merged #377 agent evals, including 276 matched routing cells and a later 46-cell grep follow-up

The source CLI live smoke reached and passed the new oversized-context JSON parity check, then failed the existing experimental `resolve expressjs` assertion after 103 steps because the live backend now returns the direct site candidate at `medium` confidence instead of `exact|high`. The site and related package/repository targets remain present. This same backend mismatch was reproduced and documented in #377; no assertion was weakened.

Release preparation only. Merge requires separate approval. Publication follows the approved merge and successful Main workflow. Hosted clients then require `remote-mcp` to adopt `@githits/mcp@0.16.1` and deploy it.
