### PR TITLE
chore: release githits and MCP 0.16.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,12 +6,12 @@
   },
   "metadata": {
     "description": "The code context layer for AI coding agents",
-    "version": "0.16.1"
+    "version": "0.16.2"
   },
   "plugins": [
     {
       "name": "githits",
-      "version": "0.16.1",
+      "version": "0.16.2",
       "description": "The code context layer for AI coding agents",
       "author": {
         "name": "GitHits"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,15 @@ are historical records and change only to correct blatant factual errors.
 
 ### Changed
 
+- **Compact wait guidance** - Move repeated MCP wait and indexing-recovery guidance into the shared `quick_start` and `githits-mcp` skill, and shorten wait parameter descriptions to units and bounds derived from shared constants. The next CLI and MCP releases carry the updated guidance.
+- **Longer default indexing wait** - Increase the shared CLI and MCP search, search-status, and code-navigation wait from 20 to 30 seconds to allow more time for indexing and metadata fetches before returning progress. Explicit wait overrides and the 60-second maximum remain unchanged.
 - **Read exact documentation sections and ranges** - Search now emits indexed fragments as ready-to-read targets, while `docs read` and `docs_read` resolve them without synthetic bounds, preserve absolute page coordinates, and keep unresolved sections distinct from missing pages; deploy the compatible backend schema before releasing this client.
 - **Ask follow-up scope** - Explain how to change project, version, or topic in an existing thread and keep the thread when clarifying a failed lookup.
 - **Prefer token-efficient MCP text output** - Keep model-visible results in text and reserve JSON for direct host-side field handling or fields absent from text, not ordinary MCP or TypeScript invocation.
 
 ### Fixed
 
+- **Search path-prefix validation** - Reject path prefixes locally when no code search source is selected, and correct CLI/MCP guidance to explain that documentation and symbol searches do not support this filter.
 - **Ask guidance** - Remove the instruction to report defects using an Ask run ID because no such reporting action is available.
 - **Local evaluation cleanup** - Wait for both target preflights before returning a setup failure, preventing Windows cleanup from racing an outstanding Git subprocess.
 
@@ -22,12 +25,15 @@ are historical records and change only to correct blatant factual errors.
 
 ### Changed
 
+- **Compact wait guidance** - Move repeated MCP wait and indexing-recovery guidance into the shared `quick_start` and `githits-mcp` skill, and shorten wait parameter descriptions to units and bounds derived from shared constants. The next CLI and MCP releases carry the updated guidance.
+- **Longer default indexing wait** - Increase the shared CLI and MCP search, search-status, and code-navigation wait from 20 to 30 seconds to allow more time for indexing and metadata fetches before returning progress. Explicit wait overrides and the 60-second maximum remain unchanged.
 - **Read exact documentation sections and ranges** - Search now emits indexed fragments as ready-to-read targets, while `docs read` and `docs_read` resolve them without synthetic bounds, preserve absolute page coordinates, and keep unresolved sections distinct from missing pages; deploy the compatible backend schema before releasing this client.
 - **Ask follow-up scope** - Explain how to change project, version, or topic in an existing thread and keep the thread when clarifying a failed lookup.
 - **Prefer token-efficient MCP text output** - Keep model-visible results in text and reserve JSON for direct host-side field handling or fields absent from text, not ordinary MCP or TypeScript invocation.
 
 ### Fixed
 
+- **Search path-prefix validation** - Reject path prefixes locally when no code search source is selected, and correct CLI/MCP guidance to explain that documentation and symbol searches do not support this filter.
 - **Ask guidance** - Remove the instruction to report defects using an Ask run ID because no such reporting action is available.
 
 ## [githits 0.16.1] - 2026-09-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ changes use independent files under [`changes/`](changes/README.md) and are
 consolidated here only during release preparation. Dated, versioned sections
 are historical records and change only to correct blatant factual errors.
 
+## [githits 0.16.2] - 2026-09-11
+
+### Changed
+
+- **Read exact documentation sections and ranges** - Search now emits indexed fragments as ready-to-read targets, while `docs read` and `docs_read` resolve them without synthetic bounds, preserve absolute page coordinates, and keep unresolved sections distinct from missing pages; deploy the compatible backend schema before releasing this client.
+- **Ask follow-up scope** - Explain how to change project, version, or topic in an existing thread and keep the thread when clarifying a failed lookup.
+- **Prefer token-efficient MCP text output** - Keep model-visible results in text and reserve JSON for direct host-side field handling or fields absent from text, not ordinary MCP or TypeScript invocation.
+
+### Fixed
+
+- **Ask guidance** - Remove the instruction to report defects using an Ask run ID because no such reporting action is available.
+- **Local evaluation cleanup** - Wait for both target preflights before returning a setup failure, preventing Windows cleanup from racing an outstanding Git subprocess.
+
+## [@githits/mcp 0.16.2] - 2026-09-11
+
+### Changed
+
+- **Read exact documentation sections and ranges** - Search now emits indexed fragments as ready-to-read targets, while `docs read` and `docs_read` resolve them without synthetic bounds, preserve absolute page coordinates, and keep unresolved sections distinct from missing pages; deploy the compatible backend schema before releasing this client.
+- **Ask follow-up scope** - Explain how to change project, version, or topic in an existing thread and keep the thread when clarifying a failed lookup.
+- **Prefer token-efficient MCP text output** - Keep model-visible results in text and reserve JSON for direct host-side field handling or fields absent from text, not ordinary MCP or TypeScript invocation.
+
+### Fixed
+
+- **Ask guidance** - Remove the instruction to report defects using an Ask run ID because no such reporting action is available.
+
 ## [githits 0.16.1] - 2026-09-10
 
 Patch release: routes agents through a smaller self-contained MCP guide and

--- a/bun.lock
+++ b/bun.lock
@@ -45,7 +45,7 @@
     },
     "packages/mcp": {
       "name": "@githits/mcp",
-      "version": "0.16.1",
+      "version": "0.16.2",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "^4.4.3",

--- a/changes/adopt-doc-fragment-ranges.changed.md
+++ b/changes/adopt-doc-fragment-ranges.changed.md
@@ -1,6 +1,0 @@
----
-"githits": patch
-"@githits/mcp": patch
----
-
-- **Read exact documentation sections and ranges** - Search now emits indexed fragments as ready-to-read targets, while `docs read` and `docs_read` resolve them without synthetic bounds, preserve absolute page coordinates, and keep unresolved sections distinct from missing pages; deploy the compatible backend schema before releasing this client.

--- a/changes/ask-reporting-guidance.fixed.md
+++ b/changes/ask-reporting-guidance.fixed.md
@@ -1,6 +1,0 @@
----
-"githits": patch
-"@githits/mcp": patch
----
-
-- **Ask guidance** - Remove the instruction to report defects using an Ask run ID because no such reporting action is available.

--- a/changes/ask-thread-scope.changed.md
+++ b/changes/ask-thread-scope.changed.md
@@ -1,6 +1,0 @@
----
-"githits": patch
-"@githits/mcp": patch
----
-
-- **Ask follow-up scope** - Explain how to change project, version, or topic in an existing thread and keep the thread when clarifying a failed lookup.

--- a/changes/compact-wait-guidance.changed.md
+++ b/changes/compact-wait-guidance.changed.md
@@ -1,6 +1,0 @@
----
-"githits": patch
-"@githits/mcp": patch
----
-
-- **Compact wait guidance** - Move repeated MCP wait and indexing-recovery guidance into the shared `quick_start` and `githits-mcp` skill, and shorten wait parameter descriptions to units and bounds derived from shared constants. The next CLI and MCP releases carry the updated guidance.

--- a/changes/eval-preflight-cleanup.fixed.md
+++ b/changes/eval-preflight-cleanup.fixed.md
@@ -1,6 +1,0 @@
----
-"githits": none
-"@githits/mcp": none
----
-
-- **Local evaluation cleanup** - Wait for both target preflights before returning a setup failure, preventing Windows cleanup from racing an outstanding Git subprocess.

--- a/changes/prefer-text-tool-output.changed.md
+++ b/changes/prefer-text-tool-output.changed.md
@@ -1,6 +1,0 @@
----
-"githits": patch
-"@githits/mcp": patch
----
-
-- **Prefer token-efficient MCP text output** - Keep model-visible results in text and reserve JSON for direct host-side field handling or fields absent from text, not ordinary MCP or TypeScript invocation.

--- a/changes/search-path-prefix-validation.fixed.md
+++ b/changes/search-path-prefix-validation.fixed.md
@@ -1,6 +1,0 @@
----
-"githits": patch
-"@githits/mcp": patch
----
-
-- **Search path-prefix validation** - Reject path prefixes locally when no code search source is selected, and correct CLI/MCP guidance to explain that documentation and symbol searches do not support this filter.

--- a/changes/thirty-second-default-wait.changed.md
+++ b/changes/thirty-second-default-wait.changed.md
@@ -1,6 +1,0 @@
----
-"githits": patch
-"@githits/mcp": patch
----
-
-- **Longer default indexing wait** - Increase the shared CLI and MCP search, search-status, and code-navigation wait from 20 to 30 seconds to allow more time for indexing and metadata fetches before returning progress. Explicit wait overrides and the 60-second maximum remain unchanged.

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "githits",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "The code context layer for AI coding agents",
   "mcpServers": {
     "githits": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "githits",
   "description": "The code context layer for AI coding agents",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "mcpName": "com.githits/githits",
   "type": "module",
   "workspaces": [

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@githits/mcp",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "Reusable MCP server APIs and tools for GitHits",
   "type": "module",
   "files": [

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "githits",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "The code context layer for AI coding agents",
   "author": {
     "name": "GitHits"

--- a/scripts/cli-smoke.ts
+++ b/scripts/cli-smoke.ts
@@ -1259,7 +1259,7 @@ async function runExperimentalLiveSmoke(
   }
 
   const siteResolveText = assertTerminalOutput(
-    await runCliWithEnv(["resolve", "expressjs"], env),
+    await runCliWithEnv(["resolve", "expressjs.com"], env),
     "experimental site resolve terminal",
   );
   assertExperimentalCliResolveText(siteResolveText);
@@ -1270,7 +1270,7 @@ async function runExperimentalLiveSmoke(
       siteResolveText.includes("Related targets:") &&
       siteResolveText.includes("npm:express · related package") &&
       siteResolveText.includes("github:expressjs/express · related repository"),
-    "experimental expressjs resolution should directly match the site and group related package/repository targets",
+    "experimental expressjs.com resolution should directly match the site and group related package/repository targets",
   );
 
   const fuzzyResolveText = assertTerminalOutput(

--- a/scripts/mcp-smoke.ts
+++ b/scripts/mcp-smoke.ts
@@ -417,7 +417,7 @@ async function runExperimentalLiveSmoke(
           "experimental ask default text",
         );
         const askThreadMatch = askTextBody.match(
-          /\nThread ID: ([0-9a-f-]+)\nFollow up using this thread ID only if the answer is insufficient\./,
+          /\nThread ID: ([0-9a-f-]+)\nUse this thread ID for follow-ups; name a new project or version in the question to change scope\./,
         );
         assert(
           askTextBody.includes("\n\nSources:\n") &&
@@ -428,7 +428,7 @@ async function runExperimentalLiveSmoke(
               askTextBody,
             ) &&
             askThreadMatch?.[1] !== undefined,
-          "experimental ask text should append callable sources, replay IDs, and conditional follow-up guidance",
+          "experimental ask text should append callable sources, replay IDs, and scope-changing follow-up guidance",
         );
 
         const askUrlJson = (await trackSmokeStep(

--- a/server.json
+++ b/server.json
@@ -16,7 +16,7 @@
     "source": "github",
     "id": "1165453165"
   },
-  "version": "0.16.1",
+  "version": "0.16.2",
   "remotes": [
     {
       "type": "streamable-http",
@@ -28,7 +28,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "githits",
-      "version": "0.16.1",
+      "version": "0.16.2",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
Prepare coordinated patch releases of `githits` and `@githits/mcp` at **0.16.2**.

- Ship exact documentation fragment/range reads, clearer Ask follow-up scope, token-efficient MCP text-output guidance, a 30-second default indexing wait, consolidated wait guidance, and local rejection of path prefixes without a code source.
- Consolidate all eight pending fragments into separate package changelog sections; align package, lockfile, registry, and generated plugin versions.
- Correct two live smoke expectations: current Ask follow-up wording and a full domain for the direct-site resolver case. The live backend returns medium confidence for `expressjs` and exact confidence for `expressjs.com`.

Validation:
- Rebased onto origin/main at `9697466`, adopting #386 and #387. Audited both 0.16.1 tag-to-HEAD ranges against all eight fragments; both baseline tags match origin. Backend documentation range compatibility was verified in #383.
- 4,570 unit tests pass on the rebased release, including the smoke-script tests.
- Build, typecheck, format, plugin generation/check, public-package validation, and built CLI/MCP smoke checks pass. Lint passes with existing warnings.
- Full authenticated CLI and MCP smoke suites pass, including experimental coverage.
- Existing Claude/Codex documentation and text-output eval evidence is recorded in #383 and #384. Fresh Codex Ask workload runs reported success, but neither exercised Ask: descriptors produced no recorded GitHits calls; full guidance produced 22 successful MCP search/read calls and no CLI calls. Agent-driven Ask thread reuse therefore remains unverified; direct experimental MCP smoke checks pass. Full-run final output and traces were inspected; no isolation-violation artifact was emitted. No quality grade is claimed.
- Rebased-release descriptor-only GitHits-intent Codex eval: 17 successful MCP calls, default text throughout, default waits on reads and explicit waits on discovery calls; inspected tool traces, final answer, and metrics. No isolation-violation artifact was emitted; no quality grade is claimed.
- Reviewed the release metadata and four-line smoke delta inline.

Hosted MCP clients receive the package changes after `remote-mcp` adopts the released dependency and is deployed. This PR prepares the release only; merge requires separate approval.

