### PR TITLE
fix: reject search path prefixes without a code source

### DIFF
--- a/changes/search-path-prefix-validation.fixed.md
+++ b/changes/search-path-prefix-validation.fixed.md
@@ -1,0 +1,6 @@
+---
+"githits": patch
+"@githits/mcp": patch
+---
+
+- **Search path-prefix validation** - Reject path prefixes locally when no code search source is selected, and correct CLI/MCP guidance to explain that documentation and symbol searches do not support this filter.

--- a/docs/implementation/tools.md
+++ b/docs/implementation/tools.md
@@ -1006,3 +1006,18 @@ See `docs/guidelines/TESTING.md` for the full testing pattern.
 - `docs/guidelines/ARCHITECTURAL_GUIDELINES.md` — service isolation and testing patterns
 
 See [Repository target grammar](repository-targets.md) for the shared GitHub, Codeberg, and GitLab addressing contract and provider-preserving response identity.
+
+### Search path-prefix compatibility
+
+Search `path_prefix` (CLI `--path-prefix`) applies only to the code source, including
+automatic selection for package/repository targets. Documentation and symbol
+sources do not apply it, including repository documentation. Site-only automatic
+search selects docs and cannot use it. The shared request builder rejects nonempty
+prefixes when no code source is selected, returning `INVALID_ARGUMENT` before
+`service.search`; it does not silently discard the requested scope. Empty strings
+remain omitted. Explicit mixed sources and automatic mixed targets remain valid
+when code is selected. Other existing docs-only filter normalization is unchanged.
+
+This mirrors the backend request source/filter contract verified on 2026-09-11.
+Hosted MCP receives the guard after the updated `@githits/mcp` package is released,
+adopted by the remote server, and deployed.

--- a/packages/mcp/src/shared/unified-search-request.test.ts
+++ b/packages/mcp/src/shared/unified-search-request.test.ts
@@ -45,10 +45,104 @@ describe("buildUnifiedSearchParams", () => {
       category: "CALLABLE",
       fileIntent: "PRODUCTION",
       publicOnly: true,
-      pathPrefix: "docs/",
     });
 
-    expect(built.params.filters).toEqual({ pathPrefix: "docs/" });
+    expect(built.params.filters).toBeUndefined();
+  });
+
+  it.each([
+    { sources: ["DOCS"] },
+    { sources: ["SYMBOL"] },
+    { sources: ["DOCS", "SYMBOL"] },
+  ] as const)(
+    "rejects path prefixes without a code source: %j",
+    ({ sources }) => {
+      expect(() =>
+        buildUnifiedSearchParams({
+          target: { registry: "NPM", packageName: "express" },
+          query: "routing",
+          sources: [...sources],
+          pathPrefix: "src/",
+        }),
+      ).toThrow("Path prefixes require a code search source");
+    },
+  );
+
+  it("rejects automatic site-only path prefixes, including empty source arrays", () => {
+    for (const sources of [
+      undefined,
+      [],
+      ["AUTO"],
+      ["AUTO", "DOCS"],
+    ] as const) {
+      expect(() =>
+        buildUnifiedSearchParams({
+          targets: [
+            { site: "site:expressjs.com" },
+            { site: "site:nodejs.org" },
+          ],
+          query: "routing",
+          sources: sources ? [...sources] : undefined,
+          pathPrefix: "guide/",
+        }),
+      ).toThrow("Remove the path prefix for documentation or symbol searches");
+    }
+  });
+
+  it("preserves prefixes for automatic mixed targets and explicit code sources", () => {
+    for (const sources of [
+      undefined,
+      [],
+      ["AUTO"],
+      ["AUTO", "SYMBOL"],
+      ["CODE"],
+      ["DOCS", "CODE"],
+      ["SYMBOL", "CODE"],
+    ] as const) {
+      const built = buildUnifiedSearchParams({
+        targets: [
+          { site: "site:expressjs.com" },
+          { repoUrl: "https://github.com/expressjs/express" },
+        ],
+        query: "routing",
+        sources: sources ? [...sources] : undefined,
+        pathPrefix: "src/",
+      });
+      expect(built.params.filters).toEqual({ pathPrefix: "src/" });
+    }
+  });
+
+  it("leaves explicit code on site targets to backend target validation", () => {
+    expect(
+      buildUnifiedSearchParams({
+        target: { site: "site:expressjs.com" },
+        query: "routing",
+        sources: ["CODE"],
+        pathPrefix: "guide/",
+      }).params.filters,
+    ).toEqual({ pathPrefix: "guide/" });
+  });
+
+  it("rejects whitespace prefixes consistently with filter serialization", () => {
+    expect(() =>
+      buildUnifiedSearchParams({
+        target: { registry: "NPM", packageName: "express" },
+        query: "routing",
+        sources: ["DOCS"],
+        pathPrefix: " ",
+      }),
+    ).toThrow("Path prefixes require a code search source");
+  });
+
+  it("omits empty path prefixes even for docs-only searches", () => {
+    expect(
+      buildUnifiedSearchParams({
+        target: { site: "site:expressjs.com" },
+        query: "routing",
+        sources: ["DOCS"],
+        pathPrefix: "",
+      }).params.filters,
+    ).toBeUndefined();
   });
 
   it("does not invent fileIntent when selected sources include code search", () => {

--- a/packages/mcp/src/shared/unified-search-request.ts
+++ b/packages/mcp/src/shared/unified-search-request.ts
@@ -42,6 +42,17 @@ export function buildUnifiedSearchParams(
   const targets = resolveTargets(input.target, input.targets);
   const rawQuery = normaliseRequiredQuery(input.query);
 
+  // Backend AUTO includes code only when a package or repository is targeted.
+  const selectsAuto = !input.sources?.length || input.sources.includes("AUTO");
+  const selectsCode =
+    input.sources?.includes("CODE") ||
+    (selectsAuto && targets.some((target) => !target.site));
+  if (input.pathPrefix && !selectsCode) {
+    throw new InvalidArgumentError(
+      "Path prefixes require a code search source. Remove the path prefix for documentation or symbol searches.",
+    );
+  }
+
   const limit = input.limit ?? DEFAULT_UNIFIED_SEARCH_LIMIT;
   const offset = input.offset ?? 0;
   const waitTimeoutMs = input.waitTimeoutMs ?? DEFAULT_WAIT_TIMEOUT_MS;

--- a/packages/mcp/src/smoke-test.test.ts
+++ b/packages/mcp/src/smoke-test.test.ts
@@ -982,6 +982,15 @@ function smokeJsonResponse(
         },
       });
     case "search":
+      if (args.path_prefix)
+        return {
+          isError: true,
+          ...jsonResult({
+            error: "Path prefixes require a code search source",
+            code: "INVALID_ARGUMENT",
+            retryable: false,
+          }),
+        };
       return jsonResult({
         completed: false,
         searchRef: "smoke-ref",

--- a/packages/mcp/src/smoke-test.ts
+++ b/packages/mcp/src/smoke-test.ts
@@ -1260,6 +1260,18 @@ async function runLiveSmoke(caller: McpSmokeCaller): Promise<void> {
     "code_grep context clamping mismatch",
   );
 
+  assertErrorCode(
+    await callTool(caller, "search", {
+      target: SMOKE_PACKAGE_TARGET,
+      query: "router",
+      source: "docs",
+      path_prefix: "docs/",
+      format: "json",
+    }),
+    "search unsupported path prefix",
+    "INVALID_ARGUMENT",
+  );
+
   const searchText = assertDefaultText(
     await callTool(caller, "search", {
       target: SMOKE_PACKAGE_TARGET,

--- a/packages/mcp/src/tools/search.test.ts
+++ b/packages/mcp/src/tools/search.test.ts
@@ -242,7 +242,6 @@ describe("searchTool", () => {
         kind: "function",
         file_intent: "production",
         public_only: true,
-        path_prefix: "guide/",
       },
       {},
     );
@@ -250,10 +249,45 @@ describe("searchTool", () => {
     expect(search).toHaveBeenCalledWith(
       expect.objectContaining({
         sources: ["DOCS"],
-        filters: { pathPrefix: "guide/" },
+        filters: undefined,
       }),
       { omitFocusedSource: true },
     );
+  });
+
+  it("rejects unsupported path scopes in text and JSON before calling the service", async () => {
+    for (const format of ["text", "json"] as const) {
+      for (const selection of [
+        { target: "npm:express", source: "docs" },
+        { target: "github:expressjs/express", source: "symbol" },
+        { target: "site:expressjs.com" },
+      ] as const) {
+        const search = mock(() => Promise.resolve(defaultUnifiedSearchOutcome));
+        const tool = createSearchTool(
+          createMockCodeNavigationService({ search }),
+        );
+        const result = await tool.handler(
+          {
+            query: "routing",
+            ...selection,
+            path_prefix: "guide/",
+            format,
+          },
+          {},
+        );
+        expect(result.isError).toBe(true);
+        expect(search).not.toHaveBeenCalled();
+        expect(result.content[0]?.text).toContain(
+          "Path prefixes require a code search source",
+        );
+        if (format === "json") {
+          expect(JSON.parse(result.content[0]?.text ?? "{}")).toMatchObject({
+            code: "INVALID_ARGUMENT",
+            retryable: false,
+          });
+        }
+      }
+    }
   });
 
   it("ignores empty targets arrays when target is provided", async () => {

--- a/packages/mcp/src/tools/search.ts
+++ b/packages/mcp/src/tools/search.ts
@@ -195,7 +195,7 @@ const schema: ZodRawShape = {
     .string()
     .optional()
     .describe(
-      "Optional target-relative path prefix for code and repository-document results. Prefer this field to an inline `path:` qualifier when the scope is already known.",
+      "Optional target-relative path prefix for code results only. Requires code in the selected sources: use source code with a package/repository, or omit source for automatic package/repository search. Omit for source docs, source symbol, and site-only searches; unsupported combinations are rejected before search.",
     ),
   file_intent: z
     .enum([
@@ -274,6 +274,7 @@ const DESCRIPTION =
   "Omit `source` to let GitHits select the best sources; set it only to restrict results to docs, code, or symbols. " +
   "Target indexed dependencies and repositories, or standalone docs with `site:<host[/path]>`. " +
   'Structured parameters combine with the `query` using AND semantics. For `source:"docs"`, code/symbol-only filters (`category`, `kind`, `file_intent`, `public_only`) are ignored because docs search does not support them. ' +
+  "A nonempty `path_prefix` requires a code source; docs-only, symbol-only, and automatic site-only searches reject it. " +
   "A `search` call can return complete results directly. Only when its response supplies both a `searchRef` and a `search_status` action, follow that action with `search_status`; never repeat `search` to poll. Terminal or unrecognized statuses are not polled; follow the response's recovery guidance instead. If the response includes advisory `sourceStatus[].suggestedSiteTargets`, retry one explicitly; do not treat suggestions as aliases or retry automatically. " +
   "Set `allow_partial_results: true` to permit a serveable subset of target/source pairs while others remain unavailable. " +
   "Use hit content directly when sufficient; follow its generated `followUp` only for more context. After discovery, use `code_grep` for deterministic exact-pattern occurrences. From text, pass a `[docs page]` target unchanged to `docs_read`; a fragment needs no bounds, and bounds replace it with a page-relative range. Use repo-doc targets/ranges with `docs_read`, and repo code/symbol targets, paths, and ranges with `code_read`." +

--- a/scripts/cli-smoke.ts
+++ b/scripts/cli-smoke.ts
@@ -2085,6 +2085,27 @@ async function runLiveSmoke(env: Record<string, string>): Promise<void> {
     "code grep invalid json missing CLI-native recovery",
   );
 
+  const searchInvalidPrefix = await runCli([
+    "search",
+    "router",
+    "--in",
+    SMOKE_PACKAGE_SPEC,
+    "--source",
+    "docs",
+    "--path-prefix",
+    "docs/",
+    "--json",
+  ]);
+  const searchInvalidPrefixEnvelope = assertCleanErrorEnvelope(
+    searchInvalidPrefix.stderr,
+    "search unsupported path prefix",
+  );
+  assert(
+    searchInvalidPrefix.exitCode !== 0 &&
+      searchInvalidPrefixEnvelope.code === "INVALID_ARGUMENT",
+    "search must reject unsupported path prefixes",
+  );
+
   const searchText = assertTerminalOutput(
     await runCli([
       "search",

--- a/skills/githits-code/references/code-and-docs.md
+++ b/skills/githits-code/references/code-and-docs.md
@@ -10,6 +10,8 @@ Search text shows producer-proven matched source and structural documentation pr
 
 Useful filters: `--kind`, `--category`, `--path-prefix`, `--intent`, `--public`, `--name`, `--lang`, `--limit`, `--offset`, `--wait`, `--allow-partial`, `--json`.
 
+`--path-prefix` filters code results only. Omit it for `--source docs`, `--source symbol`, and standalone site searches. Use it with `--source code` on a package/repository, or with automatic source selection that includes a package/repository.
+
 If search returns a `searchRef`, continue with `githits search-status <searchRef> [--wait <seconds>]` only when the output explicitly supplies that follow-up, including for active `PENDING`, `INDEXING`, or `SEARCHING` progress or a completed result with an evidence notice. The bounded wait defaults to 20 seconds, and the explicit value must be an integer from 0 to 60. Terminal `DEFERRED`, `TIMEOUT`, or `FAILED` progress, and unrecognized statuses, do not advance: keep any disclosed evidence, do not poll the same reference, and follow the rendered new-search action.
 
 Stale or provisional evidence remains queryable while refresh or indexing

--- a/src/commands/search.test.ts
+++ b/src/commands/search.test.ts
@@ -877,6 +877,38 @@ describe("searchAction", () => {
     }
   });
 
+  it("rejects docs path prefixes before calling the search service", async () => {
+    const search = mock(() => Promise.resolve(defaultUnifiedSearchOutcome));
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+    try {
+      await expect(
+        searchAction(
+          "routing",
+          {
+            in: ["npm:express"],
+            source: "docs",
+            pathPrefix: "guide/",
+            json: true,
+          },
+          createDeps({
+            codeNavigationService: createMockCodeNavigationService({ search }),
+          }),
+        ),
+      ).rejects.toThrow("process.exit");
+      expect(search).not.toHaveBeenCalled();
+      expect(JSON.parse(String(errorSpy.mock.calls[0]?.[0]))).toMatchObject({
+        code: "INVALID_ARGUMENT",
+        retryable: false,
+      });
+    } finally {
+      errorSpy.mockRestore();
+      exitSpy.mockRestore();
+    }
+  });
+
   it("does not send a file-intent filter unless the caller explicitly set one", async () => {
     const search = mock<
       (

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -239,7 +239,10 @@ export function registerSearchCommand(program: Command) {
         "Broad symbol category filter",
       ).choices([...knownSymbolCategoryList()]),
     )
-    .option("--path-prefix <prefix>", "Repository path prefix filter")
+    .option(
+      "--path-prefix <prefix>",
+      "Code-only path prefix; omit for docs, symbols, and site-only searches",
+    )
     .addOption(
       new Option(
         "--intent <intent>",

--- a/src/services/locked-auth-storage.test.ts
+++ b/src/services/locked-auth-storage.test.ts
@@ -780,7 +780,8 @@ describe("LockedAuthStorage", () => {
       new AuthStorageImpl(fs, configDir),
       fsWithHome,
       {
-        lockTimeoutMs: 100,
+        // Reclamation performs real filesystem I/O; this is not a timeout test.
+        lockTimeoutMs: 1_000,
         getProcessStartedAt: testProcessStartedAt,
         isOwnerAlive: async () => false,
       },


### PR DESCRIPTION
Search currently forwards `path_prefix` to documentation and symbol searches even though the backend supports this filter only for code. The MCP schema incorrectly advertises repository-document support. These calls produce “Filters not supported by any selected source: pathPrefix”.

The shared CLI/MCP request builder now returns `INVALID_ARGUMENT` before `service.search` when a nonempty prefix has no code source. This covers docs-only, symbol-only, and automatic site-only searches while preserving code and automatic package/repository searches. Descriptors, CLI help, skill guidance, and durable docs explain the restriction. A dual-package patch fragment records the change.

Validation:
- 4,570 tests pass; root/MCP builds, typecheck, changed-file Biome, plugin checks, and public-package validation pass.
- Regression tests assert text/JSON errors and zero service calls; stable live CLI/MCP smoke checks and both built smoke modes pass.
- The complete live suites fail later on unrelated experimental assertions: MCP `ask` source/replay guidance and CLI `expressjs` resolution related-target grouping.
- Descriptor-only GitHits-intent evaluation completed nine successful MCP calls, including four valid searches, with no isolation violations. The neutral discovery run used no GitHits tools, so it provides no descriptor evidence. No answer-quality grading was run.
- One stale-lock success test hit its 100 ms real-filesystem budget during validation; its budget now matches nearby tests at 1 second. No lock runtime behavior changed.

One plan review found no blockers; the small runtime delta was reviewed inline. Hosted clients receive the guard after `@githits/mcp` is released and adopted/deployed by the remote server.


Production verification: Datadog logs from September 5–10 confirm both documentation-only searches with repository-relative paths and symbol-only package searches with file paths produce this exact backend error. Three representative source/target/filter combinations were replayed through the patched request builder; all were rejected locally without invoking a service. No further guard change was needed.
